### PR TITLE
Use  a default reporting currency if the reporting rules don't specify one

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/FraPricingExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/FraPricingExample.java
@@ -11,7 +11,6 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.BuySell;
-import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.collect.id.StandardId;
 import com.opengamma.strata.engine.CalculationEngine;
@@ -63,7 +62,7 @@ public class FraPricingExample {
     CalculationRules rules = CalculationRules.builder()
         .pricingRules(OpenGammaPricingRules.standard())
         .marketDataRules(ExampleMarketData.rules())
-        .reportingRules(ReportingRules.fixedCurrency(Currency.USD))
+        .reportingRules(ReportingRules.empty())
         .build();
 
     // Use an empty snapshot of market data, indicating only the valuation date.

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SwapPricingExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SwapPricingExample.java
@@ -88,7 +88,7 @@ public class SwapPricingExample {
     CalculationRules rules = CalculationRules.builder()
         .pricingRules(OpenGammaPricingRules.standard())
         .marketDataRules(ExampleMarketData.rules())
-        .reportingRules(ReportingRules.fixedCurrency(Currency.USD))
+        .reportingRules(ReportingRules.empty())
         .build();
 
     // Use an empty snapshot of market data, indicating only the valuation date.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/function/CalculationFunction.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/function/CalculationFunction.java
@@ -5,7 +5,10 @@
  */
 package com.opengamma.strata.engine.calculations.function;
 
+import java.util.Optional;
+
 import com.opengamma.strata.basics.CalculationTarget;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.engine.marketdata.CalculationRequirements;
 
 /**
@@ -27,4 +30,21 @@ public interface CalculationFunction<T extends CalculationTarget> {
    * @return requirements specifying the market data the function needs to perform its calculations for the target
    */
   public abstract CalculationRequirements requirements(T target);
+
+  /**
+   * Returns the default reporting currency for the result of performing the calculation for the target
+   * if there is a sensible default.
+   * <p>
+   * This is the currency to which currency amounts are converted if the reporting rules don't specify
+   * a reporting currency. This is normally the 'natural' currency for the trade, for example
+   * the currency of a FRA or the base currency of an FX forward.
+   * <p>
+   * The default implementation returns an empty optional.
+   *
+   * @param target  the target of the calculation
+   * @return the default reporting currency for the target if there is a sensible default
+   */
+  public default Optional<Currency> defaultReportingCurrency(T target) {
+    return Optional.empty();
+  }
 }

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/CalculationTaskTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/CalculationTaskTest.java
@@ -10,6 +10,7 @@ import static com.opengamma.strata.collect.Guavate.toImmutableList;
 import static com.opengamma.strata.collect.TestHelper.date;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -78,9 +79,9 @@ public class CalculationTaskTest {
 
   /**
    * Test that the result is converted to the reporting currency if it implements CurrencyConvertible and
-   * the FX rates are available in the market data
+   * the FX rates are available in the market data. The reporting currency is taken from the reporting rules.
    */
-  public void convertResultCurrency() {
+  public void convertResultCurrencyUsingReportingRules() {
     double[] values = {1, 2, 3};
     List<FxRate> rates = ImmutableList.of(1.61, 1.62, 1.63).stream()
         .map(rate -> FxRate.of(Currency.GBP, Currency.USD, rate))
@@ -91,6 +92,29 @@ public class CalculationTaskTest {
         .build();
     ConvertibleFunction fn = ConvertibleFunction.of(() -> list);
     CalculationTask task = new CalculationTask(TARGET, 0, 0, fn, MAPPINGS, REPORTING_RULES);
+
+    double[] expectedValues = {1 * 1.61, 2 * 1.62, 3 * 1.63};
+    CurrencyValuesArray expectedArray = CurrencyValuesArray.of(Currency.USD, expectedValues);
+    CalculationResult calculationResult = task.execute(marketData);
+    Result<?> result = calculationResult.getResult();
+    assertThat(result).hasValue(expectedArray);
+  }
+
+  /**
+   * Test that the result is converted to the reporting currency if it implements CurrencyConvertible and
+   * the FX rates are available in the market data. The default reporting currency is taken from the function.
+   */
+  public void convertResultCurrencyUsingDefaultReportingCurrency() {
+    double[] values = {1, 2, 3};
+    List<FxRate> rates = ImmutableList.of(1.61, 1.62, 1.63).stream()
+        .map(rate -> FxRate.of(Currency.GBP, Currency.USD, rate))
+        .collect(toImmutableList());
+    CurrencyValuesArray list = CurrencyValuesArray.of(Currency.GBP, values);
+    ScenarioMarketData marketData = ScenarioMarketData.builder(3, date(2011, 3, 8))
+        .addValues(FxRateId.of(Currency.GBP, Currency.USD), rates)
+        .build();
+    ConvertibleFunction fn = ConvertibleFunction.of(() -> list, Currency.USD);
+    CalculationTask task = new CalculationTask(TARGET, 0, 0, fn, MAPPINGS, ReportingRules.empty());
 
     double[] expectedValues = {1 * 1.61, 2 * 1.62, 3 * 1.63};
     CurrencyValuesArray expectedArray = CurrencyValuesArray.of(Currency.USD, expectedValues);
@@ -122,7 +146,7 @@ public class CalculationTaskTest {
   }
 
   /**
-   * Test the result is returned unchanged if it is convertible but no reporting currency is available.
+   * Test a failure is returned for a convertible value if there is no reporting currency.
    */
   public void convertResultCurrencyNoReportingCurrency() {
     double[] values = {1, 2, 3};
@@ -139,7 +163,18 @@ public class CalculationTaskTest {
 
     CalculationResult calculationResult = task.execute(marketData);
     Result<?> result = calculationResult.getResult();
-    assertThat(result).hasValue(list);
+    assertThat(result).hasFailureMessageMatching("No reporting currency available.*");
+  }
+
+  /**
+   * Test a non-convertible result is returned even if there is no reporting currency.
+   */
+  public void nonConvertibleResultReturnedWhenNoReportingCurrency() {
+    TestFunction fn = new TestFunction();
+    CalculationTask task = new CalculationTask(TARGET, 0, 0, fn, MAPPINGS, ReportingRules.empty());
+    CalculationResult calculationResult = task.execute(ScenarioMarketData.builder(1, date(2011, 3, 8)).build());
+    Result<?> result = calculationResult.getResult();
+    assertThat(result).hasValue("bar");
   }
 
   /**
@@ -256,13 +291,19 @@ public class CalculationTaskTest {
       implements CalculationSingleFunction<TestTarget, CurrencyValuesArray> {
 
     private final Supplier<CurrencyValuesArray> supplier;
+    private final Optional<Currency> reportingCurrency;
 
     public static ConvertibleFunction of(Supplier<CurrencyValuesArray> supplier) {
-      return new ConvertibleFunction(supplier);
+      return new ConvertibleFunction(supplier, Optional.<Currency>empty());
     }
 
-    private ConvertibleFunction(Supplier<CurrencyValuesArray> supplier) {
+    public static ConvertibleFunction of(Supplier<CurrencyValuesArray> supplier, Currency reportingCurrency) {
+      return new ConvertibleFunction(supplier, Optional.of(reportingCurrency));
+    }
+
+    private ConvertibleFunction(Supplier<CurrencyValuesArray> supplier, Optional<Currency> reportingCurrency) {
       this.supplier = supplier;
+      this.reportingCurrency = reportingCurrency;
     }
 
     @Override
@@ -273,6 +314,11 @@ public class CalculationTaskTest {
     @Override
     public CalculationRequirements requirements(TestTarget target) {
       return CalculationRequirements.empty();
+    }
+
+    @Override
+    public Optional<Currency> defaultReportingCurrency(TestTarget target) {
+      return reportingCurrency;
     }
   }
 

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/AbstractFxForwardFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/AbstractFxForwardFunction.java
@@ -7,11 +7,13 @@ package com.opengamma.strata.function.fx;
 
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toScenarioResult;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.engine.calculations.DefaultSingleCalculationMarketData;
 import com.opengamma.strata.engine.calculations.function.CalculationSingleFunction;
 import com.opengamma.strata.engine.calculations.function.result.ScenarioResult;
@@ -91,6 +93,20 @@ public abstract class AbstractFxForwardFunction<T>
         .map(MarketDataRatesProvider::new)
         .map(provider -> execute(product, provider))
         .collect(toScenarioResult(convertCurrencies));
+  }
+
+  /**
+   * Returns the base currency of the market convention pair of the trade currencies.
+   *
+   * @param target  the target of the calculation
+   * @return the base currency of the market convention pair of the trade currencies
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(FxForwardTrade target) {
+    Currency base = target.getProduct().getBaseCurrencyAmount().getCurrency();
+    Currency counter = target.getProduct().getCounterCurrencyAmount().getCurrency();
+    CurrencyPair marketConventionPair = CurrencyPair.of(base, counter).toConventional();
+    return Optional.of(marketConventionPair.getBase());
   }
 
   // execute for a single trade

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/AbstractFxNonDeliverableForwardFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/AbstractFxNonDeliverableForwardFunction.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.function.fx;
 
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toScenarioResult;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -91,6 +92,18 @@ public abstract class AbstractFxNonDeliverableForwardFunction<T>
         .map(MarketDataRatesProvider::new)
         .map(provider -> execute(product, provider))
         .collect(toScenarioResult(convertCurrencies));
+  }
+
+  /**
+   * Returns the base currency of the market convention currency pair of the trade currencies.
+   *
+   * @param target  the target of the calculation
+   * @return the base currency of the market convention currency pair of the trade currencies
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(FxNonDeliverableForwardTrade target) {
+    Currency base = target.getProduct().getAgreedFxRate().getPair().toConventional().getBase();
+    return Optional.of(base);
   }
 
   // execute for a single trade

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/AbstractFxSwapFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/fx/AbstractFxSwapFunction.java
@@ -7,11 +7,13 @@ package com.opengamma.strata.function.fx;
 
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toScenarioResult;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.engine.calculations.DefaultSingleCalculationMarketData;
 import com.opengamma.strata.engine.calculations.function.CalculationSingleFunction;
 import com.opengamma.strata.engine.calculations.function.result.ScenarioResult;
@@ -91,6 +93,20 @@ public abstract class AbstractFxSwapFunction<T>
         .map(MarketDataRatesProvider::new)
         .map(provider -> execute(product, provider))
         .collect(toScenarioResult(convertCurrencies));
+  }
+
+  /**
+   * Returns the base currency of the market convention pair of the near leg currencies.
+   *
+   * @param target  the target of the calculation
+   * @return the base currency of the market convention pair of the near leg currencies
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(FxSwapTrade target) {
+    Currency base = target.getProduct().getNearLeg().getBaseCurrencyAmount().getCurrency();
+    Currency counter = target.getProduct().getNearLeg().getCounterCurrencyAmount().getCurrency();
+    CurrencyPair marketConventionPair = CurrencyPair.of(base, counter).toConventional();
+    return Optional.of(marketConventionPair.getBase());
   }
 
   // execute for a single trade

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/deposit/AbstractTermDepositFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/deposit/AbstractTermDepositFunction.java
@@ -7,10 +7,12 @@ package com.opengamma.strata.function.rate.deposit;
 
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toScenarioResult;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.engine.calculations.DefaultSingleCalculationMarketData;
 import com.opengamma.strata.engine.calculations.function.CalculationSingleFunction;
 import com.opengamma.strata.engine.calculations.function.result.ScenarioResult;
@@ -88,6 +90,17 @@ public abstract class AbstractTermDepositFunction<T>
         .map(MarketDataRatesProvider::new)
         .map(provider -> execute(product, provider))
         .collect(toScenarioResult(convertCurrencies));
+  }
+
+  /**
+   * Returns the currency of the trade.
+   *
+   * @param target  the the target of the calculation
+   * @return the currency of the trade
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(TermDepositTrade target) {
+    return Optional.of(target.getProduct().getCurrency());
   }
 
   // execute for a single trade

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/fra/AbstractFraFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/fra/AbstractFraFunction.java
@@ -9,11 +9,13 @@ import static com.opengamma.strata.collect.Guavate.toImmutableSet;
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toScenarioResult;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.market.MarketDataKey;
 import com.opengamma.strata.basics.market.ObservableKey;
@@ -110,6 +112,18 @@ public abstract class AbstractFraFunction<T>
         .map(MarketDataRatesProvider::new)
         .map(provider -> execute(product, provider))
         .collect(toScenarioResult(convertCurrencies));
+  }
+
+
+  /**
+   * Returns the currency of the FRA.
+   *
+   * @param target  the FRA that is the target of the calculation
+   * @return the currency of the FRA
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(FraTrade target) {
+    return Optional.of(target.getProduct().getCurrency());
   }
 
   // execute for a single trade

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/swap/SwapAccruedInterestFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/swap/SwapAccruedInterestFunction.java
@@ -7,9 +7,11 @@ package com.opengamma.strata.function.rate.swap;
 
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toFxConvertibleList;
 
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.Iterables;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.date.DayCounts;
@@ -49,6 +51,17 @@ public class SwapAccruedInterestFunction
         .map(MarketDataRatesProvider::new)
         .map(env -> accruedInterest(env, expandedSwap))
         .collect(toFxConvertibleList());
+  }
+
+  /**
+   * Returns the currency of the first leg of the swap.
+   *
+   * @param target  the swap that is the target of the calculation
+   * @return the currency of the first leg of the swap
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(SwapTrade target) {
+    return Optional.of(target.getProduct().getLegs().get(0).getCurrency());
   }
   
   private MultiCurrencyAmount accruedInterest(MarketDataRatesProvider env, ExpandedSwap expandedSwap) {

--- a/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/swap/SwapLegNotionalFunction.java
+++ b/modules/function-beta/src/main/java/com/opengamma/strata/function/rate/swap/SwapLegNotionalFunction.java
@@ -9,6 +9,7 @@ import static com.opengamma.strata.engine.calculations.function.FunctionUtils.to
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import com.opengamma.strata.basics.currency.Currency;
@@ -40,6 +41,17 @@ public class SwapLegNotionalFunction
     return IntStream.range(0, marketData.getScenarioCount())
         .mapToObj(i -> notional)
         .collect(toScenarioResult());
+  }
+
+  /**
+   * Returns the currency of the first leg of the swap.
+   *
+   * @param target  the swap that is the target of the calculation
+   * @return the currency of the first leg of the swap
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(SwapTrade target) {
+    return Optional.of(target.getProduct().getLegs().get(0).getCurrency());
   }
 
   private LegAmounts getNotional(SwapTrade input) {

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/rate/swap/AbstractSwapFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/rate/swap/AbstractSwapFunction.java
@@ -8,10 +8,12 @@ package com.opengamma.strata.function.calculation.rate.swap;
 import static com.opengamma.strata.collect.Guavate.toImmutableSet;
 import static com.opengamma.strata.engine.calculations.function.FunctionUtils.toScenarioResult;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
 import com.google.common.collect.Sets;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.market.MarketDataKey;
 import com.opengamma.strata.basics.market.ObservableKey;
@@ -103,6 +105,17 @@ public abstract class AbstractSwapFunction<T>
         .map(MarketDataRatesProvider::new)
         .map(provider -> execute(product, provider))
         .collect(toScenarioResult(isConvertCurrencies()));
+  }
+
+  /**
+   * Returns the currency of the first leg.
+   *
+   * @param target  the swap that is the target of the calculation
+   * @return the currency of the first leg
+   */
+  @Override
+  public Optional<Currency> defaultReportingCurrency(SwapTrade target) {
+    return Optional.of(target.getProduct().getLegs().get(0).getCurrency());
   }
 
   // execute for a single trade


### PR DESCRIPTION
This PR changes the behaviour of the engine when the `ReportingRules` don't specify a reporting currency. Previously the function result was returned without any conversion being applied. 

The new behaviour is to query the function for a default reporting currency and use that for the conversion. If there is no default a failure is returned instead of the unconverted result.

This ensures that the same type is returned for every cell in a column and there is no longer the chance of mixing `CurrencyAmount` and `MultiCurrencyAmount` in the same column.

All existing functions that return a currency related amount also provide a default reporting currency based on the common-sense default for the trade type.

The examples now use an empty set of reporting rules so the default reporting currency is used for conversion.

Fixes #301 
