### PR TITLE
Add known amount swap leg periods

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/Payment.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/Payment.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.basics.currency;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjuster;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -24,6 +25,7 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.opengamma.strata.basics.PayReceive;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 
 /**
  * A single payment of a known amount on a specific date.
@@ -124,6 +126,21 @@ public final class Payment
    */
   public PayReceive getPayReceive() {
     return PayReceive.ofSignedAmount(value.getAmount());
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Adjusts the payment date using the rules of the specified adjuster.
+   * <p>
+   * The adjuster is typically an instance of {@link BusinessDayAdjustment}.
+   * If the date is unchanged by the adjuster, {@code this} payment will be returned.
+   * 
+   * @param adjuster  the adjuster to apply to the payment date
+   * @return the adjusted payment
+   */
+  public Payment adjustDate(TemporalAdjuster adjuster) {
+    LocalDate adjusted = date.with(adjuster);
+    return adjusted.equals(date) ? this : toBuilder().date(adjusted).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/PaymentTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/PaymentTest.java
@@ -12,8 +12,10 @@ import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 
 import org.testng.annotations.Test;
 
@@ -69,6 +71,18 @@ public class PaymentTest {
     assertEquals(test.getAmount(), 1_000, 0d);
     assertEquals(test.getPayReceive(), PayReceive.RECEIVE);
     assertEquals(test.getDate(), DATE_2015_06_30);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_adjustDate() {
+    Payment test = Payment.ofReceive(GBP_P1000, DATE_2015_06_29);
+    Payment expected = Payment.of(GBP_P1000, DATE_2015_06_29.plusDays(1));
+    assertEquals(test.adjustDate(TemporalAdjusters.ofDateAdjuster(d -> d.plusDays(1))), expected);
+  }
+
+  public void test_adjustDate_noChange() {
+    Payment test = Payment.ofReceive(GBP_P1000, DATE_2015_06_29);
+    assertSame(test.adjustDate(TemporalAdjusters.ofDateAdjuster(d -> d.plusDays(1).minusDays(1))), test);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/KnownAmountPaymentPeriod.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/KnownAmountPaymentPeriod.java
@@ -1,0 +1,677 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjuster;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutablePreBuild;
+import org.joda.beans.ImmutableValidator;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.schedule.SchedulePeriod;
+import com.opengamma.strata.collect.ArgChecker;
+
+/**
+ * A period within a swap that results in a known amount.
+ * <p>
+ * A swap leg consists of one or more periods that result in a payment.
+ * The standard class, {@link RatePaymentPeriod}, represents a payment period calculated
+ * from a fixed or floating rate. By contrast, this class represents a period
+ * where the amount of the payment is known and fixed.
+ */
+@BeanDefinition
+public final class KnownAmountPaymentPeriod
+    implements PaymentPeriod, ImmutableBean, Serializable {
+
+  /**
+   * The payment.
+   * <p>
+   * This includes the payment date and amount.
+   * If the schedule adjusts for business days, then the date is the adjusted date.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final Payment payment;
+  /**
+   * The start date of the payment period.
+   * <p>
+   * This is the first date in the period.
+   * If the schedule adjusts for business days, then this is the adjusted date.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final LocalDate startDate;
+  /**
+   * The end date of the payment period.
+   * <p>
+   * This is the last date in the period.
+   * If the schedule adjusts for business days, then this is the adjusted date.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final LocalDate endDate;
+  /**
+   * The unadjusted start date.
+   * <p>
+   * The start date before any business day adjustment is applied.
+   * <p>
+   * When building, this will default to the start date if not specified.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final LocalDate unadjustedStartDate;
+  /**
+   * The unadjusted end date.
+   * <p>
+   * The end date before any business day adjustment is applied.
+   * <p>
+   * When building, this will default to the end date if not specified.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final LocalDate unadjustedEndDate;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains an instance based on a payment and schedule period.
+   * 
+   * @param payment  the payment
+   * @param period  the schedule period
+   * @return the period
+   */
+  public static KnownAmountPaymentPeriod of(Payment payment, SchedulePeriod period) {
+    return KnownAmountPaymentPeriod.builder()
+        .payment(payment)
+        .startDate(period.getStartDate())
+        .endDate(period.getEndDate())
+        .unadjustedStartDate(period.getUnadjustedStartDate())
+        .unadjustedEndDate(period.getUnadjustedEndDate())
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  @ImmutablePreBuild
+  private static void preBuild(Builder builder) {
+    if (builder.unadjustedStartDate == null && builder.startDate != null) {
+      builder.unadjustedStartDate = builder.startDate;
+    }
+    if (builder.unadjustedEndDate == null && builder.endDate != null) {
+      builder.unadjustedEndDate = builder.endDate;
+    }
+  }
+
+  @ImmutableValidator
+  private void validate() {
+    // check for unadjusted must be after firstNonNull
+    ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
+    ArgChecker.inOrderNotEqual(unadjustedStartDate, unadjustedEndDate, "unadjustedStartDate", "unadjustedEndDate");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public LocalDate getPaymentDate() {
+    return payment.getDate();
+  }
+
+  @Override
+  public Currency getCurrency() {
+    return payment.getCurrency();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public KnownAmountPaymentPeriod adjustPaymentDate(TemporalAdjuster adjuster) {
+    Payment adjusted = payment.adjustDate(adjuster);
+    return adjusted == payment ? this : toBuilder().payment(adjusted).build();
+  }
+
+  @Override
+  public void collectIndices(ImmutableSet.Builder<Index> builder) {
+    // no indices
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code KnownAmountPaymentPeriod}.
+   * @return the meta-bean, not null
+   */
+  public static KnownAmountPaymentPeriod.Meta meta() {
+    return KnownAmountPaymentPeriod.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(KnownAmountPaymentPeriod.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static KnownAmountPaymentPeriod.Builder builder() {
+    return new KnownAmountPaymentPeriod.Builder();
+  }
+
+  private KnownAmountPaymentPeriod(
+      Payment payment,
+      LocalDate startDate,
+      LocalDate endDate,
+      LocalDate unadjustedStartDate,
+      LocalDate unadjustedEndDate) {
+    JodaBeanUtils.notNull(payment, "payment");
+    JodaBeanUtils.notNull(startDate, "startDate");
+    JodaBeanUtils.notNull(endDate, "endDate");
+    JodaBeanUtils.notNull(unadjustedStartDate, "unadjustedStartDate");
+    JodaBeanUtils.notNull(unadjustedEndDate, "unadjustedEndDate");
+    this.payment = payment;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.unadjustedStartDate = unadjustedStartDate;
+    this.unadjustedEndDate = unadjustedEndDate;
+    validate();
+  }
+
+  @Override
+  public KnownAmountPaymentPeriod.Meta metaBean() {
+    return KnownAmountPaymentPeriod.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the payment.
+   * <p>
+   * This includes the payment date and amount.
+   * If the schedule adjusts for business days, then the date is the adjusted date.
+   * @return the value of the property, not null
+   */
+  public Payment getPayment() {
+    return payment;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the start date of the payment period.
+   * <p>
+   * This is the first date in the period.
+   * If the schedule adjusts for business days, then this is the adjusted date.
+   * @return the value of the property, not null
+   */
+  @Override
+  public LocalDate getStartDate() {
+    return startDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the end date of the payment period.
+   * <p>
+   * This is the last date in the period.
+   * If the schedule adjusts for business days, then this is the adjusted date.
+   * @return the value of the property, not null
+   */
+  @Override
+  public LocalDate getEndDate() {
+    return endDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the unadjusted start date.
+   * <p>
+   * The start date before any business day adjustment is applied.
+   * <p>
+   * When building, this will default to the start date if not specified.
+   * @return the value of the property, not null
+   */
+  public LocalDate getUnadjustedStartDate() {
+    return unadjustedStartDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the unadjusted end date.
+   * <p>
+   * The end date before any business day adjustment is applied.
+   * <p>
+   * When building, this will default to the end date if not specified.
+   * @return the value of the property, not null
+   */
+  public LocalDate getUnadjustedEndDate() {
+    return unadjustedEndDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      KnownAmountPaymentPeriod other = (KnownAmountPaymentPeriod) obj;
+      return JodaBeanUtils.equal(getPayment(), other.getPayment()) &&
+          JodaBeanUtils.equal(getStartDate(), other.getStartDate()) &&
+          JodaBeanUtils.equal(getEndDate(), other.getEndDate()) &&
+          JodaBeanUtils.equal(getUnadjustedStartDate(), other.getUnadjustedStartDate()) &&
+          JodaBeanUtils.equal(getUnadjustedEndDate(), other.getUnadjustedEndDate());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(getPayment());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getStartDate());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getEndDate());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getUnadjustedStartDate());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getUnadjustedEndDate());
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(192);
+    buf.append("KnownAmountPaymentPeriod{");
+    buf.append("payment").append('=').append(getPayment()).append(',').append(' ');
+    buf.append("startDate").append('=').append(getStartDate()).append(',').append(' ');
+    buf.append("endDate").append('=').append(getEndDate()).append(',').append(' ');
+    buf.append("unadjustedStartDate").append('=').append(getUnadjustedStartDate()).append(',').append(' ');
+    buf.append("unadjustedEndDate").append('=').append(JodaBeanUtils.toString(getUnadjustedEndDate()));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code KnownAmountPaymentPeriod}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code payment} property.
+     */
+    private final MetaProperty<Payment> payment = DirectMetaProperty.ofImmutable(
+        this, "payment", KnownAmountPaymentPeriod.class, Payment.class);
+    /**
+     * The meta-property for the {@code startDate} property.
+     */
+    private final MetaProperty<LocalDate> startDate = DirectMetaProperty.ofImmutable(
+        this, "startDate", KnownAmountPaymentPeriod.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code endDate} property.
+     */
+    private final MetaProperty<LocalDate> endDate = DirectMetaProperty.ofImmutable(
+        this, "endDate", KnownAmountPaymentPeriod.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code unadjustedStartDate} property.
+     */
+    private final MetaProperty<LocalDate> unadjustedStartDate = DirectMetaProperty.ofImmutable(
+        this, "unadjustedStartDate", KnownAmountPaymentPeriod.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code unadjustedEndDate} property.
+     */
+    private final MetaProperty<LocalDate> unadjustedEndDate = DirectMetaProperty.ofImmutable(
+        this, "unadjustedEndDate", KnownAmountPaymentPeriod.class, LocalDate.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "payment",
+        "startDate",
+        "endDate",
+        "unadjustedStartDate",
+        "unadjustedEndDate");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -786681338:  // payment
+          return payment;
+        case -2129778896:  // startDate
+          return startDate;
+        case -1607727319:  // endDate
+          return endDate;
+        case 1457691881:  // unadjustedStartDate
+          return unadjustedStartDate;
+        case 31758114:  // unadjustedEndDate
+          return unadjustedEndDate;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public KnownAmountPaymentPeriod.Builder builder() {
+      return new KnownAmountPaymentPeriod.Builder();
+    }
+
+    @Override
+    public Class<? extends KnownAmountPaymentPeriod> beanType() {
+      return KnownAmountPaymentPeriod.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code payment} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Payment> payment() {
+      return payment;
+    }
+
+    /**
+     * The meta-property for the {@code startDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> startDate() {
+      return startDate;
+    }
+
+    /**
+     * The meta-property for the {@code endDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> endDate() {
+      return endDate;
+    }
+
+    /**
+     * The meta-property for the {@code unadjustedStartDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> unadjustedStartDate() {
+      return unadjustedStartDate;
+    }
+
+    /**
+     * The meta-property for the {@code unadjustedEndDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> unadjustedEndDate() {
+      return unadjustedEndDate;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case -786681338:  // payment
+          return ((KnownAmountPaymentPeriod) bean).getPayment();
+        case -2129778896:  // startDate
+          return ((KnownAmountPaymentPeriod) bean).getStartDate();
+        case -1607727319:  // endDate
+          return ((KnownAmountPaymentPeriod) bean).getEndDate();
+        case 1457691881:  // unadjustedStartDate
+          return ((KnownAmountPaymentPeriod) bean).getUnadjustedStartDate();
+        case 31758114:  // unadjustedEndDate
+          return ((KnownAmountPaymentPeriod) bean).getUnadjustedEndDate();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code KnownAmountPaymentPeriod}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<KnownAmountPaymentPeriod> {
+
+    private Payment payment;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDate unadjustedStartDate;
+    private LocalDate unadjustedEndDate;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(KnownAmountPaymentPeriod beanToCopy) {
+      this.payment = beanToCopy.getPayment();
+      this.startDate = beanToCopy.getStartDate();
+      this.endDate = beanToCopy.getEndDate();
+      this.unadjustedStartDate = beanToCopy.getUnadjustedStartDate();
+      this.unadjustedEndDate = beanToCopy.getUnadjustedEndDate();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -786681338:  // payment
+          return payment;
+        case -2129778896:  // startDate
+          return startDate;
+        case -1607727319:  // endDate
+          return endDate;
+        case 1457691881:  // unadjustedStartDate
+          return unadjustedStartDate;
+        case 31758114:  // unadjustedEndDate
+          return unadjustedEndDate;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case -786681338:  // payment
+          this.payment = (Payment) newValue;
+          break;
+        case -2129778896:  // startDate
+          this.startDate = (LocalDate) newValue;
+          break;
+        case -1607727319:  // endDate
+          this.endDate = (LocalDate) newValue;
+          break;
+        case 1457691881:  // unadjustedStartDate
+          this.unadjustedStartDate = (LocalDate) newValue;
+          break;
+        case 31758114:  // unadjustedEndDate
+          this.unadjustedEndDate = (LocalDate) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public KnownAmountPaymentPeriod build() {
+      preBuild(this);
+      return new KnownAmountPaymentPeriod(
+          payment,
+          startDate,
+          endDate,
+          unadjustedStartDate,
+          unadjustedEndDate);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the payment.
+     * <p>
+     * This includes the payment date and amount.
+     * If the schedule adjusts for business days, then the date is the adjusted date.
+     * @param payment  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder payment(Payment payment) {
+      JodaBeanUtils.notNull(payment, "payment");
+      this.payment = payment;
+      return this;
+    }
+
+    /**
+     * Sets the start date of the payment period.
+     * <p>
+     * This is the first date in the period.
+     * If the schedule adjusts for business days, then this is the adjusted date.
+     * @param startDate  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder startDate(LocalDate startDate) {
+      JodaBeanUtils.notNull(startDate, "startDate");
+      this.startDate = startDate;
+      return this;
+    }
+
+    /**
+     * Sets the end date of the payment period.
+     * <p>
+     * This is the last date in the period.
+     * If the schedule adjusts for business days, then this is the adjusted date.
+     * @param endDate  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder endDate(LocalDate endDate) {
+      JodaBeanUtils.notNull(endDate, "endDate");
+      this.endDate = endDate;
+      return this;
+    }
+
+    /**
+     * Sets the unadjusted start date.
+     * <p>
+     * The start date before any business day adjustment is applied.
+     * <p>
+     * When building, this will default to the start date if not specified.
+     * @param unadjustedStartDate  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder unadjustedStartDate(LocalDate unadjustedStartDate) {
+      JodaBeanUtils.notNull(unadjustedStartDate, "unadjustedStartDate");
+      this.unadjustedStartDate = unadjustedStartDate;
+      return this;
+    }
+
+    /**
+     * Sets the unadjusted end date.
+     * <p>
+     * The end date before any business day adjustment is applied.
+     * <p>
+     * When building, this will default to the end date if not specified.
+     * @param unadjustedEndDate  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder unadjustedEndDate(LocalDate unadjustedEndDate) {
+      JodaBeanUtils.notNull(unadjustedEndDate, "unadjustedEndDate");
+      this.unadjustedEndDate = unadjustedEndDate;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(192);
+      buf.append("KnownAmountPaymentPeriod.Builder{");
+      buf.append("payment").append('=').append(JodaBeanUtils.toString(payment)).append(',').append(' ');
+      buf.append("startDate").append('=').append(JodaBeanUtils.toString(startDate)).append(',').append(' ');
+      buf.append("endDate").append('=').append(JodaBeanUtils.toString(endDate)).append(',').append(' ');
+      buf.append("unadjustedStartDate").append('=').append(JodaBeanUtils.toString(unadjustedStartDate)).append(',').append(' ');
+      buf.append("unadjustedEndDate").append('=').append(JodaBeanUtils.toString(unadjustedEndDate));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/KnownAmountPaymentPeriodTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/KnownAmountPaymentPeriodTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.schedule.SchedulePeriod;
+
+/**
+ * Test {@link KnownAmountPaymentPeriod}.
+ */
+@Test
+public class KnownAmountPaymentPeriodTest {
+
+  private static final CurrencyAmount GBP_P1000 = CurrencyAmount.of(GBP, 1000);
+  private static final LocalDate DATE_2014_03_30 = date(2014, 3, 30);
+  private static final LocalDate DATE_2014_06_30 = date(2014, 6, 30);
+  private static final LocalDate DATE_2014_09_30 = date(2014, 9, 30);
+  private static final LocalDate DATE_2014_10_01 = date(2014, 10, 1);
+  private static final LocalDate DATE_2014_10_03 = date(2014, 10, 3);
+  private static final Payment PAYMENT_2014_10_01 = Payment.of(GBP_P1000, DATE_2014_10_01);
+  private static final Payment PAYMENT_2014_10_03 = Payment.of(GBP_P1000, DATE_2014_10_03);
+
+  //-------------------------------------------------------------------------
+  public void test_of() {
+    SchedulePeriod sched = SchedulePeriod.of(DATE_2014_03_30, DATE_2014_09_30);
+    KnownAmountPaymentPeriod test = KnownAmountPaymentPeriod.of(PAYMENT_2014_10_03, sched);
+    assertEquals(test.getPayment(), PAYMENT_2014_10_03);
+    assertEquals(test.getStartDate(), DATE_2014_03_30);
+    assertEquals(test.getUnadjustedStartDate(), DATE_2014_03_30);
+    assertEquals(test.getEndDate(), DATE_2014_09_30);
+    assertEquals(test.getUnadjustedEndDate(), DATE_2014_09_30);
+    assertEquals(test.getPaymentDate(), DATE_2014_10_03);
+    assertEquals(test.getCurrency(), GBP);
+  }
+
+  public void test_builder_defaultDates() {
+    KnownAmountPaymentPeriod test = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_03_30)
+        .endDate(DATE_2014_10_01)
+        .build();
+    assertEquals(test.getPayment(), PAYMENT_2014_10_03);
+    assertEquals(test.getStartDate(), DATE_2014_03_30);
+    assertEquals(test.getUnadjustedStartDate(), DATE_2014_03_30);
+    assertEquals(test.getEndDate(), DATE_2014_10_01);
+    assertEquals(test.getUnadjustedEndDate(), DATE_2014_10_01);
+    assertEquals(test.getPaymentDate(), DATE_2014_10_03);
+    assertEquals(test.getCurrency(), GBP);
+  }
+
+  public void test_builder_invalid() {
+    assertThrowsIllegalArg(() -> KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .endDate(DATE_2014_10_01)
+        .build());
+    assertThrowsIllegalArg(() -> KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_10_01)
+        .build());
+    assertThrowsIllegalArg(() -> KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_10_01)
+        .endDate(DATE_2014_10_01)
+        .build());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_adjustPaymentDate() {
+    KnownAmountPaymentPeriod test = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_01)
+        .startDate(DATE_2014_03_30)
+        .unadjustedStartDate(DATE_2014_03_30)
+        .endDate(DATE_2014_10_01)
+        .unadjustedEndDate(DATE_2014_09_30)
+        .build();
+    KnownAmountPaymentPeriod expected = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_03_30)
+        .unadjustedStartDate(DATE_2014_03_30)
+        .endDate(DATE_2014_10_01)
+        .unadjustedEndDate(DATE_2014_09_30)
+        .build();
+    assertEquals(test.adjustPaymentDate(TemporalAdjusters.ofDateAdjuster(d -> d.plusDays(0))), test);
+    assertEquals(test.adjustPaymentDate(TemporalAdjusters.ofDateAdjuster(d -> d.plusDays(2))), expected);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_collectIndices_simple() {
+    KnownAmountPaymentPeriod test = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_03_30)
+        .unadjustedStartDate(DATE_2014_03_30)
+        .endDate(DATE_2014_10_01)
+        .unadjustedEndDate(DATE_2014_09_30)
+        .build();
+    ImmutableSet.Builder<Index> builder = ImmutableSet.builder();
+    test.collectIndices(builder);
+    assertEquals(builder.build(), ImmutableSet.of());
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    KnownAmountPaymentPeriod test = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_03_30)
+        .unadjustedStartDate(DATE_2014_03_30)
+        .endDate(DATE_2014_10_01)
+        .unadjustedEndDate(DATE_2014_09_30)
+        .build();
+    coverImmutableBean(test);
+    KnownAmountPaymentPeriod test2 = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03.negated())
+        .startDate(DATE_2014_06_30)
+        .endDate(DATE_2014_09_30)
+        .build();
+    coverBeanEquals(test, test2);
+  }
+
+  public void test_serialization() {
+    KnownAmountPaymentPeriod test = KnownAmountPaymentPeriod.builder()
+        .payment(PAYMENT_2014_10_03)
+        .startDate(DATE_2014_03_30)
+        .unadjustedStartDate(DATE_2014_03_30)
+        .endDate(DATE_2014_10_01)
+        .unadjustedEndDate(DATE_2014_09_30)
+        .build();
+    assertSerialization(test);
+  }
+
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingKnownAmountPaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingKnownAmountPaymentPeriodPricer.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.impl.rate.swap;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.time.LocalDate;
+
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.finance.rate.swap.KnownAmountPaymentPeriod;
+import com.opengamma.strata.market.explain.ExplainKey;
+import com.opengamma.strata.market.explain.ExplainMapBuilder;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.pricer.DiscountingPaymentPricer;
+import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.swap.PaymentPeriodPricer;
+
+/**
+ * Pricer implementation for swap payment periods based on a known amount.
+ * <p>
+ * This pricer performs discounting of the known amount.
+ */
+public class DiscountingKnownAmountPaymentPeriodPricer
+    implements PaymentPeriodPricer<KnownAmountPaymentPeriod> {
+
+  /**
+   * Default implementation.
+   */
+  public static final DiscountingKnownAmountPaymentPeriodPricer DEFAULT = new DiscountingKnownAmountPaymentPeriodPricer(
+      DiscountingPaymentPricer.DEFAULT);
+
+  /**
+   * Payment pricer.
+   */
+  private final DiscountingPaymentPricer paymentPricer;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param paymentPricer  the payment pricer
+   */
+  public DiscountingKnownAmountPaymentPeriodPricer(DiscountingPaymentPricer paymentPricer) {
+    this.paymentPricer = ArgChecker.notNull(paymentPricer, "paymentPricer");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public double presentValue(KnownAmountPaymentPeriod period, RatesProvider provider) {
+    return paymentPricer.presentValue(period.getPayment(), provider).getAmount();
+  }
+
+  @Override
+  public double futureValue(KnownAmountPaymentPeriod period, RatesProvider provider) {
+    if (period.getPaymentDate().isBefore(provider.getValuationDate())) {
+      return 0;
+    }
+    return period.getPayment().getAmount();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public PointSensitivityBuilder presentValueSensitivity(KnownAmountPaymentPeriod period, RatesProvider provider) {
+    return paymentPricer.presentValueSensitivity(period.getPayment(), provider);
+  }
+
+  @Override
+  public PointSensitivityBuilder futureValueSensitivity(KnownAmountPaymentPeriod period, RatesProvider provider) {
+    return PointSensitivityBuilder.none();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public void explainPresentValue(KnownAmountPaymentPeriod period, RatesProvider provider, ExplainMapBuilder builder) {
+    Currency currency = period.getCurrency();
+    LocalDate paymentDate = period.getPaymentDate();
+
+    builder.put(ExplainKey.ENTRY_TYPE, "KnownAmountPaymentPeriod");
+    builder.put(ExplainKey.PAYMENT_DATE, paymentDate);
+    builder.put(ExplainKey.PAYMENT_CURRENCY, currency);
+    builder.put(ExplainKey.START_DATE, period.getStartDate());
+    builder.put(ExplainKey.UNADJUSTED_START_DATE, period.getUnadjustedStartDate());
+    builder.put(ExplainKey.END_DATE, period.getEndDate());
+    builder.put(ExplainKey.ACCRUAL_DAYS, (int) DAYS.between(period.getStartDate(), period.getEndDate()));
+    builder.put(ExplainKey.UNADJUSTED_END_DATE, period.getUnadjustedEndDate());
+    if (paymentDate.isBefore(provider.getValuationDate())) {
+      builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.zero(currency));
+      builder.put(ExplainKey.PRESENT_VALUE, CurrencyAmount.zero(currency));
+    } else {
+      builder.put(ExplainKey.DISCOUNT_FACTOR, provider.discountFactor(currency, paymentDate));
+      builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.of(currency, futureValue(period, provider)));
+      builder.put(ExplainKey.PRESENT_VALUE, CurrencyAmount.of(currency, presentValue(period, provider)));
+    }
+  }
+
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricer.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.pricer.impl.rate.swap;
 
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.finance.rate.swap.KnownAmountPaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.PaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.RatePaymentPeriod;
 import com.opengamma.strata.market.explain.ExplainMapBuilder;
@@ -25,21 +26,29 @@ public class DispatchingPaymentPeriodPricer
    * Default implementation.
    */
   public static final DispatchingPaymentPeriodPricer DEFAULT = new DispatchingPaymentPeriodPricer(
-      DiscountingRatePaymentPeriodPricer.DEFAULT);
+      DiscountingRatePaymentPeriodPricer.DEFAULT,
+      DiscountingKnownAmountPaymentPeriodPricer.DEFAULT);
 
   /**
    * Pricer for {@link RatePaymentPeriod}.
    */
   private final PaymentPeriodPricer<RatePaymentPeriod> ratePaymentPeriodPricer;
+  /**
+   * Pricer for {@link KnownAmountPaymentPeriod}.
+   */
+  private final PaymentPeriodPricer<KnownAmountPaymentPeriod> knownAmountPaymentPeriodPricer;
 
   /**
    * Creates an instance.
    * 
    * @param ratePaymentPeriodPricer  the pricer for {@link RatePaymentPeriod}
+   * @param knownAmountPaymentPeriodPricer  the pricer for {@link KnownAmountPaymentPeriod}
    */
   public DispatchingPaymentPeriodPricer(
-      PaymentPeriodPricer<RatePaymentPeriod> ratePaymentPeriodPricer) {
+      PaymentPeriodPricer<RatePaymentPeriod> ratePaymentPeriodPricer,
+      PaymentPeriodPricer<KnownAmountPaymentPeriod> knownAmountPaymentPeriodPricer) {
     this.ratePaymentPeriodPricer = ArgChecker.notNull(ratePaymentPeriodPricer, "ratePaymentPeriodPricer");
+    this.knownAmountPaymentPeriodPricer = ArgChecker.notNull(knownAmountPaymentPeriodPricer, "knownAmountPaymentPeriodPricer");
   }
 
   //-------------------------------------------------------------------------
@@ -48,6 +57,8 @@ public class DispatchingPaymentPeriodPricer
     // dispatch by runtime type
     if (paymentPeriod instanceof RatePaymentPeriod) {
       return ratePaymentPeriodPricer.presentValue((RatePaymentPeriod) paymentPeriod, provider);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      return knownAmountPaymentPeriodPricer.presentValue((KnownAmountPaymentPeriod) paymentPeriod, provider);
     } else {
       throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
     }
@@ -59,6 +70,8 @@ public class DispatchingPaymentPeriodPricer
     // dispatch by runtime type
     if (paymentPeriod instanceof RatePaymentPeriod) {
       return ratePaymentPeriodPricer.presentValueSensitivity((RatePaymentPeriod) paymentPeriod, provider);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      return knownAmountPaymentPeriodPricer.presentValueSensitivity((KnownAmountPaymentPeriod) paymentPeriod, provider);
     } else {
       throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
     }
@@ -70,6 +83,8 @@ public class DispatchingPaymentPeriodPricer
     // dispatch by runtime type
     if (paymentPeriod instanceof RatePaymentPeriod) {
       return ratePaymentPeriodPricer.futureValue((RatePaymentPeriod) paymentPeriod, provider);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      return knownAmountPaymentPeriodPricer.futureValue((KnownAmountPaymentPeriod) paymentPeriod, provider);
     } else {
       throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
     }
@@ -81,6 +96,8 @@ public class DispatchingPaymentPeriodPricer
     // dispatch by runtime type
     if (paymentPeriod instanceof RatePaymentPeriod) {
       return ratePaymentPeriodPricer.futureValueSensitivity((RatePaymentPeriod) paymentPeriod, provider);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      return knownAmountPaymentPeriodPricer.futureValueSensitivity((KnownAmountPaymentPeriod) paymentPeriod, provider);
     } else {
       throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
     }
@@ -92,6 +109,8 @@ public class DispatchingPaymentPeriodPricer
     // dispatch by runtime type
     if (paymentPeriod instanceof RatePaymentPeriod) {
       ratePaymentPeriodPricer.explainPresentValue((RatePaymentPeriod) paymentPeriod, provider, builder);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      knownAmountPaymentPeriodPricer.explainPresentValue((KnownAmountPaymentPeriod) paymentPeriod, provider, builder);
     } else {
       throw new IllegalArgumentException("Unknown PaymentEvent type: " + paymentPeriod.getClass().getSimpleName());
     }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingKnownAmountPaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingKnownAmountPaymentPeriodPricerTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.impl.rate.swap;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.finance.rate.swap.KnownAmountPaymentPeriod;
+import com.opengamma.strata.market.curve.ConstantNodalCurve;
+import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.explain.ExplainKey;
+import com.opengamma.strata.market.explain.ExplainMap;
+import com.opengamma.strata.market.explain.ExplainMapBuilder;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.sensitivity.ZeroRateSensitivity;
+import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.SimpleDiscountFactors;
+import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.SimpleRatesProvider;
+
+/**
+ * Test {@link DiscountingKnownAmountPaymentPeriodPricer}
+ */
+@Test
+public class DiscountingKnownAmountPaymentPeriodPricerTest {
+
+  private static final DiscountingKnownAmountPaymentPeriodPricer PRICER = DiscountingKnownAmountPaymentPeriodPricer.DEFAULT;
+  private static final LocalDate VAL_DATE = LocalDate.of(2014, 1, 22);
+  private static final DayCount DAY_COUNT = DayCounts.ACT_360;
+  private static final LocalDate DATE_1 = LocalDate.of(2014, 1, 24);
+  private static final LocalDate DATE_2 = LocalDate.of(2014, 4, 25);
+  private static final LocalDate DATE_2U = LocalDate.of(2014, 4, 24);
+  private static final double AMOUNT_1000 = 1000d;
+  private static final CurrencyAmount AMOUNT_GBP1000 = CurrencyAmount.of(GBP, 1000);
+  private static final LocalDate PAYMENT_DATE = LocalDate.of(2014, 4, 26);
+  private static final double DISCOUNT_FACTOR = 0.976d;
+  private static final double TOLERANCE_PV = 1E-7;
+
+  private static final Payment PAYMENT = Payment.of(AMOUNT_GBP1000, PAYMENT_DATE);
+  private static final Payment PAYMENT_PAST = Payment.of(AMOUNT_GBP1000, VAL_DATE.minusDays(1));
+
+  private static final KnownAmountPaymentPeriod PERIOD = KnownAmountPaymentPeriod.builder()
+      .payment(PAYMENT)
+      .startDate(DATE_1)
+      .endDate(DATE_2)
+      .unadjustedEndDate(DATE_2U)
+      .build();
+  private static final KnownAmountPaymentPeriod PERIOD_PAST = KnownAmountPaymentPeriod.builder()
+      .payment(PAYMENT_PAST)
+      .startDate(DATE_1)
+      .endDate(DATE_2)
+      .build();
+
+  //-------------------------------------------------------------------------
+  public void test_presentValue() {
+    SimpleRatesProvider prov = createProvider();
+
+    double pvExpected = AMOUNT_1000 * DISCOUNT_FACTOR;
+    double pvComputed = PRICER.presentValue(PERIOD, prov);
+    assertEquals(pvComputed, pvExpected, TOLERANCE_PV);
+  }
+
+  public void test_presentValue_inPast() {
+    SimpleRatesProvider prov = createProvider();
+
+    double pvComputed = PRICER.presentValue(PERIOD_PAST, prov);
+    assertEquals(pvComputed, 0, TOLERANCE_PV);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_futureValue() {
+    SimpleRatesProvider prov = createProvider();
+
+    double fvExpected = AMOUNT_1000;
+    double fvComputed = PRICER.futureValue(PERIOD, prov);
+    assertEquals(fvComputed, fvExpected, TOLERANCE_PV);
+  }
+
+  public void test_futureValue_inPast() {
+    SimpleRatesProvider prov = createProvider();
+
+    double fvComputed = PRICER.futureValue(PERIOD_PAST, prov);
+    assertEquals(fvComputed, 0, TOLERANCE_PV);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueSensitivity() {
+    SimpleRatesProvider prov = createProvider();
+
+    PointSensitivities point = PRICER.presentValueSensitivity(PERIOD, prov).build();
+    double relativeYearFraction = DAY_COUNT.relativeYearFraction(VAL_DATE, PAYMENT_DATE);
+    double expected = -DISCOUNT_FACTOR * relativeYearFraction * AMOUNT_1000;
+    ZeroRateSensitivity actual = (ZeroRateSensitivity) point.getSensitivities().get(0);
+    assertEquals(actual.getCurrency(), GBP);
+    assertEquals(actual.getCurveCurrency(), GBP);
+    assertEquals(actual.getDate(), PAYMENT_DATE);
+    assertEquals(actual.getSensitivity(), expected, AMOUNT_1000 * TOLERANCE_PV);
+  }
+
+  public void test_presentValueSensitivity_inPast() {
+    SimpleRatesProvider prov = createProvider();
+
+    PointSensitivities computed = PRICER.presentValueSensitivity(PERIOD_PAST, prov)
+        .build();
+    assertEquals(computed, PointSensitivities.empty());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_futureValueSensitivity() {
+    SimpleRatesProvider prov = createProvider();
+
+    assertEquals(PRICER.futureValueSensitivity(PERIOD, prov), PointSensitivityBuilder.none());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_explainPresentValue() {
+    RatesProvider prov = createProvider();
+
+    ExplainMapBuilder builder = ExplainMap.builder();
+    PRICER.explainPresentValue(PERIOD, prov, builder);
+    ExplainMap explain = builder.build();
+
+    assertEquals(explain.get(ExplainKey.ENTRY_TYPE).get(), "KnownAmountPaymentPeriod");
+    assertEquals(explain.get(ExplainKey.PAYMENT_DATE).get(), PERIOD.getPaymentDate());
+    assertEquals(explain.get(ExplainKey.PAYMENT_CURRENCY).get(), PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.DISCOUNT_FACTOR).get(), DISCOUNT_FACTOR, TOLERANCE_PV);
+
+    int daysBetween = (int) DAYS.between(DATE_1, DATE_2);
+    assertEquals(explain.get(ExplainKey.START_DATE).get(), PERIOD.getStartDate());
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_START_DATE).get(), PERIOD.getUnadjustedStartDate());
+    assertEquals(explain.get(ExplainKey.END_DATE).get(), PERIOD.getEndDate());
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_END_DATE).get(), PERIOD.getUnadjustedEndDate());
+    assertEquals(explain.get(ExplainKey.ACCRUAL_DAYS).get(), (Integer) daysBetween);
+
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getCurrency(), PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getAmount(), AMOUNT_1000, TOLERANCE_PV);
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getCurrency(), PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getAmount(), AMOUNT_1000 * DISCOUNT_FACTOR, TOLERANCE_PV);
+  }
+
+  public void test_explainPresentValue_inPast() {
+    RatesProvider prov = createProvider();
+
+    ExplainMapBuilder builder = ExplainMap.builder();
+    PRICER.explainPresentValue(PERIOD_PAST, prov, builder);
+    ExplainMap explain = builder.build();
+
+    assertEquals(explain.get(ExplainKey.ENTRY_TYPE).get(), "KnownAmountPaymentPeriod");
+    assertEquals(explain.get(ExplainKey.PAYMENT_DATE).get(), PERIOD_PAST.getPaymentDate());
+    assertEquals(explain.get(ExplainKey.PAYMENT_CURRENCY).get(), PERIOD_PAST.getCurrency());
+
+    int daysBetween = (int) DAYS.between(DATE_1, DATE_2);
+    assertEquals(explain.get(ExplainKey.START_DATE).get(), PERIOD_PAST.getStartDate());
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_START_DATE).get(), PERIOD_PAST.getUnadjustedStartDate());
+    assertEquals(explain.get(ExplainKey.END_DATE).get(), PERIOD_PAST.getEndDate());
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_END_DATE).get(), PERIOD_PAST.getUnadjustedEndDate());
+    assertEquals(explain.get(ExplainKey.ACCRUAL_DAYS).get(), (Integer) daysBetween);
+
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getCurrency(), PERIOD_PAST.getCurrency());
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getAmount(), 0, TOLERANCE_PV);
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getCurrency(), PERIOD_PAST.getCurrency());
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getAmount(), 0 * DISCOUNT_FACTOR, TOLERANCE_PV);
+  }
+
+  //-------------------------------------------------------------------------
+  // creates a simple provider
+  private SimpleRatesProvider createProvider() {
+    Curve curve = ConstantNodalCurve.of(Curves.discountFactors("Test", DAY_COUNT), DISCOUNT_FACTOR);
+    DiscountFactors df = SimpleDiscountFactors.of(GBP, VAL_DATE, curve);
+    SimpleRatesProvider prov = new SimpleRatesProvider(VAL_DATE);
+    prov.setDayCount(DAY_COUNT);
+    prov.setDiscountFactors(df);
+    return prov;
+  }
+
+}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricerTest.java
@@ -5,15 +5,23 @@
  */
 package com.opengamma.strata.pricer.impl.rate.swap;
 
+import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.collect.TestHelper.ignoreThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.finance.rate.swap.KnownAmountPaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.PaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.RatePaymentPeriod;
+import com.opengamma.strata.market.explain.ExplainMap;
+import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.pricer.impl.MockRatesProvider;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.rate.swap.PaymentPeriodPricer;
@@ -26,13 +34,15 @@ import com.opengamma.strata.pricer.rate.swap.SwapDummyData;
 public class DispatchingPaymentPeriodPricerTest {
 
   private static final RatesProvider MOCK_PROV = new MockRatesProvider();
+  private static final PaymentPeriodPricer<RatePaymentPeriod> MOCK_RATE = mock(PaymentPeriodPricer.class);
+  private static final PaymentPeriodPricer<KnownAmountPaymentPeriod> MOCK_KNOWN = mock(PaymentPeriodPricer.class);
 
   public void test_presentValue_RatePaymentPeriod() {
     double expected = 0.0123d;
     PaymentPeriodPricer<RatePaymentPeriod> mockNotionalExchangeFn = mock(PaymentPeriodPricer.class);
     when(mockNotionalExchangeFn.presentValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV))
         .thenReturn(expected);
-    DispatchingPaymentPeriodPricer test = new DispatchingPaymentPeriodPricer(mockNotionalExchangeFn);
+    DispatchingPaymentPeriodPricer test = new DispatchingPaymentPeriodPricer(mockNotionalExchangeFn, MOCK_KNOWN);
     assertEquals(test.presentValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV), expected, 0d);
   }
 
@@ -48,7 +58,7 @@ public class DispatchingPaymentPeriodPricerTest {
     PaymentPeriodPricer<RatePaymentPeriod> mockNotionalExchangeFn = mock(PaymentPeriodPricer.class);
     when(mockNotionalExchangeFn.futureValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV))
         .thenReturn(expected);
-    DispatchingPaymentPeriodPricer test = new DispatchingPaymentPeriodPricer(mockNotionalExchangeFn);
+    DispatchingPaymentPeriodPricer test = new DispatchingPaymentPeriodPricer(mockNotionalExchangeFn, MOCK_KNOWN);
     assertEquals(test.futureValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV), expected, 0d);
   }
 
@@ -70,6 +80,41 @@ public class DispatchingPaymentPeriodPricerTest {
     PaymentPeriod mockPaymentPeriod = mock(PaymentPeriod.class);
     DispatchingPaymentPeriodPricer test = DispatchingPaymentPeriodPricer.DEFAULT;
     assertThrowsIllegalArg(() -> test.futureValueSensitivity(mockPaymentPeriod, MOCK_PROV));
+  }
+
+  //------------------------------------------------------------------------- 
+  public void coverage() {
+    DispatchingPaymentPeriodPricer test = new DispatchingPaymentPeriodPricer(
+        MOCK_RATE,
+        MOCK_KNOWN);
+
+    PaymentPeriod kapp = KnownAmountPaymentPeriod.builder()
+        .payment(Payment.of(CurrencyAmount.of(GBP, 1000), date(2015, 8, 21)))
+        .startDate(date(2015, 5, 19))
+        .endDate(date(2015, 8, 19))
+        .build();
+    PaymentPeriod mockPaymentPeriod = mock(PaymentPeriod.class);
+
+    ignoreThrows(() -> test.presentValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
+    ignoreThrows(() -> test.presentValue(kapp, MOCK_PROV));
+    ignoreThrows(() -> test.presentValue(mockPaymentPeriod, MOCK_PROV));
+
+    ignoreThrows(() -> test.futureValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
+    ignoreThrows(() -> test.futureValue(kapp, MOCK_PROV));
+    ignoreThrows(() -> test.futureValue(mockPaymentPeriod, MOCK_PROV));
+
+    ignoreThrows(() -> test.presentValueSensitivity(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
+    ignoreThrows(() -> test.presentValueSensitivity(kapp, MOCK_PROV));
+    ignoreThrows(() -> test.presentValueSensitivity(mockPaymentPeriod, MOCK_PROV));
+
+    ignoreThrows(() -> test.futureValueSensitivity(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
+    ignoreThrows(() -> test.futureValueSensitivity(kapp, MOCK_PROV));
+    ignoreThrows(() -> test.futureValueSensitivity(mockPaymentPeriod, MOCK_PROV));
+
+    ExplainMapBuilder explain = ExplainMap.builder();
+    ignoreThrows(() -> test.explainPresentValue(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV, explain));
+    ignoreThrows(() -> test.explainPresentValue(kapp, MOCK_PROV, explain));
+    ignoreThrows(() -> test.explainPresentValue(mockPaymentPeriod, MOCK_PROV, explain));
   }
 
 }


### PR DESCRIPTION
Allow a swap leg period to be defined as known up front.
This commit provides the period and associated pricer. When merged, another commit adding a swap leg will be added.