### PR TITLE
Special handling of Results returned by functions

### DIFF
--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationTask.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationTask.java
@@ -108,7 +108,16 @@ public class CalculationTask {
    */
   public CalculationResult execute(ScenarioMarketData scenarioData) {
     CalculationMarketData calculationData = new DefaultCalculationMarketData(scenarioData, marketDataMappings);
-    Result<?> result = Result.of(() -> function.execute(target, calculationData));
+    Result<?> result;
+
+    try {
+      Object value = function.execute(target, calculationData);
+      result = value instanceof Result ?
+          (Result<?>) value :
+          Result.success(value);
+    } catch (RuntimeException e) {
+      result = Result.failure(e);
+    }
     return CalculationResult.of(target, rowIndex, columnIndex, convertToReportingCurrency(result, calculationData));
   }
 


### PR DESCRIPTION
This PR adds special case behaviour if a function returns an instance of `Result`. Previously all return values were wrapped using `Result.success()`. This change adds a check to see if the value is already a `Result` and returns it without wrapping.

The initial plan was to add this behaviour directly to the `Result` class but the resulting type signature would have been a mess.
