### PR TITLE
Accurate node dates on TenorCurveNodeMetadata

### DIFF
--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/FraTemplate.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/FraTemplate.java
@@ -62,7 +62,7 @@ public final class FraTemplate
   @PropertyDefinition(validate = "notNull")
   private final Period periodToStart;
   /**
-   * The period between the spot value date and the start date.
+   * The period between the spot value date and the end date.
    * <p>
    * In a FRA described as '2 x 5', the period to the end date is 5 months.
    * The difference between the start date and the end date typically matches the tenor of the index,
@@ -225,7 +225,7 @@ public final class FraTemplate
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the period between the spot value date and the start date.
+   * Gets the period between the spot value date and the end date.
    * <p>
    * In a FRA described as '2 x 5', the period to the end date is 5 months.
    * The difference between the start date and the end date typically matches the tenor of the index,

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/config/FixedIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/config/FixedIborSwapCurveNode.java
@@ -26,6 +26,10 @@ import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.BuySell;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.finance.Trade;
+import com.opengamma.strata.finance.rate.swap.ExpandedSwap;
+import com.opengamma.strata.finance.rate.swap.ExpandedSwapLeg;
+import com.opengamma.strata.finance.rate.swap.SwapLegType;
+import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapTemplate;
 import com.opengamma.strata.market.curve.CurveParameterMetadata;
 import com.opengamma.strata.market.curve.TenorCurveNodeMetadata;
@@ -83,8 +87,10 @@ public final class FixedIborSwapCurveNode implements CurveNode, ImmutableBean {
 
   @Override
   public CurveParameterMetadata metadata(LocalDate valuationDate) {
-    // The swaps start at spot and the tenor of the swap is the tenor of the curve node.
-    return TenorCurveNodeMetadata.of(valuationDate.plus(template.getTenor()), template.getTenor());
+    SwapTrade trade = template.toTrade(valuationDate, BuySell.BUY, 1, 1);
+    ExpandedSwap expandedSwap = trade.getProduct().expand();
+    ExpandedSwapLeg fixedLeg = expandedSwap.getLegs(SwapLegType.FIXED).get(0);
+    return TenorCurveNodeMetadata.of(fixedLeg.getEndDate(), template.getTenor());
   }
 
   // returns the rate from the market data for the rate key or throws an exception if it isn't available

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/config/FraCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/config/FraCurveNode.java
@@ -27,7 +27,9 @@ import com.opengamma.strata.basics.BuySell;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.finance.Trade;
+import com.opengamma.strata.finance.rate.fra.ExpandedFra;
 import com.opengamma.strata.finance.rate.fra.FraTemplate;
+import com.opengamma.strata.finance.rate.fra.FraTrade;
 import com.opengamma.strata.market.curve.CurveParameterMetadata;
 import com.opengamma.strata.market.curve.TenorCurveNodeMetadata;
 
@@ -87,8 +89,9 @@ public final class FraCurveNode implements CurveNode, ImmutableBean {
 
   @Override
   public CurveParameterMetadata metadata(LocalDate valuationDate) {
-    Tenor endTenor = Tenor.of(template.getPeriodToEnd());
-    return TenorCurveNodeMetadata.of(valuationDate.plus(endTenor), endTenor);
+    FraTrade trade = template.toTrade(valuationDate, BuySell.BUY, 1, 1);
+    ExpandedFra expandedFra = trade.getProduct().expand();
+    return TenorCurveNodeMetadata.of(expandedFra.getEndDate(), Tenor.of(template.getPeriodToEnd()));
   }
 
   /**


### PR DESCRIPTION
This PR fixes the dates on `TenorCurveNodeMetadata` so they accurately reflect the date of the curve node.
