### PR TITLE
Swap Pricer: added par spread and par spread sensitivity methods.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapLegPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapLegPricer.java
@@ -124,26 +124,26 @@ public class DiscountingSwapLegPricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Computes the Present Value of a Basis Point for a fixed swap leg. 
+   * Computes the Present Value of a Basis Point for a swap leg. 
    * <p>
    * The Present Value of a Basis Point is the value of the leg when the rate is equal to 1.
    * A better name would be "Present Value of 1".
    * The quantity is also known as "physical annuity" or "level".
    * <p>
    * All the payments periods must be of type {@link RatePaymentPeriod}.
-   * Each period must have a fixed rate, no FX reset and no compounding.
+   * Each period must not have FX reset or compounding.
    * 
    * @param leg  the swap leg
    * @param provider  the rates provider
    * @return the Present Value of a Basis Point
    */
   public double pvbp(SwapLeg leg, RatesProvider provider) {
-    double pvbpFixedLeg = 0.0;
+    double pvbpLeg = 0.0;
     for (PaymentPeriod period : leg.expand().getPaymentPeriods()) {
       ArgChecker.isTrue(period instanceof RatePaymentPeriod, "PaymentPeriod must be instance of RatePaymentPeriod");
-      pvbpFixedLeg += pvbpPayment((RatePaymentPeriod) period, provider);
+      pvbpLeg += pvbpPayment((RatePaymentPeriod) period, provider);
     }
-    return pvbpFixedLeg;
+    return pvbpLeg;
   }
 
   // computes Present Value of a Basis Point for payment with a unique accrual period (no compounding) 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricer.java
@@ -196,6 +196,27 @@ public class DiscountingSwapProductPricer {
     }
   }
 
+  /**
+   * Computes the par spread for swaps. 
+   * <p>
+   * The par spread is the common spread on all payments of the first leg for which the total swap present value is 0.
+   * <p>
+   * The par spread will be computed with respect to the first leg. For that leg, all the payments have a unique 
+   * accrual period (no compounding) and no FX reset.
+   * 
+   * @param product  the swap product for which the par rate should be computed
+   * @param provider  the rates provider
+   * @return the par rate
+   */
+  public double parSpread(SwapProduct product, RatesProvider provider) {
+    ExpandedSwap swap = product.expand();
+    SwapLeg referenceLeg = swap.getLegs().get(0);
+    Currency ccyReferenceLeg = referenceLeg.getCurrency();
+    double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
+    double pvbp = legPricer.pvbp(referenceLeg, provider);
+    return -convertedPv / pvbp;
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Calculates the present value sensitivity of the swap product.
@@ -212,6 +233,28 @@ public class DiscountingSwapProductPricer {
         product.expand(),
         provider,
         legPricer::presentValueSensitivity);
+  }
+
+  /**
+   * Calculates the present value sensitivity of the swap product converted in a given currency.
+   * <p>
+   * The present value sensitivity of the product is the sensitivity of the present value to
+   * the underlying curves.
+   * 
+   * @param product  the product to price
+   * @param currency  the currency to convert to
+   * @param provider  the rates provider
+   * @return the present value curve sensitivity of the swap product converted in the given currency
+   */
+  public PointSensitivityBuilder presentValueSensitivity(SwapProduct product, Currency currency, RatesProvider provider) {
+    PointSensitivityBuilder builder = PointSensitivityBuilder.none();
+    for (ExpandedSwapLeg leg : product.expand().getLegs()) {
+      PointSensitivityBuilder ls = legPricer.presentValueSensitivity(leg, provider);
+      PointSensitivityBuilder lsConverted = 
+          ls.withCurrency(currency).multipliedBy(provider.fxRate(leg.getCurrency(), currency));
+      builder = builder.combinedWith(lsConverted);
+    }
+    return builder;    
   }
 
   /**
@@ -245,7 +288,7 @@ public class DiscountingSwapProductPricer {
   }
 
   /**
-   * Calculates the par rate curve sensitivity for a fixed swap leg. 
+   * Calculates the par rate curve sensitivity for a swap with a fixed leg. 
    * <p>
    * The par rate is the common rate on all payments of the fixed leg for which the total swap present value is 0.
    * <p>
@@ -288,6 +331,32 @@ public class DiscountingSwapProductPricer {
     return pvbpFixedLegDr.multipliedBy(pvbpFixedLegBar)
         .combinedWith(fixedLegEventsPvDr.multipliedBy(fixedLegEventsPvBar))
         .combinedWith(otherLegsConvertedPvDr.multipliedBy(otherLegsConvertedPvBar));
+  }
+
+  /**
+   * Calculates the par spread curve sensitivity for a swap. 
+   * <p>
+   * The par spread is the common spread on all payments of the first leg for which the total swap present value is 0.
+   * <p>
+   * The par spread is computed with respect to the first leg. For that leg, all the payments have a unique 
+   * accrual period (no compounding) and no FX reset.
+   * 
+   * @param product  the product to price
+   * @param provider  the rates provider
+   * @return the par spread curve sensitivity of the swap product
+   */
+  public PointSensitivityBuilder parSpreadSensitivity(SwapProduct product, RatesProvider provider) {
+    ExpandedSwap swap = product.expand();
+    SwapLeg referenceLeg = swap.getLegs().get(0);
+    Currency ccyReferenceLeg = referenceLeg.getCurrency();
+    double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
+    double pvbp = legPricer.pvbp(referenceLeg, provider);
+    // Backward sweep
+    double convertedPvBar = - 1/ pvbp;
+    double pvbpBar = convertedPv / (pvbp * pvbp);
+    PointSensitivityBuilder pvbpDr = legPricer.pvbpSensitivity(referenceLeg, provider);
+    PointSensitivityBuilder convertedPvDr = presentValueSensitivity(swap, ccyReferenceLeg, provider);
+    return convertedPvDr.multipliedBy(convertedPvBar).combinedWith(pvbpDr.multipliedBy(pvbpBar));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricer.java
@@ -352,7 +352,7 @@ public class DiscountingSwapProductPricer {
     double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
     double pvbp = legPricer.pvbp(referenceLeg, provider);
     // Backward sweep
-    double convertedPvBar = - 1/ pvbp;
+    double convertedPvBar = -1d / pvbp;
     double pvbpBar = convertedPv / (pvbp * pvbp);
     PointSensitivityBuilder pvbpDr = legPricer.pvbpSensitivity(referenceLeg, provider);
     PointSensitivityBuilder convertedPvDr = presentValueSensitivity(swap, ccyReferenceLeg, provider);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
@@ -6,12 +6,16 @@
 package com.opengamma.strata.pricer.rate.swap;
 
 import static com.opengamma.strata.basics.PayReceive.RECEIVE;
+import static com.opengamma.strata.basics.BuySell.BUY;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.HolidayCalendars.GBLO;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_6M;
 import static com.opengamma.strata.basics.index.PriceIndices.GB_RPI;
+import static com.opengamma.strata.finance.rate.swap.type.FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FIXED_EXPANDED_SWAP_LEG_PAY;
@@ -32,12 +36,15 @@ import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_CROSS_CUR
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_INFLATION;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_TRADE;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_TRADE_CROSS_CURRENCY;
+import static com.opengamma.strata.basics.date.Tenor.TENOR_5Y;
+import static com.opengamma.strata.pricer.datasets.RatesProviderDataSets.MULTI_USD;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.YearMonth;
 
 import org.testng.annotations.Test;
@@ -67,6 +74,11 @@ import com.opengamma.strata.finance.rate.swap.PaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.PaymentSchedule;
 import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.Swap;
+import com.opengamma.strata.finance.rate.swap.SwapTrade;
+import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapTemplate;
+import com.opengamma.strata.finance.rate.swap.type.IborIborSwapConvention;
+import com.opengamma.strata.finance.rate.swap.type.IborIborSwapTemplate;
+import com.opengamma.strata.finance.rate.swap.type.IborRateSwapLegConvention;
 import com.opengamma.strata.market.amount.CashFlow;
 import com.opengamma.strata.market.amount.CashFlows;
 import com.opengamma.strata.market.curve.Curves;
@@ -104,6 +116,7 @@ public class DiscountingSwapProductPricerTest {
 
   private static final double TOLERANCE_RATE = 1.0e-12;
   private static final double TOLERANCE_RATE_DELTA = 1.0E-6;
+  private static final double TOLERANCE_PV = 1.0e-2;
 
   private static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.LINEAR_INSTANCE;
   private static final LocalDate VAL_DATE_INFLATION = date(2014, 7, 8);
@@ -119,6 +132,40 @@ public class DiscountingSwapProductPricerTest {
           new double[] {1, 1000},
           new double[] {CONSTANT_INDEX, CONSTANT_INDEX},
           INTERPOLATOR));
+  
+
+  private static final IborIborSwapConvention CONV_USD_LIBOR3M_LIBOR6M = // No compounding
+      IborIborSwapConvention.of(IborRateSwapLegConvention.of(USD_LIBOR_3M), IborRateSwapLegConvention.of(USD_LIBOR_6M));
+  private static final double FIXED_RATE = 0.01;
+  private static final double SPREAD = 0.0015;
+  private static final double NOTIONAL_SWAP = 100_000_000;
+  private static final SwapTrade SWAP_USD_FIXED_6M_LIBOR_3M_5Y = FixedIborSwapTemplate
+      .of(Period.ZERO, TENOR_5Y, USD_FIXED_6M_LIBOR_3M)
+      .toTrade(MULTI_USD.getValuationDate(), BUY, NOTIONAL_SWAP, FIXED_RATE);
+  private static final SwapTrade SWAP_USD_LIBOR_3M_LIBOR_6M_5Y = IborIborSwapTemplate
+      .of(Period.ZERO, TENOR_5Y, CONV_USD_LIBOR3M_LIBOR6M)
+      .toTrade(MULTI_USD.getValuationDate(), BUY, NOTIONAL_SWAP, SPREAD);
+  
+  private static final DiscountingSwapProductPricer SWAP_PRODUCT_PRICER = DiscountingSwapProductPricer.DEFAULT;
+
+  //-------------------------------------------------------------------------
+  public void par_spread_sensitivity_fixed_ibor() {
+    ExpandedSwap expanded = SWAP_USD_FIXED_6M_LIBOR_3M_5Y.getProduct().expand();
+    PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();
+    CurveCurrencyParameterSensitivities prAd = MULTI_USD.curveParameterSensitivity(point);
+    CurveCurrencyParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
+        MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
+    assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
+  }
+  
+  public void par_spread_sensitivity_ibor_ibor() {
+    ExpandedSwap expanded = SWAP_USD_LIBOR_3M_LIBOR_6M_5Y.getProduct().expand();
+    PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();
+    CurveCurrencyParameterSensitivities prAd = MULTI_USD.curveParameterSensitivity(point);
+    CurveCurrencyParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
+        MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
+    assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
+  }
 
   //-------------------------------------------------------------------------
   public void test_legPricer() {
@@ -632,6 +679,25 @@ public class DiscountingSwapProductPricerTest {
     assertEquals(explainLeg1.get(ExplainKey.PAYMENT_EVENTS).get().size(), 1);
     assertEquals(explainLeg1.get(ExplainKey.FUTURE_VALUE).get().getCurrency(), leg1.getCurrency());
     assertEquals(explainLeg1.get(ExplainKey.FUTURE_VALUE).get().getAmount(), fv1, TOLERANCE_RATE);
+  }
+  
+  //-------------------------------------------------------------------------
+  public void par_spread_fixed_ibor() {
+    double ps = SWAP_PRODUCT_PRICER.parSpread(SWAP_USD_FIXED_6M_LIBOR_3M_5Y.getProduct(), MULTI_USD);
+    SwapTrade swap0 = FixedIborSwapTemplate
+        .of(Period.ZERO, TENOR_5Y, USD_FIXED_6M_LIBOR_3M)
+        .toTrade(MULTI_USD.getValuationDate(), BUY, NOTIONAL_SWAP, FIXED_RATE + ps);
+    CurrencyAmount pv0 = SWAP_PRODUCT_PRICER.presentValue(swap0.getProduct(), USD, MULTI_USD);
+    assertEquals(pv0.getAmount(),  0, TOLERANCE_PV);
+  }
+  
+  public void par_spread_ibor_ibor() {
+    double ps = SWAP_PRODUCT_PRICER.parSpread(SWAP_USD_LIBOR_3M_LIBOR_6M_5Y.getProduct(), MULTI_USD);
+    SwapTrade swap0 = IborIborSwapTemplate
+        .of(Period.ZERO, TENOR_5Y, CONV_USD_LIBOR3M_LIBOR6M)
+        .toTrade(MULTI_USD.getValuationDate(), BUY, NOTIONAL_SWAP, SPREAD + ps);
+    CurrencyAmount pv0 = SWAP_PRODUCT_PRICER.presentValue(swap0.getProduct(), USD, MULTI_USD);
+    assertEquals(pv0.getAmount(),  0, TOLERANCE_PV);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
@@ -149,25 +149,6 @@ public class DiscountingSwapProductPricerTest {
   private static final DiscountingSwapProductPricer SWAP_PRODUCT_PRICER = DiscountingSwapProductPricer.DEFAULT;
 
   //-------------------------------------------------------------------------
-  public void par_spread_sensitivity_fixed_ibor() {
-    ExpandedSwap expanded = SWAP_USD_FIXED_6M_LIBOR_3M_5Y.getProduct().expand();
-    PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();
-    CurveCurrencyParameterSensitivities prAd = MULTI_USD.curveParameterSensitivity(point);
-    CurveCurrencyParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
-        MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
-    assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
-  }
-  
-  public void par_spread_sensitivity_ibor_ibor() {
-    ExpandedSwap expanded = SWAP_USD_LIBOR_3M_LIBOR_6M_5Y.getProduct().expand();
-    PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();
-    CurveCurrencyParameterSensitivities prAd = MULTI_USD.curveParameterSensitivity(point);
-    CurveCurrencyParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
-        MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
-    assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
-  }
-
-  //-------------------------------------------------------------------------
   public void test_legPricer() {
     PaymentPeriodPricer<PaymentPeriod> mockPeriod = mock(PaymentPeriodPricer.class);
     PaymentEventPricer<PaymentEvent> mockEvent = mock(PaymentEventPricer.class);
@@ -698,6 +679,25 @@ public class DiscountingSwapProductPricerTest {
         .toTrade(MULTI_USD.getValuationDate(), BUY, NOTIONAL_SWAP, SPREAD + ps);
     CurrencyAmount pv0 = SWAP_PRODUCT_PRICER.presentValue(swap0.getProduct(), USD, MULTI_USD);
     assertEquals(pv0.getAmount(),  0, TOLERANCE_PV);
+  }
+
+  //-------------------------------------------------------------------------
+  public void par_spread_sensitivity_fixed_ibor() {
+    ExpandedSwap expanded = SWAP_USD_FIXED_6M_LIBOR_3M_5Y.getProduct().expand();
+    PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();
+    CurveCurrencyParameterSensitivities prAd = MULTI_USD.curveParameterSensitivity(point);
+    CurveCurrencyParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
+        MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
+    assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
+  }
+  
+  public void par_spread_sensitivity_ibor_ibor() {
+    ExpandedSwap expanded = SWAP_USD_LIBOR_3M_LIBOR_6M_5Y.getProduct().expand();
+    PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();
+    CurveCurrencyParameterSensitivities prAd = MULTI_USD.curveParameterSensitivity(point);
+    CurveCurrencyParameterSensitivities prFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
+        MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
+    assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
   }
 
 }


### PR DESCRIPTION
The par spread measure is required for curve calibration. 
Description of the new measure in OpenGamma Documentation n30: Swap pricing in Strata.