### PR TITLE
Ability to request set of configured measures for a target

### DIFF
--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/CompositePricingRules.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/CompositePricingRules.java
@@ -55,11 +55,11 @@ final class CompositePricingRules implements PricingRules, ImmutableBean {
         .flatMap(Guavate::stream)
         .findFirst();
   }
-  
+
   @Override
-  public ImmutableSet<Measure> measuresConfigured(CalculationTarget target) {
+  public ImmutableSet<Measure> configuredMeasures(CalculationTarget target) {
     return rules.stream()
-        .flatMap(rule -> rule.measuresConfigured(target).stream())
+        .flatMap(rule -> rule.configuredMeasures(target).stream())
         .collect(toImmutableSet());
   }
 

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/DefaultFunctionGroup.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/DefaultFunctionGroup.java
@@ -94,9 +94,9 @@ public final class DefaultFunctionGroup<T extends CalculationTarget>
         Optional.ofNullable(this.functionConfig.get(measure)) :
         Optional.empty();
   }
-  
+
   @Override
-  public ImmutableSet<Measure> measuresConfigured(CalculationTarget target) {
+  public ImmutableSet<Measure> configuredMeasures(CalculationTarget target) {
     return functionConfig.keySet();
   }
 

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/DefaultPricingRules.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/DefaultPricingRules.java
@@ -74,11 +74,11 @@ public final class DefaultPricingRules implements PricingRules, ImmutableBean {
         .flatMap(Guavate::stream)
         .findFirst();
   }
-  
+
   @Override
-  public ImmutableSet<Measure> measuresConfigured(CalculationTarget target) {
+  public ImmutableSet<Measure> configuredMeasures(CalculationTarget target) {
     return rules.stream()
-        .flatMap(rule -> rule.measuresConfigured(target).stream())
+        .flatMap(rule -> rule.configuredMeasures(target).stream())
         .collect(toImmutableSet());
   }
 

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/EmptyPricingRules.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/EmptyPricingRules.java
@@ -44,9 +44,9 @@ final class EmptyPricingRules implements PricingRules, ImmutableBean {
   public Optional<ConfiguredFunctionGroup> functionGroup(CalculationTarget target, Measure measure) {
     return Optional.empty();
   }
-  
+
   @Override
-  public ImmutableSet<Measure> measuresConfigured(CalculationTarget target) {
+  public ImmutableSet<Measure> configuredMeasures(CalculationTarget target) {
     return ImmutableSet.of();
   }
 

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/FunctionGroup.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/FunctionGroup.java
@@ -41,13 +41,13 @@ public interface FunctionGroup<T extends CalculationTarget> {
    * @return configuration for a function to calculate the value of a measure for a target if this group has one
    */
   Optional<FunctionConfig<T>> functionConfig(CalculationTarget target, Measure measure);
-  
+
   /**
    * Returns the set of measures configured for a calculation target.
    * 
    * @param target  the calculation target
    * @return the set of measures configured for a calculation target
    */
-  ImmutableSet<Measure> measuresConfigured(CalculationTarget target);
-  
+  ImmutableSet<Measure> configuredMeasures(CalculationTarget target);
+
 }

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/PricingRule.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/PricingRule.java
@@ -113,20 +113,20 @@ public final class PricingRule<T extends CalculationTarget>
         Optional.of(configuredFunctionGroup) :
         Optional.empty();
   }
-  
+
   /**
    * Returns the set of measures configured for a calculation target.
    * 
    * @param target  a target
    * @return the set of measures configured by this rule
    */
-  public ImmutableSet<Measure> measuresConfigured(CalculationTarget target) {
+  public ImmutableSet<Measure> configuredMeasures(CalculationTarget target) {
     if (!targetType.isInstance(target)) {
       return ImmutableSet.of();
     }
-    Set<Measure> measuresConfigured = functionGroup.measuresConfigured(target);
+    Set<Measure> measuresConfigured = functionGroup.configuredMeasures(target);
     if (!measures.isEmpty()) {
-      measuresConfigured = Sets.intersection(measures, functionGroup.measuresConfigured(target));
+      measuresConfigured = Sets.intersection(measures, functionGroup.configuredMeasures(target));
     }
     return ImmutableSet.copyOf(measuresConfigured);
   }

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/PricingRules.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/pricing/PricingRules.java
@@ -69,13 +69,13 @@ public interface PricingRules {
    * @return a function group specifying how a measure should be calculated for the target
    */
   public abstract Optional<ConfiguredFunctionGroup> functionGroup(CalculationTarget target, Measure measure);
-  
+
   /**
    * Returns the set of measures that are configured for a calculation target.
    * 
    * @param target  a target
    * @return a set of available measures for the target
    */
-  public abstract ImmutableSet<Measure> measuresConfigured(CalculationTarget target);
-  
+  public abstract ImmutableSet<Measure> configuredMeasures(CalculationTarget target);
+
 }

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/config/pricing/PricingRuleTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/config/pricing/PricingRuleTest.java
@@ -21,6 +21,9 @@ import com.opengamma.strata.engine.config.Measure;
 import com.opengamma.strata.engine.marketdata.CalculationMarketData;
 import com.opengamma.strata.engine.marketdata.CalculationRequirements;
 
+/**
+ * Test {@link PricingRule}.
+ */
 @Test
 public class PricingRuleTest {
 
@@ -73,11 +76,11 @@ public class PricingRuleTest {
 
     Optional<ConfiguredFunctionGroup> functionGroup = pricingRule.functionGroup(new TestTrade2(), MEASURE2);
     assertThat(functionGroup).isEmpty();
-        
-    Set<Measure> trade1Measures = pricingRule.measuresConfigured(new TestTrade1());
+
+    Set<Measure> trade1Measures = pricingRule.configuredMeasures(new TestTrade1());
     assertThat(trade1Measures).containsOnly(MEASURE1);
-    
-    Set<Measure> trade2Measures = pricingRule.measuresConfigured(new TestTrade2());
+
+    Set<Measure> trade2Measures = pricingRule.configuredMeasures(new TestTrade2());
     assertThat(trade2Measures).isEmpty();
   }
 
@@ -89,22 +92,24 @@ public class PricingRuleTest {
         PricingRule.builder(TestTrade1.class)
             .functionGroup(GROUP)
             .build();
-    
+
     Optional<ConfiguredFunctionGroup> functionGroup = rule.functionGroup(new TestTrade1(), MEASURE1);
     assertThat(functionGroup).hasValue(ConfiguredFunctionGroup.of(GROUP));
-    
-    Set<Measure> measures = rule.measuresConfigured(new TestTrade1());
+
+    Set<Measure> measures = rule.configuredMeasures(new TestTrade1());
     assertThat(measures).containsOnly(MEASURE1, MEASURE2);
   }
-  
+
   public void measuresMatchingFunctionGroup() {
-    Set<Measure> measures = PRICING_RULE.measuresConfigured(new TestTrade1());
+    Set<Measure> measures = PRICING_RULE.configuredMeasures(new TestTrade1());
     assertThat(measures).containsOnly(MEASURE1, MEASURE2);
   }
 
-  private static final class TestTrade1 implements CalculationTarget { }
+  private static final class TestTrade1 implements CalculationTarget {
+  }
 
-  private static final class TestTrade2 implements CalculationTarget { }
+  private static final class TestTrade2 implements CalculationTarget {
+  }
 
   private static final class TestFunction1 implements CalculationSingleFunction<TestTrade1, Object> {
 
@@ -131,19 +136,5 @@ public class PricingRuleTest {
       return "foo";
     }
   }
-
-  private static final class TestFunction3 implements CalculationSingleFunction<TestTrade2, Object> {
-
-    @Override
-    public CalculationRequirements requirements(TestTrade2 target) {
-      return CalculationRequirements.empty();
-    }
-
-    @Override
-    public Object execute(TestTrade2 target, CalculationMarketData marketData) {
-      return "bar";
-    }
-  }
-
 
 }

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/config/pricing/PricingRulesTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/config/pricing/PricingRulesTest.java
@@ -19,6 +19,9 @@ import com.opengamma.strata.engine.config.Measure;
 import com.opengamma.strata.engine.marketdata.CalculationMarketData;
 import com.opengamma.strata.engine.marketdata.CalculationRequirements;
 
+/**
+ * Test {@link PricingRules}.
+ */
 @Test
 public class PricingRulesTest {
 
@@ -59,7 +62,7 @@ public class PricingRulesTest {
   public void ofEmpty() {
     PricingRules rules = PricingRules.of();
     Optional<ConfiguredFunctionGroup> functionGroup = rules.functionGroup(TRADE1, FOO_MEASURE);
-    Set<Measure> measures = rules.measuresConfigured(TRADE1);
+    Set<Measure> measures = rules.configuredMeasures(TRADE1);
 
     assertThat(rules).isInstanceOf(EmptyPricingRules.class);
     assertThat(functionGroup).isEmpty();
@@ -69,7 +72,7 @@ public class PricingRulesTest {
   public void ofSingle() {
     PricingRules rules = PricingRules.of(PRICING_RULES1);
     Optional<ConfiguredFunctionGroup> functionGroup = rules.functionGroup(TRADE1, FOO_MEASURE);
-    Set<Measure> measures = rules.measuresConfigured(TRADE1);
+    Set<Measure> measures = rules.configuredMeasures(TRADE1);
 
     assertThat(rules).isInstanceOf(DefaultPricingRules.class);
     assertThat(functionGroup).hasValue(ConfiguredFunctionGroup.of(FUNCTION_GROUP1));
@@ -87,18 +90,18 @@ public class PricingRulesTest {
     assertThat(functionGroup2).hasValue(ConfiguredFunctionGroup.of(FUNCTION_GROUP1));
     assertThat(functionGroup3).hasValue(ConfiguredFunctionGroup.of(FUNCTION_GROUP2));
     assertThat(functionGroup4).isEmpty();
-    
-    Set<Measure> measures1 = rules.measuresConfigured(TRADE1);
+
+    Set<Measure> measures1 = rules.configuredMeasures(TRADE1);
     assertThat(measures1).containsOnly(FOO_MEASURE, BAR_MEASURE);
-    
-    Set<Measure> measures2 = rules.measuresConfigured(TRADE2);
+
+    Set<Measure> measures2 = rules.configuredMeasures(TRADE2);
     assertThat(measures2).containsOnly(FOO_MEASURE);
   }
 
   public void composedWithEmpty() {
     PricingRules rules = PricingRules.empty().composedWith(PRICING_RULES1);
     Optional<ConfiguredFunctionGroup> functionConfig = rules.functionGroup(TRADE1, FOO_MEASURE);
-    Set<Measure> measures = rules.measuresConfigured(TRADE1);
+    Set<Measure> measures = rules.configuredMeasures(TRADE1);
 
     assertThat(rules).isInstanceOf(DefaultPricingRules.class);
     assertThat(functionConfig).hasValue(ConfiguredFunctionGroup.of(FUNCTION_GROUP1));
@@ -122,9 +125,11 @@ public class PricingRulesTest {
     assertThat(functionGroup6).isEmpty();
   }
 
-  private static final class TestTrade1 implements CalculationTarget { }
+  private static final class TestTrade1 implements CalculationTarget {
+  }
 
-  private static final class TestTrade2 implements CalculationTarget { }
+  private static final class TestTrade2 implements CalculationTarget {
+  }
 
   private static final class TestFunction1 implements CalculationSingleFunction<TestTrade1, Object> {
 


### PR DESCRIPTION
This PR allows the pricing rules to be queried to obtain the set of configured measures for a given target. This is useful for higher-level components that invoke the engine with a set of pricing rules, in order that they can guide a user through selecting an available measure for a given target.
