### PR TITLE
Define Fra to use payment date not offset

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/DaysAdjustment.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/DaysAdjustment.java
@@ -23,8 +23,6 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
-import com.opengamma.strata.collect.ArgChecker;
-
 /**
  * An adjustment that alters a date by adding a period of days.
  * <p>
@@ -192,7 +190,7 @@ public final class DaysAdjustment
    * The calculation is performed in two steps.
    * <p>
    * Step one, use {@link HolidayCalendar#shift(LocalDate, int)} to add the number of days.
-   * If the holiday calendar is 'None' this will effectively add using simple arithmetic.
+   * If the holiday calendar is 'None' this will effectively add calendar days.
    * <p>
    * Step two, use {@link BusinessDayAdjustment#adjust(LocalDate)} to adjust the result of step one.
    * 
@@ -201,9 +199,24 @@ public final class DaysAdjustment
    */
   @Override
   public LocalDate adjust(LocalDate date) {
-    ArgChecker.notNull(date, "date");
     LocalDate added = calendar.shift(date, days);
     return adjustment.adjust(added);
+  }
+
+  /**
+   * Returns an adjustable date instance resulting from applying this adjustment to a date.
+   * <p>
+   * The number of days of this adjustment is added to the specified date using the
+   * {@link HolidayCalendar#shift(LocalDate, int)}.
+   * If the holiday calendar is 'None' this will effectively add calendar days.
+   * The result is then created from the shifted date and the result of {@link #getAdjustment()}.
+   * 
+   * @param date  the date to adjust
+   * @return the adjusted date
+   */
+  public AdjustableDate toAdjustedDate(LocalDate date) {
+    LocalDate added = calendar.shift(date, days);
+    return AdjustableDate.of(added, adjustment);
   }
 
   /**

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/DaysAdjustmentTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/DaysAdjustmentTest.java
@@ -152,6 +152,23 @@ public class DaysAdjustmentTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_toAdjustedDate1() {
+    DaysAdjustment test = DaysAdjustment.ofBusinessDays(3, HOLCAL_SAT_SUN);
+    // Wed +3 = Mon
+    assertEquals(test.toAdjustedDate(date(2015, 6, 10)), AdjustableDate.of(date(2015, 6, 15), BDA_NONE));
+    // Fri +3 = Wed
+    assertEquals(test.toAdjustedDate(date(2015, 6, 12)), AdjustableDate.of(date(2015, 6, 17), BDA_NONE));
+  }
+
+  public void test_toAdjustedDate2() {
+    DaysAdjustment test = DaysAdjustment.ofBusinessDays(3, HOLCAL_SAT_SUN, BDA_FOLLOW_WED_THU);
+    // Wed +3 = Mon
+    assertEquals(test.toAdjustedDate(date(2015, 6, 10)), AdjustableDate.of(date(2015, 6, 15), BDA_FOLLOW_WED_THU));
+    // Fri +3 = Wed
+    assertEquals(test.toAdjustedDate(date(2015, 6, 12)), AdjustableDate.of(date(2015, 6, 17), BDA_FOLLOW_WED_THU));
+  }
+
+  //-------------------------------------------------------------------------
   public void test_getEffectiveResultCalendar1() {
     DaysAdjustment test = DaysAdjustment.ofBusinessDays(3, HOLCAL_SAT_SUN);
     assertEquals(test.getEffectiveResultCalendar(), HOLCAL_SAT_SUN);

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/Fra.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/Fra.java
@@ -33,6 +33,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.opengamma.strata.basics.BuySell;
 import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DaysAdjustment;
@@ -122,14 +123,15 @@ public final class Fra
   @PropertyDefinition(get = "optional")
   private final BusinessDayAdjustment businessDayAdjustment;
   /**
-   * The offset of the payment date from the start date, optional.
+   * The payment date.
    * <p>
-   * Defines the offset from the start date to the payment date.
-   * If this optional property is present, then the offset will be applied to the start to obtain the payment date.
-   * In most cases, the payment date is the same as the start date, so this property is empty.
+   * The payment date is typically the same as the start date.
+   * The date may be subject to adjustment to ensure it is a business day.
+   * <p>
+   * When building, this will default to the start date with no adjustments if not specified.
    */
-  @PropertyDefinition(get = "optional")
-  private final DaysAdjustment paymentDateOffset;
+  @PropertyDefinition(validate = "notNull")
+  private final AdjustableDate paymentDate;
   /**
    * The fixed rate of interest.
    * A 5% rate will be expressed as 0.05.
@@ -210,6 +212,9 @@ public final class Fra
         builder.discounting = (curr.equals(AUD) || curr.equals(NZD) ? AFMA : ISDA);
       }
     }
+    if (builder.paymentDate == null && builder.startDate != null) {
+      builder.paymentDate = AdjustableDate.of(builder.startDate);
+    }
   }
 
   @ImmutableValidator
@@ -234,9 +239,8 @@ public final class Fra
   public ExpandedFra expand() {
     LocalDate start = getBusinessDayAdjustment().orElse(BusinessDayAdjustment.NONE).adjust(startDate);
     LocalDate end = getBusinessDayAdjustment().orElse(BusinessDayAdjustment.NONE).adjust(endDate);
-    LocalDate payment = getPaymentDateOffset().orElse(DaysAdjustment.NONE).adjust(start);
     return ExpandedFra.builder()
-        .paymentDate(payment)
+        .paymentDate(getPaymentDate().adjusted())
         .startDate(start)
         .endDate(end)
         .yearFraction(dayCount.yearFraction(start, end))
@@ -292,7 +296,7 @@ public final class Fra
       LocalDate startDate,
       LocalDate endDate,
       BusinessDayAdjustment businessDayAdjustment,
-      DaysAdjustment paymentDateOffset,
+      AdjustableDate paymentDate,
       double fixedRate,
       IborIndex index,
       IborIndex indexInterpolated,
@@ -304,6 +308,7 @@ public final class Fra
     ArgChecker.notNegative(notional, "notional");
     JodaBeanUtils.notNull(startDate, "startDate");
     JodaBeanUtils.notNull(endDate, "endDate");
+    JodaBeanUtils.notNull(paymentDate, "paymentDate");
     JodaBeanUtils.notNull(index, "index");
     JodaBeanUtils.notNull(fixingDateOffset, "fixingDateOffset");
     JodaBeanUtils.notNull(dayCount, "dayCount");
@@ -314,7 +319,7 @@ public final class Fra
     this.startDate = startDate;
     this.endDate = endDate;
     this.businessDayAdjustment = businessDayAdjustment;
-    this.paymentDateOffset = paymentDateOffset;
+    this.paymentDate = paymentDate;
     this.fixedRate = fixedRate;
     this.index = index;
     this.indexInterpolated = indexInterpolated;
@@ -423,15 +428,16 @@ public final class Fra
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the offset of the payment date from the start date, optional.
+   * Gets the payment date.
    * <p>
-   * Defines the offset from the start date to the payment date.
-   * If this optional property is present, then the offset will be applied to the start to obtain the payment date.
-   * In most cases, the payment date is the same as the start date, so this property is empty.
-   * @return the optional value of the property, not null
+   * The payment date is typically the same as the start date.
+   * The date may be subject to adjustment to ensure it is a business day.
+   * <p>
+   * When building, this will default to the start date with no adjustments if not specified.
+   * @return the value of the property, not null
    */
-  public Optional<DaysAdjustment> getPaymentDateOffset() {
-    return Optional.ofNullable(paymentDateOffset);
+  public AdjustableDate getPaymentDate() {
+    return paymentDate;
   }
 
   //-----------------------------------------------------------------------
@@ -541,7 +547,7 @@ public final class Fra
           JodaBeanUtils.equal(getStartDate(), other.getStartDate()) &&
           JodaBeanUtils.equal(getEndDate(), other.getEndDate()) &&
           JodaBeanUtils.equal(businessDayAdjustment, other.businessDayAdjustment) &&
-          JodaBeanUtils.equal(paymentDateOffset, other.paymentDateOffset) &&
+          JodaBeanUtils.equal(getPaymentDate(), other.getPaymentDate()) &&
           JodaBeanUtils.equal(getFixedRate(), other.getFixedRate()) &&
           JodaBeanUtils.equal(getIndex(), other.getIndex()) &&
           JodaBeanUtils.equal(indexInterpolated, other.indexInterpolated) &&
@@ -561,7 +567,7 @@ public final class Fra
     hash = hash * 31 + JodaBeanUtils.hashCode(getStartDate());
     hash = hash * 31 + JodaBeanUtils.hashCode(getEndDate());
     hash = hash * 31 + JodaBeanUtils.hashCode(businessDayAdjustment);
-    hash = hash * 31 + JodaBeanUtils.hashCode(paymentDateOffset);
+    hash = hash * 31 + JodaBeanUtils.hashCode(getPaymentDate());
     hash = hash * 31 + JodaBeanUtils.hashCode(getFixedRate());
     hash = hash * 31 + JodaBeanUtils.hashCode(getIndex());
     hash = hash * 31 + JodaBeanUtils.hashCode(indexInterpolated);
@@ -581,7 +587,7 @@ public final class Fra
     buf.append("startDate").append('=').append(getStartDate()).append(',').append(' ');
     buf.append("endDate").append('=').append(getEndDate()).append(',').append(' ');
     buf.append("businessDayAdjustment").append('=').append(businessDayAdjustment).append(',').append(' ');
-    buf.append("paymentDateOffset").append('=').append(paymentDateOffset).append(',').append(' ');
+    buf.append("paymentDate").append('=').append(getPaymentDate()).append(',').append(' ');
     buf.append("fixedRate").append('=').append(getFixedRate()).append(',').append(' ');
     buf.append("index").append('=').append(getIndex()).append(',').append(' ');
     buf.append("indexInterpolated").append('=').append(indexInterpolated).append(',').append(' ');
@@ -633,10 +639,10 @@ public final class Fra
     private final MetaProperty<BusinessDayAdjustment> businessDayAdjustment = DirectMetaProperty.ofImmutable(
         this, "businessDayAdjustment", Fra.class, BusinessDayAdjustment.class);
     /**
-     * The meta-property for the {@code paymentDateOffset} property.
+     * The meta-property for the {@code paymentDate} property.
      */
-    private final MetaProperty<DaysAdjustment> paymentDateOffset = DirectMetaProperty.ofImmutable(
-        this, "paymentDateOffset", Fra.class, DaysAdjustment.class);
+    private final MetaProperty<AdjustableDate> paymentDate = DirectMetaProperty.ofImmutable(
+        this, "paymentDate", Fra.class, AdjustableDate.class);
     /**
      * The meta-property for the {@code fixedRate} property.
      */
@@ -678,7 +684,7 @@ public final class Fra
         "startDate",
         "endDate",
         "businessDayAdjustment",
-        "paymentDateOffset",
+        "paymentDate",
         "fixedRate",
         "index",
         "indexInterpolated",
@@ -707,8 +713,8 @@ public final class Fra
           return endDate;
         case -1065319863:  // businessDayAdjustment
           return businessDayAdjustment;
-        case -716438393:  // paymentDateOffset
-          return paymentDateOffset;
+        case -1540873516:  // paymentDate
+          return paymentDate;
         case 747425396:  // fixedRate
           return fixedRate;
         case 100346066:  // index
@@ -790,11 +796,11 @@ public final class Fra
     }
 
     /**
-     * The meta-property for the {@code paymentDateOffset} property.
+     * The meta-property for the {@code paymentDate} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<DaysAdjustment> paymentDateOffset() {
-      return paymentDateOffset;
+    public MetaProperty<AdjustableDate> paymentDate() {
+      return paymentDate;
     }
 
     /**
@@ -861,8 +867,8 @@ public final class Fra
           return ((Fra) bean).getEndDate();
         case -1065319863:  // businessDayAdjustment
           return ((Fra) bean).businessDayAdjustment;
-        case -716438393:  // paymentDateOffset
-          return ((Fra) bean).paymentDateOffset;
+        case -1540873516:  // paymentDate
+          return ((Fra) bean).getPaymentDate();
         case 747425396:  // fixedRate
           return ((Fra) bean).getFixedRate();
         case 100346066:  // index
@@ -902,7 +908,7 @@ public final class Fra
     private LocalDate startDate;
     private LocalDate endDate;
     private BusinessDayAdjustment businessDayAdjustment;
-    private DaysAdjustment paymentDateOffset;
+    private AdjustableDate paymentDate;
     private double fixedRate;
     private IborIndex index;
     private IborIndex indexInterpolated;
@@ -927,7 +933,7 @@ public final class Fra
       this.startDate = beanToCopy.getStartDate();
       this.endDate = beanToCopy.getEndDate();
       this.businessDayAdjustment = beanToCopy.businessDayAdjustment;
-      this.paymentDateOffset = beanToCopy.paymentDateOffset;
+      this.paymentDate = beanToCopy.getPaymentDate();
       this.fixedRate = beanToCopy.getFixedRate();
       this.index = beanToCopy.getIndex();
       this.indexInterpolated = beanToCopy.indexInterpolated;
@@ -952,8 +958,8 @@ public final class Fra
           return endDate;
         case -1065319863:  // businessDayAdjustment
           return businessDayAdjustment;
-        case -716438393:  // paymentDateOffset
-          return paymentDateOffset;
+        case -1540873516:  // paymentDate
+          return paymentDate;
         case 747425396:  // fixedRate
           return fixedRate;
         case 100346066:  // index
@@ -992,8 +998,8 @@ public final class Fra
         case -1065319863:  // businessDayAdjustment
           this.businessDayAdjustment = (BusinessDayAdjustment) newValue;
           break;
-        case -716438393:  // paymentDateOffset
-          this.paymentDateOffset = (DaysAdjustment) newValue;
+        case -1540873516:  // paymentDate
+          this.paymentDate = (AdjustableDate) newValue;
           break;
         case 747425396:  // fixedRate
           this.fixedRate = (Double) newValue;
@@ -1053,7 +1059,7 @@ public final class Fra
           startDate,
           endDate,
           businessDayAdjustment,
-          paymentDateOffset,
+          paymentDate,
           fixedRate,
           index,
           indexInterpolated,
@@ -1157,16 +1163,18 @@ public final class Fra
     }
 
     /**
-     * Sets the offset of the payment date from the start date, optional.
+     * Sets the payment date.
      * <p>
-     * Defines the offset from the start date to the payment date.
-     * If this optional property is present, then the offset will be applied to the start to obtain the payment date.
-     * In most cases, the payment date is the same as the start date, so this property is empty.
-     * @param paymentDateOffset  the new value
+     * The payment date is typically the same as the start date.
+     * The date may be subject to adjustment to ensure it is a business day.
+     * <p>
+     * When building, this will default to the start date with no adjustments if not specified.
+     * @param paymentDate  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder paymentDateOffset(DaysAdjustment paymentDateOffset) {
-      this.paymentDateOffset = paymentDateOffset;
+    public Builder paymentDate(AdjustableDate paymentDate) {
+      JodaBeanUtils.notNull(paymentDate, "paymentDate");
+      this.paymentDate = paymentDate;
       return this;
     }
 
@@ -1276,7 +1284,7 @@ public final class Fra
       buf.append("startDate").append('=').append(JodaBeanUtils.toString(startDate)).append(',').append(' ');
       buf.append("endDate").append('=').append(JodaBeanUtils.toString(endDate)).append(',').append(' ');
       buf.append("businessDayAdjustment").append('=').append(JodaBeanUtils.toString(businessDayAdjustment)).append(',').append(' ');
-      buf.append("paymentDateOffset").append('=').append(JodaBeanUtils.toString(paymentDateOffset)).append(',').append(' ');
+      buf.append("paymentDate").append('=').append(JodaBeanUtils.toString(paymentDate)).append(',').append(' ');
       buf.append("fixedRate").append('=').append(JodaBeanUtils.toString(fixedRate)).append(',').append(' ');
       buf.append("index").append('=').append(JodaBeanUtils.toString(index)).append(',').append(' ');
       buf.append("indexInterpolated").append('=').append(JodaBeanUtils.toString(indexInterpolated)).append(',').append(' ');

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/FraConvention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/fra/FraConvention.java
@@ -387,7 +387,7 @@ public final class FraConvention
             .startDate(startDate)
             .endDate(endDate)
             .businessDayAdjustment(getBusinessDayAdjustment())
-            .paymentDateOffset(getPaymentDateOffset() != DaysAdjustment.NONE ? getPaymentDateOffset() : null)
+            .paymentDate(getPaymentDateOffset().toAdjustedDate(startDate))
             .fixedRate(fixedRate)
             .index(index)
             .fixingDateOffset(getFixingDateOffset())

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/fra/FraConventionTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/fra/FraConventionTest.java
@@ -223,7 +223,7 @@ public class FraConventionTest {
         .startDate(date(2015, 8, 5))
         .endDate(date(2015, 11, 5))
         .businessDayAdjustment(BDA_MOD_FOLLOW)
-        .paymentDateOffset(PLUS_TWO_DAYS)
+        .paymentDate(PLUS_TWO_DAYS.toAdjustedDate(startDate))
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
         .build();

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/fra/FraTemplateTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/fra/FraTemplateTest.java
@@ -96,7 +96,7 @@ public class FraTemplateTest {
         .startDate(date(2015, 8, 5))
         .endDate(date(2015, 11, 5))
         .businessDayAdjustment(BDA_MOD_FOLLOW)
-        .paymentDateOffset(PLUS_TWO_DAYS)
+        .paymentDate(PLUS_TWO_DAYS.toAdjustedDate(date(2015, 8, 5)))
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
         .build();

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/fra/FraTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/fra/FraTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.TenorAdjustment;
@@ -48,7 +49,6 @@ public class FraTest {
   private static final double NOTIONAL_1M = 1_000_000d;
   private static final double NOTIONAL_2M = 2_000_000d;
   private static final BusinessDayAdjustment BDA_MOD_FOLLOW = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO);
-  private static final DaysAdjustment PLUS_ONE_DAY = DaysAdjustment.ofBusinessDays(1, GBLO);
   private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
   private static final DaysAdjustment MINUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(-2, GBLO);
   private static final DaysAdjustment MINUS_FIVE_DAYS = DaysAdjustment.ofBusinessDays(-5, GBLO);
@@ -69,7 +69,7 @@ public class FraTest {
     assertEquals(test.getStartDate(), date(2015, 6, 15));
     assertEquals(test.getEndDate(), date(2015, 9, 15));
     assertEquals(test.getBusinessDayAdjustment(), Optional.empty());
-    assertEquals(test.getPaymentDateOffset(), Optional.empty());
+    assertEquals(test.getPaymentDate(), AdjustableDate.of(date(2015, 6, 15)));
     assertEquals(test.getFixedRate(), 0.25d, 0d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getIndexInterpolated(), Optional.empty());
@@ -93,7 +93,7 @@ public class FraTest {
         .notional(NOTIONAL_1M)
         .startDate(date(2015, 6, 15))
         .endDate(date(2015, 9, 15))
-        .paymentDateOffset(PLUS_ONE_DAY)
+        .paymentDate(AdjustableDate.of(date(2015, 6, 16)))
         .fixedRate(0.25d)
         .index(dummyIndex)
         .fixingDateOffset(MINUS_TWO_DAYS)
@@ -104,7 +104,7 @@ public class FraTest {
     assertEquals(test.getStartDate(), date(2015, 6, 15));
     assertEquals(test.getEndDate(), date(2015, 9, 15));
     assertEquals(test.getBusinessDayAdjustment(), Optional.empty());
-    assertEquals(test.getPaymentDateOffset(), Optional.of(PLUS_ONE_DAY));
+    assertEquals(test.getPaymentDate(), AdjustableDate.of(date(2015, 6, 16)));
     assertEquals(test.getFixedRate(), 0.25d, 0d);
     assertEquals(test.getIndex(), dummyIndex);
     assertEquals(test.getIndexInterpolated(), Optional.empty());
@@ -128,7 +128,7 @@ public class FraTest {
         .notional(NOTIONAL_1M)
         .startDate(date(2015, 6, 15))
         .endDate(date(2015, 9, 15))
-        .paymentDateOffset(PLUS_ONE_DAY)
+        .paymentDate(AdjustableDate.of(date(2015, 6, 16)))
         .fixedRate(0.25d)
         .index(dummyIndex)
         .fixingDateOffset(MINUS_TWO_DAYS)
@@ -139,7 +139,7 @@ public class FraTest {
     assertEquals(test.getStartDate(), date(2015, 6, 15));
     assertEquals(test.getEndDate(), date(2015, 9, 15));
     assertEquals(test.getBusinessDayAdjustment(), Optional.empty());
-    assertEquals(test.getPaymentDateOffset(), Optional.of(PLUS_ONE_DAY));
+    assertEquals(test.getPaymentDate(), AdjustableDate.of(date(2015, 6, 16)));
     assertEquals(test.getFixedRate(), 0.25d, 0d);
     assertEquals(test.getIndex(), dummyIndex);
     assertEquals(test.getIndexInterpolated(), Optional.empty());
@@ -186,7 +186,7 @@ public class FraTest {
         .notional(NOTIONAL_1M)
         .startDate(date(2015, 6, 15))
         .endDate(date(2015, 9, 15))
-        .paymentDateOffset(PLUS_ONE_DAY)
+        .paymentDate(AdjustableDate.of(date(2015, 6, 20), BDA_MOD_FOLLOW))
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
         .fixingDateOffset(MINUS_TWO_DAYS)
@@ -194,9 +194,9 @@ public class FraTest {
     ExpandedFra test = fra.expand();
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getNotional(), NOTIONAL_1M, 0d);
-    assertEquals(test.getPaymentDate(), date(2015, 6, 16));
     assertEquals(test.getStartDate(), date(2015, 6, 15));
     assertEquals(test.getEndDate(), date(2015, 9, 15));
+    assertEquals(test.getPaymentDate(), date(2015, 6, 22));
     assertEquals(test.getFixedRate(), 0.25d, 0d);
     assertEquals(test.getFloatingRate(), IborRateObservation.of(GBP_LIBOR_3M, date(2015, 6, 11)));
     assertEquals(test.getYearFraction(), ACT_365F.yearFraction(date(2015, 6, 15), date(2015, 9, 15)), 0d);
@@ -210,7 +210,6 @@ public class FraTest {
         .startDate(date(2015, 6, 12))
         .endDate(date(2015, 9, 5))
         .businessDayAdjustment(BDA_MOD_FOLLOW)
-        .paymentDateOffset(PLUS_TWO_DAYS)
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
         .indexInterpolated(GBP_LIBOR_2M)
@@ -219,9 +218,9 @@ public class FraTest {
     ExpandedFra test = fra.expand();
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getNotional(), -NOTIONAL_1M, 0d); // sell
-    assertEquals(test.getPaymentDate(), date(2015, 6, 16));
     assertEquals(test.getStartDate(), date(2015, 6, 12));
     assertEquals(test.getEndDate(), date(2015, 9, 7));
+    assertEquals(test.getPaymentDate(), date(2015, 6, 12));
     assertEquals(test.getFixedRate(), 0.25d, 0d);
     assertEquals(test.getFloatingRate(),
         IborInterpolatedRateObservation.of(GBP_LIBOR_2M, GBP_LIBOR_3M, date(2015, 6, 10)));
@@ -247,7 +246,7 @@ public class FraTest {
         .startDate(date(2015, 6, 16))
         .endDate(date(2015, 8, 17))
         .businessDayAdjustment(BDA_MOD_FOLLOW)
-        .paymentDateOffset(PLUS_ONE_DAY)
+        .paymentDate(AdjustableDate.of(date(2015, 6, 17)))
         .dayCount(ACT_360)
         .fixedRate(0.30d)
         .index(GBP_LIBOR_2M)


### PR DESCRIPTION
This change makes Fra closer to standards.
Payment date offset retained in convention.