### PR TITLE
PLT-486 - Initial master

### DIFF
--- a/modules/source/src/main/java/com/opengamma/platform/source/ClassifyingType.java
+++ b/modules/source/src/main/java/com/opengamma/platform/source/ClassifyingType.java
@@ -16,9 +16,9 @@ import java.lang.annotation.Target;
  * <p>
  * This means that the data will be available to use when searching for objects.
  * For example, search for all objects implementing the {@code SpecialTrade} interface,
- * where {@code SpecialTrade} has been annotated as a {@code CategorisingType}
+ * where {@code SpecialTrade} has been annotated as a {@code ClassifyingType}
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface CategorisingType {
+public @interface ClassifyingType {
 }

--- a/modules/source/src/main/java/com/opengamma/platform/source/Search.java
+++ b/modules/source/src/main/java/com/opengamma/platform/source/Search.java
@@ -50,7 +50,7 @@ public final class Search implements ImmutableBean, Serializable {
    * <p>
    * If the specified type is an interface then ideally
    * the interface should be annotated with
-   * {@link CategorisingType}. This will result in better
+   * {@link ClassifyingType}. This will result in better
    * performance. Note that if the specified type is too broad,
    * the search may be slow.
    * <p>
@@ -143,7 +143,7 @@ public final class Search implements ImmutableBean, Serializable {
    * <p>
    * If the specified type is an interface then ideally
    * the interface should be annotated with
-   * {@link CategorisingType}. This will result in better
+   * {@link ClassifyingType}. This will result in better
    * performance. Note that if the specified type is too broad,
    * the search may be slow.
    * <p>

--- a/modules/source/src/main/java/com/opengamma/platform/source/id/StandardIdentifiable.java
+++ b/modules/source/src/main/java/com/opengamma/platform/source/id/StandardIdentifiable.java
@@ -5,6 +5,10 @@
  */
 package com.opengamma.platform.source.id;
 
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
 /**
  * Provides uniform access to objects that can supply a standard identifier.
  * <p>
@@ -18,6 +22,19 @@ public interface StandardIdentifiable {
    *
    * @return the identifier
    */
-  StandardId getStandardId();
+  public abstract StandardId getStandardId();
+
+  /**
+   * Gets secondary identifiers for the instance.
+   * <p>
+   * The default implementation will return an immutable empty set.
+   * This can be overridden to provide a set of ids. Note that the
+   * set should not contain the primary id.
+   *
+   * @return the set of secondary ids
+   */
+  public default Set<StandardId> getSecondaryIds() {
+    return ImmutableSet.of();
+  }
 
 }


### PR DESCRIPTION
- Rename CategorisingType -> ClassifyingType (to match db table names)
- Additional standard ids now allowed, this allows a bean to have mutliple
  ids (e.g. security data with multiple tickets)
