### PR TITLE
Remove value from explain map of accrual period

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricer.java
@@ -362,7 +362,11 @@ public class DiscountingRatePaymentPeriodPricer
         accrualPeriod.getRateObservation(), accrualPeriod.getStartDate(), accrualPeriod.getEndDate(), provider, builder);
     double payOffRate = rawRate * accrualPeriod.getGearing() + accrualPeriod.getSpread();
     double ua = unitNotionalAccrual(accrualPeriod, accrualPeriod.getSpread(), provider);
-    double fv = ua * notional;
+
+    // Note that the future value is not published since this is potentially misleading when
+    // compounding is being applied, and when it isn't then it's the same as the future
+    // value of the payment period.
+    
     builder.put(ExplainKey.ENTRY_TYPE, "AccrualPeriod");
     builder.put(ExplainKey.START_DATE, accrualPeriod.getStartDate());
     builder.put(ExplainKey.UNADJUSTED_START_DATE, accrualPeriod.getUnadjustedStartDate());
@@ -374,7 +378,6 @@ public class DiscountingRatePaymentPeriodPricer
     builder.put(ExplainKey.SPREAD, accrualPeriod.getSpread());
     builder.put(ExplainKey.PAY_OFF_RATE, accrualPeriod.getNegativeRateMethod().adjust(payOffRate));
     builder.put(ExplainKey.UNIT_AMOUNT, ua);
-    builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.of(currency, fv));
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingRatePaymentPeriodPricerTest.java
@@ -628,8 +628,6 @@ public class DiscountingRatePaymentPeriodPricerTest {
     assertEquals(explainAccrual.get(ExplainKey.FIXED_RATE).get(), RATE_1, TOLERANCE_PV);
     assertEquals(explainAccrual.get(ExplainKey.PAY_OFF_RATE).get(), RATE_1, TOLERANCE_PV);
     assertEquals(explainAccrual.get(ExplainKey.UNIT_AMOUNT).get(), ua, TOLERANCE_PV);
-    assertEquals(explainAccrual.get(ExplainKey.FUTURE_VALUE).get().getCurrency(), currency);
-    assertEquals(explainAccrual.get(ExplainKey.FUTURE_VALUE).get().getAmount(), fv, TOLERANCE_PV);
   }
 
   public void test_explainPresentValue_single_paymentDateInPast() {
@@ -704,8 +702,6 @@ public class DiscountingRatePaymentPeriodPricerTest {
     assertEquals(explainAccrual.get(ExplainKey.FIXED_RATE).get(), RATE_1, TOLERANCE_PV);
     assertEquals(explainAccrual.get(ExplainKey.PAY_OFF_RATE).get(), RATE_1, TOLERANCE_PV);
     assertEquals(explainAccrual.get(ExplainKey.UNIT_AMOUNT).get(), ua, TOLERANCE_PV);
-    assertEquals(explainAccrual.get(ExplainKey.FUTURE_VALUE).get().getCurrency(), currency);
-    assertEquals(explainAccrual.get(ExplainKey.FUTURE_VALUE).get().getAmount(), fv, TOLERANCE_PV);
   }
 
   public void test_explainPresentValue_single_gearingSpread() {
@@ -750,8 +746,6 @@ public class DiscountingRatePaymentPeriodPricerTest {
     assertEquals(explainAccrual.get(ExplainKey.FIXED_RATE).get(), RATE_1, TOLERANCE_PV);
     assertEquals(explainAccrual.get(ExplainKey.PAY_OFF_RATE).get(), payOffRate, TOLERANCE_PV);
     assertEquals(explainAccrual.get(ExplainKey.UNIT_AMOUNT).get(), ua, TOLERANCE_PV);
-    assertEquals(explainAccrual.get(ExplainKey.FUTURE_VALUE).get().getCurrency(), currency);
-    assertEquals(explainAccrual.get(ExplainKey.FUTURE_VALUE).get().getAmount(), fv, TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
This PR removes the value from the explain map of an accrual period, since it is misleading when compounding is in effect. When compounding is not being applied then it is the same as the value published to the explain map in the payment period.
