### PR TITLE
Remove ImmutableBean from interfaces

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/Rounding.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/Rounding.java
@@ -8,8 +8,6 @@ package com.opengamma.strata.basics.value;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * A convention defining how to round a number.
  * <p>
@@ -25,8 +23,7 @@ import org.joda.beans.ImmutableBean;
  * <p>
  * All implementations of this interface must be immutable and thread-safe.
  */
-public interface Rounding
-    extends ImmutableBean {
+public interface Rounding {
 
   /**
    * Obtains an instance that performs no rounding.

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/NoRoundingTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/NoRoundingTest.java
@@ -36,8 +36,7 @@ public class NoRoundingTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    Rounding test = Rounding.none();
-    coverImmutableBean(test);
+    coverImmutableBean(NoRounding.INSTANCE);
   }
 
   public void test_serialization() {

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/id/Link.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/id/Link.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.collect.id;
 
-import org.joda.beans.ImmutableBean;
-
 import com.google.common.reflect.TypeToken;
 
 /**
@@ -35,7 +33,7 @@ import com.google.common.reflect.TypeToken;
  * @param <T> the type of the target
  */
 public interface Link<T extends IdentifiableBean>
-    extends StandardIdentifiable, ImmutableBean {
+    extends StandardIdentifiable {
 
   /**
    * Checks if the link is resolved.

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeries.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeries.java
@@ -19,8 +19,6 @@ import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.function.ObjDoublePredicate;
 import com.opengamma.strata.collect.tuple.Pair;
@@ -41,7 +39,7 @@ import com.opengamma.strata.collect.tuple.Pair;
  * Note that {@link Double#NaN} is used internally as a sentinel
  * value and is therefore not allowed as a value.
  */
-public interface LocalDateDoubleTimeSeries extends ImmutableBean {
+public interface LocalDateDoubleTimeSeries {
 
   /**
    * Returns an empty time-series. Generally a singleton instance

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -26,7 +26,9 @@ import java.util.OptionalDouble;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
+import org.joda.beans.ImmutableBean;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -297,7 +299,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
     LocalDateDoubleTimeSeries test =
         LocalDateDoubleTimeSeries.builder().putAll(DATES_2015_1_WEEK, VALUES_1_WEEK).build();
-    double[] array = (double[]) test.property("points").get();
+    double[] array = (double[]) ((Bean) test).property("points").get();
     array[0] = -1;
     LocalDateDoublePoint[] points = test.stream().toArray(LocalDateDoublePoint[]::new);
     assertEquals(points[0], LocalDateDoublePoint.of(DATE_2015_01_05, 10d));
@@ -806,7 +808,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
   //-------------------------------------------------------------------------
   public void test_coverage() {
     TestHelper.coverImmutableBean(
-        DenseLocalDateDoubleTimeSeries.of(DATE_2015_01_05, DATE_2015_01_05,
+        (ImmutableBean) DenseLocalDateDoubleTimeSeries.of(DATE_2015_01_05, DATE_2015_01_05,
             Stream.of(LocalDateDoublePoint.of(DATE_2015_01_05, 1d)), SKIP_WEEKENDS));
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/SparseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/SparseLocalDateDoubleTimeSeriesTest.java
@@ -23,6 +23,7 @@ import java.util.NoSuchElementException;
 import java.util.OptionalDouble;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -229,7 +230,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
 
   public void test_immutableDatesViaBeanGet() {
     LocalDateDoubleTimeSeries test = LocalDateDoubleTimeSeries.builder().putAll(DATES_2010_12, VALUES_10_12).build();
-    LocalDate[] array = (LocalDate[]) test.property("dates").get();
+    LocalDate[] array = (LocalDate[]) ((Bean) test).property("dates").get();
     array[0] = DATE_2012_01_01;
     LocalDateDoublePoint[] points = test.stream().toArray(LocalDateDoublePoint[]::new);
     assertEquals(points[0], LocalDateDoublePoint.of(DATE_2010_01_01, 10d));
@@ -239,7 +240,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
 
   public void test_immutableValuesViaBeanGet() {
     LocalDateDoubleTimeSeries test = LocalDateDoubleTimeSeries.builder().putAll(DATES_2010_12, VALUES_10_12).build();
-    double[] array = (double[]) test.property("values").get();
+    double[] array = (double[]) ((Bean) test).property("values").get();
     array[0] = -1;
     LocalDateDoublePoint[] points = test.stream().toArray(LocalDateDoublePoint[]::new);
     assertEquals(points[0], LocalDateDoublePoint.of(DATE_2010_01_01, 10d));

--- a/modules/finance-beta/src/main/java/com/opengamma/strata/finance/rate/swaption/SwaptionProduct.java
+++ b/modules/finance-beta/src/main/java/com/opengamma/strata/finance/rate/swaption/SwaptionProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate.swaption;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -19,6 +17,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface SwaptionProduct
-    extends Product, Expandable<Swaption>, ImmutableBean {
+    extends Product, Expandable<Swaption> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/Convention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/Convention.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * A market convention.
  * <p>
@@ -25,7 +23,6 @@ import org.joda.beans.ImmutableBean;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface Convention
-    extends ImmutableBean {
+public interface Convention {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/Product.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/Product.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * A financial product that can be traded.
  * <p>
@@ -18,7 +16,6 @@ import org.joda.beans.ImmutableBean;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface Product
-    extends ImmutableBean {
+public interface Product {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/Security.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/Security.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance;
 
-import org.joda.beans.ImmutableBean;
-
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.collect.id.IdentifiableBean;
 import com.opengamma.strata.collect.id.StandardId;
@@ -27,7 +25,7 @@ import com.opengamma.strata.collect.id.StandardId;
  * @param <P>  the type of the product
  */
 public interface Security<P extends Product>
-    extends IdentifiableBean, Attributable, ImmutableBean {
+    extends IdentifiableBean, Attributable {
 
   /**
    * The primary standard identifier for the security.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/Template.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/Template.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * A template used to create a trade.
  * <p>
@@ -21,7 +19,6 @@ import org.joda.beans.ImmutableBean;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface Template
-    extends ImmutableBean {
+public interface Template {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/Trade.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/Trade.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.CalculationTarget;
 
 /**
@@ -19,7 +17,7 @@ import com.opengamma.strata.basics.CalculationTarget;
  * Implementations of this interface must be immutable beans.
  */
 public interface Trade
-    extends CalculationTarget, ImmutableBean {
+    extends CalculationTarget {
 
   /**
    * The additional trade information.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/credit/CdsProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/credit/CdsProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.credit;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -26,6 +24,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface CdsProduct
-    extends Product, Expandable<ExpandedCds>, ImmutableBean {
+    extends Product, Expandable<ExpandedCds> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/equity/EquityProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/equity/EquityProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.equity;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Product;
 
 /**
@@ -18,6 +16,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface EquityProduct
-    extends Product, ImmutableBean {
+    extends Product {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxNonDeliverableForwardProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxNonDeliverableForwardProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.fx;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -20,6 +18,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface FxNonDeliverableForwardProduct
-    extends Product, Expandable<ExpandedFxNonDeliverableForward>, ImmutableBean {
+    extends Product, Expandable<ExpandedFxNonDeliverableForward> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.fx;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -22,6 +20,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface FxProduct
-    extends Product, Expandable<ExpandedFx>, ImmutableBean {
+    extends Product, Expandable<ExpandedFx> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxSwapProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxSwapProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.fx;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -24,6 +22,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface FxSwapProduct
-    extends Product, Expandable<ExpandedFxSwap>, ImmutableBean {
+    extends Product, Expandable<ExpandedFxSwap> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxVanillaOptionProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/fx/FxVanillaOptionProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.fx;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -19,6 +17,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface FxVanillaOptionProduct
-    extends Product, Expandable<FxVanillaOption>, ImmutableBean {
+    extends Product, Expandable<FxVanillaOption> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/RateObservation.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/RateObservation.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate;
 
-import org.joda.beans.ImmutableBean;
-
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.index.Index;
 
@@ -24,8 +22,7 @@ import com.opengamma.strata.basics.index.Index;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface RateObservation
-    extends ImmutableBean {
+public interface RateObservation {
 
   /**
    * Collects all the indices referred to by this observation.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/deposit/IborFixingDepositProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/deposit/IborFixingDepositProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate.deposit;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -21,6 +19,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface IborFixingDepositProduct
-    extends Product, Expandable<ExpandedIborFixingDeposit>, ImmutableBean {
+    extends Product, Expandable<ExpandedIborFixingDeposit> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/deposit/TermDepositProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/deposit/TermDepositProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate.deposit;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -20,6 +18,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface TermDepositProduct
-    extends Product, Expandable<ExpandedTermDeposit>, ImmutableBean {
+    extends Product, Expandable<ExpandedTermDeposit> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/FraProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/FraProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate.fra;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -22,6 +20,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface FraProduct
-    extends Product, Expandable<ExpandedFra>, ImmutableBean {
+    extends Product, Expandable<ExpandedFra> {
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/PaymentEvent.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/PaymentEvent.java
@@ -8,8 +8,6 @@ package com.opengamma.strata.finance.rate.swap;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjuster;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 
@@ -24,8 +22,7 @@ import com.opengamma.strata.basics.date.BusinessDayAdjustment;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface PaymentEvent
-    extends ImmutableBean {
+public interface PaymentEvent {
 
   /**
    * Gets the date that the payment is made.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/PaymentPeriod.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/PaymentPeriod.java
@@ -8,8 +8,6 @@ package com.opengamma.strata.finance.rate.swap;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjuster;
 
-import org.joda.beans.ImmutableBean;
-
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
@@ -27,8 +25,7 @@ import com.opengamma.strata.basics.index.Index;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface PaymentPeriod
-    extends ImmutableBean {
+public interface PaymentPeriod {
 
   /**
    * Gets the date that the payment is made.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculation.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculation.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate.swap;
 
-import org.joda.beans.ImmutableBean;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.index.Index;
@@ -20,8 +18,7 @@ import com.opengamma.strata.basics.schedule.Schedule;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface RateCalculation
-    extends ImmutableBean {
+public interface RateCalculation {
 
   /**
    * Gets the type of the leg, such as Fixed or Ibor.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapLeg.java
@@ -7,8 +7,6 @@ package com.opengamma.strata.finance.rate.swap;
 
 import java.time.LocalDate;
 
-import org.joda.beans.ImmutableBean;
-
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.PayReceive;
 import com.opengamma.strata.basics.currency.Currency;
@@ -32,8 +30,7 @@ import com.opengamma.strata.basics.index.Index;
  * <p>
  * Implementations must be immutable and thread-safe beans.
  */
-public interface SwapLeg
-    extends ImmutableBean {
+public interface SwapLeg {
 
   /**
    * Gets the type of the leg, such as Fixed or Ibor.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapProduct.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/SwapProduct.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.finance.rate.swap;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.finance.Expandable;
 import com.opengamma.strata.finance.Product;
 
@@ -25,6 +23,6 @@ import com.opengamma.strata.finance.Product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface SwapProduct
-    extends Product, Expandable<ExpandedSwap>, ImmutableBean {
+    extends Product, Expandable<ExpandedSwap> {
 
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/Curve.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/Curve.java
@@ -7,8 +7,6 @@ package com.opengamma.strata.market.curve;
 
 import java.time.Period;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * A curve that maps a {@code double} x-value to a {@code double} y-value.
  * <p>
@@ -20,8 +18,7 @@ import org.joda.beans.ImmutableBean;
  * 
  * @see InterpolatedNodalCurve
  */
-public interface Curve
-    extends ImmutableBean {
+public interface Curve {
 
   /**
    * Gets the curve metadata.

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveMetadata.java
@@ -8,8 +8,6 @@ package com.opengamma.strata.market.curve;
 import java.util.List;
 import java.util.Optional;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.market.value.ValueType;
@@ -27,8 +25,7 @@ import com.opengamma.strata.market.value.ValueType;
  * <p>
  * See {@link Curves} for helper methods that create common curve types.
  */
-public interface CurveMetadata
-    extends ImmutableBean {
+public interface CurveMetadata {
 
   /**
    * Gets the curve name.

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/config/CurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/config/CurveNode.java
@@ -9,8 +9,6 @@ import java.time.LocalDate;
 import java.util.Map;
 import java.util.Set;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.finance.Trade;
 import com.opengamma.strata.market.curve.CurveParameterMetadata;
@@ -20,7 +18,7 @@ import com.opengamma.strata.market.curve.CurveParameterMetadata;
  * <p>
  * A curve node is associated with an instrument and provides a method to create a trade representing the instrument.
  */
-public interface CurveNode extends ImmutableBean {
+public interface CurveNode {
 
   /**
    * Returns requirements for the market data needed to build a trade representing the instrument at the node.
@@ -45,4 +43,5 @@ public interface CurveNode extends ImmutableBean {
    * @return metadata for the node
    */
   public abstract CurveParameterMetadata metadata(LocalDate valuationDate);
+
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/PointSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/PointSensitivity.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.market.sensitivity;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxConvertible;
 import com.opengamma.strata.basics.currency.FxRateProvider;
@@ -27,7 +25,7 @@ import com.opengamma.strata.basics.currency.FxRateProvider;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface PointSensitivity
-    extends FxConvertible<PointSensitivity>, ImmutableBean {
+    extends FxConvertible<PointSensitivity> {
 
   /**
    * Gets the currency of the point sensitivity.

--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/SurfaceMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/SurfaceMetadata.java
@@ -8,8 +8,6 @@ package com.opengamma.strata.market.surface;
 import java.util.List;
 import java.util.Optional;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.market.value.ValueType;
@@ -25,8 +23,7 @@ import com.opengamma.strata.market.value.ValueType;
  * This metadata can be used by applications to interpret the parameters of the surface.
  * For example, the scenario framework uses the data when applying perturbations.
  */
-public interface SurfaceMetadata
-    extends ImmutableBean {
+public interface SurfaceMetadata {
 
   /**
    * Gets the surface name.

--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/SurfaceParameterMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/SurfaceParameterMetadata.java
@@ -8,8 +8,6 @@ package com.opengamma.strata.market.surface;
 import java.util.Collections;
 import java.util.List;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * Information about a parameter underlying a surface.
  * <p>
@@ -17,8 +15,7 @@ import org.joda.beans.ImmutableBean;
  * 
  * @see SurfaceMetadata
  */
-public interface SurfaceParameterMetadata
-    extends ImmutableBean {
+public interface SurfaceParameterMetadata {
 
   /**
    * Gets an empty metadata instance.

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/DefaultCurveMetadataTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/DefaultCurveMetadataTest.java
@@ -64,7 +64,7 @@ public class DefaultCurveMetadataTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    CurveMetadata test = DefaultCurveMetadata.of(CURVE_NAME);
+    DefaultCurveMetadata test = DefaultCurveMetadata.of(CURVE_NAME);
     coverImmutableBean(test);
     DefaultCurveMetadata test2 = DefaultCurveMetadata.builder()
         .curveName(CURVE_NAME)

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/credit/IsdaCdsPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/credit/IsdaCdsPricer.java
@@ -6,10 +6,6 @@
 package com.opengamma.strata.pricer.credit;
 
 import java.time.LocalDate;
-import java.util.Set;
-
-import org.joda.beans.MetaBean;
-import org.joda.beans.Property;
 
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.finance.credit.ExpandedCds;
@@ -176,21 +172,6 @@ public class IsdaCdsPricer {
     @Override
     public double firstDerivative(double x) {
       return 0;
-    }
-
-    @Override
-    public MetaBean metaBean() {
-      return null;
-    }
-
-    @Override
-    public <R> Property<R> property(String s) {
-      return null;
-    }
-
-    @Override
-    public Set<String> propertyNames() {
-      return null;
     }
 
     // bootstraps a yield curve from par rates

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/IborFutureProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/IborFutureProvider.java
@@ -5,12 +5,9 @@
  */
 package com.opengamma.strata.pricer.rate.future;
 
-import org.joda.beans.ImmutableBean;
-
 /**
  * Data provider for for model parameters related to Ibor futures and their options.
  */
-public interface IborFutureProvider
-    extends ImmutableBean {
+public interface IborFutureProvider {
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityIborFutureProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityIborFutureProvider.java
@@ -10,15 +10,13 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.joda.beans.ImmutableBean;
-
 import com.opengamma.strata.basics.index.IborIndex;
 
 /**
  * Data provider of volatility for Ibor future options in the normal or Bachelier model.
  */
 public interface NormalVolatilityIborFutureProvider
-    extends IborFutureProvider, ImmutableBean {
+    extends IborFutureProvider {
 
   /**
    * Gets the valuation date-time.

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
@@ -21,10 +21,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
-import org.joda.beans.MetaBean;
-import org.joda.beans.Property;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -367,22 +364,6 @@ public class ImmutableRatesProviderParameterSensitivityTest {
     public double firstDerivative(double x) {
       throw new UnsupportedOperationException();
     }
-
-    @Override
-    public MetaBean metaBean() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <R> Property<R> property(String arg0) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Set<String> propertyNames() {
-      throw new UnsupportedOperationException();
-    }
-
   }
   
 }

--- a/modules/report-beta/src/main/java/com/opengamma/strata/report/result/TradeTokenEvaluator.java
+++ b/modules/report-beta/src/main/java/com/opengamma/strata/report/result/TradeTokenEvaluator.java
@@ -8,6 +8,10 @@ package com.opengamma.strata.report.result;
 import java.util.Optional;
 import java.util.Set;
 
+import org.joda.beans.Bean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaBean;
+
 import com.google.common.collect.Sets;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.result.FailureReason;
@@ -29,17 +33,19 @@ public class TradeTokenEvaluator extends TokenEvaluator<Trade> {
 
   @Override
   public Set<String> tokens(Trade trade) {
-    return Sets.union(trade.propertyNames(), trade.getTradeInfo().propertyNames());
+    MetaBean metaBean = JodaBeanUtils.metaBean(trade.getClass());
+    return Sets.union(metaBean.metaPropertyMap().keySet(), trade.getTradeInfo().propertyNames());
   }
 
   @Override
   public Result<?> evaluate(Trade trade, String token) {
+    MetaBean metaBean = JodaBeanUtils.metaBean(trade.getClass());
     // trade
-    Optional<String> propertyName1 = trade.propertyNames().stream()
+    Optional<String> propertyName1 = metaBean.metaPropertyMap().keySet().stream()
         .filter(p -> p.equalsIgnoreCase(token))
         .findFirst();
     if (propertyName1.isPresent()) {
-      Object propertyValue = trade.property(propertyName1.get()).get();
+      Object propertyValue = metaBean.metaProperty(propertyName1.get()).get((Bean) trade);
       return propertyValue != null ? Result.success(propertyValue) : Result.failure(FailureReason.INVALID_INPUT,
           Messages.format("Property '{}' not set", token));
     }


### PR DESCRIPTION
While implementations should be beans, it is not helpful to force it