### PR TITLE
Minor time-series changes

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeries.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeries.java
@@ -285,12 +285,6 @@ public interface LocalDateDoubleTimeSeries extends ImmutableBean {
   public abstract LocalDateDoubleTimeSeries filter(ObjDoublePredicate<LocalDate> predicate);
 
   //-------------------------------------------------------------------------
-  // TODO: remove when analytics repo updated
-  @Deprecated
-  public default LocalDateDoubleTimeSeries combineWith(LocalDateDoubleTimeSeries other, DoubleBinaryOperator mapper) {
-    return intersection(other, mapper);
-  }
-
   /**
    * Obtains the intersection of a pair of time series.
    * <p>

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/TradeToDerivativeConverter.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/TradeToDerivativeConverter.java
@@ -17,7 +17,6 @@ import com.opengamma.analytics.financial.instrument.fra.ForwardRateAgreementDefi
 import com.opengamma.analytics.financial.instrument.index.GeneratorSwapFixedIbor;
 import com.opengamma.analytics.financial.instrument.swap.SwapFixedIborDefinition;
 import com.opengamma.analytics.financial.interestrate.InstrumentDerivative;
-import com.opengamma.analytics.util.timeseries.zdt.ImmutableZonedDateTimeDoubleTimeSeries;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
 import com.opengamma.strata.basics.date.HolidayCalendar;
 import com.opengamma.strata.basics.index.IborIndex;
@@ -86,9 +85,8 @@ class TradeToDerivativeConverter {
         expandedFra.getFixedRate(),
         index.getFixingCalendar());
 
-    return analyticFraDefn.toDerivative(
-        valuationDate.atStartOfDay(ZoneOffset.UTC),
-        ImmutableZonedDateTimeDoubleTimeSeries.ofEmptyUTC());
+    // no need for time-series
+    return analyticFraDefn.toDerivative(valuationDate.atStartOfDay(ZoneOffset.UTC));
   }
 
   private static InstrumentDerivative convertSwap(SwapTrade trade, LocalDate valuationDate) {


### PR DESCRIPTION
Remove time-series from FRA to Analytics conversion. Calling a different method avoids dependency on `ZonedDateTime` time-series here.

Remove deprecated time-series method. Fixes a TODO (method was replaced a while back)
