### PR TITLE
Increase examples test coverage

### DIFF
--- a/eclipse/launch/All Strata-Examples.launch
+++ b/eclipse/launch/All Strata-Examples.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.testng.eclipse.launchconfig">
+<listAttribute key="com.mountainminds.eclemma.core.SCOPE_IDS">
+<listEntry value="=strata-examples/src\/main\/java"/>
+</listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.testng.remote.RemoteTestNG"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="strata-examples"/>
@@ -11,11 +14,12 @@
 <stringAttribute key="org.testng.eclipse.LOG_LEVEL" value="2"/>
 <listAttribute key="org.testng.eclipse.METHOD_TEST_LIST"/>
 <listAttribute key="org.testng.eclipse.PACKAGE_TEST_LIST">
-<listEntry value="com.opengamma.strata.examples.credit"/>
+<listEntry value="com.opengamma.strata.examples.finance"/>
+<listEntry value="com.opengamma.strata.examples.finance.credit"/>
 <listEntry value="com.opengamma.strata.examples.marketdata"/>
 <listEntry value="com.opengamma.strata.examples.marketdata.curve"/>
 <listEntry value="com.opengamma.strata.examples.marketdata.timeseries"/>
-<listEntry value="com.opengamma.strata.examples.regression"/>
+<listEntry value="com.opengamma.strata.examples.report"/>
 </listAttribute>
 <mapAttribute key="org.testng.eclipse.PARAMETERS"/>
 <stringAttribute key="org.testng.eclipse.PRE_DEFINED_LISTENERS" value=""/>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -94,6 +94,14 @@
       <artifactId>jcommander</artifactId>
       <version>1.48</version>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>com.opengamma.strata</groupId>
+      <artifactId>strata-collect</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- ==================================================================== -->

--- a/examples/src/test/java/com/opengamma/strata/examples/finance/ExamplesTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/finance/ExamplesTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.examples.finance;
+
+import static com.opengamma.strata.collect.TestHelper.caputureSystemOut;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test examples do not throw exceptions.
+ */
+@Test
+public class ExamplesTest {
+
+  private static final String[] NO_ARGS = new String[0];
+
+  public void test_csdPricing() {
+    String captured = caputureSystemOut(() -> CdsPricingExample.main(NO_ARGS));
+    assertTrue(captured.contains("+------"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_fraPricing() {
+    String captured = caputureSystemOut(() -> FraPricingExample.main(NO_ARGS));
+    assertTrue(captured.contains("+------"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_genericFuturePricing() {
+    String captured = caputureSystemOut(() -> GenericFuturePricingExample.main(NO_ARGS));
+    assertTrue(captured.contains("+------"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_swapPricing() {
+    String captured = caputureSystemOut(() -> SwapPricingExample.main(NO_ARGS));
+    assertTrue(captured.contains("+------"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_curveScenario() {
+    String captured = caputureSystemOut(() -> CurveScenarioExample.main(NO_ARGS));
+    assertTrue(captured.contains("PV01"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_historicalScenario() {
+    String captured = caputureSystemOut(() -> HistoricalScenarioExample.main(NO_ARGS));
+    assertTrue(captured.contains("Base PV"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_cdsTrade() {
+    String captured = caputureSystemOut(() -> CdsTradeExample.main(NO_ARGS));
+    assertTrue(captured.contains("<product>"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_swapTrade() {
+    String captured = caputureSystemOut(() -> SwapTradeModelDemo.main(NO_ARGS));
+    assertTrue(captured.contains("<product>"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+}

--- a/examples/src/test/java/com/opengamma/strata/examples/marketdata/timeseries/FixingSeriesCsvLoaderTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/marketdata/timeseries/FixingSeriesCsvLoaderTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.examples.marketdata.timeseries;
 
+import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -101,6 +102,11 @@ public class FixingSeriesCsvLoaderTest {
         .build();
 
     assertEquals(actualSeries, expectedSeries);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverPrivateConstructor(FixingSeriesCsvLoader.class);
   }
 
 }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/TestHelper.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/TestHelper.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -284,12 +285,75 @@ public class TestHelper {
    * @param runner  the lambda containing the code to test
    */
   public static void ignoreThrows(AssertRunnable runner) {
-    assertNotNull(runner, "assertThrows() called with null AssertRunnable");
+    assertNotNull(runner, "ignoreThrows() called with null AssertRunnable");
     try {
       runner.run();
     } catch (Throwable ex) {
       // ignore
     }
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Capture system out for testing.
+   * <p>
+   * This returns the output from calls to {@code System.out}.
+   * This is thread-safe, providing that no other utility alters system out.
+   * <p>
+   * For example:
+   * <pre>
+   *  String sysOut = caputureSystemOut(() -> myCode);
+   * </pre>
+   * 
+   * @param runner  the lambda containing the code to test
+   * @return the captured output
+   */
+  public static synchronized String caputureSystemOut(Runnable runner) {
+    // it would be possible to use some form of thread-local PrintStream to increase concurrency,
+    // but that should be done only if synchronized is insufficient
+    assertNotNull(runner, "caputureSystemOut() called with null Runnable");
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+    PrintStream ps = new PrintStream(baos);
+    PrintStream old = System.out;
+    try {
+      System.setOut(ps);
+      runner.run();
+      System.out.flush();
+    } finally {
+      System.setOut(old);
+    }
+    return baos.toString();
+  }
+
+  /**
+   * Capture system err for testing.
+   * <p>
+   * This returns the output from calls to {@code System.err}.
+   * This is thread-safe, providing that no other utility alters system out.
+   * <p>
+   * For example:
+   * <pre>
+   *  String sysErr = caputureSystemerr(() -> myCode);
+   * </pre>
+   * 
+   * @param runner  the lambda containing the code to test
+   * @return the captured output
+   */
+  public static synchronized String caputureSystemErr(Runnable runner) {
+    // it would be possible to use some form of thread-local PrintStream to increase concurrency,
+    // but that should be done only if synchronized is insufficient
+    assertNotNull(runner, "caputureSystemErr() called with null Runnable");
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+    PrintStream ps = new PrintStream(baos);
+    PrintStream old = System.err;
+    try {
+      System.setErr(ps);
+      runner.run();
+      System.err.flush();
+    } finally {
+      System.setErr(old);
+    }
+    return baos.toString();
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Enhance `TestHelper` to add methods to capture `System.out` and `System.err`.