### PR TITLE
Ability to output version of report runner tool

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,6 +24,8 @@
           <archive>
             <manifest>
               <mainClass>com.opengamma.strata.examples.report.ReportRunnerTool</mainClass>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
             </manifest>
           </archive>
           <descriptorRefs>

--- a/examples/src/main/java/com/opengamma/strata/examples/report/ReportRunnerTool.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/report/ReportRunnerTool.java
@@ -63,6 +63,9 @@ public class ReportRunnerTool {
 
   @Parameter(names = {"-h", "--help"}, description = "Displays this message", help = true)
   private boolean help;
+  
+  @Parameter(names = {"-v", "--version"}, description = "Prints the version of this tool", help = true)
+  private boolean version;
 
   /**
    * Runs the tool.
@@ -83,6 +86,12 @@ public class ReportRunnerTool {
     }
     if (reportRunner.help) {
       commander.usage();
+    } else if (reportRunner.version) {
+      String versionName = ReportRunnerTool.class.getPackage().getImplementationVersion();
+      if (versionName == null) {
+        versionName = "unknown";
+      }
+      System.out.println("Strata Report Runner Tool, version " + versionName);
     } else {
       try {
         reportRunner.run();


### PR DESCRIPTION
This PR adds a `-v` or `--version` option to the report runner tool that causes it to output its version, if this can be found from the manifest when the tool is packaged as a JAR.
