### PR TITLE
Fix value of historic swaps

### DIFF
--- a/modules/pricer-impl/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DefaultExpandedSwapLegPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DefaultExpandedSwapLegPricerFn.java
@@ -70,10 +70,13 @@ public class DefaultExpandedSwapLegPricerFn
       ExpandedSwapLeg swapLeg,
       ToDoubleBiFunction<PricingEnvironment, PaymentPeriod> periodFn,
       ToDoubleBiFunction<PricingEnvironment, PaymentEvent> eventFn) {
+
     double valuePeriods = swapLeg.getPaymentPeriods().stream()
+        .filter(p -> !p.getPaymentDate().isBefore(env.getValuationDate()))
         .mapToDouble(p -> periodFn.applyAsDouble(env, p))
         .sum();
     double valueEvents = swapLeg.getPaymentEvents().stream()
+        .filter(p -> !p.getPaymentDate().isBefore(env.getValuationDate()))
         .mapToDouble(e -> eventFn.applyAsDouble(env, e))
         .sum();
     return valuePeriods + valueEvents;

--- a/modules/pricer-impl/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerFn.java
+++ b/modules/pricer-impl/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerFn.java
@@ -55,10 +55,6 @@ public class DiscountingRatePaymentPeriodPricerFn
 
   @Override
   public double futureValue(PricingEnvironment env, RatePaymentPeriod period) {
-    // historic payments have zero pv
-    if (period.getPaymentDate().isBefore(env.getValuationDate())) {
-      return 0;
-    }
     // notional * fxRate
     // fxRate is 1 if no FX conversion
     double notional = period.getNotional() * fxRate(env, period);

--- a/modules/pricer-impl/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DefaultExpandedSwapLegPricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DefaultExpandedSwapLegPricerFnTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.pricer.impl.rate.swap;
 
+import static com.opengamma.strata.collect.TestHelper.date;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -24,7 +25,8 @@ import com.opengamma.strata.pricer.rate.swap.PaymentPeriodPricerFn;
 @Test
 public class DefaultExpandedSwapLegPricerFnTest {
 
-  private static final PricingEnvironment MOCK_ENV = new MockPricingEnvironment();
+  private static final PricingEnvironment MOCK_ENV = new MockPricingEnvironment(date(2014, 1, 22));
+  private static final PricingEnvironment MOCK_ENV_FUTURE = new MockPricingEnvironment(date(2040, 1, 22));
 
   public void test_presentValue() {
     PaymentPeriodPricerFn<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricerFn.class);
@@ -37,6 +39,14 @@ public class DefaultExpandedSwapLegPricerFnTest {
     assertEquals(test.presentValue(MOCK_ENV, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), 2000d, 0d);
   }
 
+  public void test_presentValue_past() {
+    PaymentPeriodPricerFn<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricerFn.class);
+    PaymentEventPricerFn<PaymentEvent> mockEvent = mock(PaymentEventPricerFn.class);
+    DefaultExpandedSwapLegPricerFn test = new DefaultExpandedSwapLegPricerFn(mockPeriod, mockEvent);
+    assertEquals(test.presentValue(MOCK_ENV_FUTURE, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), 0d, 0d);
+  }
+
+  //-------------------------------------------------------------------------
   public void test_futureValue() {
     PaymentPeriodPricerFn<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricerFn.class);
     when(mockPeriod.futureValue(MOCK_ENV, SwapDummyData.IBOR_RATE_PAYMENT_PERIOD))
@@ -46,6 +56,13 @@ public class DefaultExpandedSwapLegPricerFnTest {
         .thenReturn(1000d);
     DefaultExpandedSwapLegPricerFn test = new DefaultExpandedSwapLegPricerFn(mockPeriod, mockEvent);
     assertEquals(test.futureValue(MOCK_ENV, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), 2000d, 0d);
+  }
+
+  public void test_futureValue_past() {
+    PaymentPeriodPricerFn<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricerFn.class);
+    PaymentEventPricerFn<PaymentEvent> mockEvent = mock(PaymentEventPricerFn.class);
+    DefaultExpandedSwapLegPricerFn test = new DefaultExpandedSwapLegPricerFn(mockPeriod, mockEvent);
+    assertEquals(test.futureValue(MOCK_ENV_FUTURE, SwapDummyData.IBOR_EXPANDED_SWAP_LEG), 0d, 0d);
   }
 
 }

--- a/modules/pricer-impl/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerFnTest.java
+++ b/modules/pricer-impl/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerFnTest.java
@@ -135,14 +135,6 @@ public class DiscountingRatePaymentPeriodPricerFnTest {
   // rate observation is separated from this class, so nothing is missed in unit test terms
   // most testing on futureValue as methods only differ in discountFactor
   //-------------------------------------------------------------------------
-  public void test_presentValue_single_paymentBeforeToday() {
-    PricingEnvironment env = mock(PricingEnvironment.class);
-    when(env.getValuationDate()).thenReturn(PAYMENT_DATE_1.plusDays(1));
-    when(env.discountFactor(USD, PAYMENT_DATE_1)).thenReturn(DISCOUNT_FACTOR);
-    double fvComputed = DiscountingRatePaymentPeriodPricerFn.DEFAULT.presentValue(env, PAYMENT_PERIOD_1);
-    assertEquals(fvComputed, 0d, TOLERANCE_PV);
-  }
-
   public void test_presentValue_single() {
     PricingEnvironment env = mock(PricingEnvironment.class);
     when(env.getValuationDate()).thenReturn(VALUATION_DATE);
@@ -153,13 +145,6 @@ public class DiscountingRatePaymentPeriodPricerFnTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_futureValue_single_paymentBeforeToday() {
-    PricingEnvironment env = mock(PricingEnvironment.class);
-    when(env.getValuationDate()).thenReturn(PAYMENT_DATE_1.plusDays(1));
-    double fvComputed = DiscountingRatePaymentPeriodPricerFn.DEFAULT.futureValue(env, PAYMENT_PERIOD_1);
-    assertEquals(fvComputed, 0d, TOLERANCE_PV);
-  }
-
   public void test_futureValue_single() {
     PricingEnvironment env = mock(PricingEnvironment.class);
     when(env.getValuationDate()).thenReturn(VALUATION_DATE);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/PaymentEventPricerFn.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/PaymentEventPricerFn.java
@@ -24,6 +24,9 @@ public interface PaymentEventPricerFn<T extends PaymentEvent> {
    * <p>
    * The amount is expressed in the currency of the event.
    * This returns the value of the event with discounting.
+   * <p>
+   * The payment date of the event should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
    * 
    * @param env  the pricing environment
    * @param event  the event to price
@@ -36,6 +39,9 @@ public interface PaymentEventPricerFn<T extends PaymentEvent> {
    * <p>
    * The amount is expressed in the currency of the event.
    * This returns the value of the event without discounting.
+   * <p>
+   * The payment date of the event should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
    * 
    * @param env  the pricing environment
    * @param event  the event to price

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/PaymentPeriodPricerFn.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/PaymentPeriodPricerFn.java
@@ -24,6 +24,9 @@ public interface PaymentPeriodPricerFn<T extends PaymentPeriod> {
    * <p>
    * The amount is expressed in the currency of the period.
    * This returns the value of the period with discounting.
+   * <p>
+   * The payment date of the period should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
    * 
    * @param env  the pricing environment
    * @param period  the period to price
@@ -36,6 +39,9 @@ public interface PaymentPeriodPricerFn<T extends PaymentPeriod> {
    * <p>
    * The amount is expressed in the currency of the period.
    * This returns the value of the period without discounting.
+   * <p>
+   * The payment date of the period should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
    * 
    * @param env  the pricing environment
    * @param period  the period to price


### PR DESCRIPTION
- If the payment date is before the valuation date then periods/events have no value
- Use stream filtering to apply this consistently
