### PR TITLE
PLT-636 FX reset notional exchange pricing

### DIFF
--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DiscountingFxResetNotionalExchangePricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DiscountingFxResetNotionalExchangePricerFn.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import com.opengamma.platform.finance.swap.FxResetNotionalExchange;
+import com.opengamma.platform.pricer.PricingEnvironment;
+import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
+
+/**
+ * Pricer implementation for the exchange of FX reset notionals.
+ * <p>
+ * The FX reset notional exchange is priced by discounting the value of the exchange.
+ * The value of the exchange is calculated by performing an FX conversion on the amount.
+ */
+public class DiscountingFxResetNotionalExchangePricerFn
+    implements PaymentEventPricerFn<FxResetNotionalExchange> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DiscountingFxResetNotionalExchangePricerFn DEFAULT =
+      new DiscountingFxResetNotionalExchangePricerFn();
+
+  /**
+   * Creates an instance.
+   */
+  public DiscountingFxResetNotionalExchangePricerFn() {
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(PricingEnvironment env, FxResetNotionalExchange event) {
+    // futureValue * discountFactor
+    double df = env.discountFactor(event.getCurrency(), event.getPaymentDate());
+    return futureValue(env, event) * df;
+  }
+
+  @Override
+  public double futureValue(PricingEnvironment env, FxResetNotionalExchange event) {
+    // notional * fxRate
+    double fxRate = env.fxIndexRate(event.getIndex(), event.getReferenceCurrency(), event.getFixingDate());
+    return event.getNotional() * fxRate;
+  }
+
+}

--- a/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventPricerFn.java
@@ -6,6 +6,7 @@
 package com.opengamma.platform.pricer.impl.swap;
 
 import com.opengamma.collect.ArgChecker;
+import com.opengamma.platform.finance.swap.FxResetNotionalExchange;
 import com.opengamma.platform.finance.swap.NotionalExchange;
 import com.opengamma.platform.finance.swap.PaymentEvent;
 import com.opengamma.platform.pricer.PricingEnvironment;
@@ -23,21 +24,30 @@ public class DispatchingPaymentEventPricerFn
    * Default implementation.
    */
   public static final DispatchingPaymentEventPricerFn DEFAULT = new DispatchingPaymentEventPricerFn(
-      DiscountingNotionalExchangePricerFn.DEFAULT);
+      DiscountingNotionalExchangePricerFn.DEFAULT,
+      DiscountingFxResetNotionalExchangePricerFn.DEFAULT);
 
   /**
    * Pricer for {@link NotionalExchange}.
    */
   private final PaymentEventPricerFn<NotionalExchange> notionalExchangePricerFn;
+  /**
+   * Pricer for {@link FxResetNotionalExchange}.
+   */
+  private final PaymentEventPricerFn<FxResetNotionalExchange> fxResetNotionalExchangePricerFn;
 
   /**
    * Creates an instance.
    * 
    * @param notionalExchangePricerFn  the pricer for {@link NotionalExchange}
+   * @param fxResetNotionalExchangePricerFn  the pricer for {@link FxResetNotionalExchange}
    */
   public DispatchingPaymentEventPricerFn(
-      PaymentEventPricerFn<NotionalExchange> notionalExchangePricerFn) {
+      PaymentEventPricerFn<NotionalExchange> notionalExchangePricerFn,
+      PaymentEventPricerFn<FxResetNotionalExchange> fxResetNotionalExchangePricerFn) {
     this.notionalExchangePricerFn = ArgChecker.notNull(notionalExchangePricerFn, "notionalExchangePricerFn");
+    this.fxResetNotionalExchangePricerFn =
+        ArgChecker.notNull(fxResetNotionalExchangePricerFn, "fxResetNotionalExchangePricerFn");
   }
 
   //-------------------------------------------------------------------------
@@ -46,6 +56,8 @@ public class DispatchingPaymentEventPricerFn
     // dispatch by runtime type
     if (paymentEvent instanceof NotionalExchange) {
       return notionalExchangePricerFn.presentValue(env, (NotionalExchange) paymentEvent);
+    } else if (paymentEvent instanceof FxResetNotionalExchange) {
+      return fxResetNotionalExchangePricerFn.presentValue(env, (FxResetNotionalExchange) paymentEvent);
     } else {
       throw new IllegalArgumentException("Unknown PaymentEvent type: " + paymentEvent.getClass().getSimpleName());
     }
@@ -56,6 +68,8 @@ public class DispatchingPaymentEventPricerFn
     // dispatch by runtime type
     if (paymentEvent instanceof NotionalExchange) {
       return notionalExchangePricerFn.futureValue(env, (NotionalExchange) paymentEvent);
+    } else if (paymentEvent instanceof FxResetNotionalExchange) {
+      return fxResetNotionalExchangePricerFn.futureValue(env, (FxResetNotionalExchange) paymentEvent);
     } else {
       throw new IllegalArgumentException("Unknown PaymentEvent type: " + paymentEvent.getClass().getSimpleName());
     }

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DiscountingFxResetNotionalExchangePricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DiscountingFxResetNotionalExchangePricerFnTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.platform.pricer.impl.swap;
+
+import static com.opengamma.platform.pricer.impl.swap.SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.platform.finance.swap.FxResetNotionalExchange;
+import com.opengamma.platform.pricer.PricingEnvironment;
+
+/**
+ * Test.
+ */
+@Test
+public class DiscountingFxResetNotionalExchangePricerFnTest {
+
+  public void test_presentValue() {
+    double discountFactor = 0.98d;
+    FxResetNotionalExchange ne = FX_RESET_NOTIONAL_EXCHANGE;
+    PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+    when(mockEnv.fxIndexRate(ne.getIndex(), ne.getReferenceCurrency(), ne.getFixingDate()))
+        .thenReturn(1.6d);
+    when(mockEnv.discountFactor(ne.getCurrency(), ne.getPaymentDate()))
+        .thenReturn(discountFactor);
+    DiscountingFxResetNotionalExchangePricerFn test = new DiscountingFxResetNotionalExchangePricerFn();
+    assertEquals(
+        test.presentValue(mockEnv, ne),
+        ne.getNotional() * 1.6d * discountFactor, 0d);
+  }
+
+  public void test_futureValue() {
+    FxResetNotionalExchange ne = FX_RESET_NOTIONAL_EXCHANGE;
+    PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+    when(mockEnv.fxIndexRate(ne.getIndex(), ne.getReferenceCurrency(), ne.getFixingDate()))
+        .thenReturn(1.6d);
+    DiscountingFxResetNotionalExchangePricerFn test = new DiscountingFxResetNotionalExchangePricerFn();
+    assertEquals(
+        test.futureValue(mockEnv, ne),
+        ne.getNotional() * 1.6d, 0d);
+  }
+
+}

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventPricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/DispatchingPaymentEventPricerFnTest.java
@@ -12,6 +12,7 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.platform.finance.swap.FxResetNotionalExchange;
 import com.opengamma.platform.finance.swap.NotionalExchange;
 import com.opengamma.platform.finance.swap.PaymentEvent;
 import com.opengamma.platform.pricer.PricingEnvironment;
@@ -23,37 +24,67 @@ import com.opengamma.platform.pricer.swap.PaymentEventPricerFn;
 @Test
 public class DispatchingPaymentEventPricerFnTest {
 
-  private final PricingEnvironment mockEnv = mock(PricingEnvironment.class);
+  private static final PricingEnvironment MOCK_ENV = mock(PricingEnvironment.class);
+  private static final PaymentEventPricerFn<NotionalExchange> MOCK_NOTIONAL_EXG = mock(PaymentEventPricerFn.class);
+  private static final PaymentEventPricerFn<FxResetNotionalExchange> MOCK_FX_NOTIONAL_EXG =
+      mock(PaymentEventPricerFn.class);
 
+  //-------------------------------------------------------------------------
   public void test_presentValue_NotionalExchange() {
     double expected = 0.0123d;
-    PaymentEventPricerFn<NotionalExchange> mockNotionalExchangeFn = mock(PaymentEventPricerFn.class);
-    when(mockNotionalExchangeFn.presentValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE))
+    PaymentEventPricerFn<NotionalExchange> mockCalledFn = mock(PaymentEventPricerFn.class);
+    when(mockCalledFn.presentValue(MOCK_ENV, SwapDummyData.NOTIONAL_EXCHANGE))
         .thenReturn(expected);
-    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(mockNotionalExchangeFn);
-    assertEquals(test.presentValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE), expected, 0d);
+    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(
+        mockCalledFn,
+        MOCK_FX_NOTIONAL_EXG);
+    assertEquals(test.presentValue(MOCK_ENV, SwapDummyData.NOTIONAL_EXCHANGE), expected, 0d);
+  }
+
+  public void test_presentValue_FxResetNotionalExchange() {
+    double expected = 0.0123d;
+    PaymentEventPricerFn<FxResetNotionalExchange> mockCalledFn = mock(PaymentEventPricerFn.class);
+    when(mockCalledFn.presentValue(MOCK_ENV, SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE))
+        .thenReturn(expected);
+    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(
+        MOCK_NOTIONAL_EXG,
+        mockCalledFn);
+    assertEquals(test.presentValue(MOCK_ENV, SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE), expected, 0d);
   }
 
   public void test_presentValue_unknownType() {
     PaymentEvent mockPaymentEvent = mock(PaymentEvent.class);
     DispatchingPaymentEventPricerFn test = DispatchingPaymentEventPricerFn.DEFAULT;
-    assertThrowsIllegalArg(() -> test.presentValue(mockEnv, mockPaymentEvent));
+    assertThrowsIllegalArg(() -> test.presentValue(MOCK_ENV, mockPaymentEvent));
   }
 
   //-------------------------------------------------------------------------
   public void test_futureValue_NotionalExchange() {
     double expected = 0.0123d;
-    PaymentEventPricerFn<NotionalExchange> mockNotionalExchangeFn = mock(PaymentEventPricerFn.class);
-    when(mockNotionalExchangeFn.futureValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE))
+    PaymentEventPricerFn<NotionalExchange> mockCalledFn = mock(PaymentEventPricerFn.class);
+    when(mockCalledFn.futureValue(MOCK_ENV, SwapDummyData.NOTIONAL_EXCHANGE))
         .thenReturn(expected);
-    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(mockNotionalExchangeFn);
-    assertEquals(test.futureValue(mockEnv, SwapDummyData.NOTIONAL_EXCHANGE), expected, 0d);
+    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(
+        mockCalledFn,
+        MOCK_FX_NOTIONAL_EXG);
+    assertEquals(test.futureValue(MOCK_ENV, SwapDummyData.NOTIONAL_EXCHANGE), expected, 0d);
+  }
+
+  public void test_futureValue_FxResetNotionalExchange() {
+    double expected = 0.0123d;
+    PaymentEventPricerFn<FxResetNotionalExchange> mockCalledFn = mock(PaymentEventPricerFn.class);
+    when(mockCalledFn.futureValue(MOCK_ENV, SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE))
+        .thenReturn(expected);
+    DispatchingPaymentEventPricerFn test = new DispatchingPaymentEventPricerFn(
+        MOCK_NOTIONAL_EXG,
+        mockCalledFn);
+    assertEquals(test.futureValue(MOCK_ENV, SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE), expected, 0d);
   }
 
   public void test_futureValue_unknownType() {
     PaymentEvent mockPaymentEvent = mock(PaymentEvent.class);
     DispatchingPaymentEventPricerFn test = DispatchingPaymentEventPricerFn.DEFAULT;
-    assertThrowsIllegalArg(() -> test.futureValue(mockEnv, mockPaymentEvent));
+    assertThrowsIllegalArg(() -> test.futureValue(MOCK_ENV, mockPaymentEvent));
   }
 
 }

--- a/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/SwapDummyData.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/platform/pricer/impl/swap/SwapDummyData.java
@@ -16,6 +16,7 @@ import com.opengamma.basics.currency.CurrencyAmount;
 import com.opengamma.basics.date.BusinessDayAdjustment;
 import com.opengamma.basics.date.DayCounts;
 import com.opengamma.basics.date.DaysAdjustment;
+import com.opengamma.basics.index.FxIndices;
 import com.opengamma.basics.schedule.Frequency;
 import com.opengamma.basics.schedule.PeriodicSchedule;
 import com.opengamma.basics.value.ValueSchedule;
@@ -24,6 +25,7 @@ import com.opengamma.platform.finance.observation.FixedRateObservation;
 import com.opengamma.platform.finance.observation.IborRateObservation;
 import com.opengamma.platform.finance.swap.ExpandedSwapLeg;
 import com.opengamma.platform.finance.swap.FixedRateCalculation;
+import com.opengamma.platform.finance.swap.FxResetNotionalExchange;
 import com.opengamma.platform.finance.swap.IborRateCalculation;
 import com.opengamma.platform.finance.swap.NotionalExchange;
 import com.opengamma.platform.finance.swap.NotionalSchedule;
@@ -49,6 +51,16 @@ public final class SwapDummyData {
   public static final NotionalExchange NOTIONAL_EXCHANGE = NotionalExchange.builder()
       .paymentDate(date(2014, 7, 1))
       .paymentAmount(CurrencyAmount.of(Currency.GBP, NOTIONAL))
+      .build();
+  /**
+   * NotionalExchange.
+   */
+  public static final FxResetNotionalExchange FX_RESET_NOTIONAL_EXCHANGE = FxResetNotionalExchange.builder()
+      .paymentDate(date(2014, 7, 1))
+      .referenceCurrency(Currency.USD)
+      .notional(NOTIONAL)
+      .index(FxIndices.WM_GBP_USD)
+      .fixingDate(date(2014, 7, 1))
       .build();
 
   /**


### PR DESCRIPTION
Add FxResetNotionalExchange pricing.

Present value of an FX payment is `(fxRate * amount * discountFactor)`
