### PR TITLE
Add requirements for FX rates used in automatic currency conversion

### DIFF
--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationTask.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationTask.java
@@ -5,10 +5,16 @@
  */
 package com.opengamma.strata.engine.calculations;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
+import java.util.List;
 import java.util.Optional;
 
 import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyPair;
+import com.opengamma.strata.basics.market.FxRateKey;
+import com.opengamma.strata.basics.market.MarketDataId;
 import com.opengamma.strata.basics.market.MarketDataKey;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.result.FailureReason;
@@ -96,6 +102,25 @@ public class CalculationTask {
 
     for (MarketDataKey<?> key : calculationRequirements.getSingleValueRequirements()) {
       requirementsBuilder.addValues(marketDataMappings.getIdForKey(key));
+    }
+    Optional<Currency> optionalReportingCurrency = reportingRules.reportingCurrency(target);
+
+    if (optionalReportingCurrency.isPresent()) {
+      Currency reportingCurrency = optionalReportingCurrency.get();
+
+      // Add requirements for the FX rates needed to convert the output values into the reporting currency
+      // TODO This assumes there is a conventional pair for the combination.
+      //   If the pair has been created on the fly that isn't necessarily the case.
+      //   We need a consistent way across the whole system to construct pairs that have no market convention.
+      //   This means the pair created here will be the same pair used in the conversion code.
+      // TODO Change this when #283 is addressed. Hopefully simplify and don't worry about market convention pairs.
+      List<MarketDataId<Double>> fxRateIds = calculationRequirements.getOutputCurrencies().stream()
+          .map(outputCurrency -> CurrencyPair.of(outputCurrency, reportingCurrency))
+          .map(pair -> pair.isConventional() ? pair : pair.inverse())
+          .map(FxRateKey::of)
+          .map(marketDataMappings::getIdForKey)
+          .collect(toImmutableList());
+      requirementsBuilder.addValues(fxRateIds);
     }
     return requirementsBuilder.build();
   }

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/CalculationTaskTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/CalculationTaskTest.java
@@ -204,6 +204,19 @@ public class CalculationTaskTest {
     assertThat(result).isFailure(FailureReason.NOT_APPLICABLE).hasFailureMessageMatching("bar");
   }
 
+  /**
+   * Tests that requirements are added for the FX rates needed to convert the results into the reporting currency.
+   */
+  public void fxConversionRequirements() {
+    OutputCurrenciesFunction fn = new OutputCurrenciesFunction();
+    CalculationTask task = new CalculationTask(TARGET, 0, 0, fn, MAPPINGS, REPORTING_RULES);
+    MarketDataRequirements requirements = task.requirements();
+
+    assertThat(requirements.getNonObservables()).contains(
+        FxRateId.of(Currency.GBP, Currency.USD),
+        FxRateId.of(Currency.EUR, Currency.USD));
+  }
+
   //--------------------------------------------------------------------------------------------------------------------
 
   private static class TestTarget implements CalculationTarget { }
@@ -280,6 +293,24 @@ public class CalculationTaskTest {
     @Override
     public CalculationRequirements requirements(TestTarget target) {
       return CalculationRequirements.empty();
+    }
+  }
+
+  /**
+   * Function that returns requirements containing output currencies.
+   */
+  private static final class OutputCurrenciesFunction implements CalculationSingleFunction<TestTarget, Object> {
+
+    @Override
+    public Object execute(TestTarget target, CalculationMarketData marketData) {
+      throw new UnsupportedOperationException("execute not implemented");
+    }
+
+    @Override
+    public CalculationRequirements requirements(TestTarget target) {
+      return CalculationRequirements.builder()
+          .outputCurrencies(Currency.GBP, Currency.EUR)
+          .build();
     }
   }
 }


### PR DESCRIPTION
Enhance `CalculationTask` to add requirements for the FX rates needed to convert the calculated values into the reporting currency.

This provides the functionality needed to write example code using curves and scenarios. It will need to be revisited after #283 is complete.
