### PR TITLE
PLT-580 Swap pricer function implementations

### DIFF
--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/DispatchingTradePricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/DispatchingTradePricerFn.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl;
+
+import com.opengamma.basics.currency.MultiCurrencyAmount;
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.Trade;
+import com.opengamma.platform.finance.swap.SwapTrade;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.TradePricerFn;
+import com.opengamma.platform.pricer.impl.swap.DefaultSwapTradePricerFn;
+
+/**
+ * Pricer implementation for trades using multiple dispatch.
+ * <p>
+ * Dispatches the request to the correct implementation.
+ */
+public class DispatchingTradePricerFn
+    implements TradePricerFn<Trade> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DispatchingTradePricerFn DEFAULT = new DispatchingTradePricerFn(
+      DefaultSwapTradePricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link SwapTrade}.
+   */
+  private final TradePricerFn<SwapTrade> swapTradePricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param swapTradePricerFn  the rate provider for {@link SwapTrade}
+   */
+  public DispatchingTradePricerFn(
+      TradePricerFn<SwapTrade> swapTradePricerFn) {
+    this.swapTradePricerFn = ArgChecker.notNull(swapTradePricerFn, "swapTradePricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public MultiCurrencyAmount presentValue(PricingEnvironment env, Trade trade) {
+    // dispatch by runtime type
+    if (trade instanceof SwapTrade) {
+      return swapTradePricerFn.presentValue(env, (SwapTrade) trade);
+    } else {
+      throw new IllegalArgumentException("Unknown Trade type: " + trade.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public MultiCurrencyAmount futureValue(PricingEnvironment env, Trade trade) {
+    // dispatch by runtime type
+    if (trade instanceof SwapTrade) {
+      return swapTradePricerFn.futureValue(env, (SwapTrade) trade);
+    } else {
+      throw new IllegalArgumentException("Unknown Trade type: " + trade.getClass().getSimpleName());
+    }
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultExpandedSwapLegPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultExpandedSwapLegPricerFn.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import java.util.function.ToDoubleBiFunction;
+
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
+import com.opengamma.platform.finance.swap.PaymentEvent;
+import com.opengamma.platform.finance.swap.PaymentPeriod;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
+import com.opengamma.platform.pricer.swap.PaymentPeriodPricerFn;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+
+/**
+ * Pricer implementation for expanded swap legs.
+ * <p>
+ * The swap leg is priced by examining the periods and events.
+ */
+public class DefaultExpandedSwapLegPricerFn
+    implements SwapLegPricerFn<ExpandedSwapLeg> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DefaultExpandedSwapLegPricerFn DEFAULT = new DefaultExpandedSwapLegPricerFn(
+      DispatchingPaymentPeriodPricerFn.DEFAULT,
+      DispatchingPaymentEventPricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link PaymentPeriod}.
+   */
+  private final PaymentPeriodPricerFn<PaymentPeriod> paymentPeriodPricerFn;
+  /**
+   * Pricer for {@link PaymentEvent}.
+   */
+  private final PaymentEventPricerFn<PaymentEvent> paymentEventPricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param paymentPeriodPricerFn  the pricer for {@link PaymentPeriod}
+   * @param paymentEventPricerFn  the pricer for {@link PaymentEvent}
+   */
+  public DefaultExpandedSwapLegPricerFn(
+      PaymentPeriodPricerFn<PaymentPeriod> paymentPeriodPricerFn,
+      PaymentEventPricerFn<PaymentEvent> paymentEventPricerFn) {
+    this.paymentPeriodPricerFn = ArgChecker.notNull(paymentPeriodPricerFn, "paymentPeriodPricerFn");
+    this.paymentEventPricerFn = ArgChecker.notNull(paymentEventPricerFn, "paymentEventPricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, ExpandedSwapLeg swapLeg) {
+    return value(env, swapLeg, paymentPeriodPricerFn::presentValue, paymentEventPricerFn::presentValue);
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, ExpandedSwapLeg swapLeg) {
+    return value(env, swapLeg, paymentPeriodPricerFn::futureValue, paymentEventPricerFn::futureValue);
+  }
+
+  // calculate present or future value
+  private static double value(
+      PricingEnvironment env,
+      ExpandedSwapLeg swapLeg,
+      ToDoubleBiFunction<PricingEnvironment, PaymentPeriod> periodFn,
+      ToDoubleBiFunction<PricingEnvironment, PaymentEvent> eventFn) {
+    double valuePeriods = swapLeg.getPaymentPeriods().stream()
+        .mapToDouble(p -> periodFn.applyAsDouble(env, p))
+        .sum();
+    double valueEvents = swapLeg.getPaymentEvents().stream()
+      .mapToDouble(e -> eventFn.applyAsDouble(env, e))
+      .sum();
+     return valuePeriods + valueEvents;
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultRateCalculationSwapLegPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultRateCalculationSwapLegPricerFn.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
+import com.opengamma.platform.finance.swap.RateCalculationSwapLeg;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+
+/**
+ * Pricer implementation for rate calculation swap legs.
+ * <p>
+ * The swap leg is priced by by expanding the swap legs.
+ */
+public class DefaultRateCalculationSwapLegPricerFn
+    implements SwapLegPricerFn<RateCalculationSwapLeg> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DefaultRateCalculationSwapLegPricerFn DEFAULT = new DefaultRateCalculationSwapLegPricerFn(
+      DefaultExpandedSwapLegPricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link ExpandedSwapLeg}.
+   */
+  private final SwapLegPricerFn<ExpandedSwapLeg> expandedSwapLegPricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param expandedSwapLegPricerFn  the pricer for {@link ExpandedSwapLeg}
+   */
+  public DefaultRateCalculationSwapLegPricerFn(
+      SwapLegPricerFn<ExpandedSwapLeg> expandedSwapLegPricerFn) {
+    this.expandedSwapLegPricerFn = ArgChecker.notNull(expandedSwapLegPricerFn, "expandedSwapLegPricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, RateCalculationSwapLeg swapLeg) {
+    return expandedSwapLegPricerFn.presentValue(env, swapLeg.expand());
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, RateCalculationSwapLeg swapLeg) {
+    return expandedSwapLegPricerFn.futureValue(env, swapLeg.expand());
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapPricerFn.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import java.util.function.ToDoubleBiFunction;
+
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.currency.CurrencyAmount;
+import com.opengamma.basics.currency.MultiCurrencyAmount;
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.Swap;
+import com.opengamma.platform.finance.swap.SwapLeg;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+import com.opengamma.platform.pricer.swap.SwapPricerFn;
+
+/**
+ * Pricer implementation for swaps.
+ * <p>
+ * The swap is priced by examining the swap legs.
+ */
+public class DefaultSwapPricerFn
+    implements SwapPricerFn {
+
+  /**
+   * Default implementation.
+   */
+  public static final DefaultSwapPricerFn DEFAULT = new DefaultSwapPricerFn(
+      DispatchingSwapLegPricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link SwapLeg}.
+   */
+  private final SwapLegPricerFn<SwapLeg> swapLegPricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param swapLegPricerFn  the pricer for {@link SwapLeg}
+   */
+  public DefaultSwapPricerFn(
+      SwapLegPricerFn<SwapLeg> swapLegPricerFn) {
+    this.swapLegPricerFn = ArgChecker.notNull(swapLegPricerFn, "swapLegPricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public MultiCurrencyAmount presentValue(PricingEnvironment env, Swap swap) {
+    return value(env, swap, swapLegPricerFn::presentValue);
+  }
+
+  @Override
+  public MultiCurrencyAmount futureValue(PricingEnvironment env, Swap swap) {
+    return value(env, swap, swapLegPricerFn::futureValue);
+  }
+
+  // calculate present or future value
+  private static MultiCurrencyAmount value(
+      PricingEnvironment env,
+      Swap swap,
+      ToDoubleBiFunction<PricingEnvironment, SwapLeg> valueFn) {
+    if (swap.isCrossCurrency()) {
+      return swap.getLegs().stream()
+          .map(leg -> CurrencyAmount.of(leg.getCurrency(), valueFn.applyAsDouble(env, leg)))
+          .reduce(MultiCurrencyAmount.of(), MultiCurrencyAmount::plus, MultiCurrencyAmount::plus);
+    } else {
+      Currency currency = swap.getLegs().iterator().next().getCurrency();
+      double pv = swap.getLegs().stream()
+          .mapToDouble(leg -> valueFn.applyAsDouble(env, leg))
+          .sum();
+      return MultiCurrencyAmount.of(currency, pv);
+    }
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapTradePricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapTradePricerFn.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.basics.currency.MultiCurrencyAmount;
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.Swap;
+import com.opengamma.platform.finance.swap.SwapTrade;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.TradePricerFn;
+import com.opengamma.platform.pricer.swap.SwapPricerFn;
+
+/**
+ * Pricer implementation for swap trades.
+ * <p>
+ * The swap trade is priced by examining the embedded swap.
+ */
+public class DefaultSwapTradePricerFn
+    implements TradePricerFn<SwapTrade> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DefaultSwapTradePricerFn DEFAULT = new DefaultSwapTradePricerFn(
+      DefaultSwapPricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link Swap}.
+   */
+  private final SwapPricerFn swapPricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param swapPricerFn  the swap pricer
+   */
+  public DefaultSwapTradePricerFn(
+      SwapPricerFn swapPricerFn) {
+    this.swapPricerFn = ArgChecker.notNull(swapPricerFn, "swapPricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public MultiCurrencyAmount presentValue(PricingEnvironment env, SwapTrade trade) {
+    return swapPricerFn.presentValue(env, trade.getSwap());
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public MultiCurrencyAmount futureValue(PricingEnvironment env, SwapTrade trade) {
+    return swapPricerFn.futureValue(env, trade.getSwap());
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DiscountingNotionalExchangePricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DiscountingNotionalExchangePricerFn.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.platform.finance.swap.NotionalExchange;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
+
+/**
+ * Pricer implementation for the exchange of notionals.
+ * <p>
+ * The notional exchange is priced by discounting the value of the exchange.
+ */
+public class DiscountingNotionalExchangePricerFn
+    implements PaymentEventPricerFn<NotionalExchange> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DiscountingNotionalExchangePricerFn DEFAULT = new DiscountingNotionalExchangePricerFn();
+
+  /**
+   * Creates an instance.
+   */
+  public DiscountingNotionalExchangePricerFn() {
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, NotionalExchange event) {
+    // futureValue * discountFactor
+    double df = env.discountFactor(event.getPaymentAmount().getCurrency(), event.getPaymentDate());
+    return futureValue(env, event) * df;
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, NotionalExchange event) {
+    // paymentAmount
+    return event.getPaymentAmount().getAmount();
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventPricerFn.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.NotionalExchange;
+import com.opengamma.platform.finance.swap.PaymentEvent;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
+
+/**
+ * Pricer implementation for payment events using multiple dispatch.
+ * <p>
+ * Dispatches the request to the correct implementation.
+ */
+public class DispatchingPaymentEventPricerFn
+    implements PaymentEventPricerFn<PaymentEvent> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DispatchingPaymentEventPricerFn DEFAULT = new DispatchingPaymentEventPricerFn(
+      DiscountingNotionalExchangePricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link NotionalExchange}.
+   */
+  private final PaymentEventPricerFn<NotionalExchange> notionalExchangePricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param notionalExchangePricerFn  the pricer for {@link NotionalExchange}
+   */
+  public DispatchingPaymentEventPricerFn(
+      PaymentEventPricerFn<NotionalExchange> notionalExchangePricerFn) {
+    this.notionalExchangePricerFn = ArgChecker.notNull(notionalExchangePricerFn, "notionalExchangePricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, PaymentEvent paymentEvent) {
+    // dispatch by runtime type
+    if (paymentEvent instanceof NotionalExchange) {
+      return notionalExchangePricerFn.presentValue(env, (NotionalExchange) paymentEvent);
+    } else {
+      throw new IllegalArgumentException("Unknown PaymentEvent type: " + paymentEvent.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, PaymentEvent paymentEvent) {
+    // dispatch by runtime type
+    if (paymentEvent instanceof NotionalExchange) {
+      return notionalExchangePricerFn.futureValue(env, (NotionalExchange) paymentEvent);
+    } else {
+      throw new IllegalArgumentException("Unknown PaymentEvent type: " + paymentEvent.getClass().getSimpleName());
+    }
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentPeriodPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentPeriodPricerFn.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.platform.finance.swap.PaymentPeriod;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentPeriodPricerFn;
+
+/**
+ * Pricer implementation for payment periods using multiple dispatch.
+ * <p>
+ * Dispatches the request to the correct implementation.
+ */
+public class DispatchingPaymentPeriodPricerFn
+    implements PaymentPeriodPricerFn<PaymentPeriod> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DispatchingPaymentPeriodPricerFn DEFAULT = new DispatchingPaymentPeriodPricerFn();
+
+  /**
+   * Creates an instance.
+   */
+  public DispatchingPaymentPeriodPricerFn() {
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, PaymentPeriod paymentPeriod) {
+    // dispatch by runtime type
+    throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, PaymentPeriod paymentPeriod) {
+    // dispatch by runtime type
+    throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingSwapLegPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingSwapLegPricerFn.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
+import com.opengamma.platform.finance.swap.RateCalculationSwapLeg;
+import com.opengamma.platform.finance.swap.SwapLeg;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+
+/**
+ * Pricer implementation for swap legs using multiple dispatch.
+ * <p>
+ * Dispatches the request to the correct implementation.
+ */
+public class DispatchingSwapLegPricerFn
+    implements SwapLegPricerFn<SwapLeg> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DispatchingSwapLegPricerFn DEFAULT = new DispatchingSwapLegPricerFn(
+      DefaultExpandedSwapLegPricerFn.DEFAULT,
+      DefaultRateCalculationSwapLegPricerFn.DEFAULT);
+
+  /**
+   * Pricer for {@link ExpandedSwapLeg}.
+   */
+  private final SwapLegPricerFn<ExpandedSwapLeg> expandedSwapLegPricerFn;
+  /**
+   * Pricer for {@link RateCalculationSwapLeg}.
+   */
+  private final SwapLegPricerFn<RateCalculationSwapLeg> rateCalculationSwapLegPricerFn;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param expandedSwapLegPricerFn  the pricer for {@link ExpandedSwapLeg}
+   * @param rateCalculationSwapLegPricerFn  the pricer for {@link RateCalculationSwapLeg}
+   */
+  public DispatchingSwapLegPricerFn(
+      SwapLegPricerFn<ExpandedSwapLeg> expandedSwapLegPricerFn,
+      SwapLegPricerFn<RateCalculationSwapLeg> rateCalculationSwapLegPricerFn) {
+    this.expandedSwapLegPricerFn = ArgChecker.notNull(expandedSwapLegPricerFn, "expandedSwapLegPricerFn");
+    this.rateCalculationSwapLegPricerFn = ArgChecker.notNull(rateCalculationSwapLegPricerFn, "rateCalculationSwapLegPricerFn");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, SwapLeg swapLeg) {
+    // dispatch by runtime type
+    if (swapLeg instanceof ExpandedSwapLeg) {
+      return expandedSwapLegPricerFn.presentValue(env, (ExpandedSwapLeg) swapLeg);
+    } else if (swapLeg instanceof RateCalculationSwapLeg) {
+      return rateCalculationSwapLegPricerFn.presentValue(env, (RateCalculationSwapLeg) swapLeg);
+    } else {
+      throw new IllegalArgumentException("Unknown SwapLeg type: " + swapLeg.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, SwapLeg swapLeg) {
+    // dispatch by runtime type
+    if (swapLeg instanceof ExpandedSwapLeg) {
+      return expandedSwapLegPricerFn.futureValue(env, (ExpandedSwapLeg) swapLeg);
+    } else if (swapLeg instanceof RateCalculationSwapLeg) {
+      return rateCalculationSwapLegPricerFn.futureValue(env, (RateCalculationSwapLeg) swapLeg);
+    } else {
+      throw new IllegalArgumentException("Unknown SwapLeg type: " + swapLeg.getClass().getSimpleName());
+    }
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/package-info.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+
+/**
+ * Standard implementation of pricing for swaps.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.opengamma.platform.pricer.impl.swap;

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/DispatchingTradePricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/DispatchingTradePricerFnTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl;
+
+import static com.opengamma.collect.TestHelper.assertThrowsIllegalArg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.currency.MultiCurrencyAmount;
+import com.opengamma.platform.finance.Trade;
+import com.opengamma.platform.finance.swap.SwapTrade;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.TradePricerFn;
+import com.opengamma.platform.pricer.impl.swap.SwapDummyData;
+
+/**
+ * Test.
+ */
+@Test
+public class DispatchingTradePricerFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue_SwapTrade() {
+    TradePricerFn<SwapTrade> mockSwapFn = mock(TradePricerFn.class);
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(Currency.GBP, 0.0123d);
+    when(mockSwapFn.presentValue(mockEnv, SwapDummyData.SWAP_TRADE))
+        .thenReturn(expected);
+    DispatchingTradePricerFn test = new DispatchingTradePricerFn(mockSwapFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.SWAP_TRADE), expected);
+  }
+
+  public void test_presentValue_unknownType() {
+    Trade mockTrade = mock(Trade.class);
+    DispatchingTradePricerFn test = DispatchingTradePricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.presentValue(mockEnv, mockTrade));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_futureValue_SwapTrade() {
+    TradePricerFn<SwapTrade> mockSwapFn = mock(TradePricerFn.class);
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(Currency.GBP, 0.0123d);
+    when(mockSwapFn.futureValue(mockEnv, SwapDummyData.SWAP_TRADE))
+        .thenReturn(expected);
+    DispatchingTradePricerFn test = new DispatchingTradePricerFn(mockSwapFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.SWAP_TRADE), expected);
+  }
+
+  public void test_futureValue_unknownType() {
+    Trade mockTrade = mock(Trade.class);
+    DispatchingTradePricerFn test = DispatchingTradePricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.futureValue(mockEnv, mockTrade));
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/observation/DispatchingRateObservationFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/observation/DispatchingRateObservationFnTest.java
@@ -34,14 +34,14 @@ public class DispatchingRateObservationFnTest {
   private static final LocalDate ACCRUAL_START_DATE = date(2014, 7, 2);
   private static final LocalDate ACCRUAL_END_DATE = date(2014, 10, 2);
 
-  public void test_FixedRateObservation() {
+  public void test_rate_FixedRateObservation() {
     PricingEnvironment mockEnv = mock(PricingEnvironment.class);
     FixedRateObservation ro = FixedRateObservation.of(0.0123d);
     DispatchingRateObservationFn test = DispatchingRateObservationFn.DEFAULT;
     assertEquals(test.rate(mockEnv, ro, ACCRUAL_START_DATE, ACCRUAL_END_DATE), 0.0123d, 0d);
   }
 
-  public void test_IborRateObservation() {
+  public void test_rate_IborRateObservation() {
     PricingEnvironment mockEnv = mock(PricingEnvironment.class);
     RateObservationFn<IborRateObservation> mockIbor = mock(RateObservationFn.class);
     RateObservationFn<IborInterpolatedRateObservation> mockIborInt = mock(RateObservationFn.class);
@@ -52,7 +52,7 @@ public class DispatchingRateObservationFnTest {
     assertEquals(test.rate(mockEnv, ro, ACCRUAL_START_DATE, ACCRUAL_END_DATE), 0.0123d, 0d);
   }
 
-  public void test_IborInterpolatedRateObservation() {
+  public void test_rate_IborInterpolatedRateObservation() {
     PricingEnvironment mockEnv = mock(PricingEnvironment.class);
     double mockRate = 0.0123d;
     RateObservationFn<IborRateObservation> mockIbor = mock(RateObservationFn.class);
@@ -64,7 +64,7 @@ public class DispatchingRateObservationFnTest {
     assertEquals(test.rate(mockEnv, ro, ACCRUAL_START_DATE, ACCRUAL_END_DATE), mockRate, 0d);
   }
 
-  public void test_RateObservation_unknownType() {
+  public void test_rate_unknownType() {
     PricingEnvironment mockEnv = mock(PricingEnvironment.class);
     RateObservation mockObservation = mock(RateObservation.class);
     DispatchingRateObservationFn test = DispatchingRateObservationFn.DEFAULT;

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/observation/ForwardIborInterpolatedRateObservationFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/observation/ForwardIborInterpolatedRateObservationFnTest.java
@@ -30,7 +30,7 @@ public class ForwardIborInterpolatedRateObservationFnTest {
   private static final LocalDate ACCRUAL_END_DATE = date(2014, 11, 2);
   private static final double TOLERANCE_RATE = 1.0E-10;
 
-  public void test_IborInterpolatedRateObservation() {
+  public void test_rate() {
     PricingEnvironment mockEnv = mock(PricingEnvironment.class);
     double rate3M = 0.0123d;
     double rate6M = 0.0234d;

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/observation/ForwardIborRateObservationFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/observation/ForwardIborRateObservationFnTest.java
@@ -28,7 +28,7 @@ public class ForwardIborRateObservationFnTest {
   private static final LocalDate ACCRUAL_START_DATE = date(2014, 7, 2);
   private static final LocalDate ACCRUAL_END_DATE = date(2014, 10, 2);
 
-  public void test_FixedRateObservation() {
+  public void test_rate() {
     PricingEnvironment mockEnv = mock(PricingEnvironment.class);
     when(mockEnv.iborIndexRate(GBP_LIBOR_3M, FIXING_DATE))
         .thenReturn(0.0123d);

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultExpandedSwapLegPricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultExpandedSwapLegPricerFnTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.finance.swap.PaymentEvent;
+import com.opengamma.platform.finance.swap.PaymentPeriod;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
+import com.opengamma.platform.pricer.swap.PaymentPeriodPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DefaultExpandedSwapLegPricerFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue() {
+    PaymentPeriodPricerFn<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricerFn.class);
+    when(mockPeriod.presentValue(mockEnv, SwapDummyData.IBOR_RATE_PAYMENT_PERIOD))
+        .thenReturn(1000d);
+    PaymentEventPricerFn<PaymentEvent> mockEvent = mock(PaymentEventPricerFn.class);
+    when(mockEvent.presentValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE))
+        .thenReturn(1000d);
+    DefaultExpandedSwapLegPricerFn test = new DefaultExpandedSwapLegPricerFn(mockPeriod, mockEvent);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), 2000d, 0d);
+  }
+
+  public void test_futureValue() {
+    PaymentPeriodPricerFn<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricerFn.class);
+    when(mockPeriod.futureValue(mockEnv, SwapDummyData.IBOR_RATE_PAYMENT_PERIOD))
+        .thenReturn(1000d);
+    PaymentEventPricerFn<PaymentEvent> mockEvent = mock(PaymentEventPricerFn.class);
+    when(mockEvent.futureValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE))
+        .thenReturn(1000d);
+    DefaultExpandedSwapLegPricerFn test = new DefaultExpandedSwapLegPricerFn(mockPeriod, mockEvent);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), 2000d, 0d);
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultRateCalculationSwapLegPricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultRateCalculationSwapLegPricerFnTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DefaultRateCalculationSwapLegPricerFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue() {
+    double expected = 1000d;
+    SwapLegPricerFn<ExpandedSwapLeg> mockSwapLegFn = mock(SwapLegPricerFn.class);
+    when(mockSwapLegFn.presentValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG.expand()))
+        .thenReturn(expected);
+    DefaultRateCalculationSwapLegPricerFn test = new DefaultRateCalculationSwapLegPricerFn(mockSwapLegFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG), expected);
+  }
+
+  public void test_futureValue() {
+    double expected = 1000d;
+    SwapLegPricerFn<ExpandedSwapLeg> mockSwapLegFn = mock(SwapLegPricerFn.class);
+    when(mockSwapLegFn.futureValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG.expand()))
+        .thenReturn(expected);
+    DefaultRateCalculationSwapLegPricerFn test = new DefaultRateCalculationSwapLegPricerFn(mockSwapLegFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG), expected);
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapPricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapPricerFnTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.basics.currency.Currency.GBP;
+import static com.opengamma.basics.currency.Currency.USD;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.basics.currency.CurrencyAmount;
+import com.opengamma.basics.currency.MultiCurrencyAmount;
+import com.opengamma.platform.finance.swap.SwapLeg;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DefaultSwapPricerFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue_singleCurrency() {
+    SwapLegPricerFn<SwapLeg> mockSwapLegFn = mock(SwapLegPricerFn.class);
+    when(mockSwapLegFn.presentValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG))
+        .thenReturn(1000d);
+    when(mockSwapLegFn.presentValue(mockEnv, SwapDummyData.FIXED_EXPANDED_SWAP_LEG))
+        .thenReturn(-500d);
+    DefaultSwapPricerFn test = new DefaultSwapPricerFn(mockSwapLegFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.SWAP), MultiCurrencyAmount.of(GBP, 500d));
+  }
+
+  public void test_presentValue_crossCurrency() {
+    SwapLegPricerFn<SwapLeg> mockSwapLegFn = mock(SwapLegPricerFn.class);
+    when(mockSwapLegFn.presentValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG))
+        .thenReturn(1000d);
+    when(mockSwapLegFn.presentValue(mockEnv, SwapDummyData.FIXED_EXPANDED_SWAP_LEG_USD))
+        .thenReturn(-500d);
+    DefaultSwapPricerFn test = new DefaultSwapPricerFn(mockSwapLegFn);
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(CurrencyAmount.of(GBP, 1000d), CurrencyAmount.of(USD, -500d));
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.SWAP_CROSS_CURRENCY), expected);
+  }
+
+  public void test_futureValue_singleCurrency() {
+    SwapLegPricerFn<SwapLeg> mockSwapLegFn = mock(SwapLegPricerFn.class);
+    when(mockSwapLegFn.futureValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG))
+        .thenReturn(1000d);
+    when(mockSwapLegFn.futureValue(mockEnv, SwapDummyData.FIXED_EXPANDED_SWAP_LEG))
+        .thenReturn(-500d);
+    DefaultSwapPricerFn test = new DefaultSwapPricerFn(mockSwapLegFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.SWAP), MultiCurrencyAmount.of(GBP, 500d));
+  }
+
+  public void test_futureValue_crossCurrency() {
+    SwapLegPricerFn<SwapLeg> mockSwapLegFn = mock(SwapLegPricerFn.class);
+    when(mockSwapLegFn.futureValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG))
+        .thenReturn(1000d);
+    when(mockSwapLegFn.futureValue(mockEnv, SwapDummyData.FIXED_EXPANDED_SWAP_LEG_USD))
+        .thenReturn(-500d);
+    DefaultSwapPricerFn test = new DefaultSwapPricerFn(mockSwapLegFn);
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(CurrencyAmount.of(GBP, 1000d), CurrencyAmount.of(USD, -500d));
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.SWAP_CROSS_CURRENCY), expected);
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapTradePricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DefaultSwapTradePricerFnTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.basics.currency.Currency.GBP;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.basics.currency.MultiCurrencyAmount;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DefaultSwapTradePricerFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue() {
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(GBP, 500d);
+    SwapPricerFn mockSwapFn = mock(SwapPricerFn.class);
+    when(mockSwapFn.presentValue(mockEnv, SwapDummyData.SWAP))
+        .thenReturn(expected);
+    DefaultSwapTradePricerFn test = new DefaultSwapTradePricerFn(mockSwapFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.SWAP_TRADE), expected);
+  }
+
+  public void test_futureValue() {
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(GBP, 500d);
+    SwapPricerFn mockSwapFn = mock(SwapPricerFn.class);
+    when(mockSwapFn.futureValue(mockEnv, SwapDummyData.SWAP))
+        .thenReturn(expected);
+    DefaultSwapTradePricerFn test = new DefaultSwapTradePricerFn(mockSwapFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.SWAP_TRADE), expected);
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DiscountingNotionalExchangePricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DiscountingNotionalExchangePricerFnTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.platform.pricer.impl.swap.SwapDummyData.NOTIONAL_EXCHANGE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.pricer.PricingEnvironment;
+
+/**
+ * Test.
+ */
+@Test
+public class DiscountingNotionalExchangePricerFnTest {
+
+  public void test_presentValue() {
+    double discountFactor = 0.98d;
+    PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+    when(mockEnv.discountFactor(NOTIONAL_EXCHANGE.getCurrency(), NOTIONAL_EXCHANGE.getPaymentDate()))
+        .thenReturn(discountFactor);
+    DiscountingNotionalExchangePricerFn test = new DiscountingNotionalExchangePricerFn();
+    assertEquals(
+        test.presentValue(mockEnv, NOTIONAL_EXCHANGE),
+        NOTIONAL_EXCHANGE.getPaymentAmount().getAmount() * discountFactor, 0d);
+  }
+
+  public void test_futureValue() {
+    PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+    DiscountingNotionalExchangePricerFn test = new DiscountingNotionalExchangePricerFn();
+    assertEquals(
+        test.futureValue(mockEnv, NOTIONAL_EXCHANGE),
+        NOTIONAL_EXCHANGE.getPaymentAmount().getAmount(), 0d);
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventFnTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.collect.TestHelper.assertThrowsIllegalArg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.finance.swap.NotionalExchange;
+import com.opengamma.platform.finance.swap.PaymentEvent;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DispatchingPaymentEventFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue_NotionalExchange() {
+    double expected = 0.0123d;
+    PaymentEventPricerFn<NotionalExchange> mockNotionalExchangeFn = mock(PaymentEventPricerFn.class);
+    when(mockNotionalExchangeFn.presentValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE))
+        .thenReturn(expected);
+    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(mockNotionalExchangeFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE), expected, 0d);
+  }
+
+  public void test_presentValue_unknownType() {
+    PaymentEvent mockPaymentEvent = mock(PaymentEvent.class);
+    DispatchingPaymentEventPricerFn test = DispatchingPaymentEventPricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.presentValue(mockEnv, mockPaymentEvent));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_futureValue_NotionalExchange() {
+    double expected = 0.0123d;
+    PaymentEventPricerFn<NotionalExchange> mockNotionalExchangeFn = mock(PaymentEventPricerFn.class);
+    when(mockNotionalExchangeFn.futureValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE))
+        .thenReturn(expected);
+    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(mockNotionalExchangeFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE), expected, 0d);
+  }
+
+  public void test_futureValue_unknownType() {
+    PaymentEvent mockPaymentEvent = mock(PaymentEvent.class);
+    DispatchingPaymentEventPricerFn test = DispatchingPaymentEventPricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.futureValue(mockEnv, mockPaymentEvent));
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentPeriodFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentPeriodFnTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.collect.TestHelper.assertThrowsIllegalArg;
+import static org.mockito.Mockito.mock;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.finance.swap.PaymentPeriod;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.impl.swap.DispatchingPaymentPeriodPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DispatchingPaymentPeriodFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue_unknownType() {
+    PaymentPeriod mockPaymentPeriod = mock(PaymentPeriod.class);
+    DispatchingPaymentPeriodPricerFn test = DispatchingPaymentPeriodPricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.presentValue(mockEnv, mockPaymentPeriod));
+  }
+
+  public void test_futureValue_unknownType() {
+    PaymentPeriod mockPaymentPeriod = mock(PaymentPeriod.class);
+    DispatchingPaymentPeriodPricerFn test = DispatchingPaymentPeriodPricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.futureValue(mockEnv, mockPaymentPeriod));
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingSwapLegFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingSwapLegFnTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.collect.TestHelper.assertThrowsIllegalArg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
+import com.opengamma.platform.finance.swap.RateCalculationSwapLeg;
+import com.opengamma.platform.finance.swap.SwapLeg;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.SwapLegPricerFn;
+
+/**
+ * Test.
+ */
+@Test
+public class DispatchingSwapLegFnTest {
+
+  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+
+  public void test_presentValue_ExpandedSwapLeg() {
+    SwapLegPricerFn<ExpandedSwapLeg> mockExpandedFn = mock(SwapLegPricerFn.class);
+    SwapLegPricerFn<RateCalculationSwapLeg> mockRateCalcFn = mock(SwapLegPricerFn.class);
+    double expected = 0.0123d;
+    when(mockExpandedFn.presentValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG))
+        .thenReturn(expected);
+    DispatchingSwapLegPricerFn test = new DispatchingSwapLegPricerFn(mockExpandedFn, mockRateCalcFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), expected);
+  }
+
+  public void test_presentValue_RateCalculationSwapLeg() {
+    SwapLegPricerFn<ExpandedSwapLeg> mockExpandedFn = mock(SwapLegPricerFn.class);
+    SwapLegPricerFn<RateCalculationSwapLeg> mockRateCalcFn = mock(SwapLegPricerFn.class);
+    double expected = 0.0123d;
+    when(mockRateCalcFn.presentValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG))
+        .thenReturn(expected);
+    DispatchingSwapLegPricerFn test = new DispatchingSwapLegPricerFn(mockExpandedFn, mockRateCalcFn);
+    assertEquals(test.presentValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG), expected);
+  }
+
+  public void test_presentValue_unknownType() {
+    SwapLeg mockSwapLeg = mock(SwapLeg.class);
+    DispatchingSwapLegPricerFn test = DispatchingSwapLegPricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.presentValue(mockEnv, mockSwapLeg));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_futureValue_ExpandedSwapLeg() {
+    SwapLegPricerFn<ExpandedSwapLeg> mockExpandedFn = mock(SwapLegPricerFn.class);
+    SwapLegPricerFn<RateCalculationSwapLeg> mockRateCalcFn = mock(SwapLegPricerFn.class);
+    double expected = 0.0123d;
+    when(mockExpandedFn.futureValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG))
+        .thenReturn(expected);
+    DispatchingSwapLegPricerFn test = new DispatchingSwapLegPricerFn(mockExpandedFn, mockRateCalcFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), expected);
+  }
+
+  public void test_futureValue_RateCalculationSwapLeg() {
+    SwapLegPricerFn<ExpandedSwapLeg> mockExpandedFn = mock(SwapLegPricerFn.class);
+    SwapLegPricerFn<RateCalculationSwapLeg> mockRateCalcFn = mock(SwapLegPricerFn.class);
+    double expected = 0.0123d;
+    when(mockRateCalcFn.futureValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG))
+        .thenReturn(expected);
+    DispatchingSwapLegPricerFn test = new DispatchingSwapLegPricerFn(mockExpandedFn, mockRateCalcFn);
+    assertEquals(test.futureValue(mockEnv, SwapDummyData.IBOR_RATECALC_SWAP_LEG), expected);
+  }
+
+  public void test_futureValue_unknownType() {
+    SwapLeg mockSwapLeg = mock(SwapLeg.class);
+    DispatchingSwapLegPricerFn test = DispatchingSwapLegPricerFn.DEFAULT;
+    assertThrowsIllegalArg(() -> test.futureValue(mockEnv, mockSwapLeg));
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/SwapDummyData.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/SwapDummyData.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
+import static com.opengamma.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.collect.TestHelper.date;
+
+import com.opengamma.basics.PayReceive;
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.currency.CurrencyAmount;
+import com.opengamma.basics.date.BusinessDayAdjustment;
+import com.opengamma.basics.date.DayCounts;
+import com.opengamma.basics.date.DaysAdjustment;
+import com.opengamma.basics.schedule.Frequency;
+import com.opengamma.basics.schedule.PeriodicSchedule;
+import com.opengamma.basics.value.ValueSchedule;
+import com.opengamma.platform.finance.observation.FixedRateObservation;
+import com.opengamma.platform.finance.observation.IborRateObservation;
+import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
+import com.opengamma.platform.finance.swap.FixedRateCalculation;
+import com.opengamma.platform.finance.swap.IborRateCalculation;
+import com.opengamma.platform.finance.swap.NotionalExchange;
+import com.opengamma.platform.finance.swap.NotionalSchedule;
+import com.opengamma.platform.finance.swap.PaymentSchedule;
+import com.opengamma.platform.finance.swap.RateAccrualPeriod;
+import com.opengamma.platform.finance.swap.RateCalculationSwapLeg;
+import com.opengamma.platform.finance.swap.RatePaymentPeriod;
+import com.opengamma.platform.finance.swap.Swap;
+import com.opengamma.platform.finance.swap.SwapTrade;
+import com.opengamma.platform.source.id.StandardId;
+
+/**
+ * Basic dummy objects used when the data within is not important.
+ */
+public final class SwapDummyData {
+
+  /**
+   * The notional.
+   */
+  public static final double NOTIONAL = 1_000_000d;
+  /**
+   * NotionalExchange.
+   */
+  public static final NotionalExchange NOTIONAL_EXCHANGE = NotionalExchange.builder()
+      .paymentDate(date(2014, 7, 1))
+      .paymentAmount(CurrencyAmount.of(Currency.GBP, NOTIONAL))
+      .build();
+
+  /**
+   * IborRateObservation.
+   */
+  public static final IborRateObservation IBOR_RATE_OBSERVATION = IborRateObservation.of(GBP_LIBOR_3M, date(2014, 6, 30));
+  /**
+   * RateAccuralPeriod (ibor).
+   */
+  public static final RateAccrualPeriod IBOR_RATE_ACCRUAL_PERIOD = RateAccrualPeriod.builder()
+      .startDate(date(2014, 7, 2))
+      .endDate(date(2014, 10, 2))
+      .rateObservation(IBOR_RATE_OBSERVATION)
+      .yearFraction(0.25d)
+      .build();
+  /**
+   * RatePaymentPeriod (ibor).
+   */
+  public static final RatePaymentPeriod IBOR_RATE_PAYMENT_PERIOD = RatePaymentPeriod.builder()
+      .paymentDate(date(2014, 10, 4))
+      .accrualPeriods(IBOR_RATE_ACCRUAL_PERIOD)
+      .currency(Currency.GBP)
+      .notional(NOTIONAL)
+      .build();
+  /**
+   * ExpandedSwapLeg (ibor).
+   */
+  public static final ExpandedSwapLeg IBOR_EXPANDED_SWAP_LEG = ExpandedSwapLeg.builder()
+      .paymentPeriods(IBOR_RATE_PAYMENT_PERIOD)
+      .paymentEvents(NOTIONAL_EXCHANGE)
+      .build();
+  /**
+   * RateCalculationSwapLeg (ibor).
+   */
+  public static final RateCalculationSwapLeg IBOR_RATECALC_SWAP_LEG = RateCalculationSwapLeg.builder()
+      .payReceive(PayReceive.RECEIVE)
+      .accrualSchedule(PeriodicSchedule.builder()
+          .startDate(date(2014, 7, 2))
+          .endDate(date(2014, 10, 2))
+          .frequency(Frequency.P3M)
+          .businessDayAdjustment(BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO))
+          .build())
+      .paymentSchedule(PaymentSchedule.builder()
+          .paymentFrequency(Frequency.P3M)
+          .paymentOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+          .build())
+      .notionalSchedule(NotionalSchedule.of(Currency.GBP, NOTIONAL))
+      .calculation(IborRateCalculation.builder()
+          .dayCount(DayCounts.ACT_365F)
+          .index(GBP_LIBOR_3M)
+          .fixingOffset(DaysAdjustment.ofBusinessDays(-2, GBLO))
+          .build())
+      .build();
+
+  /**
+   * FixedRateObservation.
+   */
+  public static final FixedRateObservation FIXED_RATE_OBSERVATION = FixedRateObservation.of(0.0123d);
+  /**
+   * RateAccuralPeriod (fixed).
+   */
+  public static final RateAccrualPeriod FIXED_RATE_ACCRUAL_PERIOD = RateAccrualPeriod.builder()
+      .startDate(date(2014, 7, 2))
+      .endDate(date(2014, 10, 2))
+      .rateObservation(FIXED_RATE_OBSERVATION)
+      .yearFraction(0.25d)
+      .build();
+  /**
+   * RatePaymentPeriod (fixed).
+   */
+  public static final RatePaymentPeriod FIXED_RATE_PAYMENT_PERIOD = RatePaymentPeriod.builder()
+      .paymentDate(date(2014, 10, 4))
+      .accrualPeriods(FIXED_RATE_ACCRUAL_PERIOD)
+      .currency(Currency.GBP)
+      .notional(NOTIONAL)
+      .build();
+  /**
+   * ExpandedSwapLeg (fixed).
+   */
+  public static final ExpandedSwapLeg FIXED_EXPANDED_SWAP_LEG = ExpandedSwapLeg.builder()
+      .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD)
+      .paymentEvents(NOTIONAL_EXCHANGE)
+      .build();
+  /**
+   * RatePaymentPeriod (fixed).
+   */
+  public static final RatePaymentPeriod FIXED_RATE_PAYMENT_PERIOD_USD = RatePaymentPeriod.builder()
+      .paymentDate(date(2014, 10, 4))
+      .accrualPeriods(FIXED_RATE_ACCRUAL_PERIOD)
+      .currency(Currency.USD)
+      .notional(NOTIONAL)
+      .build();
+  /**
+   * ExpandedSwapLeg (fixed).
+   */
+  public static final ExpandedSwapLeg FIXED_EXPANDED_SWAP_LEG_USD = ExpandedSwapLeg.builder()
+      .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD_USD)
+      .build();
+  /**
+   * RateCalculationSwapLeg (fixed).
+   */
+  public static final RateCalculationSwapLeg FIXED_RATECALC_SWAP_LEG = RateCalculationSwapLeg.builder()
+      .payReceive(PayReceive.RECEIVE)
+      .accrualSchedule(PeriodicSchedule.builder()
+          .startDate(date(2014, 7, 2))
+          .endDate(date(2014, 10, 2))
+          .frequency(Frequency.P3M)
+          .businessDayAdjustment(BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO))
+          .build())
+      .paymentSchedule(PaymentSchedule.builder()
+          .paymentFrequency(Frequency.P3M)
+          .paymentOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+          .build())
+      .notionalSchedule(NotionalSchedule.of(Currency.GBP, NOTIONAL))
+      .calculation(FixedRateCalculation.builder()
+          .dayCount(DayCounts.ACT_365F)
+          .rate(ValueSchedule.of(0.0123d))
+          .build())
+      .build();
+
+  /**
+   * Swap.
+   */
+  public static final Swap SWAP = Swap.builder()
+      .legs(IBOR_EXPANDED_SWAP_LEG, FIXED_EXPANDED_SWAP_LEG)
+      .build();
+  /**
+   * Swap.
+   */
+  public static final Swap SWAP_CROSS_CURRENCY = Swap.builder()
+      .legs(IBOR_EXPANDED_SWAP_LEG, FIXED_EXPANDED_SWAP_LEG_USD)
+      .build();
+  /**
+   * SwapTrade.
+   */
+  public static final SwapTrade SWAP_TRADE = SwapTrade.builder()
+      .standardId(StandardId.of("OG-Trade", "1"))
+      .tradeDate(date(2014, 6, 30))
+      .swap(SWAP)
+      .build();
+
+  /**
+   * Restricted constructor.
+   */
+  private SwapDummyData() {
+  }
+
+}


### PR DESCRIPTION
Implementations of most of the swap pricer API.

This excludes the payment period pricing, which is the key part of the swap pricing. All the other higher level elements for swap pricing are added here.
