### PR TITLE
Change name of OpenGamma index scheme

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/Index.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/Index.java
@@ -26,14 +26,14 @@ public interface Index
   /**
    * Returns the standard identifier of the index.
    * <p>
-   * The standard identifier has a scheme of "OG-Index".
+   * The standard identifier has a scheme of "OpenGammaIndex".
    * The value is the {@linkplain #getName() name} of the index.
    * 
    * @return the standard identifier
    */
   @Override
   public default StandardId getStandardId() {
-    return StandardId.of("OG-Index", getName());
+    return StandardId.of("OpenGammaIndex", getName());
   }
 
 }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/IndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/IndexTest.java
@@ -18,7 +18,7 @@ import com.opengamma.strata.collect.id.StandardId;
 public class IndexTest {
 
   public void test_getStandardId() {
-    assertEquals(IborIndices.GBP_LIBOR_3M.getStandardId(), StandardId.of("OG-Index", "GBP-LIBOR-3M"));
+    assertEquals(IborIndices.GBP_LIBOR_3M.getStandardId(), StandardId.of("OpenGammaIndex", "GBP-LIBOR-3M"));
   }
 
 }

--- a/modules/market-data/src/main/java/com/opengamma/strata/marketdata/id/ObservableId.java
+++ b/modules/market-data/src/main/java/com/opengamma/strata/marketdata/id/ObservableId.java
@@ -16,7 +16,7 @@ import com.opengamma.strata.collect.id.StandardIdentifiable;
  * An observable ID contains three pieces of information:
  * <ul>
  *   <li>A {@link StandardId} identifying the market data. This ID can come from any system. It might be
- *   an OpenGamma ID, for example {@code OG-Index~GBP_LIBOR_3M}, or it can be an ID from a market
+ *   an OpenGamma ID, for example {@code OpenGammaIndex~GBP_LIBOR_3M}, or it can be an ID from a market
  *   data vendor, for example {@code BloombergTicker~AAPL US Equity}.</li>
  *
  *   <li>A {@link FieldName} indicating the field in the market data record containing the data. See


### PR DESCRIPTION
Use OpenGammaIndex instead of OG-Index to match naming conventions
