### PR TITLE
Rename sensitivity concepts

### DIFF
--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/FxForwardPvParameterSensitivityFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/FxForwardPvParameterSensitivityFunction.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.function.fx;
 
 import com.opengamma.strata.finance.fx.ExpandedFx;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
@@ -14,10 +14,10 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
  * Calculates the present value parameter sensitivity of an {@code FxForwardTrade} for each of a set of scenarios.
  */
 public class FxForwardPvParameterSensitivityFunction
-    extends AbstractFxForwardFunction<CurveParameterSensitivity> {
+    extends AbstractFxForwardFunction<CurveParameterSensitivities> {
 
   @Override
-  protected CurveParameterSensitivity execute(ExpandedFx product, RatesProvider provider) {
+  protected CurveParameterSensitivities execute(ExpandedFx product, RatesProvider provider) {
     PointSensitivities pointSensitivity = pricer().presentValueSensitivity(product, provider);
     return provider.parameterSensitivity(pointSensitivity);
   }

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/FxSwapPvParameterSensitivityFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/FxSwapPvParameterSensitivityFunction.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.function.fx;
 
 import com.opengamma.strata.finance.fx.ExpandedFxSwap;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
@@ -14,10 +14,10 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
  * Calculates the present value parameter sensitivity of an {@code FxSwapTrade} for each of a set of scenarios.
  */
 public class FxSwapPvParameterSensitivityFunction
-    extends AbstractFxSwapFunction<CurveParameterSensitivity> {
+    extends AbstractFxSwapFunction<CurveParameterSensitivities> {
 
   @Override
-  protected CurveParameterSensitivity execute(ExpandedFxSwap product, RatesProvider provider) {
+  protected CurveParameterSensitivities execute(ExpandedFxSwap product, RatesProvider provider) {
     PointSensitivities pointSensitivity = pricer().presentValueSensitivity(product, provider);
     return provider.parameterSensitivity(pointSensitivity);
   }

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/deposit/TermDepositParSpreadParameterSensitivityFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/deposit/TermDepositParSpreadParameterSensitivityFunction.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.function.rate.deposit;
 
 import com.opengamma.strata.finance.rate.deposit.ExpandedTermDeposit;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
@@ -14,10 +14,10 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
  * Calculates the par spread parameter sensitivity of a {@code TermDepositTrade} for each of a set of scenarios.
  */
 public class TermDepositParSpreadParameterSensitivityFunction
-    extends AbstractTermDepositFunction<CurveParameterSensitivity> {
+    extends AbstractTermDepositFunction<CurveParameterSensitivities> {
 
   @Override
-  protected CurveParameterSensitivity execute(ExpandedTermDeposit product, RatesProvider provider) {
+  protected CurveParameterSensitivities execute(ExpandedTermDeposit product, RatesProvider provider) {
     PointSensitivities pointSensitivity = pricer().parSpreadSensitivity(product, provider);
     return provider.parameterSensitivity(pointSensitivity);
   }

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/deposit/TermDepositPvParameterSensitivityFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/deposit/TermDepositPvParameterSensitivityFunction.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.function.rate.deposit;
 
 import com.opengamma.strata.finance.rate.deposit.ExpandedTermDeposit;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
@@ -14,10 +14,10 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
  * Calculates the present value parameter sensitivity of a {@code TermDepositTrade} for each of a set of scenarios.
  */
 public class TermDepositPvParameterSensitivityFunction
-    extends AbstractTermDepositFunction<CurveParameterSensitivity> {
+    extends AbstractTermDepositFunction<CurveParameterSensitivities> {
 
   @Override
-  protected CurveParameterSensitivity execute(ExpandedTermDeposit product, RatesProvider provider) {
+  protected CurveParameterSensitivities execute(ExpandedTermDeposit product, RatesProvider provider) {
     PointSensitivities pointSensitivity = pricer().presentValueSensitivity(product, provider);
     return provider.parameterSensitivity(pointSensitivity);
   }

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/fra/FraPvParameterSensitivityFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/fra/FraPvParameterSensitivityFunction.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.function.rate.fra;
 
 import com.opengamma.strata.finance.rate.fra.ExpandedFra;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
@@ -14,10 +14,10 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
  * Calculates the present value parameter sensitivity of a {@code FraTrade} for each of a set of scenarios.
  */
 public class FraPvParameterSensitivityFunction
-    extends AbstractFraFunction<CurveParameterSensitivity> {
+    extends AbstractFraFunction<CurveParameterSensitivities> {
 
   @Override
-  protected CurveParameterSensitivity execute(ExpandedFra product, RatesProvider provider) {
+  protected CurveParameterSensitivities execute(ExpandedFra product, RatesProvider provider) {
     PointSensitivities pointSensitivity = pricer().presentValueSensitivity(product, provider);
     return provider.parameterSensitivity(pointSensitivity);
   }

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/CurveParameterSensitivities.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/CurveParameterSensitivities.java
@@ -42,13 +42,13 @@ import com.opengamma.strata.collect.ArgChecker;
  * and {@linkplain NameCurrencySensitivityKey by curve and currency}.
  */
 @BeanDefinition
-public final class CurveParameterSensitivity
+public final class CurveParameterSensitivities
     implements ImmutableBean {
 
   /**
    * An empty instance.
    */
-  private static final CurveParameterSensitivity EMPTY = new CurveParameterSensitivity(ImmutableMap.of());
+  private static final CurveParameterSensitivities EMPTY = new CurveParameterSensitivities(ImmutableMap.of());
 
   /**
    * The map containing the sensitivities. 
@@ -66,7 +66,7 @@ public final class CurveParameterSensitivity
    * 
    * @return the empty instance
    */
-  public static CurveParameterSensitivity empty() {
+  public static CurveParameterSensitivities empty() {
     return EMPTY;
   }
 
@@ -80,8 +80,8 @@ public final class CurveParameterSensitivity
    * @param sensitivityArray  the sensitivity to the key, not cloned
    * @return the sensitivity instance
    */
-  public static CurveParameterSensitivity of(SensitivityKey key, double[] sensitivityArray) {
-    return new CurveParameterSensitivity(ImmutableMap.of(key, sensitivityArray));
+  public static CurveParameterSensitivities of(SensitivityKey key, double[] sensitivityArray) {
+    return new CurveParameterSensitivities(ImmutableMap.of(key, sensitivityArray));
   }
 
   /**
@@ -93,8 +93,8 @@ public final class CurveParameterSensitivity
    * @param map  the map of sensitivities
    * @return the sensitivity instance
    */
-  public static CurveParameterSensitivity of(Map<SensitivityKey, double[]> map) {
-    return new CurveParameterSensitivity(map);
+  public static CurveParameterSensitivities of(Map<SensitivityKey, double[]> map) {
+    return new CurveParameterSensitivities(map);
   }
 
   //-------------------------------------------------------------------------
@@ -116,10 +116,10 @@ public final class CurveParameterSensitivity
    * @return a sensitivity instance based on this one, with the key added
    * @throws IllegalArgumentException if the other sensitivity cannot be combined
    */
-  public CurveParameterSensitivity combinedWith(SensitivityKey key, double[] sensitivityArray) {
+  public CurveParameterSensitivities combinedWith(SensitivityKey key, double[] sensitivityArray) {
     Map<SensitivityKey, double[]> combined = new LinkedHashMap<>(sensitivities);
     combined.merge(key, sensitivityArray, this::combineArrays);
-    return new CurveParameterSensitivity(combined);
+    return new CurveParameterSensitivities(combined);
   }
 
   /**
@@ -136,7 +136,7 @@ public final class CurveParameterSensitivity
    * @return a sensitivity instance based on this one, with the other instance added
    * @throws IllegalArgumentException if the other sensitivity cannot be combined
    */
-  public CurveParameterSensitivity combinedWith(CurveParameterSensitivity other) {
+  public CurveParameterSensitivities combinedWith(CurveParameterSensitivities other) {
     if (other.sensitivities.isEmpty()) {
       return this;
     }
@@ -147,7 +147,7 @@ public final class CurveParameterSensitivity
     for (Entry<SensitivityKey, double[]> entry : other.sensitivities.entrySet()) {
       combined.merge(entry.getKey(), entry.getValue(), this::combineArrays);
     }
-    return new CurveParameterSensitivity(combined);
+    return new CurveParameterSensitivities(combined);
   }
 
   // add two arrays
@@ -171,7 +171,7 @@ public final class CurveParameterSensitivity
    * @param factor  the multiplicative factor
    * @return a sensitivity instance based on this one, with all vectors multiplied by the factor
    */
-  public CurveParameterSensitivity multipliedBy(double factor) {
+  public CurveParameterSensitivities multipliedBy(double factor) {
     return mapSensitivity(s -> s * factor);
   }
 
@@ -191,12 +191,12 @@ public final class CurveParameterSensitivity
    * @param operator  the operator to be applied to the sensitivities
    * @return the resulting builder, replacing this builder
    */
-  public CurveParameterSensitivity mapSensitivity(DoubleUnaryOperator operator) {
+  public CurveParameterSensitivities mapSensitivity(DoubleUnaryOperator operator) {
     Map<SensitivityKey, double[]> result = new LinkedHashMap<>();
     for (Entry<SensitivityKey, double[]> entry : sensitivities.entrySet()) {
       result.put(entry.getKey(), operateOnArray(operator, entry.getValue()));
     }
-    return new CurveParameterSensitivity(ImmutableMap.copyOf(result));
+    return new CurveParameterSensitivities(ImmutableMap.copyOf(result));
   }
 
   // operate on an array
@@ -245,7 +245,7 @@ public final class CurveParameterSensitivity
    * @param tolerance  the tolerance
    * @return true if equal up to the tolerance
    */
-  public boolean equalWithTolerance(CurveParameterSensitivity other, double tolerance) {
+  public boolean equalWithTolerance(CurveParameterSensitivities other, double tolerance) {
     if (!sensitivities.keySet().equals(other.sensitivities.keySet())) {
       // check that the element outside the intersection have a sensitivity below the tolerance
       Set<SensitivityKey> amb = Sets.difference(sensitivities.keySet(), other.sensitivities.keySet());
@@ -305,7 +305,7 @@ public final class CurveParameterSensitivity
       return true;
     }
     if (obj != null && obj.getClass() == this.getClass()) {
-      CurveParameterSensitivity other = (CurveParameterSensitivity) obj;
+      CurveParameterSensitivities other = (CurveParameterSensitivities) obj;
       if (!sensitivities.keySet().equals(other.sensitivities.keySet())) {
         return false;
       }
@@ -350,34 +350,34 @@ public final class CurveParameterSensitivity
   //------------------------- AUTOGENERATED START -------------------------
   ///CLOVER:OFF
   /**
-   * The meta-bean for {@code CurveParameterSensitivity}.
+   * The meta-bean for {@code CurveParameterSensitivities}.
    * @return the meta-bean, not null
    */
-  public static CurveParameterSensitivity.Meta meta() {
-    return CurveParameterSensitivity.Meta.INSTANCE;
+  public static CurveParameterSensitivities.Meta meta() {
+    return CurveParameterSensitivities.Meta.INSTANCE;
   }
 
   static {
-    JodaBeanUtils.registerMetaBean(CurveParameterSensitivity.Meta.INSTANCE);
+    JodaBeanUtils.registerMetaBean(CurveParameterSensitivities.Meta.INSTANCE);
   }
 
   /**
    * Returns a builder used to create an instance of the bean.
    * @return the builder, not null
    */
-  public static CurveParameterSensitivity.Builder builder() {
-    return new CurveParameterSensitivity.Builder();
+  public static CurveParameterSensitivities.Builder builder() {
+    return new CurveParameterSensitivities.Builder();
   }
 
-  private CurveParameterSensitivity(
+  private CurveParameterSensitivities(
       Map<SensitivityKey, double[]> sensitivities) {
     JodaBeanUtils.notNull(sensitivities, "sensitivities");
     this.sensitivities = ImmutableMap.copyOf(sensitivities);
   }
 
   @Override
-  public CurveParameterSensitivity.Meta metaBean() {
-    return CurveParameterSensitivity.Meta.INSTANCE;
+  public CurveParameterSensitivities.Meta metaBean() {
+    return CurveParameterSensitivities.Meta.INSTANCE;
   }
 
   @Override
@@ -414,7 +414,7 @@ public final class CurveParameterSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * The meta-bean for {@code CurveParameterSensitivity}.
+   * The meta-bean for {@code CurveParameterSensitivities}.
    */
   public static final class Meta extends DirectMetaBean {
     /**
@@ -427,7 +427,7 @@ public final class CurveParameterSensitivity
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
     private final MetaProperty<ImmutableMap<SensitivityKey, double[]>> sensitivities = DirectMetaProperty.ofImmutable(
-        this, "sensitivities", CurveParameterSensitivity.class, (Class) ImmutableMap.class);
+        this, "sensitivities", CurveParameterSensitivities.class, (Class) ImmutableMap.class);
     /**
      * The meta-properties.
      */
@@ -451,13 +451,13 @@ public final class CurveParameterSensitivity
     }
 
     @Override
-    public CurveParameterSensitivity.Builder builder() {
-      return new CurveParameterSensitivity.Builder();
+    public CurveParameterSensitivities.Builder builder() {
+      return new CurveParameterSensitivities.Builder();
     }
 
     @Override
-    public Class<? extends CurveParameterSensitivity> beanType() {
-      return CurveParameterSensitivity.class;
+    public Class<? extends CurveParameterSensitivities> beanType() {
+      return CurveParameterSensitivities.class;
     }
 
     @Override
@@ -479,7 +479,7 @@ public final class CurveParameterSensitivity
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
         case 1226228605:  // sensitivities
-          return ((CurveParameterSensitivity) bean).getSensitivities();
+          return ((CurveParameterSensitivities) bean).getSensitivities();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -497,9 +497,9 @@ public final class CurveParameterSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * The bean-builder for {@code CurveParameterSensitivity}.
+   * The bean-builder for {@code CurveParameterSensitivities}.
    */
-  public static final class Builder extends DirectFieldsBeanBuilder<CurveParameterSensitivity> {
+  public static final class Builder extends DirectFieldsBeanBuilder<CurveParameterSensitivities> {
 
     private Map<SensitivityKey, double[]> sensitivities = ImmutableMap.of();
 
@@ -513,7 +513,7 @@ public final class CurveParameterSensitivity
      * Restricted copy constructor.
      * @param beanToCopy  the bean to copy from, not null
      */
-    private Builder(CurveParameterSensitivity beanToCopy) {
+    private Builder(CurveParameterSensitivities beanToCopy) {
       this.sensitivities = beanToCopy.getSensitivities();
     }
 
@@ -566,8 +566,8 @@ public final class CurveParameterSensitivity
     }
 
     @Override
-    public CurveParameterSensitivity build() {
-      return new CurveParameterSensitivity(
+    public CurveParameterSensitivities build() {
+      return new CurveParameterSensitivities(
           sensitivities);
     }
 
@@ -587,7 +587,7 @@ public final class CurveParameterSensitivity
     @Override
     public String toString() {
       StringBuilder buf = new StringBuilder(64);
-      buf.append("CurveParameterSensitivity.Builder{");
+      buf.append("CurveParameterSensitivities.Builder{");
       buf.append("sensitivities").append('=').append(JodaBeanUtils.toString(sensitivities));
       buf.append('}');
       return buf.toString();

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IndexCurrencySensitivityKey.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IndexCurrencySensitivityKey.java
@@ -28,7 +28,7 @@ import com.opengamma.strata.basics.index.Index;
 /**
  * A key used for sensitivity to a curve in a specific currency, identified by the index.
  * <p>
- * This is a {@link SensitivityKey} implementation used by {@link CurveParameterSensitivity}.
+ * This is a {@link SensitivityKey} implementation used by {@link CurveParameterSensitivities}.
  * This type of key is used for present value sensitivity.
  */
 @BeanDefinition(builderScope = "private")

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/NameCurrencySensitivityKey.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/NameCurrencySensitivityKey.java
@@ -28,7 +28,7 @@ import com.opengamma.strata.market.curve.CurveName;
 /**
  * A key used for sensitivity to a curve in a specific currency, identified by the name.
  * <p>
- * This is a {@link SensitivityKey} implementation used by {@link CurveParameterSensitivity}.
+ * This is a {@link SensitivityKey} implementation used by {@link CurveParameterSensitivities}.
  */
 @BeanDefinition(builderScope = "private")
 public final class NameCurrencySensitivityKey

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/NameSensitivityKey.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/NameSensitivityKey.java
@@ -27,7 +27,7 @@ import com.opengamma.strata.market.curve.CurveName;
 /**
  * A key used for sensitivity to a curve.
  * <p>
- * This is a {@link SensitivityKey} implementation used by {@link CurveParameterSensitivity}.
+ * This is a {@link SensitivityKey} implementation used by {@link CurveParameterSensitivities}.
  */
 @BeanDefinition(builderScope = "private")
 public final class NameSensitivityKey

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/PointSensitivities.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/PointSensitivities.java
@@ -54,9 +54,9 @@ public final class PointSensitivities
     implements ImmutableBean, Serializable {
 
   /**
-   * A sensitivities instance to be used when there is no sensitivity.
+   * An empty instance.
    */
-  public static final PointSensitivities NONE = new PointSensitivities(ImmutableList.of());
+  private static final PointSensitivities EMPTY = new PointSensitivities(ImmutableList.of());
 
   /**
    * The point sensitivities.
@@ -68,13 +68,22 @@ public final class PointSensitivities
 
   //-------------------------------------------------------------------------
   /**
-   * Obtains a {@code PointSensitivities} from a single sensitivity entry.
+   * An empty sensitivity instance.
+   * 
+   * @return the empty instance
+   */
+  public static PointSensitivities empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Obtains a {@code PointSensitivities} from an array of sensitivity entries.
    * 
    * @param sensitivity  the sensitivity entry
    * @return the sensitivities instance
    */
-  public static PointSensitivities of(PointSensitivity sensitivity) {
-    return PointSensitivities.of(ImmutableList.of(sensitivity));
+  public static PointSensitivities of(PointSensitivity... sensitivity) {
+    return PointSensitivities.of(ImmutableList.copyOf(sensitivity));
   }
 
   /**

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/SensitivityKey.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/SensitivityKey.java
@@ -10,7 +10,7 @@ import org.joda.beans.ImmutableBean;
 /**
  * A key used to identify a specific sensitivity.
  * <p>
- * This is used within {@link CurveParameterSensitivity}.
+ * This is used within {@link CurveParameterSensitivities}.
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountFactors.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountFactors.java
@@ -102,16 +102,16 @@ public interface DiscountFactors {
   public abstract PointSensitivityBuilder pointSensitivity(LocalDate date, Currency sensitivityCurrency);
 
   /**
-   * Returns the parameter sensitivity of the forward rate at the specified fixing date.
+   * Returns the unit parameter sensitivity of the forward rate at the specified fixing date.
    * <p>
-   * This returns the raw sensitivity for each parameter on the underlying curve.
+   * This returns the unit sensitivity for each parameter on the underlying curve.
    * If the fixing date is before the valuation date an exception is thrown.
    * The sensitivity refers to the result of {@link #discountFactor(LocalDate)}.
    * 
-   * @param date  the fixing date to find the sensitivity for
+   * @param date  the date to find the sensitivity for
    * @return the parameter sensitivity
    * @throws RuntimeException if the value cannot be obtained
    */
-  public abstract double[] parameterSensitivity(LocalDate date);
+  public abstract double[] unitParameterSensitivity(LocalDate date);
 
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountIborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountIborIndexRates.java
@@ -166,8 +166,8 @@ public final class DiscountIborIndexRates
   }
 
   @Override
-  public double[] parameterSensitivity(LocalDate date) {
-    return discountFactors.parameterSensitivity(date);
+  public double[] unitParameterSensitivity(LocalDate date) {
+    return discountFactors.unitParameterSensitivity(date);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountOvernightIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountOvernightIndexRates.java
@@ -189,8 +189,8 @@ public final class DiscountOvernightIndexRates
 
   //-------------------------------------------------------------------------
   @Override
-  public double[] parameterSensitivity(LocalDate date) {
-    return discountFactors.parameterSensitivity(date);
+  public double[] unitParameterSensitivity(LocalDate date) {
+    return discountFactors.unitParameterSensitivity(date);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/ForwardPriceIndexValues.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/ForwardPriceIndexValues.java
@@ -222,7 +222,7 @@ public final class ForwardPriceIndexValues
 
   //-------------------------------------------------------------------------
   @Override
-  public double[] parameterSensitivity(YearMonth month) {
+  public double[] unitParameterSensitivity(YearMonth month) {
     // no sensitivity if historic month price index present in the time series
     OptionalDouble fixing = timeSeries.get(month.atEndOfMonth());
     if (fixing.isPresent()) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/IborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/IborIndexRates.java
@@ -95,9 +95,9 @@ public interface IborIndexRates {
   public abstract PointSensitivityBuilder pointSensitivity(LocalDate fixingDate);
 
   /**
-   * Returns the parameter sensitivity of the forward rate at the specified fixing date.
+   * Returns the unit parameter sensitivity of the forward rate at the specified fixing date.
    * <p>
-   * This returns the raw sensitivity for each parameter on the underlying curve.
+   * This returns the unit sensitivity for each parameter on the underlying curve.
    * If the fixing date is before the valuation date an exception is thrown.
    * The sensitivity refers to the result of {@link #rate(LocalDate)}.
    * 
@@ -105,6 +105,6 @@ public interface IborIndexRates {
    * @return the parameter sensitivity
    * @throws RuntimeException if the value cannot be obtained
    */
-  public abstract double[] parameterSensitivity(LocalDate fixingDate);
+  public abstract double[] unitParameterSensitivity(LocalDate fixingDate);
 
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/OvernightIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/OvernightIndexRates.java
@@ -127,11 +127,10 @@ public interface OvernightIndexRates {
    */
   public abstract PointSensitivityBuilder periodRatePointSensitivity(LocalDate startDate, LocalDate endDate);
 
-  //-------------------------------------------------------------------------
   /**
-   * Returns the parameter sensitivity of the forward rate at the specified fixing date.
+   * Returns the unit parameter sensitivity of the forward rate at the specified fixing date.
    * <p>
-   * This returns the raw sensitivity for each parameter on the underlying curve.
+   * This returns the unit sensitivity for each parameter on the underlying curve.
    * If the fixing date is before the valuation date an exception is thrown.
    * The sensitivity refers to the result of {@link #rate(LocalDate)}.
    * 
@@ -139,6 +138,6 @@ public interface OvernightIndexRates {
    * @return the parameter sensitivity
    * @throws RuntimeException if the value cannot be obtained
    */
-  public abstract double[] parameterSensitivity(LocalDate fixingDate);
+  public abstract double[] unitParameterSensitivity(LocalDate fixingDate);
 
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/PriceIndexValues.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/PriceIndexValues.java
@@ -96,11 +96,16 @@ public interface PriceIndexValues {
   public abstract PointSensitivityBuilder pointSensitivity(YearMonth fixingMonth);
 
   /**
-   * Returns the sensitivities of the price index to the curve parameters at a given month.
+   * Returns the unit parameter sensitivity of the price index to the curve parameters at a given month.
+   * <p>
+   * This returns the unit sensitivity for each parameter on the underlying curve.
+   * If the year-month is before the valuation date an exception is thrown.
+   * The sensitivity refers to the result of {@link #value(YearMonth)}.
    * 
    * @param month  the month to query the sensitivity for
    * @return the sensitivity array
+   * @throws RuntimeException if the value cannot be obtained
    */
-  public abstract double[] parameterSensitivity(YearMonth month);
+  public abstract double[] unitParameterSensitivity(YearMonth month);
 
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/ZeroRateDiscountFactors.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/ZeroRateDiscountFactors.java
@@ -127,7 +127,7 @@ public final class ZeroRateDiscountFactors
   }
 
   @Override
-  public double[] parameterSensitivity(LocalDate date) {
+  public double[] unitParameterSensitivity(LocalDate date) {
     double relativeTime = relativeTime(date);
     return curve.yValueParameterSensitivity(relativeTime);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/CurveParameterSensitivityTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/CurveParameterSensitivityTest.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.currency.Currency;
 
 /**
- * Test {@link CurveParameterSensitivity}.
+ * Test {@link CurveParameterSensitivities}.
  */
 @Test
 public class CurveParameterSensitivityTest {
@@ -39,27 +39,27 @@ public class CurveParameterSensitivityTest {
   private static final NameCurrencySensitivityKey KEY_3 = NameCurrencySensitivityKey.of(NAME2, USD);
 
   private static final Map<SensitivityKey, double[]> MAP_0 = ImmutableMap.of(KEY_3, VECTOR_ZERO_4);
-  private static final CurveParameterSensitivity SENSI_0 =
-      CurveParameterSensitivity.builder().sensitivities(MAP_0).build();
+  private static final CurveParameterSensitivities SENSI_0 =
+      CurveParameterSensitivities.builder().sensitivities(MAP_0).build();
 
   private static final Map<SensitivityKey, double[]> MAP_1 = ImmutableMap.of(KEY_USD, VECTOR_USD1);
-  private static final CurveParameterSensitivity SENSI_1 =
-      CurveParameterSensitivity.builder().sensitivities(MAP_1).build();
+  private static final CurveParameterSensitivities SENSI_1 =
+      CurveParameterSensitivities.builder().sensitivities(MAP_1).build();
 
   private static final Map<SensitivityKey, double[]> MAP_2 = ImmutableMap.of(KEY_USD, VECTOR_USD2, KEY_EUR, VECTOR_EUR1);
-  private static final CurveParameterSensitivity SENSI_2 =
-      CurveParameterSensitivity.builder().sensitivities(MAP_2).build();
+  private static final CurveParameterSensitivities SENSI_2 =
+      CurveParameterSensitivities.builder().sensitivities(MAP_2).build();
 
   private static final double TOLERENCE_CMP = 1.0E-8;
 
   //-------------------------------------------------------------------------
   public void test_empty() {
-    CurveParameterSensitivity test = CurveParameterSensitivity.empty();
+    CurveParameterSensitivities test = CurveParameterSensitivities.empty();
     assertThat(test.getSensitivities()).hasSize(0);
   }
 
   public void test_of_single() {
-    CurveParameterSensitivity test = CurveParameterSensitivity.of(KEY_USD, VECTOR_USD2);
+    CurveParameterSensitivities test = CurveParameterSensitivities.of(KEY_USD, VECTOR_USD2);
     assertThat(test.getSensitivities())
         .hasSize(1)
         .containsKey(KEY_USD)
@@ -68,7 +68,7 @@ public class CurveParameterSensitivityTest {
 
   public void test_of_map() {
     Map<SensitivityKey, double[]> map = ImmutableMap.of(KEY_USD, TOTAL_USD);
-    CurveParameterSensitivity test = CurveParameterSensitivity.of(map);
+    CurveParameterSensitivities test = CurveParameterSensitivities.of(map);
     assertThat(test.getSensitivities())
         .hasSize(1)
         .containsKey(KEY_USD)
@@ -77,9 +77,9 @@ public class CurveParameterSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_combinedWith_one() {
-    CurveParameterSensitivity test = SENSI_1.combinedWith(KEY_USD, VECTOR_USD2);
+    CurveParameterSensitivities test = SENSI_1.combinedWith(KEY_USD, VECTOR_USD2);
     Map<SensitivityKey, double[]> map = ImmutableMap.of(KEY_USD, TOTAL_USD);
-    CurveParameterSensitivity expected = CurveParameterSensitivity.builder().sensitivities(map).build();
+    CurveParameterSensitivities expected = CurveParameterSensitivities.builder().sensitivities(map).build();
     assertThat(test).isEqualTo(expected);
   }
 
@@ -88,25 +88,25 @@ public class CurveParameterSensitivityTest {
   }
 
   public void test_combinedWith_other() {
-    CurveParameterSensitivity test = SENSI_1.combinedWith(SENSI_2);
+    CurveParameterSensitivities test = SENSI_1.combinedWith(SENSI_2);
     Map<SensitivityKey, double[]> map = ImmutableMap.of(KEY_USD, TOTAL_USD, KEY_EUR, VECTOR_EUR1);
-    CurveParameterSensitivity expected = CurveParameterSensitivity.builder().sensitivities(map).build();
+    CurveParameterSensitivities expected = CurveParameterSensitivities.builder().sensitivities(map).build();
     assertThat(test).isEqualTo(expected);
   }
 
   public void test_combinedWith_otherEmpty() {
-    CurveParameterSensitivity test = SENSI_1.combinedWith(CurveParameterSensitivity.empty());
+    CurveParameterSensitivities test = SENSI_1.combinedWith(CurveParameterSensitivities.empty());
     assertThat(test).isSameAs(SENSI_1);
   }
 
   public void test_combinedWith_empty() {
-    CurveParameterSensitivity test = CurveParameterSensitivity.empty().combinedWith(SENSI_1);
+    CurveParameterSensitivities test = CurveParameterSensitivities.empty().combinedWith(SENSI_1);
     assertThat(test).isSameAs(SENSI_1);
   }
 
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
-    CurveParameterSensitivity multiplied = SENSI_1.multipliedBy(FACTOR1);
+    CurveParameterSensitivities multiplied = SENSI_1.multipliedBy(FACTOR1);
     double[] test = multiplied.getSensitivities().get(KEY_USD);
     for (int i = 0; i < VECTOR_USD1.length; i++) {
       assertThat(test[i]).isEqualTo(VECTOR_USD1[i] * FACTOR1);
@@ -114,7 +114,7 @@ public class CurveParameterSensitivityTest {
   }
 
   public void test_mapSensitivity() {
-    CurveParameterSensitivity multiplied = SENSI_1.mapSensitivity(a -> 1 / a);
+    CurveParameterSensitivities multiplied = SENSI_1.mapSensitivity(a -> 1 / a);
     double[] test = multiplied.getSensitivities().get(KEY_USD);
     for (int i = 0; i < VECTOR_USD1.length; i++) {
       assertThat(test[i]).isEqualTo(1 / VECTOR_USD1[i]);
@@ -122,8 +122,8 @@ public class CurveParameterSensitivityTest {
   }
 
   public void test_multipliedBy_vs_combinedWith() {
-    CurveParameterSensitivity multiplied = SENSI_2.multipliedBy(2d);
-    CurveParameterSensitivity added = SENSI_2.combinedWith(SENSI_2);
+    CurveParameterSensitivities multiplied = SENSI_2.multipliedBy(2d);
+    CurveParameterSensitivities added = SENSI_2.combinedWith(SENSI_2);
     assertThat(multiplied).isEqualTo(added);
   }
 
@@ -153,22 +153,22 @@ public class CurveParameterSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_equalWithTolerance() {
     assertThat(SENSI_1.equalWithTolerance(SENSI_1, TOLERENCE_CMP)).isTrue();
-    assertThat(SENSI_1.equalWithTolerance(CurveParameterSensitivity.of(KEY_USD, TOTAL_USD), TOLERENCE_CMP)).isFalse();
-    assertThat(SENSI_1.equalWithTolerance(CurveParameterSensitivity.of(KEY_USD, VECTOR_EUR1), TOLERENCE_CMP)).isFalse();
+    assertThat(SENSI_1.equalWithTolerance(CurveParameterSensitivities.of(KEY_USD, TOTAL_USD), TOLERENCE_CMP)).isFalse();
+    assertThat(SENSI_1.equalWithTolerance(CurveParameterSensitivities.of(KEY_USD, VECTOR_EUR1), TOLERENCE_CMP)).isFalse();
     assertThat(SENSI_1.equalWithTolerance(SENSI_2, TOLERENCE_CMP)).isFalse();
     assertThat(SENSI_2.equalWithTolerance(SENSI_1, TOLERENCE_CMP)).isFalse();
-    assertThat(SENSI_0.equalWithTolerance(CurveParameterSensitivity.empty(), TOLERENCE_CMP)).isTrue();
-    assertThat(CurveParameterSensitivity.empty().equalWithTolerance(SENSI_0, TOLERENCE_CMP)).isTrue();
+    assertThat(SENSI_0.equalWithTolerance(CurveParameterSensitivities.empty(), TOLERENCE_CMP)).isTrue();
+    assertThat(CurveParameterSensitivities.empty().equalWithTolerance(SENSI_0, TOLERENCE_CMP)).isTrue();
     assertThat(SENSI_2.equalWithTolerance(SENSI_2.combinedWith(SENSI_0), TOLERENCE_CMP)).isTrue();
     assertThat(SENSI_2.combinedWith(SENSI_0).equalWithTolerance(SENSI_2, TOLERENCE_CMP)).isTrue();
   }
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    coverImmutableBean(CurveParameterSensitivity.empty());
+    coverImmutableBean(CurveParameterSensitivities.empty());
     coverImmutableBean(SENSI_1);
     coverBeanEquals(SENSI_1, SENSI_2);
-    CurveParameterSensitivity test = CurveParameterSensitivity.of(KEY_USD, VECTOR_USD2);
+    CurveParameterSensitivities test = CurveParameterSensitivities.of(KEY_USD, VECTOR_USD2);
     coverBeanEquals(SENSI_1, test);
   }
 

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/PointSensitivitiesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/PointSensitivitiesTest.java
@@ -30,10 +30,10 @@ public class PointSensitivitiesTest {
   private static final PointSensitivity CS3 = ZeroRateSensitivity.of(GBP, date(2015, 8, 30), 32d);
   private static final PointSensitivity CS3B = ZeroRateSensitivity.of(GBP, date(2015, 8, 30), 3d);
 
-  public void test_of_single() {
-    PointSensitivities test = PointSensitivities.of(CS1);
-    assertEquals(test.getSensitivities(), ImmutableList.of(CS1));
-    assertEquals(test.size(), 1);
+  public void test_of_array() {
+    PointSensitivities test = PointSensitivities.of(CS1, CS2);
+    assertEquals(test.getSensitivities(), ImmutableList.of(CS1, CS2));
+    assertEquals(test.size(), 2);
   }
 
   public void test_of_List() {
@@ -76,7 +76,7 @@ public class PointSensitivitiesTest {
   }
 
   public void test_normalized_empty() {
-    assertEquals(PointSensitivities.NONE.normalized(), PointSensitivities.NONE);
+    assertEquals(PointSensitivities.empty().normalized(), PointSensitivities.empty());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/value/DiscountIborIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/value/DiscountIborIndexRatesTest.java
@@ -152,7 +152,7 @@ public class DiscountIborIndexRatesTest {
     DiscountIborIndexRates test = DiscountIborIndexRates.of(GBP_LIBOR_3M, SERIES, DFCURVE);
     double relativeTime = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
     double[] expected = CURVE.yValueParameterSensitivity(relativeTime);
-    assertEquals(test.parameterSensitivity(DATE_AFTER), expected);
+    assertEquals(test.unitParameterSensitivity(DATE_AFTER), expected);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/value/DiscountOvernightIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/value/DiscountOvernightIndexRatesTest.java
@@ -180,7 +180,7 @@ public class DiscountOvernightIndexRatesTest {
     DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, SERIES, DFCURVE);
     double relativeTime = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
     double[] expected = CURVE.yValueParameterSensitivity(relativeTime);
-    assertEquals(test.parameterSensitivity(DATE_AFTER), expected);
+    assertEquals(test.unitParameterSensitivity(DATE_AFTER), expected);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/value/ForwardPriceIndexValuesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/value/ForwardPriceIndexValuesTest.java
@@ -143,7 +143,7 @@ public class ForwardPriceIndexValuesTest {
   public void test_curve_sensitivity() {
     double shift = 0.0001;
     for (int i = 0; i < TEST_MONTHS.length; i++) {
-      double[] sensitivityComputed = INSTANCE.parameterSensitivity(TEST_MONTHS[i]);
+      double[] sensitivityComputed = INSTANCE.unitParameterSensitivity(TEST_MONTHS[i]);
       double[] sensitivityExpected = new double[VALUES.length];
       for (int j = 0; j < VALUES.length; j++) {
         double[] valueFd = new double[2];

--- a/modules/market/src/test/java/com/opengamma/strata/market/value/ZeroRateDiscountFactorsTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/value/ZeroRateDiscountFactorsTest.java
@@ -88,7 +88,7 @@ public class ZeroRateDiscountFactorsTest {
     ZeroRateDiscountFactors test = ZeroRateDiscountFactors.of(GBP, DATE_VAL, ACT_365F, CURVE);
     double relativeTime = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
     double[] expected = YIELD_CURVE.getInterestRateParameterSensitivity(relativeTime);
-    assertEquals(test.parameterSensitivity(DATE_AFTER), expected);
+    assertEquals(test.unitParameterSensitivity(DATE_AFTER), expected);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer-beta/src/main/java/com/opengamma/strata/pricer/sensitivity/MarketQuoteSensitivityCalculator.java
+++ b/modules/pricer-beta/src/main/java/com/opengamma/strata/pricer/sensitivity/MarketQuoteSensitivityCalculator.java
@@ -17,7 +17,7 @@ import com.opengamma.analytics.math.matrix.OGMatrixAlgebra;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.tuple.Pair;
 import com.opengamma.strata.market.curve.CurveName;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.NameCurrencySensitivityKey;
 import com.opengamma.strata.market.sensitivity.NameSensitivityKey;
 import com.opengamma.strata.market.sensitivity.SensitivityKey;
@@ -38,12 +38,12 @@ public class MarketQuoteSensitivityCalculator {
   private static final MatrixAlgebra MATRIX_ALGEBRA = new OGMatrixAlgebra();
   //TODO: The method internally uses DoubleMatrix1D and DoubleMatrix2D. This should be reviewed.
   
-  public CurveParameterSensitivity fromParameterSensitivity(CurveParameterSensitivity parameterSensitivity,
+  public CurveParameterSensitivities fromParameterSensitivity(CurveParameterSensitivities parameterSensitivity,
       CurveBuildingBlockBundle blocks) {
     ArgChecker.notNull(parameterSensitivity, "Sensitivity");
     ArgChecker.notNull(blocks, "Units");
     ImmutableMap<SensitivityKey, double[]> sensitivityMap = parameterSensitivity.getSensitivities();
-    CurveParameterSensitivity result = CurveParameterSensitivity.empty();
+    CurveParameterSensitivities result = CurveParameterSensitivities.empty();
     for(Entry<SensitivityKey, double[]> entry: sensitivityMap.entrySet()) {
       SensitivityKey key = entry.getKey();
       // TODO: improve types of sensitivity key

--- a/modules/pricer-beta/src/test/java/com/opengamma/strata/pricer/rate/swaption/NormalSwaptionProductPricerTest.java
+++ b/modules/pricer-beta/src/test/java/com/opengamma/strata/pricer/rate/swaption/NormalSwaptionProductPricerTest.java
@@ -45,7 +45,7 @@ import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.Swap;
 import com.opengamma.strata.finance.rate.swap.SwapLegType;
 import com.opengamma.strata.finance.rate.swaption.Swaption;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.datasets.RatesProviderDataSets;
 import com.opengamma.strata.pricer.provider.NormalVolatilityExpiryTenorSwaptionProvider;
@@ -160,8 +160,8 @@ public class NormalSwaptionProductPricerTest {
   public void present_value_sensitivity_FD() {
     PointSensitivities pvpt = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT).build();
-    CurveParameterSensitivity pvpsAd = MULTI_USD.parameterSensitivity(pvpt);
-    CurveParameterSensitivity pvpsFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(MULTI_USD,
+    CurveParameterSensitivities pvpsAd = MULTI_USD.parameterSensitivity(pvpt);
+    CurveParameterSensitivities pvpsFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(MULTI_USD,
         (p) -> PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, p, NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT));
     assertTrue(pvpsAd.equalWithTolerance(pvpsFd, TOLERANCE_PV_DELTA));
   }
@@ -172,8 +172,8 @@ public class NormalSwaptionProductPricerTest {
         .presentValueSensitivityStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD).build();
     PointSensitivities pvptShort = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD).build();
-    CurveParameterSensitivity pvpsLong = MULTI_USD.parameterSensitivity(pvptLong);
-    CurveParameterSensitivity pvpsShort = MULTI_USD.parameterSensitivity(pvptShort);
+    CurveParameterSensitivities pvpsLong = MULTI_USD.parameterSensitivity(pvptLong);
+    CurveParameterSensitivities pvpsShort = MULTI_USD.parameterSensitivity(pvptShort);
     assertTrue(pvpsLong.equalWithTolerance(pvpsShort.multipliedBy(-1.0), TOLERANCE_PV_DELTA));
   }
   
@@ -184,9 +184,9 @@ public class NormalSwaptionProductPricerTest {
     PointSensitivities pvptShortRec = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD).build();
     PointSensitivities pvptSwapRec = PRICER_SWAP.presentValueSensitivity(SWAP_PAY, MULTI_USD).build();
-    CurveParameterSensitivity pvpsLongPay = MULTI_USD.parameterSensitivity(pvptLongPay);
-    CurveParameterSensitivity pvpsShortRec = MULTI_USD.parameterSensitivity(pvptShortRec);
-    CurveParameterSensitivity pvpsSwapRec = MULTI_USD.parameterSensitivity(pvptSwapRec);
+    CurveParameterSensitivities pvpsLongPay = MULTI_USD.parameterSensitivity(pvptLongPay);
+    CurveParameterSensitivities pvpsShortRec = MULTI_USD.parameterSensitivity(pvptShortRec);
+    CurveParameterSensitivities pvpsSwapRec = MULTI_USD.parameterSensitivity(pvptSwapRec);
     assertTrue(pvpsLongPay.combinedWith(pvpsShortRec).equalWithTolerance(pvpsSwapRec, TOLERANCE_PV_DELTA));
   }
   

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/PriceIndexProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/PriceIndexProvider.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ListMultimap;
 import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.tuple.ObjectDoublePair;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.IndexCurrencySensitivityKey;
 import com.opengamma.strata.market.sensitivity.InflationRateSensitivity;
 import com.opengamma.strata.market.sensitivity.NameCurrencySensitivityKey;
@@ -119,13 +119,13 @@ public final class PriceIndexProvider
   /**
    * Computes the parameter sensitivity.
    * <p>
-   * This computes the {@link CurveParameterSensitivity} associated with the {@link PointSensitivities}.
+   * This computes the {@link CurveParameterSensitivities} associated with the {@link PointSensitivities}.
    * This corresponds to the projection of the point sensitivity to the curve internal parameters representation.
    * 
    * @param pointSensitivities the point sensitivity
    * @return  the sensitivity to the curve parameters
    */
-  public CurveParameterSensitivity parameterSensitivity(PointSensitivities pointSensitivities) {
+  public CurveParameterSensitivities parameterSensitivity(PointSensitivities pointSensitivities) {
 
     Map<SensitivityKey, double[]> mutableMap = new HashMap<>();
     // group by currency
@@ -148,7 +148,7 @@ public final class PriceIndexProvider
       double[] sensiParam = parameterSensitivityIndex(values, grouped.get(key));
       mutableMap.merge(keyParam, sensiParam, PriceIndexProvider::combineArrays);
     }
-    return CurveParameterSensitivity.of(mutableMap);
+    return CurveParameterSensitivities.of(mutableMap);
   }
 
   // DoublesPair should contain a pair of reference time and point sensitivity value
@@ -156,10 +156,10 @@ public final class PriceIndexProvider
     int nbParameters = values.getParameterCount();
     double[] result = new double[nbParameters];
     for (ObjectDoublePair<YearMonth> timeAndS : pointSensitivity) {
-      double[] sensiPt = values.parameterSensitivity(timeAndS.getFirst());
+      double[] unitSens = values.unitParameterSensitivity(timeAndS.getFirst());
       double forwardBar = timeAndS.getSecond();
       for (int i = 0; i < nbParameters; i++) {
-        result[i] += sensiPt[i] * forwardBar;
+        result[i] += unitSens[i] * forwardBar;
       }
     }
     return result;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import com.opengamma.strata.basics.index.FxIndex;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.OvernightIndex;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.value.FxIndexRates;
 import com.opengamma.strata.market.value.IborIndexRates;
@@ -93,7 +93,7 @@ public interface RatesProvider
   /**
    * Computes the parameter sensitivity.
    * <p>
-   * This computes the {@link CurveParameterSensitivity} associated with the {@link PointSensitivities}.
+   * This computes the {@link CurveParameterSensitivities} associated with the {@link PointSensitivities}.
    * This corresponds to the projection of the point sensitivity to the curve internal parameters representation.
    * <p>
    * For example, the point sensitivities could represent the sensitivity to a date on the first
@@ -104,7 +104,7 @@ public interface RatesProvider
    * @param pointSensitivities  the point sensitivity
    * @return the sensitivity to the curve parameters
    */
-  CurveParameterSensitivity parameterSensitivity(PointSensitivities pointSensitivities);
+  CurveParameterSensitivities parameterSensitivity(PointSensitivities pointSensitivities);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/RatesFiniteDifferenceSensitivityCalculator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/RatesFiniteDifferenceSensitivityCalculator.java
@@ -17,7 +17,7 @@ import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.NodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.NameCurrencySensitivityKey;
 import com.opengamma.strata.market.sensitivity.SensitivityKey;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -62,27 +62,27 @@ public class RatesFiniteDifferenceSensitivityCalculator {
    * @param valueFn  the function from a rate provider to a currency amount for which the sensitivity should be computed
    * @return the sensitivity with the {@link SensitivityKey} containing the curves names.
    */
-  public CurveParameterSensitivity sensitivity(
+  public CurveParameterSensitivities sensitivity(
       ImmutableRatesProvider provider,
       Function<ImmutableRatesProvider, CurrencyAmount> valueFn) {
 
     CurrencyAmount valueInit = valueFn.apply(provider);
-    CurveParameterSensitivity discounting = sensitivity(
+    CurveParameterSensitivities discounting = sensitivity(
         provider, valueFn, ImmutableRatesProvider.meta().discountCurves(), valueInit);
-    CurveParameterSensitivity forward = sensitivity(
+    CurveParameterSensitivities forward = sensitivity(
         provider, valueFn, ImmutableRatesProvider.meta().indexCurves(), valueInit);
     return discounting.combinedWith(forward);
   }
 
   // computes the sensitivity with respect to the curves
-  private <T> CurveParameterSensitivity sensitivity(
+  private <T> CurveParameterSensitivities sensitivity(
       ImmutableRatesProvider provider,
       Function<ImmutableRatesProvider, CurrencyAmount> valueFn,
       MetaProperty<? extends Map<T, Curve>> metaProperty,
       CurrencyAmount valueInit) {
 
     Map<T, Curve> baseCurves = metaProperty.get(provider);
-    CurveParameterSensitivity result = CurveParameterSensitivity.empty();
+    CurveParameterSensitivities result = CurveParameterSensitivities.empty();
     for (Entry<T, Curve> entry : baseCurves.entrySet()) {
       NodalCurve curveInt = checkNodal(entry.getValue());
       int nbNodePoint = curveInt.getXValues().length;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
@@ -12,7 +12,7 @@ import com.opengamma.strata.basics.index.FxIndex;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.market.MarketDataKey;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.market.value.FxIndexRates;
@@ -96,7 +96,7 @@ public class MockRatesProvider
 
   //-------------------------------------------------------------------------
   @Override
-  public CurveParameterSensitivity parameterSensitivity(PointSensitivities pointSensitivities) {
+  public CurveParameterSensitivities parameterSensitivity(PointSensitivities pointSensitivities) {
     throw new UnsupportedOperationException();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ApproxForwardOvernightAveragedRateObservationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ApproxForwardOvernightAveragedRateObservationFnTest.java
@@ -30,7 +30,7 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeriesBuilder;
 import com.opengamma.strata.finance.rate.OvernightAveragedRateObservation;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.OvernightRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.value.OvernightIndexRates;
@@ -1114,9 +1114,9 @@ public class ApproxForwardOvernightAveragedRateObservationFnTest {
           .build();
       PointSensitivityBuilder sensitivityBuilderComputed =
           OBS_FN_APPROX_FWD.rateSensitivity(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, prov);
-      CurveParameterSensitivity parameterSensitivityComputed =
+      CurveParameterSensitivities parameterSensitivityComputed =
           prov.parameterSensitivity(sensitivityBuilderComputed.build());
-      CurveParameterSensitivity parameterSensitivityExpected =
+      CurveParameterSensitivities parameterSensitivityExpected =
           CAL_FD.sensitivity(prov, (p) -> CurrencyAmount.of(USD_FED_FUND.getCurrency(),
               OBS_FN_APPROX_FWD.rate(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(parameterSensitivityExpected, EPS_FD * 10.0));
@@ -1138,9 +1138,9 @@ public class ApproxForwardOvernightAveragedRateObservationFnTest {
           .build();
       PointSensitivityBuilder sensitivityBuilderComputed =
           OBS_FN_APPROX_FWD.rateSensitivity(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, prov);
-      CurveParameterSensitivity parameterSensitivityComputed =
+      CurveParameterSensitivities parameterSensitivityComputed =
           prov.parameterSensitivity(sensitivityBuilderComputed.build());
-      CurveParameterSensitivity parameterSensitivityExpected =
+      CurveParameterSensitivities parameterSensitivityExpected =
           CAL_FD.sensitivity(prov, (p) -> CurrencyAmount.of(USD_FED_FUND.getCurrency(),
               OBS_FN_APPROX_FWD.rate(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(parameterSensitivityExpected, EPS_FD * 10.0));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardOvernightAveragedRateObservationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardOvernightAveragedRateObservationFnTest.java
@@ -32,7 +32,7 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeriesBuilder;
 import com.opengamma.strata.finance.rate.OvernightAveragedRateObservation;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.OvernightRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -334,10 +334,10 @@ public class ForwardOvernightAveragedRateObservationFnTest {
 
       PointSensitivityBuilder sensitivityBuilderComputed =
           obsFn.rateSensitivity(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, prov);
-      CurveParameterSensitivity parameterSensitivityComputed =
+      CurveParameterSensitivities parameterSensitivityComputed =
           prov.parameterSensitivity(sensitivityBuilderComputed.build());
 
-      CurveParameterSensitivity parameterSensitivityExpected =
+      CurveParameterSensitivities parameterSensitivityExpected =
           CAL_FD.sensitivity(prov, (p) -> CurrencyAmount.of(USD_FED_FUND.getCurrency(),
               obsFn.rate(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(parameterSensitivityExpected, EPS_FD * 10.0));
@@ -361,10 +361,10 @@ public class ForwardOvernightAveragedRateObservationFnTest {
 
       PointSensitivityBuilder sensitivityBuilderComputed =
           obsFn.rateSensitivity(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, prov);
-      CurveParameterSensitivity parameterSensitivityComputed =
+      CurveParameterSensitivities parameterSensitivityComputed =
           prov.parameterSensitivity(sensitivityBuilderComputed.build());
 
-      CurveParameterSensitivity parameterSensitivityExpected =
+      CurveParameterSensitivities parameterSensitivityExpected =
           CAL_FD.sensitivity(prov, (p) -> CurrencyAmount.of(CHF_TOIS.getCurrency(),
               obsFn.rate(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(parameterSensitivityExpected, EPS_FD * 10.0));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardOvernightCompoundedRateObservationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardOvernightCompoundedRateObservationFnTest.java
@@ -29,7 +29,7 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeriesBuilder;
 import com.opengamma.strata.finance.rate.OvernightCompoundedRateObservation;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.OvernightRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.value.OvernightIndexRates;
@@ -989,9 +989,9 @@ public class ForwardOvernightCompoundedRateObservationFnTest {
           .build();
       PointSensitivityBuilder sensitivityBuilderComputed =
           OBS_FWD_ONCMP.rateSensitivity(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, prov);
-      CurveParameterSensitivity parameterSensitivityComputed =
+      CurveParameterSensitivities parameterSensitivityComputed =
           prov.parameterSensitivity(sensitivityBuilderComputed.build());
-      CurveParameterSensitivity parameterSensitivityExpected =
+      CurveParameterSensitivities parameterSensitivityExpected =
           CAL_FD.sensitivity(prov, (p) -> CurrencyAmount.of(USD_FED_FUND.getCurrency(),
               OBS_FWD_ONCMP.rate(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(parameterSensitivityExpected, EPS_FD * 10.0));
@@ -1013,9 +1013,9 @@ public class ForwardOvernightCompoundedRateObservationFnTest {
           .build();
       PointSensitivityBuilder sensitivityBuilderComputed =
           OBS_FWD_ONCMP.rateSensitivity(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, prov);
-      CurveParameterSensitivity parameterSensitivityComputed =
+      CurveParameterSensitivities parameterSensitivityComputed =
           prov.parameterSensitivity(sensitivityBuilderComputed.build());
-      CurveParameterSensitivity parameterSensitivityExpected =
+      CurveParameterSensitivities parameterSensitivityExpected =
           CAL_FD.sensitivity(prov, (p) -> CurrencyAmount.of(USD_FED_FUND.getCurrency(),
               OBS_FWD_ONCMP.rate(ro, DUMMY_ACCRUAL_START_DATE, DUMMY_ACCRUAL_END_DATE, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(parameterSensitivityExpected, EPS_FD * 10.0));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingFxResetNotionalExchangePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingFxResetNotionalExchangePricerTest.java
@@ -29,7 +29,7 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.rate.swap.FxResetNotionalExchange;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.market.value.FxIndexRates;
@@ -98,9 +98,9 @@ public class DiscountingFxResetNotionalExchangePricerTest {
       DiscountingFxResetNotionalExchangePricer test = new DiscountingFxResetNotionalExchangePricer();
 
       PointSensitivityBuilder pointSensitivityComputed = test.presentValueSensitivity(expanded[i], prov);
-      CurveParameterSensitivity parameterSensitivityComputed = prov.parameterSensitivity(
+      CurveParameterSensitivities parameterSensitivityComputed = prov.parameterSensitivity(
           pointSensitivityComputed.build());
-      CurveParameterSensitivity parameterSensitivityExpected = FD_CALCULATOR.sensitivity(
+      CurveParameterSensitivities parameterSensitivityExpected = FD_CALCULATOR.sensitivity(
           prov, (p) -> CurrencyAmount.of(fxReset.getCurrency(), test.presentValue(fxReset, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(
           parameterSensitivityExpected, Math.abs(expanded[i].getNotional()) * EPS_FD * 10.0));
@@ -137,9 +137,9 @@ public class DiscountingFxResetNotionalExchangePricerTest {
       DiscountingFxResetNotionalExchangePricer test = new DiscountingFxResetNotionalExchangePricer();
 
       PointSensitivityBuilder pointSensitivityComputed = test.futureValueSensitivity(expanded[i], prov);
-      CurveParameterSensitivity parameterSensitivityComputed = prov.parameterSensitivity(
+      CurveParameterSensitivities parameterSensitivityComputed = prov.parameterSensitivity(
           pointSensitivityComputed.build());
-      CurveParameterSensitivity parameterSensitivityExpected = FD_CALCULATOR.sensitivity(
+      CurveParameterSensitivities parameterSensitivityExpected = FD_CALCULATOR.sensitivity(
           prov, (p) -> CurrencyAmount.of(fxReset.getCurrency(), test.futureValue(fxReset, (p))));
       assertTrue(parameterSensitivityComputed.equalWithTolerance(
           parameterSensitivityExpected, Math.abs(expanded[i].getNotional()) * EPS_FD * 10.0));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingNotionalExchangePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingNotionalExchangePricerTest.java
@@ -87,7 +87,7 @@ public class DiscountingNotionalExchangePricerTest {
     PointSensitivities senseComputed = pricer.futureValueSensitivity(NOTIONAL_EXCHANGE_REC_GBP, mockProv).build();
 
     double eps = 1.0e-12;
-    PointSensitivities senseExpected = PointSensitivities.NONE;
+    PointSensitivities senseExpected = PointSensitivities.empty();
     assertTrue(senseComputed.equalWithTolerance(
         senseExpected, NOTIONAL_EXCHANGE_REC_GBP.getPaymentAmount().getAmount() * eps));
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerTest.java
@@ -35,7 +35,7 @@ import com.opengamma.strata.finance.rate.swap.FxReset;
 import com.opengamma.strata.finance.rate.swap.NegativeRateMethod;
 import com.opengamma.strata.finance.rate.swap.RateAccrualPeriod;
 import com.opengamma.strata.finance.rate.swap.RatePaymentPeriod;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -476,18 +476,18 @@ public class DiscountingRatePaymentPeriodPricerTest {
     ImmutableRatesProvider provider = MULTI_GBP_USD;
     PointSensitivityBuilder pointSensiComputedUSD =
         pricer.futureValueSensitivity(PAYMENT_PERIOD_FULL_GS_FX_USD, provider);
-    CurveParameterSensitivity sensiComputedUSD =
+    CurveParameterSensitivities sensiComputedUSD =
         provider.parameterSensitivity(pointSensiComputedUSD.build().normalized());
-    CurveParameterSensitivity sensiExpectedUSD = CAL_FD.sensitivity(
+    CurveParameterSensitivities sensiExpectedUSD = CAL_FD.sensitivity(
         provider, (p) -> CurrencyAmount.of(USD, pricer.futureValue(PAYMENT_PERIOD_FULL_GS_FX_USD, (p))));
     assertTrue(sensiComputedUSD.equalWithTolerance(
         sensiExpectedUSD, EPS_FD * PAYMENT_PERIOD_FULL_GS_FX_USD.getNotional()));
 
     PointSensitivityBuilder pointSensiComputedGBP =
         pricer.futureValueSensitivity(PAYMENT_PERIOD_FULL_GS_FX_GBP, provider);
-    CurveParameterSensitivity sensiComputedGBP =
+    CurveParameterSensitivities sensiComputedGBP =
         provider.parameterSensitivity(pointSensiComputedGBP.build().normalized());
-    CurveParameterSensitivity sensiExpectedGBP = CAL_FD.sensitivity(
+    CurveParameterSensitivities sensiExpectedGBP = CAL_FD.sensitivity(
         provider, (p) -> CurrencyAmount.of(GBP, pricer.futureValue(PAYMENT_PERIOD_FULL_GS_FX_GBP, (p))));
     assertTrue(sensiComputedGBP.equalWithTolerance(
         sensiExpectedGBP, EPS_FD * PAYMENT_PERIOD_FULL_GS_FX_GBP.getNotional()));
@@ -498,18 +498,18 @@ public class DiscountingRatePaymentPeriodPricerTest {
     ImmutableRatesProvider provider = MULTI_GBP_USD;
     PointSensitivityBuilder pointSensiComputedUSD =
         pricer.presentValueSensitivity(PAYMENT_PERIOD_FULL_GS_FX_USD, provider);
-    CurveParameterSensitivity sensiComputedUSD =
+    CurveParameterSensitivities sensiComputedUSD =
         provider.parameterSensitivity(pointSensiComputedUSD.build().normalized());
-    CurveParameterSensitivity sensiExpectedUSD = CAL_FD.sensitivity(
+    CurveParameterSensitivities sensiExpectedUSD = CAL_FD.sensitivity(
         provider, (p) -> CurrencyAmount.of(USD, pricer.presentValue(PAYMENT_PERIOD_FULL_GS_FX_USD, (p))));
     assertTrue(sensiComputedUSD.equalWithTolerance(
         sensiExpectedUSD, EPS_FD * PAYMENT_PERIOD_FULL_GS_FX_USD.getNotional()));
 
     PointSensitivityBuilder pointSensiComputedGBP =
         pricer.presentValueSensitivity(PAYMENT_PERIOD_FULL_GS_FX_GBP, provider);
-    CurveParameterSensitivity sensiComputedGBP =
+    CurveParameterSensitivities sensiComputedGBP =
         provider.parameterSensitivity(pointSensiComputedGBP.build().normalized());
-    CurveParameterSensitivity sensiExpectedGBP = CAL_FD.sensitivity(
+    CurveParameterSensitivities sensiExpectedGBP = CAL_FD.sensitivity(
         provider, (p) -> CurrencyAmount.of(GBP, pricer.presentValue(PAYMENT_PERIOD_FULL_GS_FX_GBP, (p))));
     assertTrue(sensiComputedGBP.equalWithTolerance(
         sensiExpectedGBP, EPS_FD * PAYMENT_PERIOD_FULL_GS_FX_GBP.getNotional()));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
@@ -39,7 +39,7 @@ import com.opengamma.strata.collect.tuple.DoublesPair;
 import com.opengamma.strata.collect.tuple.Pair;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveMetadata;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.FxIndexSensitivity;
 import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
 import com.opengamma.strata.market.sensitivity.NameCurrencySensitivityKey;
@@ -134,29 +134,29 @@ public class ImmutableRatesProviderParameterSensitivityTest {
   private static final double TOLERANCE_SENSI = 1.0E-8;
 
   public void pointToParameterOnePointZero() {
-    CurveParameterSensitivity ps = PROVIDER.parameterSensitivity(POINT_ZERO_1);
+    CurveParameterSensitivities ps = PROVIDER.parameterSensitivity(POINT_ZERO_1);
     DoublesPair pair = DoublesPair.of(PROVIDER.relativeTime(DATE_1), AMOUNT_1);
     List<DoublesPair> list = new ArrayList<>();
     list.add(pair);
     double[] vectorExpected = MULTICURVE.parameterSensitivity(MULTICURVE.getName(USD), list);
     NameCurrencySensitivityKey key = NameCurrencySensitivityKey.of(MULTICURVE.getName(USD), USD);
-    CurveParameterSensitivity psExpected = CurveParameterSensitivity.of(key, vectorExpected);
+    CurveParameterSensitivities psExpected = CurveParameterSensitivities.of(key, vectorExpected);
     assertTrue(ps.equalWithTolerance(psExpected, TOLERANCE_SENSI));
   }
 
   public void pointToParameterOnePointZeroTwoCurrency() {
-    CurveParameterSensitivity ps = PROVIDER.parameterSensitivity(POINT_ZERO_4);
+    CurveParameterSensitivities ps = PROVIDER.parameterSensitivity(POINT_ZERO_4);
     DoublesPair pair = DoublesPair.of(PROVIDER.relativeTime(DATE_1), AMOUNT_1);
     List<DoublesPair> list = new ArrayList<>();
     list.add(pair);
     double[] vectorExpected = MULTICURVE.parameterSensitivity(MULTICURVE.getName(EUR), list);
     NameCurrencySensitivityKey key = NameCurrencySensitivityKey.of(MULTICURVE.getName(EUR), USD);
-    CurveParameterSensitivity psExpected = CurveParameterSensitivity.of(key, vectorExpected);
+    CurveParameterSensitivities psExpected = CurveParameterSensitivities.of(key, vectorExpected);
     assertTrue(ps.equalWithTolerance(psExpected, TOLERANCE_SENSI));
   }
 
   public void pointToParameterOnePointIbor() {
-    CurveParameterSensitivity ps = PROVIDER.parameterSensitivity(POINT_IBOR_1);
+    CurveParameterSensitivities ps = PROVIDER.parameterSensitivity(POINT_IBOR_1);
     LocalDate startDate = USD_LIBOR_3M.calculateEffectiveFromFixing(DATE_1);
     LocalDate endDate = USD_LIBOR_3M.calculateMaturityFromEffective(startDate);
     double startTime = PROVIDER.relativeTime(startDate);
@@ -168,12 +168,12 @@ public class ImmutableRatesProviderParameterSensitivityTest {
     String curveName = MULTICURVE.getName(Legacy.iborIndex(USD_LIBOR_3M));
     double[] vectorExpected = MULTICURVE.parameterForwardSensitivity(curveName, list);
     NameCurrencySensitivityKey key = NameCurrencySensitivityKey.of(curveName, USD);
-    CurveParameterSensitivity psExpected = CurveParameterSensitivity.of(key, vectorExpected);
+    CurveParameterSensitivities psExpected = CurveParameterSensitivities.of(key, vectorExpected);
     assertTrue(ps.equalWithTolerance(psExpected, TOLERANCE_SENSI));
   }
 
   public void pointToParameterOnePointOnOneDate() {
-    CurveParameterSensitivity ps = PROVIDER.parameterSensitivity(POINT_ON_1);
+    CurveParameterSensitivities ps = PROVIDER.parameterSensitivity(POINT_ON_1);
     LocalDate startDate = USD_FED_FUND.calculateEffectiveFromFixing(DATE_1);
     LocalDate endDate = USD_FED_FUND.calculateMaturityFromEffective(startDate);
     double startTime = PROVIDER.relativeTime(startDate);
@@ -185,12 +185,12 @@ public class ImmutableRatesProviderParameterSensitivityTest {
     String curveName = MULTICURVE.getName(Legacy.overnightIndex(USD_FED_FUND));
     double[] vectorExpected = MULTICURVE.parameterForwardSensitivity(curveName, list);
     NameCurrencySensitivityKey key = NameCurrencySensitivityKey.of(curveName, USD);
-    CurveParameterSensitivity psExpected = CurveParameterSensitivity.of(key, vectorExpected);
+    CurveParameterSensitivities psExpected = CurveParameterSensitivities.of(key, vectorExpected);
     assertTrue(ps.equalWithTolerance(psExpected, TOLERANCE_SENSI));
   }
 
   public void pointToParameterOnePointOnTwoDates() {
-    CurveParameterSensitivity psComputed = PROVIDER.parameterSensitivity(POINT_ON_2);
+    CurveParameterSensitivities psComputed = PROVIDER.parameterSensitivity(POINT_ON_2);
     LocalDate startDate = USD_FED_FUND.calculateEffectiveFromFixing(DATE_1);
     double startTime = PROVIDER.relativeTime(startDate);
     double endTime = PROVIDER.relativeTime(DATE_2);
@@ -201,14 +201,14 @@ public class ImmutableRatesProviderParameterSensitivityTest {
     String curveName = MULTICURVE.getName(Legacy.overnightIndex(USD_FED_FUND));
     double[] vectorExpected = MULTICURVE.parameterForwardSensitivity(curveName, list);
     NameCurrencySensitivityKey key = NameCurrencySensitivityKey.of(curveName, USD);
-    CurveParameterSensitivity psExpected = CurveParameterSensitivity.of(key, vectorExpected);
+    CurveParameterSensitivities psExpected = CurveParameterSensitivities.of(key, vectorExpected);
     assertTrue(psComputed.equalWithTolerance(psExpected, TOLERANCE_SENSI));
   }
 
   public void pointToParameterMultiple() {
-    CurveParameterSensitivity psComputed = PROVIDER.parameterSensitivity(POINT);
+    CurveParameterSensitivities psComputed = PROVIDER.parameterSensitivity(POINT);
     assertEquals(psComputed.getSensitivities().size(), 6);
-    CurveParameterSensitivity psExpected = CurveParameterSensitivity.empty();
+    CurveParameterSensitivities psExpected = CurveParameterSensitivities.empty();
     for (int i = 0; i < POINTS.length; i++) {
       psExpected = psExpected.combinedWith(PROVIDER.parameterSensitivity(POINTS[i]));
     }
@@ -275,8 +275,8 @@ public class ImmutableRatesProviderParameterSensitivityTest {
         test_usd_dw.fxIndexRates(WM_GBP_USD).rate(GBP, DATE_VAL)) / EPS_FD * (-maturityTime * USD_DSC);
     PointSensitivityBuilder sensiBuildDecGBP = ZeroRateSensitivity.of(GBP, USD, matuirtyDate, sense_gbp1);
     sensiBuildDecGBP = sensiBuildDecGBP.combinedWith(ZeroRateSensitivity.of(USD, USD, matuirtyDate, sense_usd1));
-    CurveParameterSensitivity paramSensiCmpGBP = test.parameterSensitivity(sensiBuildCmpGBP.build().normalized());
-    CurveParameterSensitivity paramSensiExpGBP = test.parameterSensitivity(sensiBuildDecGBP.build().normalized());
+    CurveParameterSensitivities paramSensiCmpGBP = test.parameterSensitivity(sensiBuildCmpGBP.build().normalized());
+    CurveParameterSensitivities paramSensiExpGBP = test.parameterSensitivity(sensiBuildDecGBP.build().normalized());
     assertTrue(paramSensiCmpGBP.equalWithTolerance(paramSensiExpGBP, EPS_FD));
     // USD based
     PointSensitivityBuilder sensiBuildCmpUSD = test.fxIndexRates(WM_GBP_USD).pointSensitivity(USD, DATE_VAL);
@@ -288,8 +288,8 @@ public class ImmutableRatesProviderParameterSensitivityTest {
         test_usd_dw.fxIndexRates(WM_GBP_USD).rate(USD, DATE_VAL)) / EPS_FD * (-maturityTime * USD_DSC);
     PointSensitivityBuilder sensiBuildDecUSD = ZeroRateSensitivity.of(GBP, GBP, matuirtyDate, sense_gbp2);
     sensiBuildDecUSD = sensiBuildDecUSD.combinedWith(ZeroRateSensitivity.of(USD, GBP, matuirtyDate, sense_usd2));
-    CurveParameterSensitivity paramSensiCmpUSD = test.parameterSensitivity(sensiBuildCmpUSD.build().normalized());
-    CurveParameterSensitivity paramSensiExpUSD = test.parameterSensitivity(sensiBuildDecUSD.build().normalized());
+    CurveParameterSensitivities paramSensiCmpUSD = test.parameterSensitivity(sensiBuildCmpUSD.build().normalized());
+    CurveParameterSensitivities paramSensiExpUSD = test.parameterSensitivity(sensiBuildDecUSD.build().normalized());
     assertTrue(paramSensiCmpUSD.equalWithTolerance(paramSensiExpUSD, EPS_FD));
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/PriceIndexProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/PriceIndexProviderTest.java
@@ -25,7 +25,7 @@ import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.InflationRateSensitivity;
 import com.opengamma.strata.market.sensitivity.NameCurrencySensitivityKey;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -81,8 +81,8 @@ public class PriceIndexProviderTest {
   public void test_parameterSensitivity_empty() {
     PointSensitivityBuilder pointSensi = PointSensitivityBuilder.none();
     PriceIndexProvider priceIndexProvider = PriceIndexProvider.empty();
-    CurveParameterSensitivity computed = priceIndexProvider.parameterSensitivity(pointSensi.build());
-    assertEquals(computed, CurveParameterSensitivity.empty());
+    CurveParameterSensitivities computed = priceIndexProvider.parameterSensitivity(pointSensi.build());
+    assertEquals(computed, CurveParameterSensitivities.empty());
   }
 
   public void test_parameterSensitivity() {
@@ -104,12 +104,12 @@ public class PriceIndexProviderTest {
     double pointSensiValue = 2.5;
     YearMonth refMonth = YearMonth.from(valuationDate.plusMonths(9));
     InflationRateSensitivity pointSensi = InflationRateSensitivity.of(GB_RPI, refMonth, pointSensiValue);
-    CurveParameterSensitivity computed = priceIndexProvider.parameterSensitivity(pointSensi.build());
+    CurveParameterSensitivities computed = priceIndexProvider.parameterSensitivity(pointSensi.build());
     double[] sensiComputed =
         computed.getSensitivities().get(NameCurrencySensitivityKey.of(curveName, pointSensi.getCurrency()));
 
     double[] sensiExpectedUnit =
-        priceIndexProvider.getPriceIndexValues().get(GB_RPI).parameterSensitivity(refMonth);
+        priceIndexProvider.getPriceIndexValues().get(GB_RPI).unitParameterSensitivity(refMonth);
     assertEquals(sensiComputed.length, sensiExpectedUnit.length);
     for (int i = 0; i < sensiComputed.length; ++i) {
       assertEquals(sensiComputed[i], sensiExpectedUnit[i] * pointSensiValue, eps);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimpleRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimpleRatesProvider.java
@@ -27,7 +27,7 @@ import com.opengamma.strata.basics.index.FxIndex;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.market.MarketDataKey;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.market.value.FxIndexRates;
@@ -116,7 +116,7 @@ public class SimpleRatesProvider
   }
 
   @Override
-  public CurveParameterSensitivity parameterSensitivity(PointSensitivities pointSensitivities) {
+  public CurveParameterSensitivities parameterSensitivity(PointSensitivities pointSensitivities) {
     throw new UnsupportedOperationException();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositProductPricerTest.java
@@ -29,7 +29,7 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.rate.deposit.ExpandedIborFixingDeposit;
 import com.opengamma.strata.finance.rate.deposit.IborFixingDeposit;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.impl.rate.ForwardIborRateObservationFn;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -118,8 +118,8 @@ public class DiscountingIborFixingDepositProductPricerTest {
   public void test_presentValueSensitivity() {
     DiscountingIborFixingDepositProductPricer test = DiscountingIborFixingDepositProductPricer.DEFAULT;
     PointSensitivities computed = test.presentValueSensitivity(DEPOSIT, IMM_PROV);
-    CurveParameterSensitivity sensiComputed = IMM_PROV.parameterSensitivity(computed);
-    CurveParameterSensitivity sensiExpected = CAL_FD.sensitivity(IMM_PROV, (p) -> test.presentValue(DEPOSIT, (p)));
+    CurveParameterSensitivities sensiComputed = IMM_PROV.parameterSensitivity(computed);
+    CurveParameterSensitivities sensiExpected = CAL_FD.sensitivity(IMM_PROV, (p) -> test.presentValue(DEPOSIT, (p)));
     assertTrue(sensiComputed.equalWithTolerance(sensiExpected, NOTIONAL * EPS_FD));
   }
 
@@ -180,8 +180,8 @@ public class DiscountingIborFixingDepositProductPricerTest {
   public void test_parSpreadSensitivity() {
     DiscountingIborFixingDepositProductPricer test = DiscountingIborFixingDepositProductPricer.DEFAULT;
     PointSensitivities computed = test.parSpreadSensitivity(DEPOSIT, IMM_PROV);
-    CurveParameterSensitivity sensiComputed = IMM_PROV.parameterSensitivity(computed);
-    CurveParameterSensitivity sensiExpected =
+    CurveParameterSensitivities sensiComputed = IMM_PROV.parameterSensitivity(computed);
+    CurveParameterSensitivities sensiExpected =
         CAL_FD.sensitivity(IMM_PROV, (p) -> CurrencyAmount.of(EUR, test.parSpread(DEPOSIT, (p))));
     assertTrue(sensiComputed.equalWithTolerance(sensiExpected, NOTIONAL * EPS_FD));
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingTermDepositProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingTermDepositProductPricerTest.java
@@ -28,7 +28,7 @@ import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
 import com.opengamma.strata.finance.rate.deposit.TermDeposit;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -120,8 +120,8 @@ public class DiscountingTermDepositProductPricerTest {
 
   public void test_presentValueSensitivity() {
     PointSensitivities computed = PRICER.presentValueSensitivity(TERM_DEPOSIT, IMM_PROV);
-    CurveParameterSensitivity sensiComputed = IMM_PROV.parameterSensitivity(computed);
-    CurveParameterSensitivity sensiExpected =
+    CurveParameterSensitivities sensiComputed = IMM_PROV.parameterSensitivity(computed);
+    CurveParameterSensitivities sensiExpected =
         CAL_FD.sensitivity(IMM_PROV, (p) -> PRICER.presentValue(TERM_DEPOSIT, (p)));
     assertTrue(sensiComputed.equalWithTolerance(sensiExpected, NOTIONAL * EPS_FD));
   }
@@ -162,8 +162,8 @@ public class DiscountingTermDepositProductPricerTest {
 
   public void test_parSpreadSensitivity() {
     PointSensitivities computed = PRICER.parSpreadSensitivity(TERM_DEPOSIT, IMM_PROV);
-    CurveParameterSensitivity sensiComputed = IMM_PROV.parameterSensitivity(computed);
-    CurveParameterSensitivity sensiExpected =
+    CurveParameterSensitivities sensiComputed = IMM_PROV.parameterSensitivity(computed);
+    CurveParameterSensitivities sensiExpected =
         CAL_FD.sensitivity(IMM_PROV, (p) -> CurrencyAmount.of(EUR, PRICER.parSpread(TERM_DEPOSIT, (p))));
     assertTrue(sensiComputed.equalWithTolerance(sensiExpected, NOTIONAL * EPS_FD));
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapLegPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapLegPricerTest.java
@@ -75,7 +75,7 @@ import com.opengamma.strata.market.amount.CashFlow;
 import com.opengamma.strata.market.amount.CashFlows;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -291,8 +291,8 @@ public class DiscountingSwapLegPricerTest {
   public void test_presentValueSensitivity_finiteDifference() {
     ExpandedSwapLeg expSwapLeg = IBOR_EXPANDED_SWAP_LEG_REC_GBP;
     PointSensitivities point = PRICER_LEG.presentValueSensitivity(expSwapLeg, RATES_GBP).build();
-    CurveParameterSensitivity psAd = RATES_GBP.parameterSensitivity(point);
-    CurveParameterSensitivity psFd =
+    CurveParameterSensitivities psAd = RATES_GBP.parameterSensitivity(point);
+    CurveParameterSensitivities psFd =
         FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_GBP, (p) -> PRICER_LEG.presentValue(expSwapLeg, p));
     ImmutableMap<SensitivityKey, double[]> mapAd = psAd.getSensitivities();
     ImmutableMap<SensitivityKey, double[]> mapFd = psFd.getSensitivities();
@@ -304,8 +304,8 @@ public class DiscountingSwapLegPricerTest {
   public void test_presentValueSensitivity_events() {
     ExpandedSwapLeg expSwapLeg = IBOR_EXPANDED_SWAP_LEG_REC_GBP;
     PointSensitivities point = PRICER_LEG.presentValueSensitivityEventsInternal(expSwapLeg, RATES_GBP).build();
-    CurveParameterSensitivity psAd = RATES_GBP.parameterSensitivity(point);
-    CurveParameterSensitivity psFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_GBP,
+    CurveParameterSensitivities psAd = RATES_GBP.parameterSensitivity(point);
+    CurveParameterSensitivities psFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_GBP,
         (p) -> CurrencyAmount.of(GBP, PRICER_LEG.presentValueEventsInternal(expSwapLeg, p)));
     assertTrue(psAd.equalWithTolerance(psFd, TOLERANCE_DELTA));
   }
@@ -313,8 +313,8 @@ public class DiscountingSwapLegPricerTest {
   public void test_presentValueSensitivity_periods() {
     ExpandedSwapLeg expSwapLeg = IBOR_EXPANDED_SWAP_LEG_REC_GBP;
     PointSensitivities point = PRICER_LEG.presentValueSensitivityPeriodsInternal(expSwapLeg, RATES_GBP).build();
-    CurveParameterSensitivity psAd = RATES_GBP.parameterSensitivity(point);
-    CurveParameterSensitivity psFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_GBP,
+    CurveParameterSensitivities psAd = RATES_GBP.parameterSensitivity(point);
+    CurveParameterSensitivities psFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_GBP,
         (p) -> CurrencyAmount.of(GBP, PRICER_LEG.presentValuePeriodsInternal(expSwapLeg, p)));
     assertTrue(psAd.equalWithTolerance(psFd, TOLERANCE_DELTA));
   }
@@ -327,8 +327,8 @@ public class DiscountingSwapLegPricerTest {
         .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD_PAY_USD, FIXED_RATE_PAYMENT_PERIOD_PAY_USD_2)
         .build();
     PointSensitivities point = PRICER_LEG.pvbpSensitivity(leg, RATES_USD).build();
-    CurveParameterSensitivity pvbpsAd = RATES_USD.parameterSensitivity(point);
-    CurveParameterSensitivity pvbpsFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_USD,
+    CurveParameterSensitivities pvbpsAd = RATES_USD.parameterSensitivity(point);
+    CurveParameterSensitivities pvbpsFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(RATES_USD,
         (p) -> CurrencyAmount.of(USD, PRICER_LEG.pvbp(leg, p)));
     assertTrue(pvbpsAd.equalWithTolerance(pvbpsFd, TOLERANCE_DELTA));
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
@@ -70,7 +70,7 @@ import com.opengamma.strata.finance.rate.swap.Swap;
 import com.opengamma.strata.market.amount.CashFlow;
 import com.opengamma.strata.market.amount.CashFlows;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -438,8 +438,8 @@ public class DiscountingSwapProductPricerTest {
   public void test_parRateSensitivity_singleCurrency() {
     ExpandedSwap expanded = SWAP.expand();
     PointSensitivities point = PRICER_SWAP.parRateSensitivity(expanded, RATES_GBP).build();
-    CurveParameterSensitivity prAd = RATES_GBP.parameterSensitivity(point);
-    CurveParameterSensitivity prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
+    CurveParameterSensitivities prAd = RATES_GBP.parameterSensitivity(point);
+    CurveParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
         RATES_GBP, p -> CurrencyAmount.of(GBP, PRICER_SWAP.parRate(expanded, p)));
     assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
   }
@@ -447,8 +447,8 @@ public class DiscountingSwapProductPricerTest {
   public void test_parRateSensitivity_crossCurrency() {
     ExpandedSwap expanded = SWAP_CROSS_CURRENCY.expand();
     PointSensitivities point = PRICER_SWAP.parRateSensitivity(expanded, RATES_GBP_USD).build();
-    CurveParameterSensitivity prAd = RATES_GBP_USD.parameterSensitivity(point);
-    CurveParameterSensitivity prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
+    CurveParameterSensitivities prAd = RATES_GBP_USD.parameterSensitivity(point);
+    CurveParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
         RATES_GBP_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parRate(expanded, p)));
     assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/RatesFiniteDifferenceSensitivityCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/RatesFiniteDifferenceSensitivityCalculatorTest.java
@@ -19,7 +19,7 @@ import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
-import com.opengamma.strata.market.sensitivity.CurveParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.CurveParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.NameCurrencySensitivityKey;
 import com.opengamma.strata.market.sensitivity.SensitivityKey;
 import com.opengamma.strata.pricer.datasets.RatesProviderDataSets;
@@ -37,7 +37,7 @@ public class RatesFiniteDifferenceSensitivityCalculatorTest {
 
   @Test
   public void sensitivity_single_curve() {
-    CurveParameterSensitivity sensiComputed = FD_CALCULATOR.sensitivity(RatesProviderDataSets.USD_SINGLE, this::fn);
+    CurveParameterSensitivities sensiComputed = FD_CALCULATOR.sensitivity(RatesProviderDataSets.USD_SINGLE, this::fn);
     double[] times = RatesProviderDataSets.TIMES_1;
     ImmutableMap<SensitivityKey, double[]> sensi = sensiComputed.getSensitivities();
     assertEquals(sensi.size(), 1);
@@ -50,7 +50,7 @@ public class RatesFiniteDifferenceSensitivityCalculatorTest {
 
   @Test
   public void sensitivity_multi_curve() {
-    CurveParameterSensitivity sensiComputed = FD_CALCULATOR.sensitivity(RatesProviderDataSets.MULTI_USD, this::fn);
+    CurveParameterSensitivities sensiComputed = FD_CALCULATOR.sensitivity(RatesProviderDataSets.MULTI_USD, this::fn);
     double[] times1 = RatesProviderDataSets.TIMES_1;
     double[] times2 = RatesProviderDataSets.TIMES_2;
     double[] times3 = RatesProviderDataSets.TIMES_3;


### PR DESCRIPTION
Use "unit" for basic dimensionless curve paremeter sensitivity.
Rename CurveParameterSensitivity to CurveParameterSensitivities.
Change NONE to empty() in point sensitivities.
This is essentially a refactoring commit.
