### PR TITLE
PLT-536 - Alter how secondary ids are held

### DIFF
--- a/modules/source/src/main/java/com/opengamma/platform/source/id/StandardIdentifiable.java
+++ b/modules/source/src/main/java/com/opengamma/platform/source/id/StandardIdentifiable.java
@@ -5,10 +5,6 @@
  */
 package com.opengamma.platform.source.id;
 
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
-
 /**
  * Provides uniform access to objects that can supply a standard identifier.
  * <p>
@@ -23,18 +19,5 @@ public interface StandardIdentifiable {
    * @return the identifier
    */
   public abstract StandardId getStandardId();
-
-  /**
-   * Gets secondary identifiers for the instance.
-   * <p>
-   * The default implementation will return an immutable empty set.
-   * This can be overridden to provide a set of ids. Note that the
-   * set should not contain the primary id.
-   *
-   * @return the set of secondary ids
-   */
-  public default Set<StandardId> getSecondaryIds() {
-    return ImmutableSet.of();
-  }
 
 }


### PR DESCRIPTION
- removed getSecondaryIds from IdentifiableBean

Note that this change should be merged before https://github.com/OpenGamma/OG-PlatformServer/pull/8 
