### PR TITLE
Ibor Future Option: Minor refactor of volatility data objects to use expiry time.

### DIFF
--- a/modules/collect/src/test/java/com/opengamma/strata/collect/TestHelper.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/TestHelper.java
@@ -103,6 +103,19 @@ public class TestHelper {
 
   //-------------------------------------------------------------------------
   /**
+   * Creates a {@code ZonedDateTime} from the date. The time is start of day and the zone is UTC.
+   * 
+   * @param year  the year
+   * @param month  the month
+   * @param dayOfMonth  the dayOfMonth
+   * @return the date
+   */
+  public static ZonedDateTime dateUtc(int year, int month, int dayOfMonth) {
+    return LocalDate.of(year, month, dayOfMonth).atStartOfDay(ZoneOffset.UTC);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Asserts that two beans are equal.
    * Provides better error messages than a normal {@code assertEquals} comparison.
    * 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/TestHelper.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/TestHelper.java
@@ -82,7 +82,7 @@ public class TestHelper {
    * 
    * @param year  the year
    * @param month  the month
-   * @param dayOfMonth  the dayOfMonth
+   * @param dayOfMonth  the day of month
    * @return the date
    */
   public static LocalDate date(int year, int month, int dayOfMonth) {
@@ -94,7 +94,7 @@ public class TestHelper {
    * 
    * @param year  the year
    * @param month  the month
-   * @param dayOfMonth  the dayOfMonth
+   * @param dayOfMonth  the day of month
    * @return the date
    */
   public static LocalDate date(int year, Month month, int dayOfMonth) {
@@ -103,12 +103,14 @@ public class TestHelper {
 
   //-------------------------------------------------------------------------
   /**
-   * Creates a {@code ZonedDateTime} from the date. The time is start of day and the zone is UTC.
+   * Creates a {@code ZonedDateTime} from the date.
+   * <p>
+   * The time is start of day and the zone is UTC.
    * 
    * @param year  the year
    * @param month  the month
-   * @param dayOfMonth  the dayOfMonth
-   * @return the date
+   * @param dayOfMonth  the day of month
+   * @return the date-time, representing the date at midnight UTC
    */
   public static ZonedDateTime dateUtc(int year, int month, int dayOfMonth) {
     return LocalDate.of(year, month, dayOfMonth).atStartOfDay(ZoneOffset.UTC);

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/future/IborFutureOption.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/future/IborFutureOption.java
@@ -144,7 +144,7 @@ public class IborFutureOption
    * 
    * @return the expiration date and time
    */
-  public ZonedDateTime getExpirationDateTime() {
+  public ZonedDateTime getExpiration() {
     return expirationDate.atTime(expirationTime).atZone(expirationZone);
   }
 

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/future/IborFutureOptionTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/future/IborFutureOptionTest.java
@@ -80,7 +80,7 @@ public class IborFutureOptionTest {
     assertEquals(test.getExpirationDate(), EXPIRY_DATE);
     assertEquals(test.getExpirationTime(), EXPIRY_TIME);
     assertEquals(test.getExpirationZone(), EXPIRY_ZONE);
-    assertEquals(test.getExpirationDateTime(), ZonedDateTime.of(EXPIRY_DATE, EXPIRY_TIME, EXPIRY_ZONE));
+    assertEquals(test.getExpiration(), ZonedDateTime.of(EXPIRY_DATE, EXPIRY_TIME, EXPIRY_ZONE));
     assertEquals(test.getRounding(), ROUNDING);
     assertEquals(test.getUnderlyingLink(), SecurityLink.resolvable(ID_1, IborFuture.class));
     assertThrows(() -> test.getUnderlyingSecurity(), IllegalStateException.class);
@@ -102,7 +102,7 @@ public class IborFutureOptionTest {
     assertEquals(test.getExpirationDate(), EXPIRY_DATE);
     assertEquals(test.getExpirationTime(), EXPIRY_TIME);
     assertEquals(test.getExpirationZone(), EXPIRY_ZONE);
-    assertEquals(test.getExpirationDateTime(), ZonedDateTime.of(EXPIRY_DATE, EXPIRY_TIME, EXPIRY_ZONE));
+    assertEquals(test.getExpiration(), ZonedDateTime.of(EXPIRY_DATE, EXPIRY_TIME, EXPIRY_ZONE));
     assertEquals(test.getRounding(), Rounding.none());
     assertEquals(test.getUnderlyingLink(), SecurityLink.resolved(IBOR_FUTURE_SECURITY_1));
     assertEquals(test.getUnderlyingSecurity(), IBOR_FUTURE_SECURITY_1);

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivity.java
@@ -49,7 +49,7 @@ public final class IborFutureOptionSensitivity
    * The expiration date of the option.
    */
   @PropertyDefinition(validate = "notNull")
-  private final ZonedDateTime expiryDate;
+  private final ZonedDateTime expiry;
   /**
    * The underlying future last trading or fixing date.
    */
@@ -134,13 +134,13 @@ public final class IborFutureOptionSensitivity
       return this;
     }
     return new IborFutureOptionSensitivity(
-        index, expiryDate, fixingDate, strikePrice, futurePrice, currency, sensitivity);
+        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
   }
 
   @Override
   public IborFutureOptionSensitivity withSensitivity(double sensitivity) {
     return new IborFutureOptionSensitivity(
-        index, expiryDate, fixingDate, strikePrice, futurePrice, currency, sensitivity);
+        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
   }
 
   @Override
@@ -149,7 +149,7 @@ public final class IborFutureOptionSensitivity
       IborFutureOptionSensitivity otherOption = (IborFutureOptionSensitivity) other;
       return ComparisonChain.start()
           .compare(index.toString(), otherOption.index.toString())
-          .compare(expiryDate, otherOption.expiryDate)
+          .compare(expiry, otherOption.expiry)
           .compare(fixingDate, otherOption.fixingDate)
           .compare(strikePrice, otherOption.strikePrice)
           .compare(futurePrice, otherOption.futurePrice)
@@ -168,13 +168,13 @@ public final class IborFutureOptionSensitivity
   @Override
   public IborFutureOptionSensitivity multipliedBy(double factor) {
     return new IborFutureOptionSensitivity(
-        index, expiryDate, fixingDate, strikePrice, futurePrice, currency, sensitivity * factor);
+        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity * factor);
   }
 
   @Override
   public IborFutureOptionSensitivity mapSensitivity(DoubleUnaryOperator operator) {
     return new IborFutureOptionSensitivity(
-        index, expiryDate, fixingDate, strikePrice, futurePrice, currency, operator.applyAsDouble(sensitivity));
+        index, expiry, fixingDate, strikePrice, futurePrice, currency, operator.applyAsDouble(sensitivity));
   }
 
   @Override
@@ -213,18 +213,18 @@ public final class IborFutureOptionSensitivity
 
   private IborFutureOptionSensitivity(
       IborIndex index,
-      ZonedDateTime expiryDate,
+      ZonedDateTime expiry,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
       Currency currency,
       double sensitivity) {
     JodaBeanUtils.notNull(index, "index");
-    JodaBeanUtils.notNull(expiryDate, "expiryDate");
+    JodaBeanUtils.notNull(expiry, "expiry");
     JodaBeanUtils.notNull(fixingDate, "fixingDate");
     JodaBeanUtils.notNull(currency, "currency");
     this.index = index;
-    this.expiryDate = expiryDate;
+    this.expiry = expiry;
     this.fixingDate = fixingDate;
     this.strikePrice = strikePrice;
     this.futurePrice = futurePrice;
@@ -261,8 +261,8 @@ public final class IborFutureOptionSensitivity
    * Gets the expiration date of the option.
    * @return the value of the property, not null
    */
-  public ZonedDateTime getExpiryDate() {
-    return expiryDate;
+  public ZonedDateTime getExpiry() {
+    return expiry;
   }
 
   //-----------------------------------------------------------------------
@@ -321,7 +321,7 @@ public final class IborFutureOptionSensitivity
     if (obj != null && obj.getClass() == this.getClass()) {
       IborFutureOptionSensitivity other = (IborFutureOptionSensitivity) obj;
       return JodaBeanUtils.equal(getIndex(), other.getIndex()) &&
-          JodaBeanUtils.equal(getExpiryDate(), other.getExpiryDate()) &&
+          JodaBeanUtils.equal(getExpiry(), other.getExpiry()) &&
           JodaBeanUtils.equal(getFixingDate(), other.getFixingDate()) &&
           JodaBeanUtils.equal(getStrikePrice(), other.getStrikePrice()) &&
           JodaBeanUtils.equal(getFuturePrice(), other.getFuturePrice()) &&
@@ -335,7 +335,7 @@ public final class IborFutureOptionSensitivity
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(getIndex());
-    hash = hash * 31 + JodaBeanUtils.hashCode(getExpiryDate());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getExpiry());
     hash = hash * 31 + JodaBeanUtils.hashCode(getFixingDate());
     hash = hash * 31 + JodaBeanUtils.hashCode(getStrikePrice());
     hash = hash * 31 + JodaBeanUtils.hashCode(getFuturePrice());
@@ -349,7 +349,7 @@ public final class IborFutureOptionSensitivity
     StringBuilder buf = new StringBuilder(256);
     buf.append("IborFutureOptionSensitivity{");
     buf.append("index").append('=').append(getIndex()).append(',').append(' ');
-    buf.append("expiryDate").append('=').append(getExpiryDate()).append(',').append(' ');
+    buf.append("expiry").append('=').append(getExpiry()).append(',').append(' ');
     buf.append("fixingDate").append('=').append(getFixingDate()).append(',').append(' ');
     buf.append("strikePrice").append('=').append(getStrikePrice()).append(',').append(' ');
     buf.append("futurePrice").append('=').append(getFuturePrice()).append(',').append(' ');
@@ -375,10 +375,10 @@ public final class IborFutureOptionSensitivity
     private final MetaProperty<IborIndex> index = DirectMetaProperty.ofImmutable(
         this, "index", IborFutureOptionSensitivity.class, IborIndex.class);
     /**
-     * The meta-property for the {@code expiryDate} property.
+     * The meta-property for the {@code expiry} property.
      */
-    private final MetaProperty<ZonedDateTime> expiryDate = DirectMetaProperty.ofImmutable(
-        this, "expiryDate", IborFutureOptionSensitivity.class, ZonedDateTime.class);
+    private final MetaProperty<ZonedDateTime> expiry = DirectMetaProperty.ofImmutable(
+        this, "expiry", IborFutureOptionSensitivity.class, ZonedDateTime.class);
     /**
      * The meta-property for the {@code fixingDate} property.
      */
@@ -410,7 +410,7 @@ public final class IborFutureOptionSensitivity
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "index",
-        "expiryDate",
+        "expiry",
         "fixingDate",
         "strikePrice",
         "futurePrice",
@@ -428,8 +428,8 @@ public final class IborFutureOptionSensitivity
       switch (propertyName.hashCode()) {
         case 100346066:  // index
           return index;
-        case -816738431:  // expiryDate
-          return expiryDate;
+        case -1289159373:  // expiry
+          return expiry;
         case 1255202043:  // fixingDate
           return fixingDate;
         case 50946231:  // strikePrice
@@ -469,11 +469,11 @@ public final class IborFutureOptionSensitivity
     }
 
     /**
-     * The meta-property for the {@code expiryDate} property.
+     * The meta-property for the {@code expiry} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<ZonedDateTime> expiryDate() {
-      return expiryDate;
+    public MetaProperty<ZonedDateTime> expiry() {
+      return expiry;
     }
 
     /**
@@ -522,8 +522,8 @@ public final class IborFutureOptionSensitivity
       switch (propertyName.hashCode()) {
         case 100346066:  // index
           return ((IborFutureOptionSensitivity) bean).getIndex();
-        case -816738431:  // expiryDate
-          return ((IborFutureOptionSensitivity) bean).getExpiryDate();
+        case -1289159373:  // expiry
+          return ((IborFutureOptionSensitivity) bean).getExpiry();
         case 1255202043:  // fixingDate
           return ((IborFutureOptionSensitivity) bean).getFixingDate();
         case 50946231:  // strikePrice
@@ -556,7 +556,7 @@ public final class IborFutureOptionSensitivity
   private static final class Builder extends DirectFieldsBeanBuilder<IborFutureOptionSensitivity> {
 
     private IborIndex index;
-    private ZonedDateTime expiryDate;
+    private ZonedDateTime expiry;
     private LocalDate fixingDate;
     private double strikePrice;
     private double futurePrice;
@@ -575,8 +575,8 @@ public final class IborFutureOptionSensitivity
       switch (propertyName.hashCode()) {
         case 100346066:  // index
           return index;
-        case -816738431:  // expiryDate
-          return expiryDate;
+        case -1289159373:  // expiry
+          return expiry;
         case 1255202043:  // fixingDate
           return fixingDate;
         case 50946231:  // strikePrice
@@ -598,8 +598,8 @@ public final class IborFutureOptionSensitivity
         case 100346066:  // index
           this.index = (IborIndex) newValue;
           break;
-        case -816738431:  // expiryDate
-          this.expiryDate = (ZonedDateTime) newValue;
+        case -1289159373:  // expiry
+          this.expiry = (ZonedDateTime) newValue;
           break;
         case 1255202043:  // fixingDate
           this.fixingDate = (LocalDate) newValue;
@@ -650,7 +650,7 @@ public final class IborFutureOptionSensitivity
     public IborFutureOptionSensitivity build() {
       return new IborFutureOptionSensitivity(
           index,
-          expiryDate,
+          expiry,
           fixingDate,
           strikePrice,
           futurePrice,
@@ -664,7 +664,7 @@ public final class IborFutureOptionSensitivity
       StringBuilder buf = new StringBuilder(256);
       buf.append("IborFutureOptionSensitivity.Builder{");
       buf.append("index").append('=').append(JodaBeanUtils.toString(index)).append(',').append(' ');
-      buf.append("expiryDate").append('=').append(JodaBeanUtils.toString(expiryDate)).append(',').append(' ');
+      buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
       buf.append("fixingDate").append('=').append(JodaBeanUtils.toString(fixingDate)).append(',').append(' ');
       buf.append("strikePrice").append('=').append(JodaBeanUtils.toString(strikePrice)).append(',').append(' ');
       buf.append("futurePrice").append('=').append(JodaBeanUtils.toString(futurePrice)).append(',').append(' ');

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivity.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.market.sensitivity;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -48,7 +49,7 @@ public final class IborFutureOptionSensitivity
    * The expiration date of the option.
    */
   @PropertyDefinition(validate = "notNull")
-  private final LocalDate expiryDate;
+  private final ZonedDateTime expiryDate;
   /**
    * The underlying future last trading or fixing date.
    */
@@ -91,7 +92,7 @@ public final class IborFutureOptionSensitivity
    */
   public static IborFutureOptionSensitivity of(
       IborIndex index,
-      LocalDate expiryDate,
+      ZonedDateTime expiryDate,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
@@ -115,7 +116,7 @@ public final class IborFutureOptionSensitivity
    */
   public static IborFutureOptionSensitivity of(
       IborIndex index,
-      LocalDate expiryDate,
+      ZonedDateTime expiryDate,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
@@ -212,7 +213,7 @@ public final class IborFutureOptionSensitivity
 
   private IborFutureOptionSensitivity(
       IborIndex index,
-      LocalDate expiryDate,
+      ZonedDateTime expiryDate,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
@@ -260,7 +261,7 @@ public final class IborFutureOptionSensitivity
    * Gets the expiration date of the option.
    * @return the value of the property, not null
    */
-  public LocalDate getExpiryDate() {
+  public ZonedDateTime getExpiryDate() {
     return expiryDate;
   }
 
@@ -376,8 +377,8 @@ public final class IborFutureOptionSensitivity
     /**
      * The meta-property for the {@code expiryDate} property.
      */
-    private final MetaProperty<LocalDate> expiryDate = DirectMetaProperty.ofImmutable(
-        this, "expiryDate", IborFutureOptionSensitivity.class, LocalDate.class);
+    private final MetaProperty<ZonedDateTime> expiryDate = DirectMetaProperty.ofImmutable(
+        this, "expiryDate", IborFutureOptionSensitivity.class, ZonedDateTime.class);
     /**
      * The meta-property for the {@code fixingDate} property.
      */
@@ -471,7 +472,7 @@ public final class IborFutureOptionSensitivity
      * The meta-property for the {@code expiryDate} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<LocalDate> expiryDate() {
+    public MetaProperty<ZonedDateTime> expiryDate() {
       return expiryDate;
     }
 
@@ -555,7 +556,7 @@ public final class IborFutureOptionSensitivity
   private static final class Builder extends DirectFieldsBeanBuilder<IborFutureOptionSensitivity> {
 
     private IborIndex index;
-    private LocalDate expiryDate;
+    private ZonedDateTime expiryDate;
     private LocalDate fixingDate;
     private double strikePrice;
     private double futurePrice;
@@ -598,7 +599,7 @@ public final class IborFutureOptionSensitivity
           this.index = (IborIndex) newValue;
           break;
         case -816738431:  // expiryDate
-          this.expiryDate = (LocalDate) newValue;
+          this.expiryDate = (ZonedDateTime) newValue;
           break;
         case 1255202043:  // fixingDate
           this.fixingDate = (LocalDate) newValue;

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivity.java
@@ -46,10 +46,10 @@ public final class IborFutureOptionSensitivity
   @PropertyDefinition(validate = "notNull")
   private final IborIndex index;
   /**
-   * The expiration date of the option.
+   * The expiration date-time of the option.
    */
   @PropertyDefinition(validate = "notNull")
-  private final ZonedDateTime expiry;
+  private final ZonedDateTime expiration;
   /**
    * The underlying future last trading or fixing date.
    */
@@ -83,7 +83,7 @@ public final class IborFutureOptionSensitivity
    * The currency is defaulted from the index.
    * 
    * @param index  the index of the curve
-   * @param expiryDate  the expiry date of the option
+   * @param expirationDate  the expiration date of the option
    * @param fixingDate  the fixing date of the underlying future
    * @param strikePrice  the strike price of the option
    * @param futurePrice  the price of the underlying future
@@ -92,21 +92,21 @@ public final class IborFutureOptionSensitivity
    */
   public static IborFutureOptionSensitivity of(
       IborIndex index,
-      ZonedDateTime expiryDate,
+      ZonedDateTime expirationDate,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
       double sensitivity) {
 
     return new IborFutureOptionSensitivity(
-        index, expiryDate, fixingDate, strikePrice, futurePrice, index.getCurrency(), sensitivity);
+        index, expirationDate, fixingDate, strikePrice, futurePrice, index.getCurrency(), sensitivity);
   }
 
   /**
    * Obtains an {@code IborFutureOptionSensitivity} from the key, sensitivity currency and value.
    * 
    * @param index  the index of the curve
-   * @param expiryDate  the expiry date of the option
+   * @param expirationDate  the expiration date of the option
    * @param fixingDate  the fixing date of the underlying future
    * @param strikePrice  the strike price of the option
    * @param futurePrice  the price of the underlying future
@@ -116,7 +116,7 @@ public final class IborFutureOptionSensitivity
    */
   public static IborFutureOptionSensitivity of(
       IborIndex index,
-      ZonedDateTime expiryDate,
+      ZonedDateTime expirationDate,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
@@ -124,7 +124,7 @@ public final class IborFutureOptionSensitivity
       double sensitivity) {
 
     return new IborFutureOptionSensitivity(
-        index, expiryDate, fixingDate, strikePrice, futurePrice, sensitivityCurrency, sensitivity);
+        index, expirationDate, fixingDate, strikePrice, futurePrice, sensitivityCurrency, sensitivity);
   }
 
   //-------------------------------------------------------------------------
@@ -134,13 +134,13 @@ public final class IborFutureOptionSensitivity
       return this;
     }
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
+        index, expiration, fixingDate, strikePrice, futurePrice, currency, sensitivity);
   }
 
   @Override
   public IborFutureOptionSensitivity withSensitivity(double sensitivity) {
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
+        index, expiration, fixingDate, strikePrice, futurePrice, currency, sensitivity);
   }
 
   @Override
@@ -149,7 +149,7 @@ public final class IborFutureOptionSensitivity
       IborFutureOptionSensitivity otherOption = (IborFutureOptionSensitivity) other;
       return ComparisonChain.start()
           .compare(index.toString(), otherOption.index.toString())
-          .compare(expiry, otherOption.expiry)
+          .compare(expiration, otherOption.expiration)
           .compare(fixingDate, otherOption.fixingDate)
           .compare(strikePrice, otherOption.strikePrice)
           .compare(futurePrice, otherOption.futurePrice)
@@ -168,13 +168,13 @@ public final class IborFutureOptionSensitivity
   @Override
   public IborFutureOptionSensitivity multipliedBy(double factor) {
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity * factor);
+        index, expiration, fixingDate, strikePrice, futurePrice, currency, sensitivity * factor);
   }
 
   @Override
   public IborFutureOptionSensitivity mapSensitivity(DoubleUnaryOperator operator) {
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, operator.applyAsDouble(sensitivity));
+        index, expiration, fixingDate, strikePrice, futurePrice, currency, operator.applyAsDouble(sensitivity));
   }
 
   @Override
@@ -213,18 +213,18 @@ public final class IborFutureOptionSensitivity
 
   private IborFutureOptionSensitivity(
       IborIndex index,
-      ZonedDateTime expiry,
+      ZonedDateTime expiration,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
       Currency currency,
       double sensitivity) {
     JodaBeanUtils.notNull(index, "index");
-    JodaBeanUtils.notNull(expiry, "expiry");
+    JodaBeanUtils.notNull(expiration, "expiration");
     JodaBeanUtils.notNull(fixingDate, "fixingDate");
     JodaBeanUtils.notNull(currency, "currency");
     this.index = index;
-    this.expiry = expiry;
+    this.expiration = expiration;
     this.fixingDate = fixingDate;
     this.strikePrice = strikePrice;
     this.futurePrice = futurePrice;
@@ -258,11 +258,11 @@ public final class IborFutureOptionSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the expiration date of the option.
+   * Gets the expiration date-time of the option.
    * @return the value of the property, not null
    */
-  public ZonedDateTime getExpiry() {
-    return expiry;
+  public ZonedDateTime getExpiration() {
+    return expiration;
   }
 
   //-----------------------------------------------------------------------
@@ -321,7 +321,7 @@ public final class IborFutureOptionSensitivity
     if (obj != null && obj.getClass() == this.getClass()) {
       IborFutureOptionSensitivity other = (IborFutureOptionSensitivity) obj;
       return JodaBeanUtils.equal(getIndex(), other.getIndex()) &&
-          JodaBeanUtils.equal(getExpiry(), other.getExpiry()) &&
+          JodaBeanUtils.equal(getExpiration(), other.getExpiration()) &&
           JodaBeanUtils.equal(getFixingDate(), other.getFixingDate()) &&
           JodaBeanUtils.equal(getStrikePrice(), other.getStrikePrice()) &&
           JodaBeanUtils.equal(getFuturePrice(), other.getFuturePrice()) &&
@@ -335,7 +335,7 @@ public final class IborFutureOptionSensitivity
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(getIndex());
-    hash = hash * 31 + JodaBeanUtils.hashCode(getExpiry());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getExpiration());
     hash = hash * 31 + JodaBeanUtils.hashCode(getFixingDate());
     hash = hash * 31 + JodaBeanUtils.hashCode(getStrikePrice());
     hash = hash * 31 + JodaBeanUtils.hashCode(getFuturePrice());
@@ -349,7 +349,7 @@ public final class IborFutureOptionSensitivity
     StringBuilder buf = new StringBuilder(256);
     buf.append("IborFutureOptionSensitivity{");
     buf.append("index").append('=').append(getIndex()).append(',').append(' ');
-    buf.append("expiry").append('=').append(getExpiry()).append(',').append(' ');
+    buf.append("expiration").append('=').append(getExpiration()).append(',').append(' ');
     buf.append("fixingDate").append('=').append(getFixingDate()).append(',').append(' ');
     buf.append("strikePrice").append('=').append(getStrikePrice()).append(',').append(' ');
     buf.append("futurePrice").append('=').append(getFuturePrice()).append(',').append(' ');
@@ -375,10 +375,10 @@ public final class IborFutureOptionSensitivity
     private final MetaProperty<IborIndex> index = DirectMetaProperty.ofImmutable(
         this, "index", IborFutureOptionSensitivity.class, IborIndex.class);
     /**
-     * The meta-property for the {@code expiry} property.
+     * The meta-property for the {@code expiration} property.
      */
-    private final MetaProperty<ZonedDateTime> expiry = DirectMetaProperty.ofImmutable(
-        this, "expiry", IborFutureOptionSensitivity.class, ZonedDateTime.class);
+    private final MetaProperty<ZonedDateTime> expiration = DirectMetaProperty.ofImmutable(
+        this, "expiration", IborFutureOptionSensitivity.class, ZonedDateTime.class);
     /**
      * The meta-property for the {@code fixingDate} property.
      */
@@ -410,7 +410,7 @@ public final class IborFutureOptionSensitivity
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "index",
-        "expiry",
+        "expiration",
         "fixingDate",
         "strikePrice",
         "futurePrice",
@@ -428,8 +428,8 @@ public final class IborFutureOptionSensitivity
       switch (propertyName.hashCode()) {
         case 100346066:  // index
           return index;
-        case -1289159373:  // expiry
-          return expiry;
+        case -837465425:  // expiration
+          return expiration;
         case 1255202043:  // fixingDate
           return fixingDate;
         case 50946231:  // strikePrice
@@ -469,11 +469,11 @@ public final class IborFutureOptionSensitivity
     }
 
     /**
-     * The meta-property for the {@code expiry} property.
+     * The meta-property for the {@code expiration} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<ZonedDateTime> expiry() {
-      return expiry;
+    public MetaProperty<ZonedDateTime> expiration() {
+      return expiration;
     }
 
     /**
@@ -522,8 +522,8 @@ public final class IborFutureOptionSensitivity
       switch (propertyName.hashCode()) {
         case 100346066:  // index
           return ((IborFutureOptionSensitivity) bean).getIndex();
-        case -1289159373:  // expiry
-          return ((IborFutureOptionSensitivity) bean).getExpiry();
+        case -837465425:  // expiration
+          return ((IborFutureOptionSensitivity) bean).getExpiration();
         case 1255202043:  // fixingDate
           return ((IborFutureOptionSensitivity) bean).getFixingDate();
         case 50946231:  // strikePrice
@@ -556,7 +556,7 @@ public final class IborFutureOptionSensitivity
   private static final class Builder extends DirectFieldsBeanBuilder<IborFutureOptionSensitivity> {
 
     private IborIndex index;
-    private ZonedDateTime expiry;
+    private ZonedDateTime expiration;
     private LocalDate fixingDate;
     private double strikePrice;
     private double futurePrice;
@@ -575,8 +575,8 @@ public final class IborFutureOptionSensitivity
       switch (propertyName.hashCode()) {
         case 100346066:  // index
           return index;
-        case -1289159373:  // expiry
-          return expiry;
+        case -837465425:  // expiration
+          return expiration;
         case 1255202043:  // fixingDate
           return fixingDate;
         case 50946231:  // strikePrice
@@ -598,8 +598,8 @@ public final class IborFutureOptionSensitivity
         case 100346066:  // index
           this.index = (IborIndex) newValue;
           break;
-        case -1289159373:  // expiry
-          this.expiry = (ZonedDateTime) newValue;
+        case -837465425:  // expiration
+          this.expiration = (ZonedDateTime) newValue;
           break;
         case 1255202043:  // fixingDate
           this.fixingDate = (LocalDate) newValue;
@@ -650,7 +650,7 @@ public final class IborFutureOptionSensitivity
     public IborFutureOptionSensitivity build() {
       return new IborFutureOptionSensitivity(
           index,
-          expiry,
+          expiration,
           fixingDate,
           strikePrice,
           futurePrice,
@@ -664,7 +664,7 @@ public final class IborFutureOptionSensitivity
       StringBuilder buf = new StringBuilder(256);
       buf.append("IborFutureOptionSensitivity.Builder{");
       buf.append("index").append('=').append(JodaBeanUtils.toString(index)).append(',').append(' ');
-      buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
+      buf.append("expiration").append('=').append(JodaBeanUtils.toString(expiration)).append(',').append(' ');
       buf.append("fixingDate").append('=').append(JodaBeanUtils.toString(fixingDate)).append(',').append(' ');
       buf.append("strikePrice").append('=').append(JodaBeanUtils.toString(strikePrice)).append(',').append(' ');
       buf.append("futurePrice").append('=').append(JodaBeanUtils.toString(futurePrice)).append(',').append(' ');

--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/FxVolatilitySurfaceYearFractionNodeMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/FxVolatilitySurfaceYearFractionNodeMetadata.java
@@ -29,7 +29,7 @@ import com.opengamma.strata.collect.tuple.Pair;
 import com.opengamma.strata.market.option.Strike;
 
 /**
- * Surface node metadata for a surface node with a specific time to expiry and strike.
+ * Surface node metadata for a surface node with a specific time to expiration and strike.
  */
 @BeanDefinition(builderScope = "private")
 public final class FxVolatilitySurfaceYearFractionNodeMetadata
@@ -38,7 +38,7 @@ public final class FxVolatilitySurfaceYearFractionNodeMetadata
   /**
    * The year fraction of the surface node.
    * <p>
-   * This is the time to expiry that the node on the surface is defined as.
+   * This is the time to expiration that the node on the surface is defined as.
    * There is not necessarily a direct relationship with a date from an underlying instrument.
    */
   @PropertyDefinition
@@ -161,7 +161,7 @@ public final class FxVolatilitySurfaceYearFractionNodeMetadata
   /**
    * Gets the year fraction of the surface node.
    * <p>
-   * This is the time to expiry that the node on the surface is defined as.
+   * This is the time to expiration that the node on the surface is defined as.
    * There is not necessarily a direct relationship with a date from an underlying instrument.
    * @return the value of the property
    */

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivityTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivityTest.java
@@ -13,6 +13,7 @@ import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.collect.TestHelper.dateUtc;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
@@ -22,7 +23,6 @@ import java.time.ZonedDateTime;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.opengamma.analytics.util.time.DateUtils;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxMatrix;
 
@@ -33,12 +33,12 @@ import com.opengamma.strata.basics.currency.FxMatrix;
 public class IborFutureOptionSensitivityTest {
 
   public void test_of_noCurrency() {
-    ZonedDateTime expiryDate = DateUtils.getUTCDate(2015, 8, 27);
+    ZonedDateTime expiryDate = dateUtc(2015, 8, 27);
     IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expiryDate,
         date(2015, 8, 28), 0.98, 0.99, 32d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiryDate(), expiryDate);
+    assertEquals(test.getExpiry(), expiryDate);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
     assertEquals(test.getStrikePrice(), 0.98);
     assertEquals(test.getFuturePrice(), 0.99);
@@ -46,12 +46,12 @@ public class IborFutureOptionSensitivityTest {
   }
 
   public void test_of_withCurrency() {
-    ZonedDateTime expiryDate = DateUtils.getUTCDate(2015, 8, 27);
+    ZonedDateTime expiryDate = dateUtc(2015, 8, 27);
     IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expiryDate,
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiryDate(), expiryDate);
+    assertEquals(test.getExpiry(), expiryDate);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
     assertEquals(test.getStrikePrice(), 0.98);
     assertEquals(test.getFuturePrice(), 0.99);
@@ -60,11 +60,11 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_withCurrency() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertSame(base.withCurrency(GBP), base);
 
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     IborFutureOptionSensitivity test = base.withCurrency(USD);
     assertEquals(test, expected);
@@ -72,9 +72,9 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_withSensitivity() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 20d);
     IborFutureOptionSensitivity test = base.withSensitivity(20d);
     assertEquals(test, expected);
@@ -82,21 +82,21 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_compareKey() {
-    IborFutureOptionSensitivity a1 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity a1 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity a2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity a2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity b = IborFutureOptionSensitivity.of(USD_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity b = IborFutureOptionSensitivity.of(USD_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity c = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 9, 27),
+    IborFutureOptionSensitivity c = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 9, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity d = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity d = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 9, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity e = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity e = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.99, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity f = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity f = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 1.00, GBP, 32d);
-    IborFutureOptionSensitivity g = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity g = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, date(2015, 9, 27), 32d);
     assertEquals(a1.compareKey(a2), 0);
@@ -118,7 +118,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_convertedTo() {
-    ZonedDateTime expiryDate = DateUtils.getUTCDate(2015, 8, 27);
+    ZonedDateTime expiryDate = dateUtc(2015, 8, 27);
     LocalDate fixingDate = date(2015, 8, 28);
     double strike = 0.98d;
     double forward = 0.99d;
@@ -137,9 +137,9 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d * 3.5d);
     IborFutureOptionSensitivity test = base.multipliedBy(3.5d);
     assertEquals(test, expected);
@@ -147,9 +147,9 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_mapSensitivity() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 1 / 32d);
     IborFutureOptionSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
@@ -157,7 +157,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_normalize() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity test = base.normalize();
     assertSame(test, base);
@@ -165,7 +165,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_buildInto() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
@@ -175,7 +175,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_build() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
@@ -183,7 +183,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_cloned() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity test = base.cloned();
     assertSame(test, base);
@@ -191,16 +191,16 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     coverImmutableBean(test);
-    IborFutureOptionSensitivity test2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity test2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     coverBeanEquals(test, test2);
   }
 
   public void test_serialization() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, dateUtc(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertSerialization(test);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivityTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivityTest.java
@@ -17,10 +17,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.opengamma.analytics.util.time.DateUtils;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxMatrix;
 
@@ -31,11 +33,12 @@ import com.opengamma.strata.basics.currency.FxMatrix;
 public class IborFutureOptionSensitivityTest {
 
   public void test_of_noCurrency() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    ZonedDateTime expiryDate = DateUtils.getUTCDate(2015, 8, 27);
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expiryDate,
         date(2015, 8, 28), 0.98, 0.99, 32d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiryDate(), date(2015, 8, 27));
+    assertEquals(test.getExpiryDate(), expiryDate);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
     assertEquals(test.getStrikePrice(), 0.98);
     assertEquals(test.getFuturePrice(), 0.99);
@@ -43,11 +46,12 @@ public class IborFutureOptionSensitivityTest {
   }
 
   public void test_of_withCurrency() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    ZonedDateTime expiryDate = DateUtils.getUTCDate(2015, 8, 27);
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expiryDate,
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiryDate(), date(2015, 8, 27));
+    assertEquals(test.getExpiryDate(), expiryDate);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
     assertEquals(test.getStrikePrice(), 0.98);
     assertEquals(test.getFuturePrice(), 0.99);
@@ -56,11 +60,11 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_withCurrency() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertSame(base.withCurrency(GBP), base);
 
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     IborFutureOptionSensitivity test = base.withCurrency(USD);
     assertEquals(test, expected);
@@ -68,9 +72,9 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_withSensitivity() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 20d);
     IborFutureOptionSensitivity test = base.withSensitivity(20d);
     assertEquals(test, expected);
@@ -78,21 +82,21 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_compareKey() {
-    IborFutureOptionSensitivity a1 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity a1 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity a2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity a2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity b = IborFutureOptionSensitivity.of(USD_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity b = IborFutureOptionSensitivity.of(USD_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity c = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 9, 27),
+    IborFutureOptionSensitivity c = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 9, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity d = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity d = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 9, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity e = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity e = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.99, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity f = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity f = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 1.00, GBP, 32d);
-    IborFutureOptionSensitivity g = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity g = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, date(2015, 9, 27), 32d);
     assertEquals(a1.compareKey(a2), 0);
@@ -114,7 +118,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_convertedTo() {
-    LocalDate expiryDate = date(2015, 8, 27);
+    ZonedDateTime expiryDate = DateUtils.getUTCDate(2015, 8, 27);
     LocalDate fixingDate = date(2015, 8, 28);
     double strike = 0.98d;
     double forward = 0.99d;
@@ -133,9 +137,9 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d * 3.5d);
     IborFutureOptionSensitivity test = base.multipliedBy(3.5d);
     assertEquals(test, expected);
@@ -143,9 +147,9 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_mapSensitivity() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 1 / 32d);
     IborFutureOptionSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
@@ -153,7 +157,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_normalize() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity test = base.normalize();
     assertSame(test, base);
@@ -161,7 +165,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_buildInto() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
@@ -171,7 +175,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_build() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
@@ -179,7 +183,7 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_cloned() {
-    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity test = base.cloned();
     assertSame(test, base);
@@ -187,16 +191,16 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     coverImmutableBean(test);
-    IborFutureOptionSensitivity test2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity test2 = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     coverBeanEquals(test, test2);
   }
 
   public void test_serialization() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, date(2015, 8, 27),
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, DateUtils.getUTCDate(2015, 8, 27),
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertSerialization(test);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivityTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/IborFutureOptionSensitivityTest.java
@@ -33,12 +33,12 @@ import com.opengamma.strata.basics.currency.FxMatrix;
 public class IborFutureOptionSensitivityTest {
 
   public void test_of_noCurrency() {
-    ZonedDateTime expiryDate = dateUtc(2015, 8, 27);
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expiryDate,
+    ZonedDateTime expirationDate = dateUtc(2015, 8, 27);
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expirationDate,
         date(2015, 8, 28), 0.98, 0.99, 32d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiry(), expiryDate);
+    assertEquals(test.getExpiration(), expirationDate);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
     assertEquals(test.getStrikePrice(), 0.98);
     assertEquals(test.getFuturePrice(), 0.99);
@@ -46,12 +46,12 @@ public class IborFutureOptionSensitivityTest {
   }
 
   public void test_of_withCurrency() {
-    ZonedDateTime expiryDate = dateUtc(2015, 8, 27);
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expiryDate,
+    ZonedDateTime expirationDate = dateUtc(2015, 8, 27);
+    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(GBP_LIBOR_3M, expirationDate,
         date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertEquals(test.getIndex(), GBP_LIBOR_3M);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiry(), expiryDate);
+    assertEquals(test.getExpiration(), expirationDate);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
     assertEquals(test.getStrikePrice(), 0.98);
     assertEquals(test.getFuturePrice(), 0.99);
@@ -118,18 +118,18 @@ public class IborFutureOptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_convertedTo() {
-    ZonedDateTime expiryDate = dateUtc(2015, 8, 27);
+    ZonedDateTime expirationDate = dateUtc(2015, 8, 27);
     LocalDate fixingDate = date(2015, 8, 28);
     double strike = 0.98d;
     double forward = 0.99d;
     double sensi = 32d;
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, expiryDate, fixingDate, strike, forward, GBP, sensi);
+        GBP_LIBOR_3M, expirationDate, fixingDate, strike, forward, GBP, sensi);
     double rate = 1.5d;
     FxMatrix matrix = FxMatrix.of(CurrencyPair.of(GBP, USD), rate);
     IborFutureOptionSensitivity test1 = (IborFutureOptionSensitivity) base.convertedTo(USD, matrix);
     IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, expiryDate, fixingDate, strike, forward, USD, sensi * rate);
+        GBP_LIBOR_3M, expirationDate, fixingDate, strike, forward, USD, sensi * rate);
     assertEquals(test1, expected);
     IborFutureOptionSensitivity test2 = (IborFutureOptionSensitivity) base.convertedTo(GBP, matrix);
     assertEquals(test2, base);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/EuropeanVanillaOption.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/EuropeanVanillaOption.java
@@ -32,10 +32,10 @@ public final class EuropeanVanillaOption
   @PropertyDefinition
   private final double strike;
   /**
-   * The time to expiry, year fraction.
+   * The time to expiration, year fraction.
    */
   @PropertyDefinition(validate = "ArgChecker.notNegative")
-  private final double timeToExpiry;
+  private final double timeToExpiration;
   /**
    * Call or put, true if call, false if put.
    */
@@ -47,12 +47,12 @@ public final class EuropeanVanillaOption
    * Obtains an instance.
    * 
    * @param strike  the strike
-   * @param timeToExpiry  the time to expiry, year fraction
+   * @param timeToExpiration  the time to expiration, year fraction
    * @param putCall  whether the option is put or call.
    * @return the option definition
    */
-  public static EuropeanVanillaOption of(double strike, double timeToExpiry, PutCall putCall) {
-    return new EuropeanVanillaOption(strike, timeToExpiry, putCall);
+  public static EuropeanVanillaOption of(double strike, double timeToExpiration, PutCall putCall) {
+    return new EuropeanVanillaOption(strike, timeToExpiration, putCall);
   }
 
   //-------------------------------------------------------------------------
@@ -87,12 +87,12 @@ public final class EuropeanVanillaOption
 
   private EuropeanVanillaOption(
       double strike,
-      double timeToExpiry,
+      double timeToExpiration,
       PutCall putCall) {
-    ArgChecker.notNegative(timeToExpiry, "timeToExpiry");
+    ArgChecker.notNegative(timeToExpiration, "timeToExpiration");
     JodaBeanUtils.notNull(putCall, "putCall");
     this.strike = strike;
-    this.timeToExpiry = timeToExpiry;
+    this.timeToExpiration = timeToExpiration;
     this.putCall = putCall;
   }
 
@@ -122,11 +122,11 @@ public final class EuropeanVanillaOption
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the time to expiry, year fraction.
+   * Gets the time to expiration, year fraction.
    * @return the value of the property
    */
-  public double getTimeToExpiry() {
-    return timeToExpiry;
+  public double getTimeToExpiration() {
+    return timeToExpiration;
   }
 
   //-----------------------------------------------------------------------
@@ -147,7 +147,7 @@ public final class EuropeanVanillaOption
     if (obj != null && obj.getClass() == this.getClass()) {
       EuropeanVanillaOption other = (EuropeanVanillaOption) obj;
       return JodaBeanUtils.equal(getStrike(), other.getStrike()) &&
-          JodaBeanUtils.equal(getTimeToExpiry(), other.getTimeToExpiry()) &&
+          JodaBeanUtils.equal(getTimeToExpiration(), other.getTimeToExpiration()) &&
           JodaBeanUtils.equal(getPutCall(), other.getPutCall());
     }
     return false;
@@ -157,7 +157,7 @@ public final class EuropeanVanillaOption
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(getStrike());
-    hash = hash * 31 + JodaBeanUtils.hashCode(getTimeToExpiry());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getTimeToExpiration());
     hash = hash * 31 + JodaBeanUtils.hashCode(getPutCall());
     return hash;
   }
@@ -167,7 +167,7 @@ public final class EuropeanVanillaOption
     StringBuilder buf = new StringBuilder(128);
     buf.append("EuropeanVanillaOption{");
     buf.append("strike").append('=').append(getStrike()).append(',').append(' ');
-    buf.append("timeToExpiry").append('=').append(getTimeToExpiry()).append(',').append(' ');
+    buf.append("timeToExpiration").append('=').append(getTimeToExpiration()).append(',').append(' ');
     buf.append("putCall").append('=').append(JodaBeanUtils.toString(getPutCall()));
     buf.append('}');
     return buf.toString();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalPriceFunction.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalPriceFunction.java
@@ -33,7 +33,7 @@ public final class NormalPriceFunction {
   public Function1D<NormalFunctionData, Double> getPriceFunction(EuropeanVanillaOption option) {
     ArgChecker.notNull(option, "option");
     double strike = option.getStrike();
-    double t = option.getTimeToExpiry();
+    double t = option.getTimeToExpiration();
     return new Function1D<NormalFunctionData, Double>() {
 
       @SuppressWarnings("synthetic-access")
@@ -71,7 +71,7 @@ public final class NormalPriceFunction {
     ArgChecker.notNull(priceDerivative, "derivatives");
     ArgChecker.isTrue(priceDerivative.length == 3, "array size");
     double strike = option.getStrike();
-    double t = option.getTimeToExpiry();
+    double t = option.getTimeToExpiration();
     double forward = data.getForward();
     double numeraire = data.getNumeraire();
     double sigma = data.getNormalVolatility();
@@ -122,7 +122,7 @@ public final class NormalPriceFunction {
     ArgChecker.notNull(option, "option");
     ArgChecker.notNull(data, "data");
     double strike = option.getStrike();
-    double t = option.getTimeToExpiry();
+    double t = option.getTimeToExpiration();
     double forward = data.getForward();
     double numeraire = data.getNumeraire();
     double sigma = data.getNormalVolatility();
@@ -152,7 +152,7 @@ public final class NormalPriceFunction {
     ArgChecker.notNull(option, "option");
     ArgChecker.notNull(data, "data");
     double strike = option.getStrike();
-    double t = option.getTimeToExpiry();
+    double t = option.getTimeToExpiration();
     double forward = data.getForward();
     double numeraire = data.getNumeraire();
     double sigma = data.getNormalVolatility();
@@ -179,7 +179,7 @@ public final class NormalPriceFunction {
     ArgChecker.notNull(option, "option");
     ArgChecker.notNull(data, "data");
     double strike = option.getStrike();
-    double t = option.getTimeToExpiry();
+    double t = option.getTimeToExpiration();
     double forward = data.getForward();
     double numeraire = data.getNumeraire();
     double sigma = data.getNormalVolatility();
@@ -207,7 +207,7 @@ public final class NormalPriceFunction {
     ArgChecker.notNull(option, "option");
     ArgChecker.notNull(data, "data");
     double strike = option.getStrike();
-    double t = option.getTimeToExpiry();
+    double t = option.getTimeToExpiration();
     double forward = data.getForward();
     double numeraire = data.getNumeraire();
     double sigma = data.getNormalVolatility();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricer.java
@@ -107,7 +107,7 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
     double strike = futureOption.getStrikePrice();
     IborFuture future = futureOption.getUnderlying();
     double volatility = volatilityProvider.getVolatility(
-        futureOption.getExpirationDateTime(), future.getLastTradeDate(), strike, futurePrice);
+        futureOption.getExpiration(), future.getLastTradeDate(), strike, futurePrice);
 
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, volatility);
     return NORMAL_FUNCTION.getPriceFunction(option).evaluate(normalPoint);
@@ -172,7 +172,7 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
     EuropeanVanillaOption option = createOption(futureOption, volatilityProvider);
     double strike = futureOption.getStrikePrice();
     IborFuture future = futureOption.getUnderlying();
-    double volatility = volatilityProvider.getVolatility(futureOption.getExpirationDateTime(),
+    double volatility = volatilityProvider.getVolatility(futureOption.getExpiration(),
         future.getLastTradeDate(), strike, futurePrice);
 
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, volatility);
@@ -288,11 +288,11 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
     EuropeanVanillaOption option = createOption(futureOption, volatilityProvider);
     double strike = futureOption.getStrikePrice();
     IborFuture future = futureOption.getUnderlying();
-    double volatility = volatilityProvider.getVolatility(futureOption.getExpirationDateTime(),
+    double volatility = volatilityProvider.getVolatility(futureOption.getExpiration(),
         future.getLastTradeDate(), strike, futurePrice);
 
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, volatility);
-    return IborFutureOptionSensitivity.of(future.getIndex(), futureOption.getExpirationDateTime(),
+    return IborFutureOptionSensitivity.of(future.getIndex(), futureOption.getExpiration(),
         future.getLastTradeDate(), strike, futurePrice, NORMAL_FUNCTION.getVega(option, normalPoint));
   }
 
@@ -308,8 +308,8 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
       IborFutureOption futureOption,
       NormalVolatilityIborFutureProvider volatilityProvider) {
 
-    double timeToExpiry = volatilityProvider.relativeTime(futureOption.getExpirationDateTime());
-    return EuropeanVanillaOption.of(futureOption.getStrikePrice(), timeToExpiry, futureOption.getPutCall());
+    double timeToExpiration = volatilityProvider.relativeTime(futureOption.getExpiration());
+    return EuropeanVanillaOption.of(futureOption.getStrikePrice(), timeToExpiration, futureOption.getPutCall());
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricer.java
@@ -107,7 +107,7 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
     double strike = futureOption.getStrikePrice();
     IborFuture future = futureOption.getUnderlying();
     double volatility = volatilityProvider.getVolatility(
-        futureOption.getExpirationDate(), future.getLastTradeDate(), strike, futurePrice);
+        futureOption.getExpirationDateTime(), future.getLastTradeDate(), strike, futurePrice);
 
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, volatility);
     return NORMAL_FUNCTION.getPriceFunction(option).evaluate(normalPoint);
@@ -172,7 +172,7 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
     EuropeanVanillaOption option = createOption(futureOption, volatilityProvider);
     double strike = futureOption.getStrikePrice();
     IborFuture future = futureOption.getUnderlying();
-    double volatility = volatilityProvider.getVolatility(futureOption.getExpirationDate(),
+    double volatility = volatilityProvider.getVolatility(futureOption.getExpirationDateTime(),
         future.getLastTradeDate(), strike, futurePrice);
 
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, volatility);
@@ -288,11 +288,11 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
     EuropeanVanillaOption option = createOption(futureOption, volatilityProvider);
     double strike = futureOption.getStrikePrice();
     IborFuture future = futureOption.getUnderlying();
-    double volatility = volatilityProvider.getVolatility(futureOption.getExpirationDate(),
+    double volatility = volatilityProvider.getVolatility(futureOption.getExpirationDateTime(),
         future.getLastTradeDate(), strike, futurePrice);
 
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, volatility);
-    return IborFutureOptionSensitivity.of(future.getIndex(), futureOption.getExpirationDate(),
+    return IborFutureOptionSensitivity.of(future.getIndex(), futureOption.getExpirationDateTime(),
         future.getLastTradeDate(), strike, futurePrice, NORMAL_FUNCTION.getVega(option, normalPoint));
   }
 
@@ -308,8 +308,7 @@ public class NormalIborFutureOptionMarginedProductPricer extends IborFutureOptio
       IborFutureOption futureOption,
       NormalVolatilityIborFutureProvider volatilityProvider) {
 
-    double timeToExpiry = volatilityProvider.relativeYearFraction(
-        futureOption.getExpirationDate(), futureOption.getExpirationTime(), futureOption.getExpirationZone());
+    double timeToExpiry = volatilityProvider.relativeTime(futureOption.getExpirationDateTime());
     return EuropeanVanillaOption.of(futureOption.getStrikePrice(), timeToExpiry, futureOption.getPutCall());
   }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedTradePricer.java
@@ -76,7 +76,7 @@ public final class NormalIborFutureOptionMarginedTradePricer extends IborFutureO
    * Computes the present value sensitivity to the normal volatility used in the pricing.
    * <p>
    * The result is a single sensitivity to the volatility used.
-   * The volatility is associated with the expiry/delay/strike/future price key combination.
+   * The volatility is associated with the expiration/delay/strike/future price key combination.
    * <p>
    * This calculates the underlying future price using the future pricer.
    * 
@@ -100,7 +100,7 @@ public final class NormalIborFutureOptionMarginedTradePricer extends IborFutureO
    * based on the price of the underlying future.
    * <p>
    * The result is a single sensitivity to the volatility used.
-   * The volatility is associated with the expiry/delay/strike/future price key combination.
+   * The volatility is associated with the expiration/delay/strike/future price key combination.
    * 
    * @param futureOptionTrade  the trade to price
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProvider.java
@@ -122,7 +122,7 @@ public final class NormalVolatilityExpSimpleMoneynessIborFutureProvider
   public Map<DoublesPair, Double> nodeSensitivity(IborFutureOptionSensitivity point) {
     double simpleMoneyness = isMoneynessOnPrice ?
         point.getStrikePrice() - point.getFuturePrice() : point.getFuturePrice() - point.getStrikePrice();
-    double expiryTime = relativeTime(point.getExpiryDate()); // TODO: time and zone
+    double expiryTime = relativeTime(point.getExpiry());
     @SuppressWarnings("unchecked")
     Map<DoublesPair, Double> result = parameters.getInterpolator().getNodeSensitivitiesForValue(
         (Map<Double, Interpolator1DDataBundle>) parameters.getInterpolatorData(),

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProvider.java
@@ -44,7 +44,7 @@ public final class NormalVolatilityExpSimpleMoneynessIborFutureProvider
 
   /**
    * The normal volatility surface.
-   * The order of the dimensions is expiry/simple moneyness.
+   * The order of the dimensions is expiration/simple moneyness.
    */
   @PropertyDefinition(validate = "notNull")
   private final InterpolatedDoublesSurface parameters;
@@ -94,10 +94,10 @@ public final class NormalVolatilityExpSimpleMoneynessIborFutureProvider
 
   //-------------------------------------------------------------------------
   @Override
-  public double getVolatility(ZonedDateTime expiryDateTime, LocalDate fixingDate, double strikePrice, double futurePrice) {
+  public double getVolatility(ZonedDateTime expiration, LocalDate fixingDate, double strikePrice, double futurePrice) {
     double simpleMoneyness = isMoneynessOnPrice ? strikePrice - futurePrice : futurePrice - strikePrice;
-    double expiryTime = relativeTime(expiryDateTime);
-    return parameters.getZValue(expiryTime, simpleMoneyness);
+    double expirationTime = relativeTime(expiration);
+    return parameters.getZValue(expirationTime, simpleMoneyness);
   }
 
   @Override
@@ -122,11 +122,11 @@ public final class NormalVolatilityExpSimpleMoneynessIborFutureProvider
   public Map<DoublesPair, Double> nodeSensitivity(IborFutureOptionSensitivity point) {
     double simpleMoneyness = isMoneynessOnPrice ?
         point.getStrikePrice() - point.getFuturePrice() : point.getFuturePrice() - point.getStrikePrice();
-    double expiryTime = relativeTime(point.getExpiry());
+    double expirationTime = relativeTime(point.getExpiration());
     @SuppressWarnings("unchecked")
     Map<DoublesPair, Double> result = parameters.getInterpolator().getNodeSensitivitiesForValue(
         (Map<Double, Interpolator1DDataBundle>) parameters.getInterpolatorData(),
-        DoublesPair.of(expiryTime, simpleMoneyness));
+        DoublesPair.of(expirationTime, simpleMoneyness));
     return result;
   }
 
@@ -187,7 +187,7 @@ public final class NormalVolatilityExpSimpleMoneynessIborFutureProvider
   //-----------------------------------------------------------------------
   /**
    * Gets the normal volatility surface.
-   * The order of the dimensions is expiry/simple moneyness.
+   * The order of the dimensions is expiration/simple moneyness.
    * @return the value of the property, not null
    */
   public InterpolatedDoublesSurface getParameters() {
@@ -545,7 +545,7 @@ public final class NormalVolatilityExpSimpleMoneynessIborFutureProvider
     //-----------------------------------------------------------------------
     /**
      * Sets the normal volatility surface.
-     * The order of the dimensions is expiry/simple moneyness.
+     * The order of the dimensions is expiration/simple moneyness.
      * @param parameters  the new value, not null
      * @return this, for chaining, not null
      */

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityIborFutureProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityIborFutureProvider.java
@@ -6,8 +6,6 @@
 package com.opengamma.strata.pricer.rate.future;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import com.opengamma.strata.basics.index.IborIndex;
@@ -28,13 +26,13 @@ public interface NormalVolatilityIborFutureProvider
   /**
    * Returns the normal volatility.
    * 
-   * @param expiryDate  the option expiry
+   * @param expiryDateTime  the option expiry
    * @param fixingDate  the underlying future fixing date
    * @param strikePrice  the option strike price
    * @param futurePrice  the price of the underlying future
    * @return the volatility
    */
-  public abstract double getVolatility(LocalDate expiryDate, LocalDate fixingDate, double strikePrice, double futurePrice);
+  public abstract double getVolatility(ZonedDateTime expiryDateTime, LocalDate fixingDate, double strikePrice, double futurePrice);
 
   /**
    * Returns the index on which the underlying future is based.
@@ -43,13 +41,11 @@ public interface NormalVolatilityIborFutureProvider
   public abstract IborIndex getFutureIndex();
 
   /**
-   * Converts a date to a relative year fraction.
+   * Converts a date to a relative {@code double} time.
    * 
-   * @param date  the date to find the relative year fraction of
-   * @param time  the time to find the relative year fraction of
-   * @param zone  the time zone
-   * @return the relative year fraction
+   * @param zonedDateTime  the zoned date time
+   * @return the relative time
    */
-  public abstract double relativeYearFraction(LocalDate date, LocalTime time, ZoneId zone);
+  public abstract double relativeTime(ZonedDateTime zonedDateTime);
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityIborFutureProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityIborFutureProvider.java
@@ -26,13 +26,13 @@ public interface NormalVolatilityIborFutureProvider
   /**
    * Returns the normal volatility.
    * 
-   * @param expiryDateTime  the option expiry
+   * @param expiration  the expiration date-time of the option
    * @param fixingDate  the underlying future fixing date
    * @param strikePrice  the option strike price
    * @param futurePrice  the price of the underlying future
    * @return the volatility
    */
-  public abstract double getVolatility(ZonedDateTime expiryDateTime, LocalDate fixingDate, double strikePrice, double futurePrice);
+  public abstract double getVolatility(ZonedDateTime expiration, LocalDate fixingDate, double strikePrice, double futurePrice);
 
   /**
    * Returns the index on which the underlying future is based.

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/EuropeanVanillaOptionTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/EuropeanVanillaOptionTest.java
@@ -31,7 +31,7 @@ public class EuropeanVanillaOptionTest {
   public void test_of() {
     EuropeanVanillaOption test = EuropeanVanillaOption.of(STRIKE, TIME, CALL);
     assertEquals(test.getStrike(), STRIKE, 0);
-    assertEquals(test.getTimeToExpiry(), TIME, 0);
+    assertEquals(test.getTimeToExpiration(), TIME, 0);
     assertEquals(test.getPutCall(), CALL);
     assertEquals(test.isCall(), true);
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricerTest.java
@@ -189,7 +189,7 @@ public class NormalIborFutureOptionMarginedProductPricerTest {
     IborFutureOptionSensitivity optionVegaComputed = OPTION_PRICER.priceSensitivityNormalVolatility(
         FUTURE_OPTION_PRODUCT, prov, VOL_SIMPLE_MONEY_PRICE, futurePrice);
     assertEquals(optionVegaComputed.getSensitivity(), optionVegaExpected, TOLERANCE_PRICE);
-    assertEquals(optionVegaComputed.getExpiryDate(), FUTURE_OPTION_PRODUCT.getExpirationDateTime());
+    assertEquals(optionVegaComputed.getExpiry(), FUTURE_OPTION_PRODUCT.getExpirationDateTime());
     assertEquals(optionVegaComputed.getFixingDate(), FUTURE_OPTION_PRODUCT.getUnderlying().getFixingDate());
     assertEquals(optionVegaComputed.getStrikePrice(), FUTURE_OPTION_PRODUCT.getStrikePrice());
     assertEquals(optionVegaComputed.getFuturePrice(), futurePrice);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricerTest.java
@@ -81,10 +81,10 @@ public class NormalIborFutureOptionMarginedProductPricerTest {
 
     double futurePrice = 0.9875;
     double strike = FUTURE_OPTION_PRODUCT.getStrikePrice();
-    double expiryTime = ACT_365F.relativeYearFraction(VALUATION_DATE, FUTURE_OPTION_PRODUCT.getExpirationDate());
+    double expirationTime = ACT_365F.relativeYearFraction(VALUATION_DATE, FUTURE_OPTION_PRODUCT.getExpirationDate());
     double priceSimpleMoneyness = strike - futurePrice;
-    double normalVol = PARAMETERS_PRICE.getZValue(expiryTime, priceSimpleMoneyness);
-    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expiryTime, FUTURE_OPTION_PRODUCT.getPutCall());
+    double normalVol = PARAMETERS_PRICE.getZValue(expirationTime, priceSimpleMoneyness);
+    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expirationTime, FUTURE_OPTION_PRODUCT.getPutCall());
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, normalVol);
     double optionPriceExpected = NORMAL_FUNCTION.getPriceFunction(option).evaluate(normalPoint);
     double optionPriceComputed = OPTION_PRICER.price(FUTURE_OPTION_PRODUCT, prov, VOL_SIMPLE_MONEY_PRICE, futurePrice);
@@ -112,10 +112,10 @@ public class NormalIborFutureOptionMarginedProductPricerTest {
 
     double futurePrice = 0.9875;
     double strike = FUTURE_OPTION_PRODUCT.getStrikePrice();
-    double expiryTime = ACT_365F.relativeYearFraction(VALUATION_DATE, FUTURE_OPTION_PRODUCT.getExpirationDate());
+    double expirationTime = ACT_365F.relativeYearFraction(VALUATION_DATE, FUTURE_OPTION_PRODUCT.getExpirationDate());
     double priceSimpleMoneyness = strike - futurePrice;
-    double normalVol = PARAMETERS_PRICE.getZValue(expiryTime, priceSimpleMoneyness);
-    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expiryTime, FUTURE_OPTION_PRODUCT.getPutCall());
+    double normalVol = PARAMETERS_PRICE.getZValue(expirationTime, priceSimpleMoneyness);
+    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expirationTime, FUTURE_OPTION_PRODUCT.getPutCall());
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, normalVol);
     double optionDeltaExpected = NORMAL_FUNCTION.getDelta(option, normalPoint);
     double optionDeltaComputed =
@@ -180,16 +180,16 @@ public class NormalIborFutureOptionMarginedProductPricerTest {
 
     double futurePrice = 0.9875;
     double strike = FUTURE_OPTION_PRODUCT.getStrikePrice();
-    double expiryTime = ACT_365F.relativeYearFraction(VALUATION_DATE, FUTURE_OPTION_PRODUCT.getExpirationDate());
+    double expirationTime = ACT_365F.relativeYearFraction(VALUATION_DATE, FUTURE_OPTION_PRODUCT.getExpirationDate());
     double priceSimpleMoneyness = strike - futurePrice;
-    double normalVol = PARAMETERS_PRICE.getZValue(expiryTime, priceSimpleMoneyness);
-    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expiryTime, FUTURE_OPTION_PRODUCT.getPutCall());
+    double normalVol = PARAMETERS_PRICE.getZValue(expirationTime, priceSimpleMoneyness);
+    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expirationTime, FUTURE_OPTION_PRODUCT.getPutCall());
     NormalFunctionData normalPoint = NormalFunctionData.of(futurePrice, 1.0, normalVol);
     double optionVegaExpected = NORMAL_FUNCTION.getVega(option, normalPoint);
     IborFutureOptionSensitivity optionVegaComputed = OPTION_PRICER.priceSensitivityNormalVolatility(
         FUTURE_OPTION_PRODUCT, prov, VOL_SIMPLE_MONEY_PRICE, futurePrice);
     assertEquals(optionVegaComputed.getSensitivity(), optionVegaExpected, TOLERANCE_PRICE);
-    assertEquals(optionVegaComputed.getExpiry(), FUTURE_OPTION_PRODUCT.getExpirationDateTime());
+    assertEquals(optionVegaComputed.getExpiration(), FUTURE_OPTION_PRODUCT.getExpiration());
     assertEquals(optionVegaComputed.getFixingDate(), FUTURE_OPTION_PRODUCT.getUnderlying().getFixingDate());
     assertEquals(optionVegaComputed.getStrikePrice(), FUTURE_OPTION_PRODUCT.getStrikePrice());
     assertEquals(optionVegaComputed.getFuturePrice(), futurePrice);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalIborFutureOptionMarginedProductPricerTest.java
@@ -189,7 +189,7 @@ public class NormalIborFutureOptionMarginedProductPricerTest {
     IborFutureOptionSensitivity optionVegaComputed = OPTION_PRICER.priceSensitivityNormalVolatility(
         FUTURE_OPTION_PRODUCT, prov, VOL_SIMPLE_MONEY_PRICE, futurePrice);
     assertEquals(optionVegaComputed.getSensitivity(), optionVegaExpected, TOLERANCE_PRICE);
-    assertEquals(optionVegaComputed.getExpiryDate(), FUTURE_OPTION_PRODUCT.getExpirationDate());
+    assertEquals(optionVegaComputed.getExpiryDate(), FUTURE_OPTION_PRODUCT.getExpirationDateTime());
     assertEquals(optionVegaComputed.getFixingDate(), FUTURE_OPTION_PRODUCT.getUnderlying().getFixingDate());
     assertEquals(optionVegaComputed.getStrikePrice(), FUTURE_OPTION_PRODUCT.getStrikePrice());
     assertEquals(optionVegaComputed.getFuturePrice(), futurePrice);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProviderTest.java
@@ -12,6 +12,7 @@ import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_6M;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.collect.TestHelper.dateUtc;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -26,7 +27,6 @@ import com.opengamma.analytics.math.interpolation.GridInterpolator2D;
 import com.opengamma.analytics.math.interpolation.Interpolator1D;
 import com.opengamma.analytics.math.interpolation.Interpolator1DFactory;
 import com.opengamma.analytics.math.surface.InterpolatedDoublesSurface;
-import com.opengamma.analytics.util.time.DateUtils;
 
 /**
  * Tests {@link NormalVolatilityExpSimpleMoneynessIborFutureProvider}
@@ -64,9 +64,8 @@ public class NormalVolatilityExpSimpleMoneynessIborFutureProviderTest {
       NormalVolatilityExpSimpleMoneynessIborFutureProvider.of(
           PARAMETERS_RATE, false, EUR_EURIBOR_3M, ACT_365F, VALUATION_DATE_TIME);
 
-  private static final ZonedDateTime[] TEST_EXPIRY =
-      new ZonedDateTime[] {DateUtils.getUTCDate(2015, 2, 17), DateUtils.getUTCDate(2015, 5, 17), 
-    DateUtils.getUTCDate(2015, 6, 17), DateUtils.getUTCDate(2017, 2, 17)};
+  private static final ZonedDateTime[] TEST_EXPIRY = new ZonedDateTime[] {
+      dateUtc(2015, 2, 17), dateUtc(2015, 5, 17), dateUtc(2015, 6, 17), dateUtc(2017, 2, 17)};
   private static final int NB_TEST = TEST_EXPIRY.length;
   private static final LocalDate[] TEST_FIXING =
       new LocalDate[] {date(2015, 2, 17), date(2015, 5, 17), date(2015, 5, 17), date(2015, 5, 17)};
@@ -86,8 +85,8 @@ public class NormalVolatilityExpSimpleMoneynessIborFutureProviderTest {
 
   public void volatility_price() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = VOL_SIMPLE_MONEY_RATE.relativeTime(TEST_EXPIRY[i]);
-      double volExpected = PARAMETERS_PRICE.getZValue(expiryTime, TEST_STRIKE_PRICE[i] - TEST_FUTURE_PRICE[i]);
+      double expirationTime = VOL_SIMPLE_MONEY_RATE.relativeTime(TEST_EXPIRY[i]);
+      double volExpected = PARAMETERS_PRICE.getZValue(expirationTime, TEST_STRIKE_PRICE[i] - TEST_FUTURE_PRICE[i]);
       double volComputed = VOL_SIMPLE_MONEY_PRICE.getVolatility(TEST_EXPIRY[i], TEST_FIXING[i],
           TEST_STRIKE_PRICE[i], TEST_FUTURE_PRICE[i]);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);
@@ -96,8 +95,8 @@ public class NormalVolatilityExpSimpleMoneynessIborFutureProviderTest {
 
   public void volatility_rate() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = VOL_SIMPLE_MONEY_RATE.relativeTime(TEST_EXPIRY[i]);
-      double volExpected = PARAMETERS_RATE.getZValue(expiryTime, TEST_FUTURE_PRICE[i] - TEST_STRIKE_PRICE[i]);
+      double expirationTime = VOL_SIMPLE_MONEY_RATE.relativeTime(TEST_EXPIRY[i]);
+      double volExpected = PARAMETERS_RATE.getZValue(expirationTime, TEST_FUTURE_PRICE[i] - TEST_STRIKE_PRICE[i]);
       double volComputed = VOL_SIMPLE_MONEY_RATE.getVolatility(TEST_EXPIRY[i], TEST_FIXING[i],
           TEST_STRIKE_PRICE[i], TEST_FUTURE_PRICE[i]);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/NormalVolatilityExpSimpleMoneynessIborFutureProviderTest.java
@@ -26,6 +26,7 @@ import com.opengamma.analytics.math.interpolation.GridInterpolator2D;
 import com.opengamma.analytics.math.interpolation.Interpolator1D;
 import com.opengamma.analytics.math.interpolation.Interpolator1DFactory;
 import com.opengamma.analytics.math.surface.InterpolatedDoublesSurface;
+import com.opengamma.analytics.util.time.DateUtils;
 
 /**
  * Tests {@link NormalVolatilityExpSimpleMoneynessIborFutureProvider}
@@ -63,8 +64,9 @@ public class NormalVolatilityExpSimpleMoneynessIborFutureProviderTest {
       NormalVolatilityExpSimpleMoneynessIborFutureProvider.of(
           PARAMETERS_RATE, false, EUR_EURIBOR_3M, ACT_365F, VALUATION_DATE_TIME);
 
-  private static final LocalDate[] TEST_EXPIRY =
-      new LocalDate[] {date(2015, 2, 17), date(2015, 5, 17), date(2015, 6, 17), date(2017, 2, 17)};
+  private static final ZonedDateTime[] TEST_EXPIRY =
+      new ZonedDateTime[] {DateUtils.getUTCDate(2015, 2, 17), DateUtils.getUTCDate(2015, 5, 17), 
+    DateUtils.getUTCDate(2015, 6, 17), DateUtils.getUTCDate(2017, 2, 17)};
   private static final int NB_TEST = TEST_EXPIRY.length;
   private static final LocalDate[] TEST_FIXING =
       new LocalDate[] {date(2015, 2, 17), date(2015, 5, 17), date(2015, 5, 17), date(2015, 5, 17)};
@@ -84,7 +86,7 @@ public class NormalVolatilityExpSimpleMoneynessIborFutureProviderTest {
 
   public void volatility_price() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = VOL_SIMPLE_MONEY_RATE.relativeYearFraction(TEST_EXPIRY[i], LocalTime.MIDNIGHT, LONDON_ZONE);
+      double expiryTime = VOL_SIMPLE_MONEY_RATE.relativeTime(TEST_EXPIRY[i]);
       double volExpected = PARAMETERS_PRICE.getZValue(expiryTime, TEST_STRIKE_PRICE[i] - TEST_FUTURE_PRICE[i]);
       double volComputed = VOL_SIMPLE_MONEY_PRICE.getVolatility(TEST_EXPIRY[i], TEST_FIXING[i],
           TEST_STRIKE_PRICE[i], TEST_FUTURE_PRICE[i]);
@@ -94,7 +96,7 @@ public class NormalVolatilityExpSimpleMoneynessIborFutureProviderTest {
 
   public void volatility_rate() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = VOL_SIMPLE_MONEY_RATE.relativeYearFraction(TEST_EXPIRY[i], LocalTime.MIDNIGHT, LONDON_ZONE);
+      double expiryTime = VOL_SIMPLE_MONEY_RATE.relativeTime(TEST_EXPIRY[i]);
       double volExpected = PARAMETERS_RATE.getZValue(expiryTime, TEST_FUTURE_PRICE[i] - TEST_STRIKE_PRICE[i]);
       double volComputed = VOL_SIMPLE_MONEY_RATE.getVolatility(TEST_EXPIRY[i], TEST_FIXING[i],
           TEST_STRIKE_PRICE[i], TEST_FUTURE_PRICE[i]);


### PR DESCRIPTION
Current version uses only expiry date. Also some "null" are passed as expiry time and zone in some places.