### PR TITLE
Better names in ValueAdjustment

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SwapTradeModelDemo.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SwapTradeModelDemo.java
@@ -22,6 +22,7 @@ import com.opengamma.strata.basics.schedule.Frequency;
 import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.schedule.RollConventions;
 import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.basics.value.ValueAdjustment;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.basics.value.ValueStep;
 import com.opengamma.strata.collect.id.StandardId;
@@ -99,7 +100,7 @@ public class SwapTradeModelDemo {
             .dayCount(DayCounts.ACT_ACT_ISDA)
             .rate(ValueSchedule.of(
                 0.008,
-                ValueStep.ofAbsoluteAmount(LocalDate.of(2015, 1, 31), 0.007)))
+                ValueStep.of(LocalDate.of(2015, 1, 31), ValueAdjustment.ofReplace(0.007))))
             .build())
         .build();
     // an ExpandedSwapLeg has all the dates of the cash flows

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueAdjustment.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueAdjustment.java
@@ -33,7 +33,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
  * <tr>
  * <th>Type</th><th>baseValue</th><th>modifyingValue</th><th>Calculation</th>
  * </tr><tr>
- * <td>Absolute</td><td>200</td><td>220</td><td>{@code result = modifyingValue = 220}</td>
+ * <td>Replace</td><td>200</td><td>220</td><td>{@code result = modifyingValue = 220}</td>
  * </tr><tr>
  * <td>DeltaAmount</td><td>200</td><td>20</td><td>{@code result = baseValue + modifyingValue = (200 + 20) = 220}</td>
  * </tr><tr>
@@ -67,15 +67,15 @@ public final class ValueAdjustment
 
   //-------------------------------------------------------------------------
   /**
-   * Obtains a value adjustment specifying the absolute amount.
+   * Obtains a value adjustment that replaces the base value.
    * <p>
    * The base value is ignored when calculating the result.
    * 
-   * @param absoluteAmount  the absolute amount that is the result of the adjustment
-   * @return the adjustment
+   * @param replacementValue  the replacement value to use as the result of the adjustment
+   * @return the adjustment, capturing the replacement value
    */
-  public static ValueAdjustment ofAbsoluteAmount(double absoluteAmount) {
-    return new ValueAdjustment(absoluteAmount, ValueAdjustmentType.ABSOLUTE);
+  public static ValueAdjustment ofReplace(double replacementValue) {
+    return new ValueAdjustment(replacementValue, ValueAdjustmentType.REPLACE);
   }
 
   /**
@@ -84,7 +84,7 @@ public final class ValueAdjustment
    * The result will be {@code (baseValue + deltaAmount)}.
    * 
    * @param deltaAmount  the amount to be added to the base value
-   * @return the adjustment
+   * @return the adjustment, capturing the delta amount
    */
   public static ValueAdjustment ofDeltaAmount(double deltaAmount) {
     return new ValueAdjustment(deltaAmount, ValueAdjustmentType.DELTA_AMOUNT);
@@ -97,7 +97,7 @@ public final class ValueAdjustment
    * 
    * @param deltaMultiplier  the multiplication factor to apply to the base amount
    *  with the result added to the base amount
-   * @return the adjustment
+   * @return the adjustment, capturing the delta multiplier
    */
   public static ValueAdjustment ofDeltaMultiplier(double deltaMultiplier) {
     return new ValueAdjustment(deltaMultiplier, ValueAdjustmentType.DELTA_MULTIPLIER);
@@ -135,7 +135,7 @@ public final class ValueAdjustment
       case MULTIPLIER:
         buf.append("input * ").append(modifyingValue);
         break;
-      case ABSOLUTE:
+      case REPLACE:
       default:
         buf.append(modifyingValue);
         break;

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueAdjustmentType.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueAdjustmentType.java
@@ -24,7 +24,7 @@ import com.opengamma.strata.collect.ArgChecker;
  * <tr>
  * <th>Type</th><th>baseValue</th><th>modifyingValue</th><th>Calculation</th>
  * </tr><tr>
- * <td>Absolute</td><td>200</td><td>220</td><td>{@code result = modifyingValue = 220}</td>
+ * <td>Replace</td><td>200</td><td>220</td><td>{@code result = modifyingValue = 220}</td>
  * </tr><tr>
  * <td>DeltaAmount</td><td>200</td><td>20</td><td>{@code result = baseValue + modifyingValue = (200 + 20) = 220}</td>
  * </tr><tr>
@@ -38,12 +38,12 @@ import com.opengamma.strata.collect.ArgChecker;
 public enum ValueAdjustmentType {
 
   /**
-   * The modifying value represents the result absolutely.
+   * The modifying value replaces the base value.
    * The input base value is ignored.
    * <p>
    * The result is {@code modifyingValue}.
    */
-  ABSOLUTE {
+  REPLACE {
     @Override
     public double adjust(double baseValue, double modifyingValue) {
       return modifyingValue;
@@ -53,6 +53,8 @@ public enum ValueAdjustmentType {
    * Calculates the result by treating the modifying value as a delta, adding it to the base value.
    * <p>
    * The result is {@code (baseValue + modifyingValue)}.
+   * <p>
+   * This adjustment type can be referred to as an <i>absolute shift</i>.
    */
   DELTA_AMOUNT {
     @Override
@@ -64,6 +66,8 @@ public enum ValueAdjustmentType {
    * Calculates the result by treating the modifying value as a multiplication factor, adding it to the base value.
    * <p>
    * The result is {@code (baseValue + baseValue * modifyingValue)}.
+   * <p>
+   * This adjustment type can be referred to as a <i>relative shift</i>.
    */
   DELTA_MULTIPLIER {
     @Override

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueStep.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueStep.java
@@ -114,21 +114,6 @@ public final class ValueStep
     return new ValueStep(null, date, value);
   }
 
-  /**
-   * Obtains a value adjustment specifying an absolute value.
-   * <p>
-   * This factory obtains a step that causes the value to change at the specified date.
-   * <p>
-   * The value specified is absolute, as per {@link ValueAdjustmentType#ABSOLUTE}.
-   * 
-   * @param date  the start date of the value change
-   * @param absoluteValue  the absolute value that is the result of the adjustment
-   * @return the varying step
-   */
-  public static ValueStep ofAbsoluteAmount(LocalDate date, double absoluteValue) {
-    return new ValueStep(null, date, ValueAdjustment.ofAbsoluteAmount(absoluteValue));
-  }
-
   //-------------------------------------------------------------------------
   /**
    * Finds the index of this value step in the schedule.

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueAdjustmentTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueAdjustmentTest.java
@@ -27,10 +27,10 @@ public class ValueAdjustmentTest {
     assertEquals(test.toString(), "ValueAdjustment[result = input]");
   }
 
-  public void test_ofAbsoluteAmount() {
-    ValueAdjustment test = ValueAdjustment.ofAbsoluteAmount(200);
+  public void test_ofReplace() {
+    ValueAdjustment test = ValueAdjustment.ofReplace(200);
     assertEquals(test.getModifyingValue(), 200, TOLERANCE);
-    assertEquals(test.getType(), ValueAdjustmentType.ABSOLUTE);
+    assertEquals(test.getType(), ValueAdjustmentType.REPLACE);
     assertEquals(test.adjust(100), 200, TOLERANCE);
     assertEquals(test.toString(), "ValueAdjustment[result = 200.0]");
   }
@@ -61,8 +61,8 @@ public class ValueAdjustmentTest {
 
   //-------------------------------------------------------------------------
   public void equals() {
-    ValueAdjustment a1 = ValueAdjustment.ofAbsoluteAmount(200);
-    ValueAdjustment a2 = ValueAdjustment.ofAbsoluteAmount(200);
+    ValueAdjustment a1 = ValueAdjustment.ofReplace(200);
+    ValueAdjustment a2 = ValueAdjustment.ofReplace(200);
     ValueAdjustment b = ValueAdjustment.ofDeltaMultiplier(200);
     ValueAdjustment c = ValueAdjustment.ofDeltaMultiplier(0.1);
     assertEquals(a1.equals(a2), true);
@@ -72,11 +72,11 @@ public class ValueAdjustmentTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    coverImmutableBean(ValueAdjustment.ofAbsoluteAmount(200));
+    coverImmutableBean(ValueAdjustment.ofReplace(200));
   }
 
   public void test_serialization() {
-    assertSerialization(ValueAdjustment.ofAbsoluteAmount(200));
+    assertSerialization(ValueAdjustment.ofReplace(200));
   }
 
 }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueScheduleTest.java
@@ -24,8 +24,8 @@ import com.opengamma.strata.basics.schedule.SchedulePeriod;
 public class ValueScheduleTest {
 
   private static double TOLERANCE = 1.0E-10;
-  private static ValueStep STEP1 = ValueStep.ofAbsoluteAmount(date(2014, 6, 30), 2000d);
-  private static ValueStep STEP2 = ValueStep.ofAbsoluteAmount(date(2014, 7, 30), 3000d);
+  private static ValueStep STEP1 = ValueStep.of(date(2014, 6, 30), ValueAdjustment.ofReplace(2000d));
+  private static ValueStep STEP2 = ValueStep.of(date(2014, 7, 30), ValueAdjustment.ofReplace(3000d));
 
   private static SchedulePeriod PERIOD1 = SchedulePeriod.of(date(2014, 1, 1), date(2014, 2, 1));
   private static SchedulePeriod PERIOD2 = SchedulePeriod.of(date(2014, 2, 1), date(2014, 3, 1));
@@ -91,8 +91,8 @@ public class ValueScheduleTest {
 
   //-------------------------------------------------------------------------
   public void test_resolveValues_dateBased() {
-    ValueStep step1 = ValueStep.ofAbsoluteAmount(date(2014, 2, 1), 300d);
-    ValueStep step2 = ValueStep.ofAbsoluteAmount(date(2014, 3, 1), 400d);
+    ValueStep step1 = ValueStep.of(date(2014, 2, 1), ValueAdjustment.ofReplace(300d));
+    ValueStep step2 = ValueStep.of(date(2014, 3, 1), ValueAdjustment.ofReplace(400d));
     // no steps
     ValueSchedule test0 = ValueSchedule.of(200d, ImmutableList.of());
     assertEquals(test0.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 200d));
@@ -108,8 +108,8 @@ public class ValueScheduleTest {
   }
 
   public void test_resolveValues_dateBased_matchAdjusted() {
-    ValueStep step1 = ValueStep.ofAbsoluteAmount(date(2014, 2, 1), 300d);
-    ValueStep step2 = ValueStep.ofAbsoluteAmount(date(2014, 3, 2), 400d);
+    ValueStep step1 = ValueStep.of(date(2014, 2, 1), ValueAdjustment.ofReplace(300d));
+    ValueStep step2 = ValueStep.of(date(2014, 3, 2), ValueAdjustment.ofReplace(400d));
     // no steps
     ValueSchedule test0 = ValueSchedule.of(200d, ImmutableList.of());
     assertEquals(test0.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 200d));
@@ -125,8 +125,8 @@ public class ValueScheduleTest {
   }
 
   public void test_resolveValues_indexBased() {
-    ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(300d));
-    ValueStep step2 = ValueStep.of(2, ValueAdjustment.ofAbsoluteAmount(400d));
+    ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
+    ValueStep step2 = ValueStep.of(2, ValueAdjustment.ofReplace(400d));
     // no steps
     ValueSchedule test0 = ValueSchedule.of(200d, ImmutableList.of());
     assertEquals(test0.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 200d));
@@ -142,33 +142,33 @@ public class ValueScheduleTest {
   }
 
   public void test_resolveValues_indexBased_duplicateDefinitionValid() {
-    ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(300d));
-    ValueStep step2 = ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(300d));
+    ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
+    ValueStep step2 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
     assertEquals(test.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 300d));
   }
 
   public void test_resolveValues_indexBased_duplicateDefinitionInvalid() {
-    ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(300d));
-    ValueStep step2 = ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(400d));
+    ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
+    ValueStep step2 = ValueStep.of(1, ValueAdjustment.ofReplace(400d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
     assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
   }
 
   public void test_resolveValues_indexBased_indexTooBig() {
-    ValueStep step = ValueStep.of(3, ValueAdjustment.ofAbsoluteAmount(300d));
+    ValueStep step = ValueStep.of(3, ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
     assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
   }
 
   public void test_resolveValues_dateBased_indexZeroInvalid() {
-    ValueStep step = ValueStep.ofAbsoluteAmount(date(2014, 1, 1), 300d);
+    ValueStep step = ValueStep.of(date(2014, 1, 1), ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
     assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
   }
 
   public void test_resolveValues_dateBased_dateInvalid() {
-    ValueStep step = ValueStep.ofAbsoluteAmount(date(2014, 4, 1), 300d);
+    ValueStep step = ValueStep.of(date(2014, 4, 1), ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
     assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
   }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueStepTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueStepTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 public class ValueStepTest {
 
   private static ValueAdjustment DELTA_MINUS_2000 = ValueAdjustment.ofDeltaAmount(-2000);
-  private static ValueAdjustment ABSOLUTE_100 = ValueAdjustment.ofAbsoluteAmount(100);
+  private static ValueAdjustment ABSOLUTE_100 = ValueAdjustment.ofReplace(100);
 
   public void test_of_intAdjustment() {
     ValueStep test = ValueStep.of(2, DELTA_MINUS_2000);
@@ -37,13 +37,6 @@ public class ValueStepTest {
     assertEquals(test.getDate(), Optional.of(date(2014, 6, 30)));
     assertEquals(test.getPeriodIndex(), OptionalInt.empty());
     assertEquals(test.getValue(), DELTA_MINUS_2000);
-  }
-
-  public void test_ofAbsoluteAmount_dateDouble() {
-    ValueStep test = ValueStep.ofAbsoluteAmount(date(2014, 6, 30), 100);
-    assertEquals(test.getDate(), Optional.of(date(2014, 6, 30)));
-    assertEquals(test.getPeriodIndex(), OptionalInt.empty());
-    assertEquals(test.getValue(), ABSOLUTE_100);
   }
 
   public void test_builder_invalid() {

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/FixedRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/FixedRateCalculationTest.java
@@ -95,8 +95,8 @@ public class FixedRateCalculationTest {
         .dayCount(ACT_365F)
         .rate(ValueSchedule.of(
             0.025d,
-            ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(0.020d)),
-            ValueStep.of(2, ValueAdjustment.ofAbsoluteAmount(0.015d))))
+            ValueStep.of(1, ValueAdjustment.ofReplace(0.020d)),
+            ValueStep.of(2, ValueAdjustment.ofReplace(0.015d))))
         .build();
     SchedulePeriod period1 = SchedulePeriod.of(date(2014, 1, 6), date(2014, 2, 5), date(2014, 1, 5), date(2014, 2, 5));
     SchedulePeriod period2 = SchedulePeriod.of(date(2014, 1, 5), date(2014, 2, 5), date(2014, 2, 5), date(2014, 3, 5));

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/IborRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/IborRateCalculationTest.java
@@ -579,8 +579,8 @@ public class IborRateCalculationTest {
         .fixingDateOffset(MINUS_THREE_DAYS)
         .fixingRelativeTo(PERIOD_END)
         .negativeRateMethod(NOT_NEGATIVE)
-        .gearing(ValueSchedule.of(1d, ValueStep.of(2, ValueAdjustment.ofAbsoluteAmount(2d))))
-        .spread(ValueSchedule.of(0d, ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(-0.025d))))
+        .gearing(ValueSchedule.of(1d, ValueStep.of(2, ValueAdjustment.ofReplace(2d))))
+        .spread(ValueSchedule.of(0d, ValueStep.of(1, ValueAdjustment.ofReplace(-0.025d))))
         .build();
     RateAccrualPeriod rap1 = RateAccrualPeriod.builder(ACCRUAL1)
         .yearFraction(ACCRUAL1.yearFraction(ACT_360, ACCRUAL_SCHEDULE))

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/InflationRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/InflationRateCalculationTest.java
@@ -60,7 +60,7 @@ public class InflationRateCalculationTest {
       .build();
 
   private static final ValueSchedule GEARING =
-      ValueSchedule.of(1d, ValueStep.of(2, ValueAdjustment.ofAbsoluteAmount(2d)));
+      ValueSchedule.of(1d, ValueStep.of(2, ValueAdjustment.ofReplace(2d)));
 
   //-------------------------------------------------------------------------
   public void test_of() {

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/NotionalScheduleTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/NotionalScheduleTest.java
@@ -56,7 +56,7 @@ public class NotionalScheduleTest {
   }
 
   public void test_of_CurrencyAndValueSchedule() {
-    ValueSchedule valueSchedule = ValueSchedule.of(1000d, ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(2000d)));
+    ValueSchedule valueSchedule = ValueSchedule.of(1000d, ValueStep.of(1, ValueAdjustment.ofReplace(2000d)));
     NotionalSchedule test = NotionalSchedule.of(GBP, valueSchedule);
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getAmount(), valueSchedule);

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/OvernightRateCalculationTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/OvernightRateCalculationTest.java
@@ -201,8 +201,8 @@ public class OvernightRateCalculationTest {
         .accrualMethod(AVERAGED)
         .negativeRateMethod(NOT_NEGATIVE)
         .rateCutOffDays(2)
-        .gearing(ValueSchedule.of(1d, ValueStep.of(2, ValueAdjustment.ofAbsoluteAmount(2d))))
-        .spread(ValueSchedule.of(0d, ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(-0.025d))))
+        .gearing(ValueSchedule.of(1d, ValueStep.of(2, ValueAdjustment.ofReplace(2d))))
+        .spread(ValueSchedule.of(0d, ValueStep.of(1, ValueAdjustment.ofReplace(-0.025d))))
         .build();
     RateAccrualPeriod rap1 = RateAccrualPeriod.builder(ACCRUAL1)
         .yearFraction(ACCRUAL1.yearFraction(ACT_365F, ACCRUAL_SCHEDULE))

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLegTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLegTest.java
@@ -261,7 +261,7 @@ public class RateCalculationSwapLegTest {
             .build())
         .notionalSchedule(NotionalSchedule.builder()
             .currency(GBP)
-            .amount(ValueSchedule.of(1000d, ValueStep.of(1, ValueAdjustment.ofAbsoluteAmount(1500d))))
+            .amount(ValueSchedule.of(1000d, ValueStep.of(1, ValueAdjustment.ofReplace(1500d))))
             .initialExchange(true)
             .intermediateExchange(true)
             .finalExchange(true)

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/ConstantNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/ConstantNodalCurveTest.java
@@ -107,7 +107,7 @@ public class ConstantNodalCurveTest {
 
   public void test_shiftedBy_adjustment() {
     ConstantNodalCurve base = ConstantNodalCurve.of(CURVE_NAME, VALUE);
-    ConstantNodalCurve test = base.shiftedBy(ImmutableList.of(ValueAdjustment.ofAbsoluteAmount(4d)));
+    ConstantNodalCurve test = base.shiftedBy(ImmutableList.of(ValueAdjustment.ofReplace(4d)));
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(1);
     assertThat(test.getMetadata()).isEqualTo(METADATA);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveTest.java
@@ -153,7 +153,7 @@ public class InterpolatedNodalCurveTest {
   public void test_shiftedBy_adjustment() {
     InterpolatedNodalCurve base = InterpolatedNodalCurve.of(CURVE_NAME, XVALUES, YVALUES, INTERPOLATOR);
     ImmutableList<ValueAdjustment> adjustments = ImmutableList.of(
-        ValueAdjustment.ofAbsoluteAmount(3d), ValueAdjustment.ofDeltaAmount(-2d), ValueAdjustment.ofDeltaAmount(-2d));
+        ValueAdjustment.ofReplace(3d), ValueAdjustment.ofDeltaAmount(-2d), ValueAdjustment.ofDeltaAmount(-2d));
     InterpolatedNodalCurve test = base.shiftedBy(adjustments);
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(SIZE);
@@ -167,7 +167,7 @@ public class InterpolatedNodalCurveTest {
   public void test_shiftedBy_adjustment_longList() {
     InterpolatedNodalCurve base = InterpolatedNodalCurve.of(CURVE_NAME, XVALUES, YVALUES, INTERPOLATOR);
     ImmutableList<ValueAdjustment> adjustments = ImmutableList.of(
-        ValueAdjustment.ofAbsoluteAmount(3d),
+        ValueAdjustment.ofReplace(3d),
         ValueAdjustment.ofDeltaAmount(-2d),
         ValueAdjustment.ofDeltaAmount(-2d),
         ValueAdjustment.ofDeltaAmount(2d));
@@ -184,7 +184,7 @@ public class InterpolatedNodalCurveTest {
   public void test_shiftedBy_adjustment_shortList() {
     InterpolatedNodalCurve base = InterpolatedNodalCurve.of(CURVE_NAME, XVALUES, YVALUES, INTERPOLATOR);
     ImmutableList<ValueAdjustment> adjustments = ImmutableList.of(
-        ValueAdjustment.ofAbsoluteAmount(3d));
+        ValueAdjustment.ofReplace(3d));
     double[] bumped = new double[] {3d, 7d, 8d};
     InterpolatedNodalCurve test = base.shiftedBy(adjustments);
     assertThat(test.getName()).isEqualTo(CURVE_NAME);


### PR DESCRIPTION
Rename "Absolute" to "Replace".
Refer to "absolute shift" and "relative shift" in docs.
