### PR TITLE
Improve market data error messages

### DIFF
--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/BaseMarketData.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/BaseMarketData.java
@@ -28,8 +28,11 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.engine.calculations.MissingMappingId;
+import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
 import com.opengamma.strata.marketdata.id.MarketDataId;
 import com.opengamma.strata.marketdata.id.ObservableId;
+import com.opengamma.strata.marketdata.key.MarketDataKey;
 
 // TODO This needs to store values in MarketDataItem with a timestamp and attributes (to store entitlements, ticker)
 /**
@@ -105,6 +108,15 @@ public final class BaseMarketData implements ImmutableBean {
    */
   @SuppressWarnings("unchecked")
   public <T, I extends MarketDataId<T>> T getValue(I id) {
+    // Special handling of these special ID types to provide more helpful error messages
+    if (id instanceof NoMatchingRuleId) {
+      MarketDataKey key = ((NoMatchingRuleId) id).getKey();
+      throw new IllegalArgumentException("No market data rules were available to build the market data for " + key);
+    }
+    if (id instanceof MissingMappingId) {
+      MarketDataKey<?> key = ((MissingMappingId) id).getKey();
+      throw new IllegalArgumentException("No market data mapping found for market data " + key);
+    }
     Object value = values.get(id);
 
     if (value == null) {

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DefaultScenarioMarketData.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DefaultScenarioMarketData.java
@@ -30,8 +30,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.engine.calculations.MissingMappingId;
+import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
 import com.opengamma.strata.marketdata.id.MarketDataId;
 import com.opengamma.strata.marketdata.id.ObservableId;
+import com.opengamma.strata.marketdata.key.MarketDataKey;
 
 /**
  * Basic definition of {@link ScenarioMarketData} that is a Joda bean.
@@ -70,6 +73,15 @@ public final class DefaultScenarioMarketData implements ScenarioMarketData, Immu
 
   @Override
   public <T, I extends MarketDataId<T>> List<T> getValues(I id) {
+    // Special handling of these special ID types to provide more helpful error messages
+    if (id instanceof NoMatchingRuleId) {
+      MarketDataKey key = ((NoMatchingRuleId) id).getKey();
+      throw new IllegalArgumentException("No market data rules were available to build the market data for " + key);
+    }
+    if (id instanceof MissingMappingId) {
+      MarketDataKey<?> key = ((MissingMappingId) id).getKey();
+      throw new IllegalArgumentException("No market data mapping found for market data " + key);
+    }
     List<?> values = this.values.get(id);
 
     if (values == null) {

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/BaseMarketDataTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/BaseMarketDataTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.engine.marketdata;
+
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.date;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.engine.calculations.MissingMappingId;
+import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
+import com.opengamma.strata.marketdata.key.IndexCurveKey;
+
+@Test
+public class BaseMarketDataTest {
+
+  /**
+   * Tests the special handling of {@link NoMatchingRuleId}
+   */
+  public void handleNoMatchingRulesId() {
+    BaseMarketData marketData = BaseMarketData.builder(date(2011, 3, 8)).build();
+    NoMatchingRuleId id = NoMatchingRuleId.of(IndexCurveKey.of(IborIndices.USD_LIBOR_1M));
+    String msgRegex = "No market data rules were available to build the market data for.*";
+    assertThrows(() -> marketData.getValue(id), IllegalArgumentException.class, msgRegex);
+  }
+
+  /**
+   * Tests the special handling of {@link MissingMappingId}
+   */
+  public void handleMissingMappingsId() {
+    BaseMarketData marketData = BaseMarketData.builder(date(2011, 3, 8)).build();
+    MissingMappingId id = MissingMappingId.of(IndexCurveKey.of(IborIndices.USD_LIBOR_1M));
+    String msgRegex = "No market data mapping found for market data.*";
+    assertThrows(() -> marketData.getValue(id), IllegalArgumentException.class, msgRegex);
+  }
+}

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/DefaultScenarioMarketDataTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/DefaultScenarioMarketDataTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.engine.marketdata;
+
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.date;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.engine.calculations.MissingMappingId;
+import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
+import com.opengamma.strata.marketdata.key.IndexCurveKey;
+
+@Test
+public class DefaultScenarioMarketDataTest {
+
+  /**
+   * Tests the special handling of {@link NoMatchingRuleId}
+   */
+  public void handleNoMatchingRulesId() {
+    ScenarioMarketData marketData = ScenarioMarketData.builder(1, date(2011, 3, 8)).build();
+    NoMatchingRuleId id = NoMatchingRuleId.of(IndexCurveKey.of(IborIndices.USD_LIBOR_1M));
+    String msgRegex = "No market data rules were available to build the market data for.*";
+    assertThrows(() -> marketData.getValues(id), IllegalArgumentException.class, msgRegex);
+  }
+
+  /**
+   * Tests the special handling of {@link MissingMappingId}
+   */
+  public void handleMissingMappingsId() {
+    ScenarioMarketData marketData = ScenarioMarketData.builder(1, date(2011, 3, 8)).build();
+    MissingMappingId id = MissingMappingId.of(IndexCurveKey.of(IborIndices.USD_LIBOR_1M));
+    String msgRegex = "No market data mapping found for market data.*";
+    assertThrows(() -> marketData.getValues(id), IllegalArgumentException.class, msgRegex);
+  }
+}


### PR DESCRIPTION
There are two special market data ID types used as sentinel values when there are no market data mappings or rules for a calculation. There is special handling in the market data factory to ensure there are useful error messages for those IDs, but there was no special handling of them when looking up data.

This PR adds special handling of those types to the market data containers to provide better error messages in the calculation results.
