### PR TITLE
Separate base data from scenario data in ScenarioCalculationEnvironment

### DIFF
--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/CalculationEnvironment.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/CalculationEnvironment.java
@@ -162,7 +162,7 @@ public final class CalculationEnvironment implements ImmutableBean, MarketDataLo
       if (failure != null) {
         throw new FailureException(failure);
       }
-      throw new IllegalArgumentException("No market data value available for " + id);
+      throw new IllegalArgumentException("No market data available for " + id);
     }
     if (!id.getMarketDataType().isInstance(value)) {
       throw new IllegalArgumentException(
@@ -187,7 +187,7 @@ public final class CalculationEnvironment implements ImmutableBean, MarketDataLo
     LocalDateDoubleTimeSeries timeSeries = this.timeSeries.get(id);
 
     if (timeSeries == null) {
-      throw new IllegalArgumentException("No time series available for ID " + id);
+      throw new IllegalArgumentException("No time series available for " + id);
     }
     return timeSeries;
   }

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactory.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactory.java
@@ -377,7 +377,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
       results.entrySet().stream().forEach(e -> dataBuilder.addResultUnsafe(e.getKey(), e.getValue()));
     } else {
       // Build single base value for the ID using the base data as input.
-      Result<?> result = buildNonObservableData(id, marketData.getBaseData(), marketDataConfig);
+      Result<?> result = buildNonObservableData(id, marketData.getSharedData(), marketDataConfig);
       applyScenariosToBaseResult(id, result, scenarioDefinition, dataBuilder);
     }
   }
@@ -402,7 +402,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
       ScenarioCalculationEnvironmentBuilder builder) {
 
     if (valueResult.isFailure()) {
-      builder.addBaseResult(id, valueResult);
+      builder.addSharedResult(id, valueResult);
     } else {
       addObservableValue(id, valueResult.getValue(), scenarioDefinition, builder);
     }
@@ -440,7 +440,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
         List<Double> values = mapping.applyPerturbations(value);
         builder.addValues(id, values);
       } else {
-        builder.addBaseValue(id, value);
+        builder.addSharedValue(id, value);
       }
     } catch (RuntimeException e) {
       builder.addResult(id, Result.failure(e));
@@ -614,7 +614,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
       ScenarioCalculationEnvironmentBuilder builder) {
 
     if (valueResult.isFailure()) {
-      builder.addBaseResultUnsafe(id, valueResult);
+      builder.addSharedResultUnsafe(id, valueResult);
     } else {
       addNonObservableValue(id, valueResult.getValue(), scenarioDefinition, builder);
     }
@@ -641,7 +641,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
         .findFirst();
 
     if (!optionalMapping.isPresent()) {
-      builder.addBaseValueUnsafe(id, marketDataValue);
+      builder.addSharedValueUnsafe(id, marketDataValue);
     } else {
       // This is safe because the filter matched the value and the filter and perturbation types are compatible
       @SuppressWarnings("unchecked")

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactory.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactory.java
@@ -10,7 +10,6 @@ import static com.opengamma.strata.collect.Guavate.toImmutableList;
 import static com.opengamma.strata.collect.Guavate.toImmutableMap;
 import static com.opengamma.strata.collect.Guavate.toImmutableSet;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -264,6 +263,11 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
     // needed for the calculations is available.
     //
     // The result of this method also contains details of the problems for market data can't be built or found.
+
+    // As we build the leaf nodes we need to know their dependencies are even though they are no longer in the tree.
+    // This maps from the market data ID to the original node, including all its dependencies
+    Map<MarketDataId<?>, MarketDataNode> nodeMap = root.nodeMap();
+
     while (!root.isLeaf()) {
       // Effectively final reference to buildData which can be used in a lambda expression
       ScenarioCalculationEnvironment marketData = builtData;
@@ -297,36 +301,26 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
 
       // Observable data is built in bulk so it can be efficiently requested from data provider in one operation
       Map<ObservableId, Result<Double>> observableResults = buildObservableData(observableIds);
+      observableResults.entrySet().stream()
+          .forEach(tp -> addObservableResult(tp.getKey(), tp.getValue(), scenarioDefinition, dataBuilder));
 
-      for (Map.Entry<ObservableId, Result<Double>> entry : observableResults.entrySet()) {
-        ObservableId id = entry.getKey();
-        Result<Double> result = entry.getValue();
-
-        Result<List<Double>> scenarioResult = result.flatMap(value -> applyScenarios(id, value, scenarioDefinition));
-        dataBuilder.addResult(id, scenarioResult);
-      }
-      // Copy supplied data to the scenario data after applying perturbations
+      // Copy observable data from the supplied data to the builder, applying any matching perturbations
       leafRequirements.getObservables().stream()
           .filter(suppliedData::containsValue)
-          .forEach(id -> dataBuilder.addResult(id, applyScenarios(id, suppliedData.getValue(id), scenarioDefinition)));
+          .forEach(id -> addObservableValue(id, suppliedData.getValue(id), scenarioDefinition, dataBuilder));
 
       // Non-observable data -----------------------------------------------------------------------
 
       // Filter out IDs for the data that is already available and build the rest
-      List<MarketDataId<?>> nonObservableIds = leafRequirements.getNonObservables().stream()
+      leafRequirements.getNonObservables().stream()
           .filter(not(marketData::containsValues))
           .filter(not(suppliedData::containsValue))
-          .collect(toImmutableList());
-
-      Map<MarketDataId<?>, Result<List<?>>> nonObservableScenarioResults =
-          buildNonObservableScenarioData(nonObservableIds, marketData, marketDataConfig, scenarioDefinition);
-
-      nonObservableScenarioResults.entrySet().stream().forEach(e -> dataBuilder.addResultUnsafe(e.getKey(), e.getValue()));
+          .forEach(id -> addNonObservableValues(id, marketDataConfig, nodeMap, marketData, scenarioDefinition, dataBuilder));
 
       // Copy supplied data to the scenario data after applying perturbations
       leafRequirements.getNonObservables().stream()
           .filter(suppliedData::containsValue)
-          .forEach(id -> dataBuilder.addResultUnsafe(id, perturbValue(id, suppliedData.getValue(id), scenarioDefinition)));
+          .forEach(id -> addNonObservableValue(id, suppliedData.getValue(id), scenarioDefinition, dataBuilder));
 
       // --------------------------------------------------------------------------------------------
 
@@ -340,30 +334,112 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
   }
 
   /**
-   * Applies any applicable perturbation from {@code scenarioDefinition} to an item of market data.
+   * Builds a non-observable market data value and adds it to the data builder.
+   * <p>
+   * If any of the dependencies of the item are in the scenario data then multiple values are built for the item,
+   * one for each scenario. After the values are built the perturbation mappings from the scenario definition
+   * are applied.
+   * <p>
+   * If all dependencies of the item are in the base data then a single value is built.
+   * Perturbation mappings from the scenario are applied. If none of the mappings match the value it is
+   * put into the base data. If any mappings match, the value is perturbed and the perturbed values are put
+   * into the scenario data.
+   *
+   * @param id  ID of the market data
+   * @param marketDataConfig  configuration used when building market data
+   * @param nodeMap  map of market data ID to the node in the dependency graph for the market data value
+   * @param marketData  the set of market data containing any dependencies required to build the value
+   * @param scenarioDefinition  definition of a scenario used to perturb the built value
+   * @param dataBuilder  the built values are put into this builder
+   */
+  private void addNonObservableValues(
+      MarketDataId<?> id,
+      MarketDataConfig marketDataConfig,
+      Map<MarketDataId<?>, MarketDataNode> nodeMap,
+      ScenarioCalculationEnvironment marketData,
+      ScenarioDefinition scenarioDefinition,
+      ScenarioCalculationEnvironmentBuilder dataBuilder) {
+
+    // Gets a copy of the current node including the child nodes representing the dependencies of the node's value
+    MarketDataNode node = nodeMap.get(id);
+    Set<MarketDataId<?>> dependencyIds = node.getDependencies().stream()
+        .map(MarketDataNode::getId)
+        .collect(toImmutableSet());
+    // This flag is true if any of the dependencies are in the scenario data.
+    // If this is true then multiple values must be built for the ID using the scenario data
+    // If this is false a single value must be built using the base data
+    boolean dependencyInScenario = dependencyIds.stream().anyMatch(marketData::containsScenarioValues);
+
+    if (dependencyInScenario) {
+      Map<MarketDataId<?>, Result<List<?>>> results =
+          buildNonObservableScenarioData(id, marketData, marketDataConfig, scenarioDefinition);
+
+      results.entrySet().stream().forEach(e -> dataBuilder.addResultUnsafe(e.getKey(), e.getValue()));
+    } else {
+      // Build single base value for the ID using the base data as input.
+      Result<?> result = buildNonObservableData(id, marketData.getBaseData(), marketDataConfig);
+      applyScenariosToBaseResult(id, result, scenarioDefinition, dataBuilder);
+    }
+  }
+
+  /**
+   * Adds an item of observable market data to a builder.
+   * <p>
+   * If the result is a failure it is added to the base data failures.
+   * <p>
+   * If the result is a success it is passed to {@link #addObservableValue} where the scenario definition is
+   * applied and the data is added to the builder.
+   *
+   * @param id  ID of the market data value
+   * @param valueResult  a result containing the market data value or details of why it couldn't be built
+   * @param scenarioDefinition  definition of a set of scenarios
+   * @param builder  the value or failure details are added to this builder
+   */
+  private void addObservableResult(
+      ObservableId id,
+      Result<Double> valueResult,
+      ScenarioDefinition scenarioDefinition,
+      ScenarioCalculationEnvironmentBuilder builder) {
+
+    if (valueResult.isFailure()) {
+      builder.addBaseResult(id, valueResult);
+    } else {
+      addObservableValue(id, valueResult.getValue(), scenarioDefinition, builder);
+    }
+  }
+
+  /**
+   * Adds an item of observable market data to a builder.
+   * <p>
+   * The mappings from the scenario definition is applied to the value. If any of the mappings match the value
+   * is perturbed and the perturbed values are added to the scenario data. If none of the mappings match
+   * the input value is added to the base data.
    *
    * @param id  ID of the market data value
    * @param value  the market data value
    * @param scenarioDefinition  definition of a set of scenarios
-   * @return perturbed values derived from the market data value, one for each scenario
+   * @param builder  the market data is added to this builder
    */
-  private Result<List<Double>> applyScenarios(ObservableId id, double value, ScenarioDefinition scenarioDefinition) {
+  private void addObservableValue(
+      ObservableId id,
+      double value,
+      ScenarioDefinition scenarioDefinition,
+      ScenarioCalculationEnvironmentBuilder builder) {
+
     // Filters and perturbations can be user-supplied and we can't guarantee they won't throw exceptions
     try {
-      Optional<PerturbationMapping<?>> mapping =
-          scenarioDefinition.getMappings().stream()
-              .filter(m -> m.matches(id, value))
-              .findFirst();
+      Optional<PerturbationMapping<?>> mapping = scenarioDefinition.getMappings().stream()
+          .filter(m -> m.matches(id, value))
+          .findFirst();
 
       if (mapping.isPresent()) {
         List<Double> values = mapping.get().applyPerturbations(value);
-        return Result.success(values);
+        builder.addValues(id, values);
       } else {
-        List<Double> values = Collections.nCopies(scenarioDefinition.getScenarioCount(), value);
-        return Result.success(values);
+        builder.addBaseValue(id, value);
       }
     } catch (RuntimeException e) {
-      return Result.failure(e);
+      builder.addResult(id, Result.failure(e));
     }
   }
 
@@ -437,7 +513,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
   }
 
   /**
-   * Builds multiple versions of items of market data, one for each scenario.
+   * Builds multiple versions of an item of market data, one for each scenario.
    * <p>
    * The values are rebuilt for each scenario on the assumption that its input data or market data source might be
    * different for each scenario.
@@ -445,42 +521,38 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
    * After a value is built the perturbations in the scenario definition are examined and any applicable
    * perturbation is applied to the value.
    *
-   * @param ids  IDs of the market data values
+   * @param id ID of the market data value
    * @param marketData  market data containing any dependencies of the values being built
    * @param marketDataConfig  configuration specifying how market data should be built
    * @param scenarioDefinition  definition of the scenarios
    */
   private Map<MarketDataId<?>, Result<List<?>>> buildNonObservableScenarioData(
-      List<MarketDataId<?>> ids,
+      MarketDataId<?> id,
       ScenarioCalculationEnvironment marketData,
       MarketDataConfig marketDataConfig,
       ScenarioDefinition scenarioDefinition) {
 
     ImmutableMap.Builder<MarketDataId<?>, Result<List<?>>> resultMap = ImmutableMap.builder();
 
-    for (MarketDataId<?> id : ids) {
-      List<Result<?>> results =
-          IntStream.range(0, scenarioDefinition.getScenarioCount()).boxed()
-              .map(scenarioIndex -> new ScenarioMarketDataLookup(marketData, scenarioIndex))
-              .map(data -> buildNonObservableData(id, data, marketDataConfig))
-              .collect(toImmutableList());
+    List<Result<?>> results = IntStream.range(0, scenarioDefinition.getScenarioCount()).boxed()
+        .map(scenarioIndex -> new ScenarioMarketDataLookup(marketData, scenarioIndex))
+        .map(data -> buildNonObservableData(id, data, marketDataConfig))
+        .collect(toImmutableList());
 
-      if (Result.anyFailures(results)) {
-        resultMap.put(id, Result.failure(results));
+    if (Result.anyFailures(results)) {
+      resultMap.put(id, Result.failure(results));
+    } else {
+      List<Result<?>> perturbedValues = Seq.seq(results.stream())
+          .map(Result::getValue)
+          .zipWithIndex()
+          .map(tp -> perturbValue(id, tp.v1, scenarioDefinition, tp.v2.intValue()))
+          .collect(toImmutableList());
+
+      if (Result.anyFailures(perturbedValues)) {
+        resultMap.put(id, Result.failure(perturbedValues));
       } else {
-        List<Result<?>> perturbedValues =
-            Seq.seq(results.stream())
-                .map(Result::getValue)
-                .zipWithIndex()
-                .map(tp -> perturbValue(id, tp.v1, scenarioDefinition, tp.v2.intValue()))
-                .collect(toImmutableList());
-
-        if (Result.anyFailures(perturbedValues)) {
-          resultMap.put(id, Result.failure(perturbedValues));
-        } else {
-          List<Object> values = perturbedValues.stream().map(Result::getValue).collect(toImmutableList());
-          resultMap.put(id, Result.success(values));
-        }
+        List<Object> values = perturbedValues.stream().map(Result::getValue).collect(toImmutableList());
+        resultMap.put(id, Result.success(values));
       }
     }
     return resultMap.build();
@@ -504,10 +576,9 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
       ScenarioDefinition scenarioDefinition,
       int scenarioIndex) {
 
-    Optional<PerturbationMapping<?>> mapping =
-        scenarioDefinition.getMappings().stream()
-            .filter(m -> m.matches(id, marketDataValue))
-            .findFirst();
+    Optional<PerturbationMapping<?>> mapping = scenarioDefinition.getMappings().stream()
+        .filter(m -> m.matches(id, marketDataValue))
+        .findFirst();
 
     if (!mapping.isPresent()) {
       return Result.success(marketDataValue);
@@ -522,29 +593,55 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
   }
 
   /**
-   * Applies perturbations from a scenario definition to an item of non-observable market data if there is
-   * one that applied.
+   * Applies perturbations from a scenario definition to a base market data value and puts the result into a builder.
+   * <p>
+   * If the result is a failure it is added to the base data failures. If it is a success the value is passed
+   * to {@link #addNonObservableValue} and put into the builder after applying any applicable mappings from
+   * the scenario definition.
+   *
+   * @param id  ID of the market data value
+   * @param valueResult  a result containing the market data value
+   * @param scenarioDefinition  the definition of the scenarios
+   */
+  private void applyScenariosToBaseResult(
+      MarketDataId<?> id,
+      Result<?> valueResult,
+      ScenarioDefinition scenarioDefinition,
+      ScenarioCalculationEnvironmentBuilder builder) {
+
+    if (valueResult.isFailure()) {
+      builder.addBaseResultUnsafe(id, valueResult);
+    } else {
+      addNonObservableValue(id, valueResult.getValue(), scenarioDefinition, builder);
+    }
+  }
+
+  /**
+   * Applies perturbations from a scenario definition to a base market data value and puts the result into a builder.
+   * <p>
+   * If no perturbations apply the base value is put into the base data. If there is an applicable perturbation
+   * it is applied to create a market value for each scenario. These scenario values are put into the scenario data.
    *
    * @param id  ID of the market data value
    * @param marketDataValue  the market data value
    * @param scenarioDefinition  the definition of the scenarios
-   * @return the item of data with any applicable perturbations applied
    */
-  private Result<List<?>> perturbValue(
+  private void addNonObservableValue(
       MarketDataId<?> id,
       Object marketDataValue,
-      ScenarioDefinition scenarioDefinition) {
+      ScenarioDefinition scenarioDefinition,
+      ScenarioCalculationEnvironmentBuilder builder) {
 
-    List<Result<Object>> results =
-        IntStream.range(0, scenarioDefinition.getScenarioCount())
-            .mapToObj(idx -> perturbValue(id, marketDataValue, scenarioDefinition, idx))
-            .collect(toImmutableList());
+    Optional<PerturbationMapping<?>> optionalMapping = scenarioDefinition.getMappings().stream()
+        .filter(mapping -> mapping.matches(id, marketDataValue))
+        .findFirst();
 
-    if (Result.anyFailures(results)) {
-      return Result.failure(results);
+    if (!optionalMapping.isPresent()) {
+      builder.addBaseValueUnsafe(id, marketDataValue);
     } else {
-      List<Object> values = results.stream().map(Result::getValue).collect(toImmutableList());
-      return Result.success(values);
+      PerturbationMapping<?> mapping = optionalMapping.get();
+      List<Object> perturbedValues = mapping.applyPerturbations(marketDataValue);
+      builder.addValuesUnsafe(id, perturbedValues);
     }
   }
 

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DependencyTreeBuilder.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/DependencyTreeBuilder.java
@@ -80,17 +80,17 @@ class DependencyTreeBuilder {
    *
    * @return nodes representing the dependencies of the market data required for a set of calculations
    */
-  List<MarketDataNode> childNodes() {
-    return childNodes(requirements);
+  List<MarketDataNode> dependencyNodes() {
+    return dependencyNodes(requirements);
   }
 
   /**
-   * Returns child nodes representing the dependencies of a set of market data.
+   * Returns nodes representing the dependencies of a set of market data.
    *
    * @param requirements  requirements for market data needed for a set of calculations
-   * @return child nodes representing the dependencies of a set of market data
+   * @return nodes representing the dependencies of a set of market data
    */
-  private List<MarketDataNode> childNodes(CalculationRequirements requirements) {
+  private List<MarketDataNode> dependencyNodes(CalculationRequirements requirements) {
 
     List<MarketDataNode> observableNodes =
         buildNodes(requirements.getObservables(), MarketDataNode.DataType.SINGLE_VALUE);
@@ -141,7 +141,7 @@ class DependencyTreeBuilder {
     if (builder != null) {
       @SuppressWarnings("unchecked")
       MarketDataRequirements requirements = builder.requirements(id, marketDataConfig);
-      return MarketDataNode.child(id, dataType, childNodes(CalculationRequirements.of(requirements)));
+      return MarketDataNode.child(id, dataType, dependencyNodes(CalculationRequirements.of(requirements)));
     } else {
       // If there is no builder insert a leaf node. It will be flagged as an error when the data is built
       return MarketDataNode.leaf(id, dataType);

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironment.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironment.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.engine.marketdata;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -56,6 +57,10 @@ import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
 @BeanDefinition(builderScope = "private")
 public class ScenarioCalculationEnvironment implements ImmutableBean {
 
+  /** The market data values which are the same in every scenario. */
+  @PropertyDefinition(validate = "notNull")
+  private final CalculationEnvironment baseData;
+
   /** The number of scenarios. */
   @PropertyDefinition(validate = "ArgChecker.notNegativeOrZero")
   private final int scenarioCount;
@@ -69,10 +74,6 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   @PropertyDefinition(validate = "notNull", get = "private")
   private final ImmutableListMultimap<MarketDataId<?>, ?> values;
 
-  /** Time series of observable market data values, keyed by ID, one for each scenario. */
-  @PropertyDefinition(validate = "notNull", get = "private")
-  private final ImmutableMap<ObservableId, LocalDateDoubleTimeSeries> timeSeries;
-
   /** Market dat values that are potentially applicable across all scenarios, keyed by ID. */
   @PropertyDefinition(validate = "notNull", get = "private")
   private final ImmutableMap<? extends MarketDataId<?>, Object> globalValues;
@@ -80,20 +81,6 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   /** Details of failures when building single market data values. */
   @PropertyDefinition(validate = "notNull")
   private final ImmutableMap<MarketDataId<?>, Failure> singleValueFailures;
-
-  /** Details of failures when building time series of market data values. */
-  @PropertyDefinition(validate = "notNull")
-  private final ImmutableMap<MarketDataId<?>, Failure> timeSeriesFailures;
-
-  /**
-   * Returns a mutable builder for building a set of scenario market data.
-   *
-   * @param scenarioCount  the number of scenarios
-   * @return a mutable builder for building a set of scenario market data
-   */
-  public static ScenarioCalculationEnvironmentBuilder builder(int scenarioCount) {
-    return new ScenarioCalculationEnvironmentBuilder(scenarioCount);
-  }
 
   /**
    * Returns a mutable builder for building a set of scenario market data where every scenario has the
@@ -108,56 +95,51 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   }
 
   /**
-   * Returns a set of data for a single scenario, taking the data from an instance of {@link MarketEnvironment}.
+   * Returns a set of data for a single scenario, taking the data from an instance of {@link CalculationEnvironment}.
    *
    * @param marketData  a set of data for a single scenario
    * @return a set of scenario data for a single scenario taken from {@code marketData}
    */
   public static ScenarioCalculationEnvironment of(CalculationEnvironment marketData) {
-    ScenarioCalculationEnvironmentBuilder builder = builder(1, marketData.getValuationDate());
-    builder.addTimeSeries(marketData.getTimeSeries());
-
-    for (Map.Entry<? extends MarketDataId<?>, ?> entry : marketData.getValues().entrySet()) {
-      MarketDataId<Object> id = (MarketDataId<Object>) entry.getKey();
-      Object value = entry.getValue();
-      builder.addValues(id, value);
-    }
-    return builder.build();
+    return new ScenarioCalculationEnvironment(
+        marketData,
+        1,
+        ImmutableList.of(marketData.getValuationDate()),
+        ImmutableListMultimap.of(),
+        ImmutableMap.of(),
+        ImmutableMap.of());
   }
 
   /**
    * Package-private constructor used by the builder.
    *
+   * @param baseData  the set of market data that is the same in all scenarios
    * @param scenarioCount  the number of scenarios
    * @param valuationDates  the valuation date of each scenario
    * @param values  the market data values
-   * @param timeSeries  the time series of market data values
    * @param globalValues  the single values that apply across all scenarios
    * @param singleValueFailures  the single value failures
-   * @param timeSeriesFailures  the time-series failures
    */
   @ImmutableConstructor
   ScenarioCalculationEnvironment(
+      CalculationEnvironment baseData,
       int scenarioCount,
       List<LocalDate> valuationDates,
       ListMultimap<MarketDataId<?>, ?> values,
-      Map<ObservableId, LocalDateDoubleTimeSeries> timeSeries,
       Map<? extends MarketDataId<?>, Object> globalValues,
-      Map<MarketDataId<?>, Failure> singleValueFailures,
-      Map<MarketDataId<?>, Failure> timeSeriesFailures) {
+      Map<MarketDataId<?>, Failure> singleValueFailures) {
 
     ArgChecker.notNegativeOrZero(scenarioCount, "scenarioCount");
+    JodaBeanUtils.notNull(baseData, "baseData");
     JodaBeanUtils.notNull(valuationDates, "valuationDates");
     JodaBeanUtils.notNull(values, "values");
-    JodaBeanUtils.notNull(timeSeries, "timeSeries");
     JodaBeanUtils.notNull(globalValues, "globalValues");
+    this.baseData = baseData;
     this.scenarioCount = scenarioCount;
     this.valuationDates = ImmutableList.copyOf(valuationDates);
     this.values = ImmutableListMultimap.copyOf(values);
-    this.timeSeries = ImmutableMap.copyOf(timeSeries);
     this.globalValues = ImmutableMap.copyOf(globalValues);
     this.singleValueFailures = ImmutableMap.copyOf(singleValueFailures);
-    this.timeSeriesFailures = ImmutableMap.copyOf(timeSeriesFailures);
     validate();
   }
 
@@ -192,10 +174,15 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
     List<?> values = this.values.get(id);
 
-    if (values.isEmpty()) {
-      throw new IllegalArgumentException("No values available for market data ID " + id);
+    if (!values.isEmpty()) {
+      return (List<T>) values;
     }
-    return (List<T>) values;
+    T baseValue = baseData.getValue(id);
+
+    if (baseValue != null) {
+      return Collections.nCopies(scenarioCount, baseValue);
+    }
+    throw new IllegalArgumentException("No market data available for " + id);
   }
 
   /**
@@ -209,12 +196,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    * @throws IllegalArgumentException if there is no time series for the specified ID
    */
   public LocalDateDoubleTimeSeries getTimeSeries(ObservableId id) {
-    LocalDateDoubleTimeSeries series = timeSeries.get(id);
-
-    if (series == null) {
-      throw new IllegalArgumentException("No time series available for market data ID " + id);
-    }
-    return series;
+    return baseData.getTimeSeries(id);
   }
 
   /**
@@ -232,19 +214,39 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     Object value = globalValues.get(id);
 
     if (value == null) {
-      throw new IllegalArgumentException("No values available for market data ID " + id);
+      throw new IllegalArgumentException("No market data available for " + id);
     }
     return (T) value;
   }
 
   /**
-   * Returns true if this set of data contains value for the specified ID.
+   * Returns true if this set of data contains value for the specified ID in the base data or the scenario data.
    *
    * @param id  an ID identifying an item of market data
-   * @return true if this set of data contains values for the specified ID
+   * @return true if this set of data contains values for the specified ID in the base data or the scenario data
    */
   public boolean containsValues(MarketDataId<?> id) {
+    return values.containsKey(id) || baseData.containsValue(id);
+  }
+
+  /**
+   * Returns true if this set of data contains value for the specified ID in the scenario data.
+   *
+   * @param id  an ID identifying an item of market data
+   * @return true if this set of data contains values for the specified ID in the scenario data
+   */
+  public boolean containsScenarioValues(MarketDataId<?> id) {
     return values.containsKey(id);
+  }
+
+  /**
+   * Returns true if this set of data contains a value for the specified ID in the base data.
+   *
+   * @param id  an ID identifying an item of market data
+   * @return true if this set of data contains a value for the specified ID in the base data
+   */
+  public boolean containsBaseValue(MarketDataId<?> id) {
+    return baseData.containsValue(id);
   }
 
   /**
@@ -254,7 +256,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    * @return true if this set of data contains a time series for the specified market data ID
    */
   public boolean containsTimeSeries(ObservableId id) {
-    return timeSeries.containsKey(id);
+    return baseData.containsTimeSeries(id);
   }
 
   /**
@@ -264,13 +266,12 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    */
   public ScenarioCalculationEnvironmentBuilder toBuilder() {
     return new ScenarioCalculationEnvironmentBuilder(
+        baseData,
         scenarioCount,
         valuationDates,
         values,
-        timeSeries,
         globalValues,
-        singleValueFailures,
-        timeSeriesFailures);
+        singleValueFailures);
   }
 
   //------------------------- AUTOGENERATED START -------------------------
@@ -304,6 +305,15 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the market data values which are the same in every scenario.
+   * @return the value of the property, not null
+   */
+  public CalculationEnvironment getBaseData() {
+    return baseData;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Gets the number of scenarios.
    * @return the value of the property
    */
@@ -331,15 +341,6 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
 
   //-----------------------------------------------------------------------
   /**
-   * Gets time series of observable market data values, keyed by ID, one for each scenario.
-   * @return the value of the property, not null
-   */
-  private ImmutableMap<ObservableId, LocalDateDoubleTimeSeries> getTimeSeries() {
-    return timeSeries;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
    * Gets market dat values that are potentially applicable across all scenarios, keyed by ID.
    * @return the value of the property, not null
    */
@@ -357,15 +358,6 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   }
 
   //-----------------------------------------------------------------------
-  /**
-   * Gets details of failures when building time series of market data values.
-   * @return the value of the property, not null
-   */
-  public ImmutableMap<MarketDataId<?>, Failure> getTimeSeriesFailures() {
-    return timeSeriesFailures;
-  }
-
-  //-----------------------------------------------------------------------
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
@@ -373,13 +365,12 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       ScenarioCalculationEnvironment other = (ScenarioCalculationEnvironment) obj;
-      return (getScenarioCount() == other.getScenarioCount()) &&
+      return JodaBeanUtils.equal(getBaseData(), other.getBaseData()) &&
+          (getScenarioCount() == other.getScenarioCount()) &&
           JodaBeanUtils.equal(getValuationDates(), other.getValuationDates()) &&
           JodaBeanUtils.equal(getValues(), other.getValues()) &&
-          JodaBeanUtils.equal(getTimeSeries(), other.getTimeSeries()) &&
           JodaBeanUtils.equal(getGlobalValues(), other.getGlobalValues()) &&
-          JodaBeanUtils.equal(getSingleValueFailures(), other.getSingleValueFailures()) &&
-          JodaBeanUtils.equal(getTimeSeriesFailures(), other.getTimeSeriesFailures());
+          JodaBeanUtils.equal(getSingleValueFailures(), other.getSingleValueFailures());
     }
     return false;
   }
@@ -387,19 +378,18 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(getBaseData());
     hash = hash * 31 + JodaBeanUtils.hashCode(getScenarioCount());
     hash = hash * 31 + JodaBeanUtils.hashCode(getValuationDates());
     hash = hash * 31 + JodaBeanUtils.hashCode(getValues());
-    hash = hash * 31 + JodaBeanUtils.hashCode(getTimeSeries());
     hash = hash * 31 + JodaBeanUtils.hashCode(getGlobalValues());
     hash = hash * 31 + JodaBeanUtils.hashCode(getSingleValueFailures());
-    hash = hash * 31 + JodaBeanUtils.hashCode(getTimeSeriesFailures());
     return hash;
   }
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(256);
+    StringBuilder buf = new StringBuilder(224);
     buf.append("ScenarioCalculationEnvironment{");
     int len = buf.length();
     toString(buf);
@@ -411,13 +401,12 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   }
 
   protected void toString(StringBuilder buf) {
+    buf.append("baseData").append('=').append(JodaBeanUtils.toString(getBaseData())).append(',').append(' ');
     buf.append("scenarioCount").append('=').append(JodaBeanUtils.toString(getScenarioCount())).append(',').append(' ');
     buf.append("valuationDates").append('=').append(JodaBeanUtils.toString(getValuationDates())).append(',').append(' ');
     buf.append("values").append('=').append(JodaBeanUtils.toString(getValues())).append(',').append(' ');
-    buf.append("timeSeries").append('=').append(JodaBeanUtils.toString(getTimeSeries())).append(',').append(' ');
     buf.append("globalValues").append('=').append(JodaBeanUtils.toString(getGlobalValues())).append(',').append(' ');
     buf.append("singleValueFailures").append('=').append(JodaBeanUtils.toString(getSingleValueFailures())).append(',').append(' ');
-    buf.append("timeSeriesFailures").append('=').append(JodaBeanUtils.toString(getTimeSeriesFailures())).append(',').append(' ');
   }
 
   //-----------------------------------------------------------------------
@@ -430,6 +419,11 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
      */
     static final Meta INSTANCE = new Meta();
 
+    /**
+     * The meta-property for the {@code baseData} property.
+     */
+    private final MetaProperty<CalculationEnvironment> baseData = DirectMetaProperty.ofImmutable(
+        this, "baseData", ScenarioCalculationEnvironment.class, CalculationEnvironment.class);
     /**
      * The meta-property for the {@code scenarioCount} property.
      */
@@ -448,12 +442,6 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     private final MetaProperty<ImmutableListMultimap<MarketDataId<?>, ?>> values = DirectMetaProperty.ofImmutable(
         this, "values", ScenarioCalculationEnvironment.class, (Class) ImmutableListMultimap.class);
     /**
-     * The meta-property for the {@code timeSeries} property.
-     */
-    @SuppressWarnings({"unchecked", "rawtypes" })
-    private final MetaProperty<ImmutableMap<ObservableId, LocalDateDoubleTimeSeries>> timeSeries = DirectMetaProperty.ofImmutable(
-        this, "timeSeries", ScenarioCalculationEnvironment.class, (Class) ImmutableMap.class);
-    /**
      * The meta-property for the {@code globalValues} property.
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
@@ -466,23 +454,16 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     private final MetaProperty<ImmutableMap<MarketDataId<?>, Failure>> singleValueFailures = DirectMetaProperty.ofImmutable(
         this, "singleValueFailures", ScenarioCalculationEnvironment.class, (Class) ImmutableMap.class);
     /**
-     * The meta-property for the {@code timeSeriesFailures} property.
-     */
-    @SuppressWarnings({"unchecked", "rawtypes" })
-    private final MetaProperty<ImmutableMap<MarketDataId<?>, Failure>> timeSeriesFailures = DirectMetaProperty.ofImmutable(
-        this, "timeSeriesFailures", ScenarioCalculationEnvironment.class, (Class) ImmutableMap.class);
-    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
+        "baseData",
         "scenarioCount",
         "valuationDates",
         "values",
-        "timeSeries",
         "globalValues",
-        "singleValueFailures",
-        "timeSeriesFailures");
+        "singleValueFailures");
 
     /**
      * Restricted constructor.
@@ -493,20 +474,18 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
+        case -1721984485:  // baseData
+          return baseData;
         case -1203198113:  // scenarioCount
           return scenarioCount;
         case -788641532:  // valuationDates
           return valuationDates;
         case -823812830:  // values
           return values;
-        case 779431844:  // timeSeries
-          return timeSeries;
         case -591591771:  // globalValues
           return globalValues;
         case -1633495726:  // singleValueFailures
           return singleValueFailures;
-        case -1580093459:  // timeSeriesFailures
-          return timeSeriesFailures;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -527,6 +506,14 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code baseData} property.
+     * @return the meta-property, not null
+     */
+    public final MetaProperty<CalculationEnvironment> baseData() {
+      return baseData;
+    }
+
     /**
      * The meta-property for the {@code scenarioCount} property.
      * @return the meta-property, not null
@@ -552,14 +539,6 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
 
     /**
-     * The meta-property for the {@code timeSeries} property.
-     * @return the meta-property, not null
-     */
-    public final MetaProperty<ImmutableMap<ObservableId, LocalDateDoubleTimeSeries>> timeSeries() {
-      return timeSeries;
-    }
-
-    /**
      * The meta-property for the {@code globalValues} property.
      * @return the meta-property, not null
      */
@@ -575,32 +554,22 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
       return singleValueFailures;
     }
 
-    /**
-     * The meta-property for the {@code timeSeriesFailures} property.
-     * @return the meta-property, not null
-     */
-    public final MetaProperty<ImmutableMap<MarketDataId<?>, Failure>> timeSeriesFailures() {
-      return timeSeriesFailures;
-    }
-
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
+        case -1721984485:  // baseData
+          return ((ScenarioCalculationEnvironment) bean).getBaseData();
         case -1203198113:  // scenarioCount
           return ((ScenarioCalculationEnvironment) bean).getScenarioCount();
         case -788641532:  // valuationDates
           return ((ScenarioCalculationEnvironment) bean).getValuationDates();
         case -823812830:  // values
           return ((ScenarioCalculationEnvironment) bean).getValues();
-        case 779431844:  // timeSeries
-          return ((ScenarioCalculationEnvironment) bean).getTimeSeries();
         case -591591771:  // globalValues
           return ((ScenarioCalculationEnvironment) bean).getGlobalValues();
         case -1633495726:  // singleValueFailures
           return ((ScenarioCalculationEnvironment) bean).getSingleValueFailures();
-        case -1580093459:  // timeSeriesFailures
-          return ((ScenarioCalculationEnvironment) bean).getTimeSeriesFailures();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -622,13 +591,12 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    */
   private static class Builder extends DirectFieldsBeanBuilder<ScenarioCalculationEnvironment> {
 
+    private CalculationEnvironment baseData;
     private int scenarioCount;
     private List<LocalDate> valuationDates = ImmutableList.of();
     private ListMultimap<MarketDataId<?>, ?> values = ImmutableListMultimap.of();
-    private Map<ObservableId, LocalDateDoubleTimeSeries> timeSeries = ImmutableMap.of();
     private Map<? extends MarketDataId<?>, Object> globalValues = ImmutableMap.of();
     private Map<MarketDataId<?>, Failure> singleValueFailures = ImmutableMap.of();
-    private Map<MarketDataId<?>, Failure> timeSeriesFailures = ImmutableMap.of();
 
     /**
      * Restricted constructor.
@@ -640,20 +608,18 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
+        case -1721984485:  // baseData
+          return baseData;
         case -1203198113:  // scenarioCount
           return scenarioCount;
         case -788641532:  // valuationDates
           return valuationDates;
         case -823812830:  // values
           return values;
-        case 779431844:  // timeSeries
-          return timeSeries;
         case -591591771:  // globalValues
           return globalValues;
         case -1633495726:  // singleValueFailures
           return singleValueFailures;
-        case -1580093459:  // timeSeriesFailures
-          return timeSeriesFailures;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -663,6 +629,9 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
+        case -1721984485:  // baseData
+          this.baseData = (CalculationEnvironment) newValue;
+          break;
         case -1203198113:  // scenarioCount
           this.scenarioCount = (Integer) newValue;
           break;
@@ -672,17 +641,11 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
         case -823812830:  // values
           this.values = (ListMultimap<MarketDataId<?>, ?>) newValue;
           break;
-        case 779431844:  // timeSeries
-          this.timeSeries = (Map<ObservableId, LocalDateDoubleTimeSeries>) newValue;
-          break;
         case -591591771:  // globalValues
           this.globalValues = (Map<? extends MarketDataId<?>, Object>) newValue;
           break;
         case -1633495726:  // singleValueFailures
           this.singleValueFailures = (Map<MarketDataId<?>, Failure>) newValue;
-          break;
-        case -1580093459:  // timeSeriesFailures
-          this.timeSeriesFailures = (Map<MarketDataId<?>, Failure>) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -717,19 +680,18 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     public ScenarioCalculationEnvironment build() {
       return new ScenarioCalculationEnvironment(
+          baseData,
           scenarioCount,
           valuationDates,
           values,
-          timeSeries,
           globalValues,
-          singleValueFailures,
-          timeSeriesFailures);
+          singleValueFailures);
     }
 
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(256);
+      StringBuilder buf = new StringBuilder(224);
       buf.append("ScenarioCalculationEnvironment.Builder{");
       int len = buf.length();
       toString(buf);
@@ -741,13 +703,12 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
 
     protected void toString(StringBuilder buf) {
+      buf.append("baseData").append('=').append(JodaBeanUtils.toString(baseData)).append(',').append(' ');
       buf.append("scenarioCount").append('=').append(JodaBeanUtils.toString(scenarioCount)).append(',').append(' ');
       buf.append("valuationDates").append('=').append(JodaBeanUtils.toString(valuationDates)).append(',').append(' ');
       buf.append("values").append('=').append(JodaBeanUtils.toString(values)).append(',').append(' ');
-      buf.append("timeSeries").append('=').append(JodaBeanUtils.toString(timeSeries)).append(',').append(' ');
       buf.append("globalValues").append('=').append(JodaBeanUtils.toString(globalValues)).append(',').append(' ');
       buf.append("singleValueFailures").append('=').append(JodaBeanUtils.toString(singleValueFailures)).append(',').append(' ');
-      buf.append("timeSeriesFailures").append('=').append(JodaBeanUtils.toString(timeSeriesFailures)).append(',').append(' ');
     }
 
   }

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironment.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironment.java
@@ -59,7 +59,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
 
   /** The market data values which are the same in every scenario. */
   @PropertyDefinition(validate = "notNull")
-  private final CalculationEnvironment baseData;
+  private final CalculationEnvironment sharedData;
 
   /** The number of scenarios. */
   @PropertyDefinition(validate = "ArgChecker.notNegativeOrZero")
@@ -113,7 +113,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   /**
    * Package-private constructor used by the builder.
    *
-   * @param baseData  the set of market data that is the same in all scenarios
+   * @param sharedData  the set of market data that is the same in all scenarios
    * @param scenarioCount  the number of scenarios
    * @param valuationDates  the valuation date of each scenario
    * @param values  the market data values
@@ -122,7 +122,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    */
   @ImmutableConstructor
   ScenarioCalculationEnvironment(
-      CalculationEnvironment baseData,
+      CalculationEnvironment sharedData,
       int scenarioCount,
       List<LocalDate> valuationDates,
       ListMultimap<MarketDataId<?>, ?> values,
@@ -130,11 +130,11 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
       Map<MarketDataId<?>, Failure> singleValueFailures) {
 
     ArgChecker.notNegativeOrZero(scenarioCount, "scenarioCount");
-    JodaBeanUtils.notNull(baseData, "baseData");
+    JodaBeanUtils.notNull(sharedData, "sharedData");
     JodaBeanUtils.notNull(valuationDates, "valuationDates");
     JodaBeanUtils.notNull(values, "values");
     JodaBeanUtils.notNull(globalValues, "globalValues");
-    this.baseData = baseData;
+    this.sharedData = sharedData;
     this.scenarioCount = scenarioCount;
     this.valuationDates = ImmutableList.copyOf(valuationDates);
     this.values = ImmutableListMultimap.copyOf(values);
@@ -177,12 +177,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     if (!values.isEmpty()) {
       return (List<T>) values;
     }
-    T baseValue = baseData.getValue(id);
-
-    if (baseValue != null) {
-      return Collections.nCopies(scenarioCount, baseValue);
-    }
-    throw new IllegalArgumentException("No market data available for " + id);
+    return Collections.nCopies(scenarioCount, sharedData.getValue(id));
   }
 
   /**
@@ -196,7 +191,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    * @throws IllegalArgumentException if there is no time series for the specified ID
    */
   public LocalDateDoubleTimeSeries getTimeSeries(ObservableId id) {
-    return baseData.getTimeSeries(id);
+    return sharedData.getTimeSeries(id);
   }
 
   /**
@@ -220,13 +215,13 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   }
 
   /**
-   * Returns true if this set of data contains value for the specified ID in the base data or the scenario data.
+   * Returns true if this set of data contains value for the specified ID in the shared data or the scenario data.
    *
    * @param id  an ID identifying an item of market data
-   * @return true if this set of data contains values for the specified ID in the base data or the scenario data
+   * @return true if this set of data contains values for the specified ID in the shared data or the scenario data
    */
   public boolean containsValues(MarketDataId<?> id) {
-    return values.containsKey(id) || baseData.containsValue(id);
+    return values.containsKey(id) || sharedData.containsValue(id);
   }
 
   /**
@@ -240,13 +235,13 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   }
 
   /**
-   * Returns true if this set of data contains a value for the specified ID in the base data.
+   * Returns true if this set of data contains a value for the specified ID in the shared data.
    *
    * @param id  an ID identifying an item of market data
-   * @return true if this set of data contains a value for the specified ID in the base data
+   * @return true if this set of data contains a value for the specified ID in the shared data
    */
-  public boolean containsBaseValue(MarketDataId<?> id) {
-    return baseData.containsValue(id);
+  public boolean containsSharedValue(MarketDataId<?> id) {
+    return sharedData.containsValue(id);
   }
 
   /**
@@ -256,7 +251,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    * @return true if this set of data contains a time series for the specified market data ID
    */
   public boolean containsTimeSeries(ObservableId id) {
-    return baseData.containsTimeSeries(id);
+    return sharedData.containsTimeSeries(id);
   }
 
   /**
@@ -266,7 +261,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    */
   public ScenarioCalculationEnvironmentBuilder toBuilder() {
     return new ScenarioCalculationEnvironmentBuilder(
-        baseData,
+        sharedData,
         scenarioCount,
         valuationDates,
         values,
@@ -308,8 +303,8 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    * Gets the market data values which are the same in every scenario.
    * @return the value of the property, not null
    */
-  public CalculationEnvironment getBaseData() {
-    return baseData;
+  public CalculationEnvironment getSharedData() {
+    return sharedData;
   }
 
   //-----------------------------------------------------------------------
@@ -365,7 +360,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       ScenarioCalculationEnvironment other = (ScenarioCalculationEnvironment) obj;
-      return JodaBeanUtils.equal(getBaseData(), other.getBaseData()) &&
+      return JodaBeanUtils.equal(getSharedData(), other.getSharedData()) &&
           (getScenarioCount() == other.getScenarioCount()) &&
           JodaBeanUtils.equal(getValuationDates(), other.getValuationDates()) &&
           JodaBeanUtils.equal(getValues(), other.getValues()) &&
@@ -378,7 +373,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
-    hash = hash * 31 + JodaBeanUtils.hashCode(getBaseData());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getSharedData());
     hash = hash * 31 + JodaBeanUtils.hashCode(getScenarioCount());
     hash = hash * 31 + JodaBeanUtils.hashCode(getValuationDates());
     hash = hash * 31 + JodaBeanUtils.hashCode(getValues());
@@ -401,7 +396,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
   }
 
   protected void toString(StringBuilder buf) {
-    buf.append("baseData").append('=').append(JodaBeanUtils.toString(getBaseData())).append(',').append(' ');
+    buf.append("sharedData").append('=').append(JodaBeanUtils.toString(getSharedData())).append(',').append(' ');
     buf.append("scenarioCount").append('=').append(JodaBeanUtils.toString(getScenarioCount())).append(',').append(' ');
     buf.append("valuationDates").append('=').append(JodaBeanUtils.toString(getValuationDates())).append(',').append(' ');
     buf.append("values").append('=').append(JodaBeanUtils.toString(getValues())).append(',').append(' ');
@@ -420,10 +415,10 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     static final Meta INSTANCE = new Meta();
 
     /**
-     * The meta-property for the {@code baseData} property.
+     * The meta-property for the {@code sharedData} property.
      */
-    private final MetaProperty<CalculationEnvironment> baseData = DirectMetaProperty.ofImmutable(
-        this, "baseData", ScenarioCalculationEnvironment.class, CalculationEnvironment.class);
+    private final MetaProperty<CalculationEnvironment> sharedData = DirectMetaProperty.ofImmutable(
+        this, "sharedData", ScenarioCalculationEnvironment.class, CalculationEnvironment.class);
     /**
      * The meta-property for the {@code scenarioCount} property.
      */
@@ -458,7 +453,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "baseData",
+        "sharedData",
         "scenarioCount",
         "valuationDates",
         "values",
@@ -474,8 +469,8 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
-        case -1721984485:  // baseData
-          return baseData;
+        case -1784785489:  // sharedData
+          return sharedData;
         case -1203198113:  // scenarioCount
           return scenarioCount;
         case -788641532:  // valuationDates
@@ -507,11 +502,11 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
 
     //-----------------------------------------------------------------------
     /**
-     * The meta-property for the {@code baseData} property.
+     * The meta-property for the {@code sharedData} property.
      * @return the meta-property, not null
      */
-    public final MetaProperty<CalculationEnvironment> baseData() {
-      return baseData;
+    public final MetaProperty<CalculationEnvironment> sharedData() {
+      return sharedData;
     }
 
     /**
@@ -558,8 +553,8 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
-        case -1721984485:  // baseData
-          return ((ScenarioCalculationEnvironment) bean).getBaseData();
+        case -1784785489:  // sharedData
+          return ((ScenarioCalculationEnvironment) bean).getSharedData();
         case -1203198113:  // scenarioCount
           return ((ScenarioCalculationEnvironment) bean).getScenarioCount();
         case -788641532:  // valuationDates
@@ -591,7 +586,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
    */
   private static class Builder extends DirectFieldsBeanBuilder<ScenarioCalculationEnvironment> {
 
-    private CalculationEnvironment baseData;
+    private CalculationEnvironment sharedData;
     private int scenarioCount;
     private List<LocalDate> valuationDates = ImmutableList.of();
     private ListMultimap<MarketDataId<?>, ?> values = ImmutableListMultimap.of();
@@ -608,8 +603,8 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
-        case -1721984485:  // baseData
-          return baseData;
+        case -1784785489:  // sharedData
+          return sharedData;
         case -1203198113:  // scenarioCount
           return scenarioCount;
         case -788641532:  // valuationDates
@@ -629,8 +624,8 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
-        case -1721984485:  // baseData
-          this.baseData = (CalculationEnvironment) newValue;
+        case -1784785489:  // sharedData
+          this.sharedData = (CalculationEnvironment) newValue;
           break;
         case -1203198113:  // scenarioCount
           this.scenarioCount = (Integer) newValue;
@@ -680,7 +675,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     @Override
     public ScenarioCalculationEnvironment build() {
       return new ScenarioCalculationEnvironment(
-          baseData,
+          sharedData,
           scenarioCount,
           valuationDates,
           values,
@@ -703,7 +698,7 @@ public class ScenarioCalculationEnvironment implements ImmutableBean {
     }
 
     protected void toString(StringBuilder buf) {
-      buf.append("baseData").append('=').append(JodaBeanUtils.toString(baseData)).append(',').append(' ');
+      buf.append("sharedData").append('=').append(JodaBeanUtils.toString(sharedData)).append(',').append(' ');
       buf.append("scenarioCount").append('=').append(JodaBeanUtils.toString(scenarioCount)).append(',').append(' ');
       buf.append("valuationDates").append('=').append(JodaBeanUtils.toString(valuationDates)).append(',').append(' ');
       buf.append("values").append('=').append(JodaBeanUtils.toString(values)).append(',').append(' ');

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironmentBuilder.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironmentBuilder.java
@@ -28,8 +28,8 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
  */
 public final class ScenarioCalculationEnvironmentBuilder {
 
-  /** Builder for the base market data. */
-  private final CalculationEnvironmentBuilder baseBuilder;
+  /** Builder for the market data shared between all scenarios. */
+  private final CalculationEnvironmentBuilder sharedBuilder;
 
   /** The number of scenarios. */
   private final int scenarioCount;
@@ -57,7 +57,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    */
   ScenarioCalculationEnvironmentBuilder(int scenarioCount, LocalDate valuationDate) {
     this.scenarioCount = ArgChecker.notNegativeOrZero(scenarioCount, "scenarioCount");
-    this.baseBuilder = CalculationEnvironment.builder(valuationDate);
+    this.sharedBuilder = CalculationEnvironment.builder(valuationDate);
     valuationDate(valuationDate);
   }
 
@@ -66,7 +66,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * <p>
    * This is package-private because it is intended to be used by {@code ScenarioMarketData.builder()}.
    *
-   * @param baseData  the set market data that is the same in all scenarios
+   * @param sharedData  the set market data that is the same in all scenarios
    * @param scenarioCount  the number of scenarios
    * @param valuationDates  the valuation dates for the scenarios
    * @param values  the single market data values
@@ -74,7 +74,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * @param singleValueFailures  the single value failures
    */
   ScenarioCalculationEnvironmentBuilder(
-      CalculationEnvironment baseData,
+      CalculationEnvironment sharedData,
       int scenarioCount,
       List<LocalDate> valuationDates,
       ListMultimap<MarketDataId<?>, ?> values,
@@ -86,7 +86,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
     ArgChecker.notNull(values, "values");
     ArgChecker.notNull(globalValues, "globalValues");
 
-    this.baseBuilder = baseData.toBuilder();
+    this.sharedBuilder = sharedData.toBuilder();
     this.scenarioCount = scenarioCount;
     this.values.putAll(values);
     this.globalValues.putAll(globalValues);
@@ -246,7 +246,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * @return this builder
    */
   public ScenarioCalculationEnvironmentBuilder addTimeSeries(ObservableId id, LocalDateDoubleTimeSeries timeSeries) {
-    baseBuilder.addTimeSeries(id, timeSeries);
+    sharedBuilder.addTimeSeries(id, timeSeries);
     return this;
   }
 
@@ -259,7 +259,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
   public ScenarioCalculationEnvironmentBuilder addTimeSeries(
       Map<? extends ObservableId, LocalDateDoubleTimeSeries> timeSeries) {
 
-    baseBuilder.addAllTimeSeries(timeSeries);
+    sharedBuilder.addAllTimeSeries(timeSeries);
     return this;
   }
 
@@ -274,36 +274,36 @@ public final class ScenarioCalculationEnvironmentBuilder {
       ObservableId id,
       Result<LocalDateDoubleTimeSeries> result) {
 
-    baseBuilder.addTimeSeriesResult(id, result);
+    sharedBuilder.addTimeSeriesResult(id, result);
     return this;
   }
 
   /**
-   * Adds a value to the base market data which is shared between all scenarios.
+   * Adds a value to the market data which is shared between all scenarios.
    *
    * @param id  the ID of the market data value
    * @param value  the market data value
    * @param <T>  the type of the market data value
    * @return this builder
    */
-  public <T> ScenarioCalculationEnvironmentBuilder addBaseValue(MarketDataId<T> id, T value) {
+  public <T> ScenarioCalculationEnvironmentBuilder addSharedValue(MarketDataId<T> id, T value) {
     ArgChecker.notNull(id, "id");
     ArgChecker.notNull(value, "value");
-    baseBuilder.addValue(id, value);
+    sharedBuilder.addValue(id, value);
     return this;
   }
 
   /**
-   * Adds a value to the base market data which is shared between all scenarios.
+   * Adds a value to the market data which is shared between all scenarios.
    *
    * @param id  the ID of the market data value
    * @param value  the market data value
    * @return this builder
    */
-  public ScenarioCalculationEnvironmentBuilder addBaseValueUnsafe(MarketDataId<?> id, Object value) {
+  public ScenarioCalculationEnvironmentBuilder addSharedValueUnsafe(MarketDataId<?> id, Object value) {
     ArgChecker.notNull(id, "id");
     ArgChecker.notNull(value, "value");
-    baseBuilder.addValueUnsafe(id, value);
+    sharedBuilder.addValueUnsafe(id, value);
     return this;
   }
 
@@ -315,7 +315,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * @param <T>  the type of the market data value
    * @return this builder
    */
-  public <T> ScenarioCalculationEnvironmentBuilder addBaseResult(MarketDataId<T> id, Result<T> result) {
+  public <T> ScenarioCalculationEnvironmentBuilder addSharedResult(MarketDataId<T> id, Result<T> result) {
     ArgChecker.notNull(id, "id");
     ArgChecker.notNull(result, "result");
 
@@ -336,7 +336,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * @param result  a result containing the market data value or details of why it could not be provided
    * @return this builder
    */
-  public ScenarioCalculationEnvironmentBuilder addBaseResultUnsafe(MarketDataId<?> id, Result<?> result) {
+  public ScenarioCalculationEnvironmentBuilder addSharedResultUnsafe(MarketDataId<?> id, Result<?> result) {
     ArgChecker.notNull(id, "id");
     ArgChecker.notNull(result, "result");
 
@@ -371,7 +371,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    */
   public ScenarioCalculationEnvironment build() {
     return new ScenarioCalculationEnvironment(
-        baseBuilder.build(),
+        sharedBuilder.build(),
         scenarioCount,
         valuationDates,
         values,

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironmentBuilder.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironmentBuilder.java
@@ -28,6 +28,9 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
  */
 public final class ScenarioCalculationEnvironmentBuilder {
 
+  /** Builder for the base market data. */
+  private final CalculationEnvironmentBuilder baseBuilder;
+
   /** The number of scenarios. */
   private final int scenarioCount;
 
@@ -40,29 +43,11 @@ public final class ScenarioCalculationEnvironmentBuilder {
    */
   private final ListMultimap<MarketDataId<?>, Object> values = ArrayListMultimap.create();
 
-  /**
-   * The time series of market data for the scenarios, keyed by the ID of the market data.
-   * The number of values for each key is the same as the number of scenarios.
-   */
-  private final Map<ObservableId, LocalDateDoubleTimeSeries> timeSeries = new HashMap<>();
-
   /** The global market data values that are applicable to all scenarios. */
   private final Map<MarketDataId<?>, Object> globalValues = new HashMap<>();
 
   /** Details of failures when building single market data values. */
   private final Map<MarketDataId<?>, Failure> singleValueFailures = new HashMap<>();
-
-  /** Details of failures when building time series of market data values. */
-  private final Map<MarketDataId<?>, Failure> timeSeriesFailures = new HashMap<>();
-
-  /**
-   * Creates a new builder with the specified number of scenarios.
-   *
-   * @param scenarioCount the number of scenarios
-   */
-  ScenarioCalculationEnvironmentBuilder(int scenarioCount) {
-    this.scenarioCount = ArgChecker.notNegativeOrZero(scenarioCount, "scenarioCount");
-  }
 
   /**
    * Returns a new builder where every scenario has the same valuation date.
@@ -72,6 +57,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    */
   ScenarioCalculationEnvironmentBuilder(int scenarioCount, LocalDate valuationDate) {
     this.scenarioCount = ArgChecker.notNegativeOrZero(scenarioCount, "scenarioCount");
+    this.baseBuilder = CalculationEnvironment.builder(valuationDate);
     valuationDate(valuationDate);
   }
 
@@ -80,35 +66,31 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * <p>
    * This is package-private because it is intended to be used by {@code ScenarioMarketData.builder()}.
    *
+   * @param baseData  the set market data that is the same in all scenarios
    * @param scenarioCount  the number of scenarios
    * @param valuationDates  the valuation dates for the scenarios
    * @param values  the single market data values
-   * @param timeSeries  the time series of market data values
    * @param globalValues  the single market data values applicable to all scenarios
    * @param singleValueFailures  the single value failures
-   * @param timeSeriesFailures  the time-series failures
    */
   ScenarioCalculationEnvironmentBuilder(
+      CalculationEnvironment baseData,
       int scenarioCount,
       List<LocalDate> valuationDates,
       ListMultimap<MarketDataId<?>, ?> values,
-      Map<ObservableId, LocalDateDoubleTimeSeries> timeSeries,
       Map<? extends MarketDataId<?>, Object> globalValues,
-      Map<MarketDataId<?>, Failure> singleValueFailures,
-      Map<MarketDataId<?>, Failure> timeSeriesFailures) {
+      Map<MarketDataId<?>, Failure> singleValueFailures) {
 
     ArgChecker.notNegativeOrZero(scenarioCount, "scenarioCount");
     ArgChecker.notNull(valuationDates, "valuationDates");
     ArgChecker.notNull(values, "values");
-    ArgChecker.notNull(timeSeries, "timeSeries");
     ArgChecker.notNull(globalValues, "globalValues");
 
+    this.baseBuilder = baseData.toBuilder();
     this.scenarioCount = scenarioCount;
     this.values.putAll(values);
-    this.timeSeries.putAll(timeSeries);
     this.globalValues.putAll(globalValues);
     this.singleValueFailures.putAll(singleValueFailures);
-    this.timeSeriesFailures.putAll(timeSeriesFailures);
     valuationDates(valuationDates);
   }
 
@@ -264,10 +246,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
    * @return this builder
    */
   public ScenarioCalculationEnvironmentBuilder addTimeSeries(ObservableId id, LocalDateDoubleTimeSeries timeSeries) {
-    ArgChecker.notNull(id, "id");
-    ArgChecker.notNull(timeSeries, "timeSeries");
-    this.timeSeries.put(id, timeSeries);
-    timeSeriesFailures.remove(id);
+    baseBuilder.addTimeSeries(id, timeSeries);
     return this;
   }
 
@@ -280,9 +259,7 @@ public final class ScenarioCalculationEnvironmentBuilder {
   public ScenarioCalculationEnvironmentBuilder addTimeSeries(
       Map<? extends ObservableId, LocalDateDoubleTimeSeries> timeSeries) {
 
-    ArgChecker.notNull(timeSeries, "timeSeries");
-    this.timeSeries.putAll(timeSeries);
-    timeSeries.keySet().stream().forEach(timeSeriesFailures::remove);
+    baseBuilder.addAllTimeSeries(timeSeries);
     return this;
   }
 
@@ -297,26 +274,89 @@ public final class ScenarioCalculationEnvironmentBuilder {
       ObservableId id,
       Result<LocalDateDoubleTimeSeries> result) {
 
+    baseBuilder.addTimeSeriesResult(id, result);
+    return this;
+  }
+
+  /**
+   * Adds a value to the base market data which is shared between all scenarios.
+   *
+   * @param id  the ID of the market data value
+   * @param value  the market data value
+   * @param <T>  the type of the market data value
+   * @return this builder
+   */
+  public <T> ScenarioCalculationEnvironmentBuilder addBaseValue(MarketDataId<T> id, T value) {
+    ArgChecker.notNull(id, "id");
+    ArgChecker.notNull(value, "value");
+    baseBuilder.addValue(id, value);
+    return this;
+  }
+
+  /**
+   * Adds a value to the base market data which is shared between all scenarios.
+   *
+   * @param id  the ID of the market data value
+   * @param value  the market data value
+   * @return this builder
+   */
+  public ScenarioCalculationEnvironmentBuilder addBaseValueUnsafe(MarketDataId<?> id, Object value) {
+    ArgChecker.notNull(id, "id");
+    ArgChecker.notNull(value, "value");
+    baseBuilder.addValueUnsafe(id, value);
+    return this;
+  }
+
+  /**
+   * Adds a result for a single item of market data, replacing any existing value with the same ID.
+   *
+   * @param id  the ID of the market data
+   * @param result  a result containing the market data value or details of why it could not be provided
+   * @param <T>  the type of the market data value
+   * @return this builder
+   */
+  public <T> ScenarioCalculationEnvironmentBuilder addBaseResult(MarketDataId<T> id, Result<T> result) {
     ArgChecker.notNull(id, "id");
     ArgChecker.notNull(result, "result");
 
     if (result.isSuccess()) {
-      timeSeries.put(id, result.getValue());
-      timeSeriesFailures.remove(id);
+      values.put(id, result.getValue());
+      singleValueFailures.remove(id);
     } else {
-      timeSeriesFailures.put(id, result.getFailure());
-      timeSeries.remove(id);
+      singleValueFailures.put(id, result.getFailure());
+      values.removeAll(id);
     }
     return this;
   }
 
   /**
-   * Adds a global value that is applicable to all scenarios.
+   * Adds a result for a single item of market data, replacing any existing value with the same ID.
    *
-   * @param id the identifier to associate the value with
-   * @param value the value to add
+   * @param id  the ID of the market data
+   * @param result  a result containing the market data value or details of why it could not be provided
    * @return this builder
    */
+  public ScenarioCalculationEnvironmentBuilder addBaseResultUnsafe(MarketDataId<?> id, Result<?> result) {
+    ArgChecker.notNull(id, "id");
+    ArgChecker.notNull(result, "result");
+
+    if (result.isSuccess()) {
+      values.put(id, result.getValue());
+      singleValueFailures.remove(id);
+    } else {
+      singleValueFailures.put(id, result.getFailure());
+      values.removeAll(id);
+    }
+    return this;
+  }
+
+    /**
+     * Adds a global value that is applicable to all scenarios.
+     *
+     * @param id the identifier to associate the value with
+     * @param value the value to add
+     * @return this builder
+     */
   public <T> ScenarioCalculationEnvironmentBuilder addGlobalValue(MarketDataId<T> id, T value) {
     ArgChecker.notNull(id, "id");
     ArgChecker.notNull(value, "value");
@@ -331,13 +371,12 @@ public final class ScenarioCalculationEnvironmentBuilder {
    */
   public ScenarioCalculationEnvironment build() {
     return new ScenarioCalculationEnvironment(
+        baseBuilder.build(),
         scenarioCount,
         valuationDates,
         values,
-        timeSeries,
         globalValues,
-        singleValueFailures,
-        timeSeriesFailures);
+        singleValueFailures);
   }
 
   private void checkLength(int length, String itemName) {

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/scenarios/PerturbationMapping.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/scenarios/PerturbationMapping.java
@@ -125,9 +125,9 @@ public final class PerturbationMapping<T> implements ImmutableBean {
    * @return a list of market data values derived from the input value by applying the perturbations
    */
   @SuppressWarnings("unchecked")
-  public <U> List<U> applyPerturbations(U marketData) {
+  public List<T> applyPerturbations(T marketData) {
     // Check that T and U are the same type
-    if (!marketDataType.equals(marketData.getClass())) {
+    if (!marketDataType.isInstance(marketData)) {
       throw new IllegalArgumentException(
           Messages.format(
               "Market data {} is not an instance of the required type {}",
@@ -136,7 +136,7 @@ public final class PerturbationMapping<T> implements ImmutableBean {
     }
     // T and U are the same type so the casts are safe
     return perturbations.stream()
-        .map(perturbation -> (U) perturbation.apply((T) marketData))
+        .map(perturbation -> perturbation.apply(marketData))
         .collect(toImmutableList());
   }
 

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/function/result/CurrencyValuesArrayTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/function/result/CurrencyValuesArrayTest.java
@@ -74,7 +74,7 @@ public class CurrencyValuesArrayTest {
     assertThrows(
         () -> list.convertedTo(Currency.USD, calculationMarketData),
         IllegalArgumentException.class,
-        "No values available for market data ID .*");
+        "No market data available for .*");
   }
 
   /**

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/function/result/FxConvertibleListTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/calculations/function/result/FxConvertibleListTest.java
@@ -129,7 +129,7 @@ public class FxConvertibleListTest {
     assertThrows(
         () -> list.convertedTo(Currency.USD, calculationMarketData),
         IllegalArgumentException.class,
-        "No values available for market data ID .*");
+        "No market data available for .*");
   }
 
   /**

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactoryTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactoryTest.java
@@ -654,6 +654,12 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketData.getValues(id1)).isEqualTo(ImmutableList.of(1d, 1d, 1d));
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2d, 2d, 2d));
+
+    // Check the values are in the base data, not the scenario data
+    assertThat(marketData.containsBaseValue(id1)).isTrue();
+    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsScenarioValues(id1)).isFalse();
+    assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
 
   /**
@@ -690,6 +696,12 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketData.getValues(id1)).isEqualTo(ImmutableList.of(1d, 1d, 1d));
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2d, 2d, 2d));
+
+    // Check the values are in the base data, not the scenario data
+    assertThat(marketData.containsBaseValue(id1)).isTrue();
+    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsScenarioValues(id1)).isFalse();
+    assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
 
   /**
@@ -768,6 +780,12 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketData.getValues(id1)).isEqualTo(ImmutableList.of(2d, 3d, 4d));
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2d, 2d, 2d));
+
+    // id1 was perturbed so should be in the scenario data, id2 wasn't perturbed so should be in the base data
+    assertThat(marketData.containsBaseValue(id1)).isFalse();
+    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsScenarioValues(id1)).isTrue();
+    assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
 
   /**
@@ -807,32 +825,36 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketData.getValues(id1)).isEqualTo(ImmutableList.of(1d, 1d, 1d));
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2.2d, 2.4d, 2.6d));
+
+    // id2 was perturbed so should be in the scenario data, id1 wasn't perturbed so should be in the base data
+    assertThat(marketData.containsBaseValue(id1)).isTrue();
+    assertThat(marketData.containsBaseValue(id2)).isFalse();
+    assertThat(marketData.containsScenarioValues(id1)).isFalse();
+    assertThat(marketData.containsScenarioValues(id2)).isTrue();
   }
 
   /**
    * Tests building multiple values of non-observable market data for multiple scenarios. The data isn't perturbed.
    */
   public void buildNonObservableScenarioValues() {
-    DefaultMarketDataFactory factory =
-        new DefaultMarketDataFactory(
-            new TestTimeSeriesProvider(ImmutableMap.of()),
-            new TestObservableMarketDataFunction(),
-            new TestFeedIdMapping(),
-            new NonObservableMarketDataFunction());
-    MarketEnvironment suppliedData = MarketEnvironment.empty(date(2011, 3, 8));
+    DefaultMarketDataFactory factory = new DefaultMarketDataFactory(
+        new TestTimeSeriesProvider(ImmutableMap.of()),
+        new TestObservableMarketDataFunction(),
+        new TestFeedIdMapping(),
+        new NonObservableMarketDataFunction());
 
+    MarketEnvironment suppliedData = MarketEnvironment.empty(date(2011, 3, 8));
     NonObservableId id1 = new NonObservableId("a");
     NonObservableId id2 = new NonObservableId("b");
     CalculationRequirements requirements = CalculationRequirements.builder().addValues(id1, id2).build();
 
     // This mapping doesn't perturb any data but it causes three scenarios to be built
-    PerturbationMapping<String> mapping =
-        PerturbationMapping.of(
-            String.class,
-            new FalseFilter<>(NonObservableId.class),
-            new StringAppender(""),
-            new StringAppender(""),
-            new StringAppender(""));
+    PerturbationMapping<String> mapping = PerturbationMapping.of(
+        String.class,
+        new FalseFilter<>(NonObservableId.class),
+        new StringAppender(""),
+        new StringAppender(""),
+        new StringAppender(""));
     ScenarioDefinition scenarioDefinition = ScenarioDefinition.ofMappings(ImmutableList.of(mapping));
     ScenarioCalculationEnvironment marketData = factory.buildScenarioCalculationEnvironment(
         requirements,
@@ -842,6 +864,12 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketData.getValues(id1)).isEqualTo(ImmutableList.of("1.0", "1.0", "1.0"));
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of("2.0", "2.0", "2.0"));
+
+    // Check the values are in the base data, not the scenario data
+    assertThat(marketData.containsBaseValue(id1)).isTrue();
+    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsScenarioValues(id1)).isFalse();
+    assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
 
   /**
@@ -878,6 +906,12 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketData.getValues(id1)).isEqualTo(ImmutableList.of("value1", "value1", "value1"));
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of("value2", "value2", "value2"));
+
+    // Check the values are in the base data, not the scenario data
+    assertThat(marketData.containsBaseValue(id1)).isTrue();
+    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsScenarioValues(id1)).isFalse();
+    assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
 
   /**
@@ -891,9 +925,11 @@ public class DefaultMarketDataFactoryTest {
   public void buildScenarioValuesFromSuppliedData() {
     TestMarketDataFunctionB builderB = new TestMarketDataFunctionB();
     TestMarketDataFunctionC builderC = new TestMarketDataFunctionC();
+    TestIdB idB1 = new TestIdB("1");
+    TestIdB idB2 = new TestIdB("2");
 
     CalculationRequirements requirements = CalculationRequirements.builder()
-        .addValues(new TestIdB("1"), new TestIdB("2"))
+        .addValues(idB1, idB2)
         .build();
 
     LocalDateDoubleTimeSeries timeSeries1 = LocalDateDoubleTimeSeries.builder()
@@ -947,10 +983,10 @@ public class DefaultMarketDataFactoryTest {
         MARKET_DATA_CONFIG);
 
     assertThat(marketData.getSingleValueFailures()).isEmpty();
-    assertThat(marketData.getTimeSeriesFailures()).isEmpty();
+    assertThat(marketData.getBaseData().getTimeSeriesFailures()).isEmpty();
 
-    List<TestMarketDataB> marketDataB1 = marketData.getValues(new TestIdB("1"));
-    List<TestMarketDataB> marketDataB2 = marketData.getValues(new TestIdB("2"));
+    List<TestMarketDataB> marketDataB1 = marketData.getValues(idB1);
+    List<TestMarketDataB> marketDataB2 = marketData.getValues(idB2);
 
     List<TestMarketDataB> expectedB1 = ImmutableList.of(
         new TestMarketDataB(1, new TestMarketDataC(timeSeries1.mapValues(v -> v * 1.1))),
@@ -964,6 +1000,12 @@ public class DefaultMarketDataFactoryTest {
 
     assertThat(marketDataB1).isEqualTo(expectedB1);
     assertThat(marketDataB2).isEqualTo(expectedB2);
+
+    // Check the values are in the scenario data, not the base data
+    assertThat(marketData.containsBaseValue(idB1)).isFalse();
+    assertThat(marketData.containsBaseValue(idB2)).isFalse();
+    assertThat(marketData.containsScenarioValues(idB1)).isTrue();
+    assertThat(marketData.containsScenarioValues(idB2)).isTrue();
   }
 
   /**
@@ -1114,8 +1156,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(failures.get(id1).getMessage()).matches("No market data function available.*");
     assertThat(failures.get(id2).getMessage()).matches("No market data function available.*");
 
-    assertThrows(() -> marketData.getValues(id1), IllegalArgumentException.class, "No values available for.*");
-    assertThrows(() -> marketData.getValues(id2), IllegalArgumentException.class, "No values available for.*");
+    assertThrows(() -> marketData.getValues(id1), IllegalArgumentException.class, "No market data available for.*");
+    assertThrows(() -> marketData.getValues(id2), IllegalArgumentException.class, "No market data available for.*");
   }
 
   /**
@@ -1600,6 +1642,11 @@ public class DefaultMarketDataFactoryTest {
     @Override
     public Class<String> getMarketDataType() {
       return String.class;
+    }
+
+    @Override
+    public String toString() {
+      return "NonObservableId [str='" + str + "']";
     }
   }
 

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactoryTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/DefaultMarketDataFactoryTest.java
@@ -656,8 +656,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2d, 2d, 2d));
 
     // Check the values are in the base data, not the scenario data
-    assertThat(marketData.containsBaseValue(id1)).isTrue();
-    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsSharedValue(id1)).isTrue();
+    assertThat(marketData.containsSharedValue(id2)).isTrue();
     assertThat(marketData.containsScenarioValues(id1)).isFalse();
     assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
@@ -698,8 +698,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2d, 2d, 2d));
 
     // Check the values are in the base data, not the scenario data
-    assertThat(marketData.containsBaseValue(id1)).isTrue();
-    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsSharedValue(id1)).isTrue();
+    assertThat(marketData.containsSharedValue(id2)).isTrue();
     assertThat(marketData.containsScenarioValues(id1)).isFalse();
     assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
@@ -782,8 +782,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2d, 2d, 2d));
 
     // id1 was perturbed so should be in the scenario data, id2 wasn't perturbed so should be in the base data
-    assertThat(marketData.containsBaseValue(id1)).isFalse();
-    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsSharedValue(id1)).isFalse();
+    assertThat(marketData.containsSharedValue(id2)).isTrue();
     assertThat(marketData.containsScenarioValues(id1)).isTrue();
     assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
@@ -827,8 +827,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of(2.2d, 2.4d, 2.6d));
 
     // id2 was perturbed so should be in the scenario data, id1 wasn't perturbed so should be in the base data
-    assertThat(marketData.containsBaseValue(id1)).isTrue();
-    assertThat(marketData.containsBaseValue(id2)).isFalse();
+    assertThat(marketData.containsSharedValue(id1)).isTrue();
+    assertThat(marketData.containsSharedValue(id2)).isFalse();
     assertThat(marketData.containsScenarioValues(id1)).isFalse();
     assertThat(marketData.containsScenarioValues(id2)).isTrue();
   }
@@ -866,8 +866,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of("2.0", "2.0", "2.0"));
 
     // Check the values are in the base data, not the scenario data
-    assertThat(marketData.containsBaseValue(id1)).isTrue();
-    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsSharedValue(id1)).isTrue();
+    assertThat(marketData.containsSharedValue(id2)).isTrue();
     assertThat(marketData.containsScenarioValues(id1)).isFalse();
     assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
@@ -908,8 +908,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketData.getValues(id2)).isEqualTo(ImmutableList.of("value2", "value2", "value2"));
 
     // Check the values are in the base data, not the scenario data
-    assertThat(marketData.containsBaseValue(id1)).isTrue();
-    assertThat(marketData.containsBaseValue(id2)).isTrue();
+    assertThat(marketData.containsSharedValue(id1)).isTrue();
+    assertThat(marketData.containsSharedValue(id2)).isTrue();
     assertThat(marketData.containsScenarioValues(id1)).isFalse();
     assertThat(marketData.containsScenarioValues(id2)).isFalse();
   }
@@ -983,7 +983,7 @@ public class DefaultMarketDataFactoryTest {
         MARKET_DATA_CONFIG);
 
     assertThat(marketData.getSingleValueFailures()).isEmpty();
-    assertThat(marketData.getBaseData().getTimeSeriesFailures()).isEmpty();
+    assertThat(marketData.getSharedData().getTimeSeriesFailures()).isEmpty();
 
     List<TestMarketDataB> marketDataB1 = marketData.getValues(idB1);
     List<TestMarketDataB> marketDataB2 = marketData.getValues(idB2);
@@ -1002,8 +1002,8 @@ public class DefaultMarketDataFactoryTest {
     assertThat(marketDataB2).isEqualTo(expectedB2);
 
     // Check the values are in the scenario data, not the base data
-    assertThat(marketData.containsBaseValue(idB1)).isFalse();
-    assertThat(marketData.containsBaseValue(idB2)).isFalse();
+    assertThat(marketData.containsSharedValue(idB1)).isFalse();
+    assertThat(marketData.containsSharedValue(idB2)).isFalse();
     assertThat(marketData.containsScenarioValues(idB1)).isTrue();
     assertThat(marketData.containsScenarioValues(idB2)).isTrue();
   }

--- a/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/MarketDataNodeTest.java
+++ b/modules/engine/src/test/java/com/opengamma/strata/engine/marketdata/MarketDataNodeTest.java
@@ -261,6 +261,26 @@ public class MarketDataNodeTest {
     assertThat(root).isEqualTo(expected);
   }
 
+  public void nodeMap() {
+    MarketDataNode a1 = observableNode(new TestIdA("1"));
+    MarketDataNode b3 = valueNode(new TestIdB("3"));
+    MarketDataNode a4 = observableNode(new TestIdA("4"));
+    MarketDataNode a6 = timeSeriesNode(new TestIdA("6"));
+    MarketDataNode b5 = valueNode(new TestIdB("5"), a6);
+    MarketDataNode b2 = valueNode(new TestIdB("2"), b3, a4, b5);
+    MarketDataNode b7 = valueNode(new TestIdB("7"));
+    MarketDataNode root = rootNode(a1, b2, b7);
+
+    Map<MarketDataId<?>, MarketDataNode> nodeMap = root.nodeMap();
+    assertThat(nodeMap.get(new TestIdA("1"))).isEqualTo(a1);
+    assertThat(nodeMap.get(new TestIdB("3"))).isEqualTo(b3);
+    assertThat(nodeMap.get(new TestIdA("4"))).isEqualTo(a4);
+    assertThat(nodeMap.get(new TestIdA("6"))).isEqualTo(a6);
+    assertThat(nodeMap.get(new TestIdB("5"))).isEqualTo(b5);
+    assertThat(nodeMap.get(new TestIdB("2"))).isEqualTo(b2);
+    assertThat(nodeMap.get(new TestIdB("7"))).isEqualTo(b7);
+  }
+
   //------------------------------------------------------------------------------------------
 
   private static MarketDataNode rootNode(MarketDataNode... children) {


### PR DESCRIPTION
This PR implements a refactoring of scenarios in preparation for local scenarios.

`ScenarioCalculationEnvironment` now embeds an instance of `CalculationEnvironment` containing the base data, i.e. any data that is the same in all scenarios. When data is requested the scenario data is checked first and then the request is delegated to the base data. 

This separation of base and scenario data is a closer fit to the mental model of most users. It also means the market data containers will be much smaller for environments where only a subset of the data is perturbed in each scenario.

The downside of the changes are additional complexity when building market data but this is unavoidable.