### PR TITLE
Add swap leg type

### DIFF
--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/ExpandedSwap.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/ExpandedSwap.java
@@ -5,10 +5,13 @@
  */
 package com.opengamma.strata.finance.rate.swap;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import org.joda.beans.Bean;
@@ -24,7 +27,9 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.PayReceive;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.collect.ArgChecker;
 
@@ -114,6 +119,31 @@ public final class ExpandedSwap
    */
   public boolean isCrossCurrency() {
     return crossCurrency;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the legs of the swap with the specified type.
+   * <p>
+   * This returns all the legs with the given type.
+   * 
+   * @param type  the type to find
+   * @return the matching legs of the swap
+   */
+  public ImmutableList<ExpandedSwapLeg> getLegs(SwapLegType type) {
+    return legs.stream().filter(leg -> leg.getType() == type).collect(toImmutableList());
+  }
+
+  /**
+   * Gets the first pay or receive leg of the swap.
+   * <p>
+   * This returns the first pay or receive leg of the swap, empty if no matching leg.
+   * 
+   * @param payReceive  the pay or receive flag
+   * @return the first matching leg of the swap
+   */
+  public Optional<ExpandedSwapLeg> getLeg(PayReceive payReceive) {
+    return legs.stream().filter(leg -> leg.getPayReceive() == payReceive).findFirst();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/ExpandedSwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/ExpandedSwapLeg.java
@@ -58,6 +58,13 @@ public final class ExpandedSwapLeg
     implements SwapLeg, ImmutableBean, Serializable {
 
   /**
+   * The type of the leg, such as Fixed or Ibor.
+   * <p>
+   * This provides a high level categorization of the swap leg.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final SwapLegType type;
+  /**
    * Whether the leg is pay or receive.
    * <p>
    * A value of 'Pay' implies that the resulting amount is paid to the counterparty.
@@ -96,12 +103,16 @@ public final class ExpandedSwapLeg
   //-------------------------------------------------------------------------
   @ImmutableConstructor
   private ExpandedSwapLeg(
+      SwapLegType type,
       PayReceive payReceive,
       List<PaymentPeriod> paymentPeriods,
       List<PaymentEvent> paymentEvents) {
+
+    JodaBeanUtils.notNull(type, "type");
     JodaBeanUtils.notNull(payReceive, "payReceive");
     JodaBeanUtils.notEmpty(paymentPeriods, "paymentPeriods");
     JodaBeanUtils.notNull(paymentEvents, "paymentEvents");
+    this.type = type;
     this.payReceive = payReceive;
     this.paymentPeriods = ImmutableList.copyOf(paymentPeriods);
     this.paymentEvents = ImmutableList.copyOf(paymentEvents);
@@ -214,6 +225,18 @@ public final class ExpandedSwapLeg
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the type of the leg, such as Fixed or Ibor.
+   * <p>
+   * This provides a high level categorization of the swap leg.
+   * @return the value of the property, not null
+   */
+  @Override
+  public SwapLegType getType() {
+    return type;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Gets whether the leg is pay or receive.
    * <p>
    * A value of 'Pay' implies that the resulting amount is paid to the counterparty.
@@ -272,7 +295,8 @@ public final class ExpandedSwapLeg
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       ExpandedSwapLeg other = (ExpandedSwapLeg) obj;
-      return JodaBeanUtils.equal(getPayReceive(), other.getPayReceive()) &&
+      return JodaBeanUtils.equal(getType(), other.getType()) &&
+          JodaBeanUtils.equal(getPayReceive(), other.getPayReceive()) &&
           JodaBeanUtils.equal(getPaymentPeriods(), other.getPaymentPeriods()) &&
           JodaBeanUtils.equal(getPaymentEvents(), other.getPaymentEvents());
     }
@@ -282,6 +306,7 @@ public final class ExpandedSwapLeg
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(getType());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPayReceive());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPaymentPeriods());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPaymentEvents());
@@ -290,8 +315,9 @@ public final class ExpandedSwapLeg
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(128);
+    StringBuilder buf = new StringBuilder(160);
     buf.append("ExpandedSwapLeg{");
+    buf.append("type").append('=').append(getType()).append(',').append(' ');
     buf.append("payReceive").append('=').append(getPayReceive()).append(',').append(' ');
     buf.append("paymentPeriods").append('=').append(getPaymentPeriods()).append(',').append(' ');
     buf.append("paymentEvents").append('=').append(JodaBeanUtils.toString(getPaymentEvents()));
@@ -309,6 +335,11 @@ public final class ExpandedSwapLeg
      */
     static final Meta INSTANCE = new Meta();
 
+    /**
+     * The meta-property for the {@code type} property.
+     */
+    private final MetaProperty<SwapLegType> type = DirectMetaProperty.ofImmutable(
+        this, "type", ExpandedSwapLeg.class, SwapLegType.class);
     /**
      * The meta-property for the {@code payReceive} property.
      */
@@ -331,6 +362,7 @@ public final class ExpandedSwapLeg
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
+        "type",
         "payReceive",
         "paymentPeriods",
         "paymentEvents");
@@ -344,6 +376,8 @@ public final class ExpandedSwapLeg
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return type;
         case -885469925:  // payReceive
           return payReceive;
         case -1674414612:  // paymentPeriods
@@ -370,6 +404,14 @@ public final class ExpandedSwapLeg
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code type} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<SwapLegType> type() {
+      return type;
+    }
+
     /**
      * The meta-property for the {@code payReceive} property.
      * @return the meta-property, not null
@@ -398,6 +440,8 @@ public final class ExpandedSwapLeg
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return ((ExpandedSwapLeg) bean).getType();
         case -885469925:  // payReceive
           return ((ExpandedSwapLeg) bean).getPayReceive();
         case -1674414612:  // paymentPeriods
@@ -425,6 +469,7 @@ public final class ExpandedSwapLeg
    */
   public static final class Builder extends DirectFieldsBeanBuilder<ExpandedSwapLeg> {
 
+    private SwapLegType type;
     private PayReceive payReceive;
     private List<PaymentPeriod> paymentPeriods = ImmutableList.of();
     private List<PaymentEvent> paymentEvents = ImmutableList.of();
@@ -440,6 +485,7 @@ public final class ExpandedSwapLeg
      * @param beanToCopy  the bean to copy from, not null
      */
     private Builder(ExpandedSwapLeg beanToCopy) {
+      this.type = beanToCopy.getType();
       this.payReceive = beanToCopy.getPayReceive();
       this.paymentPeriods = beanToCopy.getPaymentPeriods();
       this.paymentEvents = beanToCopy.getPaymentEvents();
@@ -449,6 +495,8 @@ public final class ExpandedSwapLeg
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return type;
         case -885469925:  // payReceive
           return payReceive;
         case -1674414612:  // paymentPeriods
@@ -464,6 +512,9 @@ public final class ExpandedSwapLeg
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          this.type = (SwapLegType) newValue;
+          break;
         case -885469925:  // payReceive
           this.payReceive = (PayReceive) newValue;
           break;
@@ -506,12 +557,24 @@ public final class ExpandedSwapLeg
     @Override
     public ExpandedSwapLeg build() {
       return new ExpandedSwapLeg(
+          type,
           payReceive,
           paymentPeriods,
           paymentEvents);
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * Sets the {@code type} property in the builder.
+     * @param type  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder type(SwapLegType type) {
+      JodaBeanUtils.notNull(type, "type");
+      this.type = type;
+      return this;
+    }
+
     /**
      * Sets the {@code payReceive} property in the builder.
      * @param payReceive  the new value, not null
@@ -568,8 +631,9 @@ public final class ExpandedSwapLeg
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(128);
+      StringBuilder buf = new StringBuilder(160);
       buf.append("ExpandedSwapLeg.Builder{");
+      buf.append("type").append('=').append(JodaBeanUtils.toString(type)).append(',').append(' ');
       buf.append("payReceive").append('=').append(JodaBeanUtils.toString(payReceive)).append(',').append(' ');
       buf.append("paymentPeriods").append('=').append(JodaBeanUtils.toString(paymentPeriods)).append(',').append(' ');
       buf.append("paymentEvents").append('=').append(JodaBeanUtils.toString(paymentEvents));

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/FixedRateCalculation.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/FixedRateCalculation.java
@@ -80,6 +80,11 @@ public final class FixedRateCalculation
 
   //-------------------------------------------------------------------------
   @Override
+  public SwapLegType getType() {
+    return SwapLegType.FIXED;
+  }
+
+  @Override
   public void collectIndices(ImmutableSet.Builder<Index> builder) {
     // no indices
   }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/IborRateCalculation.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/IborRateCalculation.java
@@ -248,6 +248,11 @@ public final class IborRateCalculation
 
   //-------------------------------------------------------------------------
   @Override
+  public SwapLegType getType() {
+    return SwapLegType.IBOR;
+  }
+
+  @Override
   public void collectIndices(ImmutableSet.Builder<Index> builder) {
     builder.add(index);
     if (initialStub != null) {

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/OvernightRateCalculation.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/OvernightRateCalculation.java
@@ -181,6 +181,11 @@ public final class OvernightRateCalculation
 
   //-------------------------------------------------------------------------
   @Override
+  public SwapLegType getType() {
+    return SwapLegType.OVERNIGHT;
+  }
+
+  @Override
   public void collectIndices(ImmutableSet.Builder<Index> builder) {
     builder.add(index);
   }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculation.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculation.java
@@ -24,6 +24,15 @@ public interface RateCalculation
     extends ImmutableBean {
 
   /**
+   * Gets the type of the leg, such as Fixed or Ibor.
+   * <p>
+   * This provides a high level categorization of the swap leg.
+   * 
+   * @return the leg type
+   */
+  public abstract SwapLegType getType();
+
+  /**
    * Collects all the indices referred to by this calculation.
    * <p>
    * A calculation will typically refer to at least one index, such as 'GBP-LIBOR-3M'.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLeg.java
@@ -98,6 +98,11 @@ public final class RateCalculationSwapLeg
   private final RateCalculation calculation;
 
   //-------------------------------------------------------------------------
+  @Override
+  public SwapLegType getType() {
+    return calculation.getType();
+  }
+
   /**
    * Gets the start date of the leg.
    * <p>
@@ -157,6 +162,7 @@ public final class RateCalculationSwapLeg
     List<RatePaymentPeriod> payPeriods = paymentSchedule.createPaymentPeriods(
         resolvedAccruals, resolvedPayments, accrualPeriods, notionalSchedule, payReceive);
     return ExpandedSwapLeg.builder()
+        .type(getType())
         .payReceive(payReceive)
         .paymentPeriods(ImmutableList.copyOf(payPeriods))  // copyOf changes generics of list without an actual copy
         .paymentEvents(notionalSchedule.createEvents(payPeriods, getStartDate()))

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RatePeriodSwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RatePeriodSwapLeg.java
@@ -68,6 +68,13 @@ public final class RatePeriodSwapLeg
     implements SwapLeg, ImmutableBean, Serializable {
 
   /**
+   * The type of the leg, such as Fixed or Ibor.
+   * <p>
+   * This provides a high level categorization of the swap leg.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final SwapLegType type;
+  /**
    * Whether the leg is pay or receive.
    * <p>
    * A value of 'Pay' implies that the resulting amount is paid to the counterparty.
@@ -154,6 +161,7 @@ public final class RatePeriodSwapLeg
   //-------------------------------------------------------------------------
   @ImmutableConstructor
   private RatePeriodSwapLeg(
+      SwapLegType type,
       PayReceive payReceive,
       List<RatePaymentPeriod> paymentPeriods,
       boolean initialExchange,
@@ -162,9 +170,11 @@ public final class RatePeriodSwapLeg
       List<PaymentEvent> paymentEvents,
       BusinessDayAdjustment paymentBusinessDayAdjustment) {
 
+    JodaBeanUtils.notNull(type, "type");
     JodaBeanUtils.notNull(payReceive, "payReceive");
     JodaBeanUtils.notEmpty(paymentPeriods, "paymentPeriods");
     JodaBeanUtils.notNull(paymentEvents, "paymentEvents");
+    this.type = type;
     this.payReceive = payReceive;
     this.paymentPeriods = ImmutableList.copyOf(paymentPeriods);
     this.initialExchange = initialExchange;
@@ -242,7 +252,8 @@ public final class RatePeriodSwapLeg
         .map(pp -> pp.adjustPaymentDate(paymentBusinessDayAdjustment))
         .collect(toImmutableList());
     return ExpandedSwapLeg.builder()
-        .payReceive(getPayReceive())
+        .type(type)
+        .payReceive(payReceive)
         .paymentPeriods(ImmutableList.copyOf(adjusted))  // copyOf needed for type conversion
         .paymentEvents(createEvents(adjusted))
         .build();
@@ -299,6 +310,18 @@ public final class RatePeriodSwapLeg
   @Override
   public Set<String> propertyNames() {
     return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the type of the leg, such as Fixed or Ibor.
+   * <p>
+   * This provides a high level categorization of the swap leg.
+   * @return the value of the property, not null
+   */
+  @Override
+  public SwapLegType getType() {
+    return type;
   }
 
   //-----------------------------------------------------------------------
@@ -425,7 +448,8 @@ public final class RatePeriodSwapLeg
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       RatePeriodSwapLeg other = (RatePeriodSwapLeg) obj;
-      return JodaBeanUtils.equal(getPayReceive(), other.getPayReceive()) &&
+      return JodaBeanUtils.equal(getType(), other.getType()) &&
+          JodaBeanUtils.equal(getPayReceive(), other.getPayReceive()) &&
           JodaBeanUtils.equal(getPaymentPeriods(), other.getPaymentPeriods()) &&
           (isInitialExchange() == other.isInitialExchange()) &&
           (isIntermediateExchange() == other.isIntermediateExchange()) &&
@@ -439,6 +463,7 @@ public final class RatePeriodSwapLeg
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(getType());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPayReceive());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPaymentPeriods());
     hash = hash * 31 + JodaBeanUtils.hashCode(isInitialExchange());
@@ -451,8 +476,9 @@ public final class RatePeriodSwapLeg
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(256);
+    StringBuilder buf = new StringBuilder(288);
     buf.append("RatePeriodSwapLeg{");
+    buf.append("type").append('=').append(getType()).append(',').append(' ');
     buf.append("payReceive").append('=').append(getPayReceive()).append(',').append(' ');
     buf.append("paymentPeriods").append('=').append(getPaymentPeriods()).append(',').append(' ');
     buf.append("initialExchange").append('=').append(isInitialExchange()).append(',').append(' ');
@@ -474,6 +500,11 @@ public final class RatePeriodSwapLeg
      */
     static final Meta INSTANCE = new Meta();
 
+    /**
+     * The meta-property for the {@code type} property.
+     */
+    private final MetaProperty<SwapLegType> type = DirectMetaProperty.ofImmutable(
+        this, "type", RatePeriodSwapLeg.class, SwapLegType.class);
     /**
      * The meta-property for the {@code payReceive} property.
      */
@@ -516,6 +547,7 @@ public final class RatePeriodSwapLeg
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
+        "type",
         "payReceive",
         "paymentPeriods",
         "initialExchange",
@@ -533,6 +565,8 @@ public final class RatePeriodSwapLeg
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return type;
         case -885469925:  // payReceive
           return payReceive;
         case -1674414612:  // paymentPeriods
@@ -567,6 +601,14 @@ public final class RatePeriodSwapLeg
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code type} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<SwapLegType> type() {
+      return type;
+    }
+
     /**
      * The meta-property for the {@code payReceive} property.
      * @return the meta-property, not null
@@ -627,6 +669,8 @@ public final class RatePeriodSwapLeg
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return ((RatePeriodSwapLeg) bean).getType();
         case -885469925:  // payReceive
           return ((RatePeriodSwapLeg) bean).getPayReceive();
         case -1674414612:  // paymentPeriods
@@ -662,6 +706,7 @@ public final class RatePeriodSwapLeg
    */
   public static final class Builder extends DirectFieldsBeanBuilder<RatePeriodSwapLeg> {
 
+    private SwapLegType type;
     private PayReceive payReceive;
     private List<RatePaymentPeriod> paymentPeriods = ImmutableList.of();
     private boolean initialExchange;
@@ -681,6 +726,7 @@ public final class RatePeriodSwapLeg
      * @param beanToCopy  the bean to copy from, not null
      */
     private Builder(RatePeriodSwapLeg beanToCopy) {
+      this.type = beanToCopy.getType();
       this.payReceive = beanToCopy.getPayReceive();
       this.paymentPeriods = beanToCopy.getPaymentPeriods();
       this.initialExchange = beanToCopy.isInitialExchange();
@@ -694,6 +740,8 @@ public final class RatePeriodSwapLeg
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return type;
         case -885469925:  // payReceive
           return payReceive;
         case -1674414612:  // paymentPeriods
@@ -717,6 +765,9 @@ public final class RatePeriodSwapLeg
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          this.type = (SwapLegType) newValue;
+          break;
         case -885469925:  // payReceive
           this.payReceive = (PayReceive) newValue;
           break;
@@ -771,6 +822,7 @@ public final class RatePeriodSwapLeg
     @Override
     public RatePeriodSwapLeg build() {
       return new RatePeriodSwapLeg(
+          type,
           payReceive,
           paymentPeriods,
           initialExchange,
@@ -781,6 +833,17 @@ public final class RatePeriodSwapLeg
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * Sets the {@code type} property in the builder.
+     * @param type  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder type(SwapLegType type) {
+      JodaBeanUtils.notNull(type, "type");
+      this.type = type;
+      return this;
+    }
+
     /**
      * Sets the {@code payReceive} property in the builder.
      * @param payReceive  the new value, not null
@@ -878,8 +941,9 @@ public final class RatePeriodSwapLeg
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(256);
+      StringBuilder buf = new StringBuilder(288);
       buf.append("RatePeriodSwapLeg.Builder{");
+      buf.append("type").append('=').append(JodaBeanUtils.toString(type)).append(',').append(' ');
       buf.append("payReceive").append('=').append(JodaBeanUtils.toString(payReceive)).append(',').append(' ');
       buf.append("paymentPeriods").append('=').append(JodaBeanUtils.toString(paymentPeriods)).append(',').append(' ');
       buf.append("initialExchange").append('=').append(JodaBeanUtils.toString(initialExchange)).append(',').append(' ');

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/Swap.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/Swap.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.finance.rate.swap;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +85,19 @@ public final class Swap
   public static Swap of(List<SwapLeg> legs) {
     ArgChecker.notEmpty(legs, "legs");
     return new Swap(ImmutableList.copyOf(legs));
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the legs of the swap with the specified type.
+   * <p>
+   * This returns all the legs with the given type.
+   * 
+   * @param type  the type to find
+   * @return the matching legs of the swap
+   */
+  public ImmutableList<SwapLeg> getLegs(SwapLegType type) {
+    return legs.stream().filter(leg -> leg.getType() == type).collect(toImmutableList());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapLeg.java
@@ -36,6 +36,15 @@ public interface SwapLeg
     extends ImmutableBean {
 
   /**
+   * Gets the type of the leg, such as Fixed or Ibor.
+   * <p>
+   * This provides a high level categorization of the swap leg.
+   * 
+   * @return the leg type
+   */
+  public abstract SwapLegType getType();
+
+  /**
    * Gets whether the leg is pay or receive.
    * <p>
    * A value of 'Pay' implies that the resulting amount is paid to the counterparty.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapLegType.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapLegType.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.google.common.base.CaseFormat;
+import com.opengamma.strata.collect.ArgChecker;
+
+/**
+ * The type of a swap leg.
+ * <p>
+ * This provides a high-level categorization of a swap leg.
+ * This is useful when it is necessary to find a specific leg.
+ */
+public enum SwapLegType {
+
+  /**
+   * A fixed rate swap leg.
+   * All periods in this leg must have a fixed rate.
+   */
+  FIXED,
+  /**
+   * A floating rate swap leg based on an Ibor index.
+   * <p>
+   * This kind of leg may include some fixed periods, such as in a stub or
+   * where the first rate is specified in the contract.
+   */
+  IBOR,
+  /**
+   * A floating rate swap leg based on an Overnight index.
+   * <p>
+   * This kind of leg may include some fixed periods, such as in a stub or
+   * where the first rate is specified in the contract.
+   */
+  OVERNIGHT,
+  /**
+   * A swap leg that is not based on a Fixed, Ibor or Overnight rate.
+   */
+  OTHER;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains the type from a unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the type
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static SwapLegType of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return valueOf(CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, uniqueName));
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Checks if the type is 'Fixed'.
+   * 
+   * @return true if fixed, false otherwise
+   */
+  public boolean isFixed() {
+    return this == FIXED;
+  }
+
+  /**
+   * Checks if the type is floating, defined as 'Ibor' or 'Overnight'.
+   * 
+   * @return true if floating, false otherwise
+   */
+  public boolean isFloat() {
+    return this == IBOR || this == OVERNIGHT;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns the formatted unique name of the type.
+   * 
+   * @return the formatted string representing the type
+   */
+  @ToString
+  @Override
+  public String toString() {
+    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, name());
+  }
+
+}

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/ExpandedSwapLegTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/ExpandedSwapLegTest.java
@@ -15,6 +15,8 @@ import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.IBOR;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
@@ -67,13 +69,15 @@ public class ExpandedSwapLegTest {
 
   public void test_builder() {
     ExpandedSwapLeg test = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
         .build();
+    assertEquals(test.getType(), IBOR);
+    assertEquals(test.getPayReceive(), RECEIVE);
     assertEquals(test.getStartDate(), DATE_2014_06_30);
     assertEquals(test.getEndDate(), DATE_2014_09_30);
-    assertEquals(test.getPayReceive(), RECEIVE);
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getPaymentPeriods(), ImmutableList.of(RPP1));
     assertEquals(test.getPaymentEvents(), ImmutableList.of(NOTIONAL_EXCHANGE));
@@ -81,6 +85,7 @@ public class ExpandedSwapLegTest {
 
   public void test_builder_invalidMixedCurrency() {
     assertThrowsIllegalArg(() -> ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP3)
         .paymentEvents(NOTIONAL_EXCHANGE)
@@ -90,6 +95,7 @@ public class ExpandedSwapLegTest {
   //-------------------------------------------------------------------------
   public void test_collectIndices() {
     ExpandedSwapLeg test = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
@@ -101,6 +107,7 @@ public class ExpandedSwapLegTest {
 
   public void test_expand() {
     ExpandedSwapLeg test = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
@@ -111,12 +118,14 @@ public class ExpandedSwapLegTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     ExpandedSwapLeg test = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
         .build();
     coverImmutableBean(test);
     ExpandedSwapLeg test2 = ExpandedSwapLeg.builder()
+        .type(FIXED)
         .payReceive(PAY)
         .paymentPeriods(RPP2)
         .build();
@@ -125,6 +134,7 @@ public class ExpandedSwapLegTest {
 
   public void test_serialization() {
     ExpandedSwapLeg test = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/FixedRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/FixedRateCalculationTest.java
@@ -13,7 +13,6 @@ import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.testng.Assert.assertEquals;
-
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -36,6 +35,7 @@ public class FixedRateCalculationTest {
 
   public void test_of() {
     FixedRateCalculation test = FixedRateCalculation.of(0.025d, ACT_365F);
+    assertEquals(test.getType(), SwapLegType.FIXED);
     assertEquals(test.getRate(), ValueSchedule.of(0.025d));
     assertEquals(test.getDayCount(), ACT_365F);
   }

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/IborRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/IborRateCalculationTest.java
@@ -110,6 +110,7 @@ public class IborRateCalculationTest {
   //-------------------------------------------------------------------------
   public void test_of() {
     IborRateCalculation test = IborRateCalculation.of(GBP_LIBOR_3M);
+    assertEquals(test.getType(), SwapLegType.IBOR);
     assertEquals(test.getDayCount(), ACT_365F);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getResetPeriods(), Optional.empty());

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/MockSwapLeg.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/MockSwapLeg.java
@@ -7,7 +7,11 @@ package com.opengamma.strata.finance.rate.swap;
 
 import static com.opengamma.strata.basics.PayReceive.PAY;
 import static com.opengamma.strata.basics.PayReceive.RECEIVE;
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.IBOR;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -39,8 +43,9 @@ import com.opengamma.strata.finance.rate.FixedRateObservation;
 @BeanDefinition
 public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
 
-  public static final SwapLeg MOCK_GBP1 = new MockSwapLeg(PAY, date(2012, 1, 15), date(2012, 8, 15), Currency.GBP);
+  public static final SwapLeg MOCK_GBP1 = new MockSwapLeg(FIXED, PAY, date(2012, 1, 15), date(2012, 8, 15), GBP);
   public static final ExpandedSwapLeg MOCK_EXPANDED_GBP1 = ExpandedSwapLeg.builder()
+      .type(FIXED)
       .payReceive(PAY)
       .paymentPeriods(RatePaymentPeriod.builder()
           .paymentDate(date(2012, 8, 15))
@@ -50,12 +55,13 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
               .rateObservation(FixedRateObservation.of(0.012d))
               .build())
           .notional(1_000_000d)
-          .currency(Currency.GBP)
+          .currency(GBP)
           .build())
       .build();
-  public static final SwapLeg MOCK_GBP2 = new MockSwapLeg(PAY, date(2012, 1, 15), date(2012, 6, 15), Currency.GBP);
-  public static final SwapLeg MOCK_USD1 = new MockSwapLeg(RECEIVE, date(2012, 1, 15), date(2012, 8, 15), Currency.USD);
+  public static final SwapLeg MOCK_GBP2 = new MockSwapLeg(FIXED, PAY, date(2012, 1, 15), date(2012, 6, 15), GBP);
+  public static final SwapLeg MOCK_USD1 = new MockSwapLeg(IBOR, RECEIVE, date(2012, 1, 15), date(2012, 8, 15), USD);
   public static final ExpandedSwapLeg MOCK_EXPANDED_USD1 = ExpandedSwapLeg.builder()
+      .type(IBOR)
       .payReceive(RECEIVE)
       .paymentPeriods(RatePaymentPeriod.builder()
           .paymentDate(date(2012, 8, 15))
@@ -65,10 +71,12 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
               .rateObservation(FixedRateObservation.of(0.012d))
               .build())
           .notional(1_000_000d)
-          .currency(Currency.USD)
+          .currency(USD)
           .build())
       .build();
 
+  @PropertyDefinition(overrideGet = true)
+  private final SwapLegType type;
   @PropertyDefinition(overrideGet = true)
   private final PayReceive payReceive;
   @PropertyDefinition(overrideGet = true)
@@ -121,10 +129,12 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
   }
 
   private MockSwapLeg(
+      SwapLegType type,
       PayReceive payReceive,
       LocalDate startDate,
       LocalDate endDate,
       Currency currency) {
+    this.type = type;
     this.payReceive = payReceive;
     this.startDate = startDate;
     this.endDate = endDate;
@@ -144,6 +154,16 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
   @Override
   public Set<String> propertyNames() {
     return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the type.
+   * @return the value of the property
+   */
+  @Override
+  public SwapLegType getType() {
+    return type;
   }
 
   //-----------------------------------------------------------------------
@@ -202,7 +222,8 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       MockSwapLeg other = (MockSwapLeg) obj;
-      return JodaBeanUtils.equal(getPayReceive(), other.getPayReceive()) &&
+      return JodaBeanUtils.equal(getType(), other.getType()) &&
+          JodaBeanUtils.equal(getPayReceive(), other.getPayReceive()) &&
           JodaBeanUtils.equal(getStartDate(), other.getStartDate()) &&
           JodaBeanUtils.equal(getEndDate(), other.getEndDate()) &&
           JodaBeanUtils.equal(getCurrency(), other.getCurrency());
@@ -213,6 +234,7 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(getType());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPayReceive());
     hash = hash * 31 + JodaBeanUtils.hashCode(getStartDate());
     hash = hash * 31 + JodaBeanUtils.hashCode(getEndDate());
@@ -222,8 +244,9 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(160);
+    StringBuilder buf = new StringBuilder(192);
     buf.append("MockSwapLeg{");
+    buf.append("type").append('=').append(getType()).append(',').append(' ');
     buf.append("payReceive").append('=').append(getPayReceive()).append(',').append(' ');
     buf.append("startDate").append('=').append(getStartDate()).append(',').append(' ');
     buf.append("endDate").append('=').append(getEndDate()).append(',').append(' ');
@@ -242,6 +265,11 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
      */
     static final Meta INSTANCE = new Meta();
 
+    /**
+     * The meta-property for the {@code type} property.
+     */
+    private final MetaProperty<SwapLegType> type = DirectMetaProperty.ofImmutable(
+        this, "type", MockSwapLeg.class, SwapLegType.class);
     /**
      * The meta-property for the {@code payReceive} property.
      */
@@ -267,6 +295,7 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
+        "type",
         "payReceive",
         "startDate",
         "endDate",
@@ -281,6 +310,8 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return type;
         case -885469925:  // payReceive
           return payReceive;
         case -2129778896:  // startDate
@@ -309,6 +340,14 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code type} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<SwapLegType> type() {
+      return type;
+    }
+
     /**
      * The meta-property for the {@code payReceive} property.
      * @return the meta-property, not null
@@ -345,6 +384,8 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return ((MockSwapLeg) bean).getType();
         case -885469925:  // payReceive
           return ((MockSwapLeg) bean).getPayReceive();
         case -2129778896:  // startDate
@@ -374,6 +415,7 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
    */
   public static final class Builder extends DirectFieldsBeanBuilder<MockSwapLeg> {
 
+    private SwapLegType type;
     private PayReceive payReceive;
     private LocalDate startDate;
     private LocalDate endDate;
@@ -390,6 +432,7 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
      * @param beanToCopy  the bean to copy from, not null
      */
     private Builder(MockSwapLeg beanToCopy) {
+      this.type = beanToCopy.getType();
       this.payReceive = beanToCopy.getPayReceive();
       this.startDate = beanToCopy.getStartDate();
       this.endDate = beanToCopy.getEndDate();
@@ -400,6 +443,8 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          return type;
         case -885469925:  // payReceive
           return payReceive;
         case -2129778896:  // startDate
@@ -416,6 +461,9 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
+        case 3575610:  // type
+          this.type = (SwapLegType) newValue;
+          break;
         case -885469925:  // payReceive
           this.payReceive = (PayReceive) newValue;
           break;
@@ -461,6 +509,7 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     @Override
     public MockSwapLeg build() {
       return new MockSwapLeg(
+          type,
           payReceive,
           startDate,
           endDate,
@@ -468,6 +517,16 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * Sets the {@code type} property in the builder.
+     * @param type  the new value
+     * @return this, for chaining, not null
+     */
+    public Builder type(SwapLegType type) {
+      this.type = type;
+      return this;
+    }
+
     /**
      * Sets the {@code payReceive} property in the builder.
      * @param payReceive  the new value
@@ -511,8 +570,9 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(160);
+      StringBuilder buf = new StringBuilder(192);
       buf.append("MockSwapLeg.Builder{");
+      buf.append("type").append('=').append(JodaBeanUtils.toString(type)).append(',').append(' ');
       buf.append("payReceive").append('=').append(JodaBeanUtils.toString(payReceive)).append(',').append(' ');
       buf.append("startDate").append('=').append(JodaBeanUtils.toString(startDate)).append(',').append(' ');
       buf.append("endDate").append('=').append(JodaBeanUtils.toString(endDate)).append(',').append(' ');

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/OvernightRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/OvernightRateCalculationTest.java
@@ -69,6 +69,7 @@ public class OvernightRateCalculationTest {
   //-------------------------------------------------------------------------
   public void test_of() {
     OvernightRateCalculation test = OvernightRateCalculation.of(GBP_SONIA);
+    assertEquals(test.getType(), SwapLegType.OVERNIGHT);
     assertEquals(test.getDayCount(), ACT_365F);
     assertEquals(test.getIndex(), GBP_SONIA);
     assertEquals(test.getAccrualMethod(), COMPOUNDED);

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLegTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLegTest.java
@@ -24,6 +24,8 @@ import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.finance.rate.swap.CompoundingMethod.STRAIGHT;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.IBOR;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -130,6 +132,7 @@ public class RateCalculationSwapLegTest {
     ImmutableSet.Builder<Index> builder = ImmutableSet.builder();
     test.collectIndices(builder);
     assertEquals(builder.build(), ImmutableSet.of(GBP_LIBOR_3M));
+    assertEquals(test.allIndices(), ImmutableSet.of(GBP_LIBOR_3M));
   }
 
   public void test_collectIndices_fxReset() {
@@ -163,6 +166,7 @@ public class RateCalculationSwapLegTest {
     ImmutableSet.Builder<Index> builder = ImmutableSet.builder();
     test.collectIndices(builder);
     assertEquals(builder.build(), ImmutableSet.of(GBP_LIBOR_3M, ECB_EUR_GBP));
+    assertEquals(test.allIndices(), ImmutableSet.of(GBP_LIBOR_3M, ECB_EUR_GBP));
   }
 
   //-------------------------------------------------------------------------
@@ -224,6 +228,7 @@ public class RateCalculationSwapLegTest {
         .build();
     // assertion
     assertEquals(test.expand(), ExpandedSwapLeg.builder()
+        .type(FIXED)
         .payReceive(PAY)
         .paymentPeriods(rpp1, rpp2, rpp3)
         .build());
@@ -319,6 +324,7 @@ public class RateCalculationSwapLegTest {
     NotionalExchange nexFinal = NotionalExchange.of(DATE_06_09, CurrencyAmount.of(GBP, -1500d));
     // assertion
     assertEquals(test.expand(), ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(PAY)
         .paymentPeriods(rpp1, rpp2, rpp3)
         .paymentEvents(nexInitial, nexIntermediate, nexFinal)
@@ -376,6 +382,7 @@ public class RateCalculationSwapLegTest {
         .build();
     // assertion
     assertEquals(test.expand(), ExpandedSwapLeg.builder()
+        .type(FIXED)
         .payReceive(PAY)
         .paymentPeriods(rpp1)
         .build());
@@ -493,6 +500,7 @@ public class RateCalculationSwapLegTest {
         .build();
     // assertion
     assertEquals(test.expand(), ExpandedSwapLeg.builder()
+        .type(FIXED)
         .payReceive(PAY)
         .paymentPeriods(rpp1, rpp2, rpp3)
         .paymentEvents(ne1a, ne1b, ne2a, ne2b, ne3a, ne3b)

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/RatePeriodSwapLegTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/RatePeriodSwapLegTest.java
@@ -18,6 +18,8 @@ import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.IBOR;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -90,6 +92,7 @@ public class RatePeriodSwapLegTest {
   //-------------------------------------------------------------------------
   public void test_builder() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .initialExchange(true)
@@ -98,6 +101,7 @@ public class RatePeriodSwapLegTest {
         .paymentEvents(NOTIONAL_EXCHANGE)
         .paymentBusinessDayAdjustment(FOLLOWING_GBLO)
         .build();
+    assertEquals(test.getType(), IBOR);
     assertEquals(test.getPayReceive(), RECEIVE);
     assertEquals(test.getStartDate(), DATE_2014_06_30);
     assertEquals(test.getEndDate(), DATE_2014_09_30);
@@ -112,6 +116,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_builder_defaults() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .build();
@@ -129,6 +134,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_builder_invalidMixedCurrency() {
     assertThrowsIllegalArg(() -> RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP3)
         .paymentEvents(NOTIONAL_EXCHANGE)
@@ -138,6 +144,7 @@ public class RatePeriodSwapLegTest {
   //-------------------------------------------------------------------------
   public void test_collectIndices() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .build();
@@ -149,11 +156,13 @@ public class RatePeriodSwapLegTest {
   //-------------------------------------------------------------------------
   public void test_expand() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
         .build();
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
@@ -163,6 +172,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_expand_createNotionalExchange() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .initialExchange(true)
@@ -170,6 +180,7 @@ public class RatePeriodSwapLegTest {
         .finalExchange(true)
         .build();
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(
@@ -181,6 +192,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_expand_fxResetNotionalExchange() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1_FXRESET, RPP2)
         .initialExchange(true)
@@ -204,6 +216,7 @@ public class RatePeriodSwapLegTest {
     NotionalExchange ne2a = NotionalExchange.of(DATE_2014_10_01, CurrencyAmount.of(GBP, -6000d));
     NotionalExchange ne2b = NotionalExchange.of(DATE_2014_01_02, CurrencyAmount.of(GBP, 6000d));
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1_FXRESET, RPP2)
         .paymentEvents(ne1a, ne1b, ne2a, ne2b)
@@ -213,6 +226,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_expand_omitFxResetNotionalExchange() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1_FXRESET)
         .initialExchange(true)
@@ -220,6 +234,7 @@ public class RatePeriodSwapLegTest {
         .finalExchange(true)
         .build();
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1_FXRESET)
         .build();
@@ -228,6 +243,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_expand_createNotionalExchange_noInitial() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .initialExchange(false)
@@ -235,6 +251,7 @@ public class RatePeriodSwapLegTest {
         .finalExchange(true)
         .build();
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NotionalExchange.of(DATE_2014_10_01, CurrencyAmount.of(GBP, 5000d)))
@@ -244,6 +261,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_expand_createNotionalExchange_initialOnly() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .initialExchange(true)
@@ -251,6 +269,7 @@ public class RatePeriodSwapLegTest {
         .finalExchange(false)
         .build();
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NotionalExchange.of(DATE_2014_06_30, CurrencyAmount.of(GBP, -5000d)))
@@ -260,6 +279,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_expand_createNotionalExchange_finalOnly() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .initialExchange(false)
@@ -267,6 +287,7 @@ public class RatePeriodSwapLegTest {
         .finalExchange(true)
         .build();
     ExpandedSwapLeg expected = ExpandedSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NotionalExchange.of(DATE_2014_10_01, CurrencyAmount.of(GBP, 5000d)))
@@ -277,6 +298,7 @@ public class RatePeriodSwapLegTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)
@@ -287,6 +309,7 @@ public class RatePeriodSwapLegTest {
         .build();
     coverImmutableBean(test);
     RatePeriodSwapLeg test2 = RatePeriodSwapLeg.builder()
+        .type(FIXED)
         .payReceive(PAY)
         .paymentPeriods(RPP2)
         .build();
@@ -295,6 +318,7 @@ public class RatePeriodSwapLegTest {
 
   public void test_serialization() {
     RatePeriodSwapLeg test = RatePeriodSwapLeg.builder()
+        .type(IBOR)
         .payReceive(RECEIVE)
         .paymentPeriods(RPP1)
         .paymentEvents(NOTIONAL_EXCHANGE)

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/SwapLegTypeTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/SwapLegTypeTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap;
+
+import static com.opengamma.strata.collect.TestHelper.assertJodaConvert;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.coverEnum;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test.
+ */
+@Test
+public class SwapLegTypeTest {
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "name")
+  static Object[][] data_name() {
+    return new Object[][] {
+        {SwapLegType.FIXED, "Fixed"},
+        {SwapLegType.IBOR, "Ibor"},
+        {SwapLegType.OVERNIGHT, "Overnight"},
+        {SwapLegType.OTHER, "Other"},
+    };
+  }
+
+  @Test(dataProvider = "name")
+  public void test_toString(SwapLegType convention, String name) {
+    assertEquals(convention.toString(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_of_lookup(SwapLegType convention, String name) {
+    assertEquals(SwapLegType.of(name), convention);
+  }
+
+  public void test_of_lookup_notFound() {
+    assertThrows(() -> SwapLegType.of("Rubbish"), IllegalArgumentException.class);
+  }
+
+  public void test_of_lookup_null() {
+    assertThrows(() -> SwapLegType.of(null), IllegalArgumentException.class);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_isFixed() {
+    assertEquals(SwapLegType.FIXED.isFixed(), true);
+    assertEquals(SwapLegType.IBOR.isFixed(), false);
+    assertEquals(SwapLegType.OVERNIGHT.isFixed(), false);
+    assertEquals(SwapLegType.OTHER.isFixed(), false);
+  }
+
+  public void test_isFloat() {
+    assertEquals(SwapLegType.FIXED.isFloat(), false);
+    assertEquals(SwapLegType.IBOR.isFloat(), true);
+    assertEquals(SwapLegType.OVERNIGHT.isFloat(), true);
+    assertEquals(SwapLegType.OTHER.isFloat(), false);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverEnum(SwapLegType.class);
+  }
+
+  public void test_serialization() {
+    assertSerialization(SwapLegType.FIXED);
+  }
+
+  public void test_jodaConvert() {
+    assertJodaConvert(SwapLegType.class, SwapLegType.IBOR);
+  }
+
+}

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/SwapTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/SwapTest.java
@@ -16,6 +16,10 @@ import static com.opengamma.strata.finance.rate.swap.MockSwapLeg.MOCK_EXPANDED_U
 import static com.opengamma.strata.finance.rate.swap.MockSwapLeg.MOCK_GBP1;
 import static com.opengamma.strata.finance.rate.swap.MockSwapLeg.MOCK_GBP2;
 import static com.opengamma.strata.finance.rate.swap.MockSwapLeg.MOCK_USD1;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.IBOR;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.OTHER;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.OVERNIGHT;
 import static org.testng.Assert.assertEquals;
 
 import java.util.List;
@@ -61,7 +65,14 @@ public class SwapTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_getLeg() {
+  public void test_getLegs_SwapLegType() {
+    assertEquals(Swap.of(MOCK_GBP1, MOCK_USD1).getLegs(FIXED), ImmutableList.of(MOCK_GBP1));
+    assertEquals(Swap.of(MOCK_GBP1, MOCK_USD1).getLegs(IBOR), ImmutableList.of(MOCK_USD1));
+    assertEquals(Swap.of(MOCK_GBP1, MOCK_USD1).getLegs(OVERNIGHT), ImmutableList.of());
+    assertEquals(Swap.of(MOCK_GBP1, MOCK_USD1).getLegs(OTHER), ImmutableList.of());
+  }
+
+  public void test_getLeg_PayReceive() {
     assertEquals(Swap.of(MOCK_GBP1, MOCK_USD1).getLeg(PAY), Optional.of(MOCK_GBP1));
     assertEquals(Swap.of(MOCK_GBP1, MOCK_USD1).getLeg(RECEIVE), Optional.of(MOCK_USD1));
     assertEquals(Swap.of(MOCK_GBP1).getLeg(PAY), Optional.of(MOCK_GBP1));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/SwapDummyData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/SwapDummyData.java
@@ -10,6 +10,8 @@ import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_F
 import static com.opengamma.strata.basics.date.HolidayCalendars.GBLO;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.IBOR;
 
 import com.opengamma.strata.basics.PayReceive;
 import com.opengamma.strata.basics.currency.Currency;
@@ -90,6 +92,7 @@ public final class SwapDummyData {
    * ExpandedSwapLeg (ibor).
    */
   public static final ExpandedSwapLeg IBOR_EXPANDED_SWAP_LEG = ExpandedSwapLeg.builder()
+      .type(IBOR)
       .payReceive(RECEIVE)
       .paymentPeriods(IBOR_RATE_PAYMENT_PERIOD)
       .paymentEvents(NOTIONAL_EXCHANGE)
@@ -139,6 +142,7 @@ public final class SwapDummyData {
    * ExpandedSwapLeg (fixed).
    */
   public static final ExpandedSwapLeg FIXED_EXPANDED_SWAP_LEG = ExpandedSwapLeg.builder()
+      .type(FIXED)
       .payReceive(RECEIVE)
       .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD)
       .paymentEvents(NOTIONAL_EXCHANGE)
@@ -156,6 +160,7 @@ public final class SwapDummyData {
    * ExpandedSwapLeg (fixed).
    */
   public static final ExpandedSwapLeg FIXED_EXPANDED_SWAP_LEG_USD = ExpandedSwapLeg.builder()
+      .type(FIXED)
       .payReceive(RECEIVE)
       .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD_USD)
       .build();


### PR DESCRIPTION
Classify swap legs to aid pricing and users. Intended as a high level classification, for both users and pricing (notably par rate).
