### PR TITLE
Market data IDs, values and config should be serializable

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/FxRateId.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/FxRateId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.basics.market;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -37,7 +38,7 @@ import com.opengamma.strata.collect.ArgChecker;
  * created from the two currencies.
  */
 @BeanDefinition(builderScope = "private")
-public final class FxRateId implements MarketDataId<FxRate>, ImmutableBean {
+public final class FxRateId implements MarketDataId<FxRate>, ImmutableBean, Serializable {
 
   /** The currency pair whose rate this identifies. */
   @PropertyDefinition(validate = "notNull")
@@ -117,6 +118,11 @@ public final class FxRateId implements MarketDataId<FxRate>, ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(FxRateId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   @Override
   public FxRateId.Meta metaBean() {

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationResult.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/CalculationResult.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.calculations;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -28,7 +29,7 @@ import com.opengamma.strata.collect.result.Result;
  * The result of a single calculation performed by a {@link CalculationRunner}.
  */
 @BeanDefinition
-public final class CalculationResult implements ImmutableBean {
+public final class CalculationResult implements ImmutableBean, Serializable {
 
   /** The target of the calculation, often a trade. */
   @PropertyDefinition(validate = "notNull")
@@ -79,6 +80,11 @@ public final class CalculationResult implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(CalculationResult.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/MissingMappingId.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/MissingMappingId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.calculations;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -32,7 +33,7 @@ import com.opengamma.strata.basics.market.MarketDataKey;
  * used to identify failures when building market data.
  */
 @BeanDefinition(builderScope = "private")
-public final class MissingMappingId implements MarketDataId<Void>, ImmutableBean {
+public final class MissingMappingId implements MarketDataId<Void>, ImmutableBean, Serializable {
 
   /** The key identifying the market data required for the calculation. */
   @PropertyDefinition(validate = "notNull")
@@ -66,6 +67,11 @@ public final class MissingMappingId implements MarketDataId<Void>, ImmutableBean
   static {
     JodaBeanUtils.registerMetaBean(MissingMappingId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private MissingMappingId(
       MarketDataKey<?> key) {

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/NoMatchingRuleId.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/NoMatchingRuleId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.calculations;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -32,7 +33,7 @@ import com.opengamma.strata.basics.market.MarketDataKey;
  * This ID is never used to identify an item of market data, it is only used with failures.
  */
 @BeanDefinition(builderScope = "private")
-public final class NoMatchingRuleId implements MarketDataId<Void>, ImmutableBean {
+public final class NoMatchingRuleId implements MarketDataId<Void>, ImmutableBean, Serializable {
 
   /** A market data key identifying market data required for a calculation. */
   @PropertyDefinition(validate = "notNull")
@@ -66,6 +67,11 @@ public final class NoMatchingRuleId implements MarketDataId<Void>, ImmutableBean
   static {
     JodaBeanUtils.registerMetaBean(NoMatchingRuleId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private NoMatchingRuleId(
       MarketDataKey<?> key) {

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/function/result/DefaultScenarioResult.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/calculations/function/result/DefaultScenarioResult.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.calculations.function.result;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -37,7 +38,7 @@ import com.google.common.collect.ImmutableList;
  * @param <T>  the type of the result
  */
 @BeanDefinition
-public final class DefaultScenarioResult<T> implements ScenarioResult<T>, ImmutableBean {
+public final class DefaultScenarioResult<T> implements ScenarioResult<T>, ImmutableBean, Serializable {
 
   /** The individual results. */
   @PropertyDefinition(validate = "notNull")
@@ -104,6 +105,11 @@ public final class DefaultScenarioResult<T> implements ScenarioResult<T>, Immuta
   static {
     JodaBeanUtils.registerMetaBean(DefaultScenarioResult.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/CalculationTaskConfig.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/CalculationTaskConfig.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.config;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -33,7 +34,7 @@ import com.opengamma.strata.engine.marketdata.mapping.MarketDataMappings;
  * mappings that specify the market data that is used in the calculation.
  */
 @BeanDefinition
-public final class CalculationTaskConfig implements ImmutableBean {
+public final class CalculationTaskConfig implements ImmutableBean, Serializable {
 
   /** The target for which the value will be calculated. */
   @PropertyDefinition(validate = "notNull")
@@ -116,6 +117,11 @@ public final class CalculationTaskConfig implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(CalculationTaskConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/CalculationTasksConfig.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/CalculationTasksConfig.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.config;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -34,7 +35,7 @@ import com.opengamma.strata.engine.Column;
  * The measures are included for reference.
  */
 @BeanDefinition
-public final class CalculationTasksConfig implements ImmutableBean {
+public final class CalculationTasksConfig implements ImmutableBean, Serializable {
 
   /** Configuration for each of tasks that perform the individual calculations. */
   @PropertyDefinition(validate = "notNull")
@@ -57,6 +58,11 @@ public final class CalculationTasksConfig implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(CalculationTasksConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/EmptyReportingRules.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/EmptyReportingRules.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.config;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -28,7 +29,7 @@ import com.opengamma.strata.collect.ArgChecker;
  * A reporting currency rule that always returns an empty optional from {@link #reportingCurrency}.
  */
 @BeanDefinition(builderScope = "private")
-final class EmptyReportingRules implements ReportingRules, ImmutableBean {
+final class EmptyReportingRules implements ReportingRules, ImmutableBean, Serializable {
 
   /** The single, shared instance of this class. */
   static final EmptyReportingRules INSTANCE = new EmptyReportingRules();
@@ -57,6 +58,11 @@ final class EmptyReportingRules implements ReportingRules, ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(EmptyReportingRules.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private EmptyReportingRules() {
   }

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/config/FunctionConfig.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/config/FunctionConfig.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.config;
 
+import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Parameter;
@@ -48,7 +49,7 @@ import com.opengamma.strata.engine.calculations.function.CalculationSingleFuncti
  * @param <T>  the type of the calculation target
  */
 @BeanDefinition(builderScope = "private", constructorScope = "package")
-public final class FunctionConfig<T extends CalculationTarget> implements ImmutableBean {
+public final class FunctionConfig<T extends CalculationTarget> implements ImmutableBean, Serializable {
 
   private static final Logger log = LoggerFactory.getLogger(FunctionConfig.class);
 
@@ -274,6 +275,11 @@ public final class FunctionConfig<T extends CalculationTarget> implements Immuta
   static {
     JodaBeanUtils.registerMetaBean(FunctionConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates an instance.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/CalculationEnvironment.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/CalculationEnvironment.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.marketdata;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -51,7 +52,7 @@ import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
  * @see MarketEnvironment
  */
 @BeanDefinition(builderScope = "private", constructorScope = "package")
-public final class CalculationEnvironment implements ImmutableBean, MarketDataLookup {
+public final class CalculationEnvironment implements ImmutableBean, MarketDataLookup, Serializable {
 
   /** The valuation date associated with the data. */
   @PropertyDefinition(validate = "notNull", overrideGet = true)
@@ -188,6 +189,11 @@ public final class CalculationEnvironment implements ImmutableBean, MarketDataLo
   static {
     JodaBeanUtils.registerMetaBean(CalculationEnvironment.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates an instance.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironment.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/ScenarioCalculationEnvironment.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.marketdata;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +55,7 @@ import com.opengamma.strata.engine.calculations.NoMatchingRuleId;
  */
 @SuppressWarnings("unchecked")
 @BeanDefinition(builderScope = "private", constructorScope = "package")
-public final class ScenarioCalculationEnvironment implements ImmutableBean {
+public final class ScenarioCalculationEnvironment implements ImmutableBean, Serializable {
 
   /** The market data values which are the same in every scenario. */
   @PropertyDefinition(validate = "notNull")
@@ -248,6 +249,11 @@ public final class ScenarioCalculationEnvironment implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(ScenarioCalculationEnvironment.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates an instance.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/config/MarketDataConfig.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/config/MarketDataConfig.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.marketdata.config;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -32,7 +33,7 @@ import com.opengamma.strata.collect.type.TypedString;
  * This class is effectively a map of arbitrary objects, keyed by their type and a name.
  */
 @BeanDefinition(builderScope = "private", constructorScope = "package")
-public final class MarketDataConfig implements ImmutableBean {
+public final class MarketDataConfig implements ImmutableBean, Serializable {
 
   /** An empty set of market data configuration. */
   private static final MarketDataConfig EMPTY = new MarketDataConfig(ImmutableMap.of());
@@ -110,6 +111,11 @@ public final class MarketDataConfig implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(MarketDataConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Creates an instance.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/config/SingleTypeMarketDataConfig.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/config/SingleTypeMarketDataConfig.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.marketdata.config;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -41,7 +42,7 @@ import com.opengamma.strata.collect.Messages;
  * the {@code SingleTypeMarketDataConfig} instances contains the configuration objects keyed by name.
  */
 @BeanDefinition
-final class SingleTypeMarketDataConfig implements ImmutableBean {
+final class SingleTypeMarketDataConfig implements ImmutableBean, Serializable {
 
   /** The type of the configuration objects. */
   @PropertyDefinition(validate = "notNull")
@@ -104,6 +105,11 @@ final class SingleTypeMarketDataConfig implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(SingleTypeMarketDataConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/mapping/DefaultMarketDataMappings.java
+++ b/modules/engine/src/main/java/com/opengamma/strata/engine/marketdata/mapping/DefaultMarketDataMappings.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.engine.marketdata.mapping;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -44,7 +45,7 @@ import com.opengamma.strata.basics.market.SimpleMarketDataKey;
  */
 @SuppressWarnings("unchecked")
 @BeanDefinition
-public final class DefaultMarketDataMappings implements MarketDataMappings, ImmutableBean {
+public final class DefaultMarketDataMappings implements MarketDataMappings, ImmutableBean, Serializable {
 
   /** An empty set of market data mappings containing no mappers. */
   static final MarketDataMappings EMPTY = new DefaultMarketDataMappings(MarketDataFeed.NONE, ImmutableMap.of());
@@ -124,6 +125,11 @@ public final class DefaultMarketDataMappings implements MarketDataMappings, Immu
   static {
     JodaBeanUtils.registerMetaBean(DefaultMarketDataMappings.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/RootFinderConfig.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/RootFinderConfig.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.function.marketdata.curve;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -28,7 +29,7 @@ import com.opengamma.strata.collect.ArgChecker;
  * Configuration for the root finder used when calibrating curves.
  */
 @BeanDefinition
-public final class RootFinderConfig implements ImmutableBean {
+public final class RootFinderConfig implements ImmutableBean, Serializable {
 
   /** The default absolute tolerance for the root finder. */
   public static final double DEFAULT_ABSOLUTE_TOLERANCE = 1e-9;
@@ -84,6 +85,11 @@ public final class RootFinderConfig implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(RootFinderConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/mapping/DiscountFactorsMapping.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/mapping/DiscountFactorsMapping.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.function.marketdata.mapping;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -38,7 +39,7 @@ import com.opengamma.strata.market.value.DiscountFactors;
  */
 @BeanDefinition
 public final class DiscountFactorsMapping
-    implements MarketDataMapping<DiscountFactors, DiscountFactorsKey>, ImmutableBean {
+    implements MarketDataMapping<DiscountFactors, DiscountFactorsKey>, ImmutableBean, Serializable {
 
   /**
    * The name of the curve group from which discounting curves should be taken.
@@ -89,6 +90,11 @@ public final class DiscountFactorsMapping
   static {
     JodaBeanUtils.registerMetaBean(DiscountFactorsMapping.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/mapping/DiscountingCurveMapping.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/mapping/DiscountingCurveMapping.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.function.marketdata.mapping;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -35,7 +36,7 @@ import com.opengamma.strata.market.key.DiscountCurveKey;
  */
 @BeanDefinition
 public final class DiscountingCurveMapping
-    implements MarketDataMapping<Curve, DiscountCurveKey>, ImmutableBean {
+    implements MarketDataMapping<Curve, DiscountCurveKey>, ImmutableBean, Serializable {
 
   /** The name of the curve group from which discounting curves should be taken. */
   @PropertyDefinition(validate = "notNull")
@@ -80,6 +81,11 @@ public final class DiscountingCurveMapping
   static {
     JodaBeanUtils.registerMetaBean(DiscountingCurveMapping.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/mapping/RateIndexCurveMapping.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/mapping/RateIndexCurveMapping.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.function.marketdata.mapping;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -35,7 +36,7 @@ import com.opengamma.strata.market.key.RateIndexCurveKey;
  */
 @BeanDefinition
 public final class RateIndexCurveMapping
-    implements MarketDataMapping<Curve, RateIndexCurveKey>, ImmutableBean {
+    implements MarketDataMapping<Curve, RateIndexCurveKey>, ImmutableBean, Serializable {
 
   /** The name of the curve group from which the curve should be taken. */
   @PropertyDefinition(validate = "notNull")
@@ -80,6 +81,11 @@ public final class RateIndexCurveMapping
   static {
     JodaBeanUtils.registerMetaBean(RateIndexCurveMapping.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/config/CurveGroupConfig.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/config/CurveGroupConfig.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.market.curve.config;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableMap;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -51,7 +52,7 @@ import com.opengamma.strata.market.curve.CurveName;
  * Every curve must be associated with at least once key.
  */
 @BeanDefinition(builderScope = "private")
-public final class CurveGroupConfig implements ImmutableBean {
+public final class CurveGroupConfig implements ImmutableBean, Serializable {
 
   /** The name of the curve group. */
   @PropertyDefinition(validate = "notNull")
@@ -109,6 +110,11 @@ public final class CurveGroupConfig implements ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(CurveGroupConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   @Override
   public CurveGroupConfig.Meta metaBean() {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/config/InterpolatedCurveConfig.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/config/InterpolatedCurveConfig.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.market.curve.config;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,7 @@ import com.opengamma.strata.market.value.ValueType;
  */
 @BeanDefinition
 public final class InterpolatedCurveConfig
-    implements CurveConfig, ImmutableBean {
+    implements CurveConfig, ImmutableBean, Serializable {
 
   /**
    * The curve name.
@@ -136,6 +137,11 @@ public final class InterpolatedCurveConfig
   static {
     JodaBeanUtils.registerMetaBean(InterpolatedCurveConfig.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/CurveGroupId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/CurveGroupId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -31,7 +32,7 @@ import com.opengamma.strata.market.curve.CurveGroupName;
  * Market data ID identifying a group of curves that are built together.
  */
 @BeanDefinition(builderScope = "private")
-public final class CurveGroupId implements MarketDataId<CurveGroup>, ImmutableBean {
+public final class CurveGroupId implements MarketDataId<CurveGroup>, ImmutableBean, Serializable {
 
   /** The name of the curve group. */
   @PropertyDefinition(validate = "notNull")
@@ -80,6 +81,11 @@ public final class CurveGroupId implements MarketDataId<CurveGroup>, ImmutableBe
   static {
     JodaBeanUtils.registerMetaBean(CurveGroupId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private CurveGroupId(
       CurveGroupName name,

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/IndexRateId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/IndexRateId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -36,7 +37,7 @@ import com.opengamma.strata.market.key.IndexRateKey;
  * The forward curve of the index is identified with an {@link RateIndexCurveId}.
  */
 @BeanDefinition(builderScope = "private")
-public final class IndexRateId implements ObservableId, ImmutableBean {
+public final class IndexRateId implements ObservableId, ImmutableBean, Serializable {
 
   /** The index. */
   @PropertyDefinition(validate = "notNull")
@@ -114,6 +115,11 @@ public final class IndexRateId implements ObservableId, ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(IndexRateId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private IndexRateId(
       Index index,

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaIndexCreditCurveParRatesId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaIndexCreditCurveParRatesId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -32,7 +33,7 @@ import com.opengamma.strata.market.curve.IsdaCreditCurveParRates;
  */
 @BeanDefinition(builderScope = "private")
 public final class IsdaIndexCreditCurveParRatesId
-    implements MarketDataId<IsdaCreditCurveParRates>, ImmutableBean {
+    implements MarketDataId<IsdaCreditCurveParRates>, ImmutableBean, Serializable {
 
   /**
    * The information that identifies the index.
@@ -70,6 +71,11 @@ public final class IsdaIndexCreditCurveParRatesId
   static {
     JodaBeanUtils.registerMetaBean(IsdaIndexCreditCurveParRatesId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private IsdaIndexCreditCurveParRatesId(
       IndexReferenceInformation referenceInformation) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaIndexRecoveryRateId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaIndexRecoveryRateId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -31,7 +32,7 @@ import com.opengamma.strata.market.value.CdsRecoveryRate;
  */
 @BeanDefinition(builderScope = "private")
 public final class IsdaIndexRecoveryRateId
-    implements MarketDataId<CdsRecoveryRate>, ImmutableBean {
+    implements MarketDataId<CdsRecoveryRate>, ImmutableBean, Serializable {
 
   /**
    * The information that identifies the single-name.
@@ -69,6 +70,11 @@ public final class IsdaIndexRecoveryRateId
   static {
     JodaBeanUtils.registerMetaBean(IsdaIndexRecoveryRateId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private IsdaIndexRecoveryRateId(
       IndexReferenceInformation referenceInformation) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaSingleNameCreditCurveParRatesId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaSingleNameCreditCurveParRatesId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -32,7 +33,7 @@ import com.opengamma.strata.market.curve.IsdaCreditCurveParRates;
  */
 @BeanDefinition(builderScope = "private")
 public final class IsdaSingleNameCreditCurveParRatesId
-    implements MarketDataId<IsdaCreditCurveParRates>, ImmutableBean {
+    implements MarketDataId<IsdaCreditCurveParRates>, ImmutableBean, Serializable {
 
   /**
    * The information that identifies the single-name.
@@ -70,6 +71,11 @@ public final class IsdaSingleNameCreditCurveParRatesId
   static {
     JodaBeanUtils.registerMetaBean(IsdaSingleNameCreditCurveParRatesId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private IsdaSingleNameCreditCurveParRatesId(
       SingleNameReferenceInformation referenceInformation) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaSingleNameRecoveryRateId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaSingleNameRecoveryRateId.java
@@ -5,9 +5,11 @@
  */
 package com.opengamma.strata.market.id;
 
-import com.opengamma.strata.basics.market.MarketDataId;
-import com.opengamma.strata.finance.credit.SingleNameReferenceInformation;
-import com.opengamma.strata.market.value.CdsRecoveryRate;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
 import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
 import org.joda.beans.BeanDefinition;
@@ -21,9 +23,9 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
+import com.opengamma.strata.basics.market.MarketDataId;
+import com.opengamma.strata.finance.credit.SingleNameReferenceInformation;
+import com.opengamma.strata.market.value.CdsRecoveryRate;
 
 /**
  * Market data ID for a recovery rate to be used in the ISDA credit model's
@@ -31,7 +33,7 @@ import java.util.Set;
  */
 @BeanDefinition(builderScope = "private")
 public final class IsdaSingleNameRecoveryRateId
-    implements MarketDataId<CdsRecoveryRate>, ImmutableBean {
+    implements MarketDataId<CdsRecoveryRate>, ImmutableBean, Serializable {
 
   /**
    * The information that identifies the single-name.
@@ -69,6 +71,11 @@ public final class IsdaSingleNameRecoveryRateId
   static {
     JodaBeanUtils.registerMetaBean(IsdaSingleNameRecoveryRateId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private IsdaSingleNameRecoveryRateId(
       SingleNameReferenceInformation referenceInformation) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaYieldCurveParRatesId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/IsdaYieldCurveParRatesId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -32,7 +33,7 @@ import com.opengamma.strata.market.curve.IsdaYieldCurveParRates;
  */
 @BeanDefinition(builderScope = "private")
 public final class IsdaYieldCurveParRatesId
-    implements MarketDataId<IsdaYieldCurveParRates>, ImmutableBean {
+    implements MarketDataId<IsdaYieldCurveParRates>, ImmutableBean, Serializable {
 
   /**
    * The currency.
@@ -70,6 +71,11 @@ public final class IsdaYieldCurveParRatesId
   static {
     JodaBeanUtils.registerMetaBean(IsdaYieldCurveParRatesId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private IsdaYieldCurveParRatesId(
       Currency currency) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/ParRatesId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/ParRatesId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -31,7 +32,7 @@ import com.opengamma.strata.market.curve.ParRates;
  * Market data ID for a set of par rates used when calibrating a curve.
  */
 @BeanDefinition
-public final class ParRatesId implements MarketDataId<ParRates>, ImmutableBean {
+public final class ParRatesId implements MarketDataId<ParRates>, ImmutableBean, Serializable {
 
   /** The name of the curve group containing the curve. */
   @PropertyDefinition(validate = "notNull")
@@ -75,6 +76,11 @@ public final class ParRatesId implements MarketDataId<ParRates>, ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(ParRatesId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   /**
    * Returns a builder used to create an instance of the bean.

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/QuoteId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/QuoteId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -59,7 +60,7 @@ import com.opengamma.strata.market.key.QuoteKey;
  * @see FieldName
  */
 @BeanDefinition(builderScope = "private")
-public final class QuoteId implements ObservableId, ImmutableBean {
+public final class QuoteId implements ObservableId, ImmutableBean, Serializable {
 
   /** The ID of the data, typically an ID from an external data provider. */
   @PropertyDefinition(validate = "notNull", overrideGet = true)
@@ -125,6 +126,11 @@ public final class QuoteId implements ObservableId, ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(QuoteId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private QuoteId(
       StandardId standardId,

--- a/modules/market/src/main/java/com/opengamma/strata/market/id/RateIndexCurveId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/id/RateIndexCurveId.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.id;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -35,7 +36,7 @@ import com.opengamma.strata.market.curve.CurveGroupName;
  * Current and historical values for the index are identified with a {@link IndexRateId}.
  */
 @BeanDefinition(builderScope = "private")
-public final class RateIndexCurveId implements RateCurveId, ImmutableBean {
+public final class RateIndexCurveId implements RateCurveId, ImmutableBean, Serializable {
 
   /** The index of the curve. */
   @PropertyDefinition(validate = "notNull")
@@ -90,6 +91,11 @@ public final class RateIndexCurveId implements RateCurveId, ImmutableBean {
   static {
     JodaBeanUtils.registerMetaBean(RateIndexCurveId.Meta.INSTANCE);
   }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
 
   private RateIndexCurveId(
       RateIndex index,


### PR DESCRIPTION
This PR makes a number of beans serializable. They are market data IDs, market data values and configuration objects used by the engine.
