### PR TITLE
Fix requirements if output and reporting currencies are the same

### DIFF
--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationTask.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationTask.java
@@ -115,6 +115,7 @@ public class CalculationTask {
       //   This means the pair created here will be the same pair used in the conversion code.
       // TODO Change this when #283 is addressed. Hopefully simplify and don't worry about market convention pairs.
       List<MarketDataId<Double>> fxRateIds = calculationRequirements.getOutputCurrencies().stream()
+          .filter(outputCurrency -> !outputCurrency.equals(reportingCurrency))
           .map(outputCurrency -> CurrencyPair.of(outputCurrency, reportingCurrency))
           .map(pair -> pair.isConventional() ? pair : pair.inverse())
           .map(FxRateKey::of)

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/CalculationTaskTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/CalculationTaskTest.java
@@ -212,7 +212,7 @@ public class CalculationTaskTest {
     CalculationTask task = new CalculationTask(TARGET, 0, 0, fn, MAPPINGS, REPORTING_RULES);
     MarketDataRequirements requirements = task.requirements();
 
-    assertThat(requirements.getNonObservables()).contains(
+    assertThat(requirements.getNonObservables()).containsExactly(
         FxRateId.of(Currency.GBP, Currency.USD),
         FxRateId.of(Currency.EUR, Currency.USD));
   }
@@ -309,7 +309,7 @@ public class CalculationTaskTest {
     @Override
     public CalculationRequirements requirements(TestTarget target) {
       return CalculationRequirements.builder()
-          .outputCurrencies(Currency.GBP, Currency.EUR)
+          .outputCurrencies(Currency.GBP, Currency.EUR, Currency.USD)
           .build();
     }
   }


### PR DESCRIPTION
Ensure `CalculationTask` doesn't request an FX rate for currency conversion if the output and reporting currencies are the same.
