### PR TITLE
Add default formatting of doubles arrays so user can see the data in …

### DIFF
--- a/modules/report-beta/src/main/java/com/opengamma/strata/report/format/UnsupportedValueFormatter.java
+++ b/modules/report-beta/src/main/java/com/opengamma/strata/report/format/UnsupportedValueFormatter.java
@@ -6,12 +6,10 @@
 package com.opengamma.strata.report.format;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.opengamma.analytics.util.ArrayUtils;
 import com.opengamma.strata.collect.Messages;


### PR DESCRIPTION
This is just an improved error message that wwill serve as a workaround until we can determine the
proper way to format vector values. But there is a common case with pv01, cs01 etc that
this will serve as a stop gap for.
