### PR TITLE
Simplify and tidy details around swaps

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SwapPricingExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SwapPricingExample.java
@@ -234,7 +234,7 @@ public class SwapPricingExample {
   private static Trade createOvernightAveragedWithSpreadVsLibor3mSwap() {
     NotionalSchedule notional = NotionalSchedule.of(Currency.USD, 100_000_000);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -250,7 +250,7 @@ public class SwapPricingExample {
         .calculation(IborRateCalculation.of(IborIndices.USD_LIBOR_3M))
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -333,7 +333,7 @@ public class SwapPricingExample {
   private static Trade createFixedVsOvernightWithFixingSwap() {
     NotionalSchedule notional = NotionalSchedule.of(Currency.USD, 100_000_000);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 17))
@@ -349,7 +349,7 @@ public class SwapPricingExample {
         .calculation(FixedRateCalculation.of(0.00123, DayCounts.ACT_360))
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 17))
@@ -384,7 +384,7 @@ public class SwapPricingExample {
   private static Trade createStub3mFixedVsLibor3mSwap() {
     NotionalSchedule notional = NotionalSchedule.of(Currency.USD, 100_000_000);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -400,7 +400,7 @@ public class SwapPricingExample {
         .calculation(IborRateCalculation.of(IborIndices.USD_LIBOR_3M))
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -432,7 +432,7 @@ public class SwapPricingExample {
   private static Trade createStub1mFixedVsLibor3mSwap() {
     NotionalSchedule notional = NotionalSchedule.of(Currency.USD, 100_000_000);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -449,7 +449,7 @@ public class SwapPricingExample {
         .calculation(IborRateCalculation.of(IborIndices.USD_LIBOR_3M))
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -481,7 +481,7 @@ public class SwapPricingExample {
   private static Trade createInterpolatedStub3mFixedVsLibor6mSwap() {
     NotionalSchedule notional = NotionalSchedule.of(Currency.USD, 100_000_000);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -501,7 +501,7 @@ public class SwapPricingExample {
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -533,7 +533,7 @@ public class SwapPricingExample {
   private static Trade createInterpolatedStub4mFixedVsLibor6mSwap() {
     NotionalSchedule notional = NotionalSchedule.of(Currency.USD, 100_000_000);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -553,7 +553,7 @@ public class SwapPricingExample {
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(PayReceive.RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SwapTradeModelDemo.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SwapTradeModelDemo.java
@@ -191,10 +191,7 @@ public class SwapTradeModelDemo {
             .currency(Currency.USD)
             .amount(ValueSchedule.of(100_000_000))
             .build())
-        .calculation(FixedRateCalculation.builder()
-            .dayCount(DayCounts.THIRTY_U_360)
-            .rate(ValueSchedule.of(0.015))
-            .build())
+        .calculation(FixedRateCalculation.of(0.015, DayCounts.THIRTY_U_360))
         .build();
     // we are receiving USD LIBOR 3M every 3 months with a 100 million notional
     RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
@@ -214,11 +211,7 @@ public class SwapTradeModelDemo {
             .currency(Currency.USD)
             .amount(ValueSchedule.of(100_000_000))
             .build())
-        .calculation(IborRateCalculation.builder()
-            .dayCount(DayCounts.ACT_360)
-            .index(IborIndices.USD_LIBOR_3M)
-            .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, HolidayCalendars.USNY))
-            .build())
+        .calculation(IborRateCalculation.of(IborIndices.USD_LIBOR_3M))
         .build();
     // a SwapTrade combines the two legs
     SwapTrade trade = SwapTrade.builder()

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/ExpandedSwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/ExpandedSwapLeg.java
@@ -86,14 +86,14 @@ public final class ExpandedSwapLeg
    * The start date and end date of the leg are determined from the first and last period.
    * As such, the periods should be sorted.
    */
-  @PropertyDefinition(validate = "notEmpty")
+  @PropertyDefinition(validate = "notEmpty", builderType = "List<? extends PaymentPeriod>")
   private final ImmutableList<PaymentPeriod> paymentPeriods;
   /**
    * The payment events that are associated with the swap leg.
    * <p>
    * Payment events include notional exchange and fees.
    */
-  @PropertyDefinition(validate = "notNull")
+  @PropertyDefinition(validate = "notNull", builderType = "List<? extends PaymentEvent>")
   private final ImmutableList<PaymentEvent> paymentEvents;
   /**
    * The currency of the leg.
@@ -105,8 +105,8 @@ public final class ExpandedSwapLeg
   private ExpandedSwapLeg(
       SwapLegType type,
       PayReceive payReceive,
-      List<PaymentPeriod> paymentPeriods,
-      List<PaymentEvent> paymentEvents) {
+      List<? extends PaymentPeriod> paymentPeriods,
+      List<? extends PaymentEvent> paymentEvents) {
 
     JodaBeanUtils.notNull(type, "type");
     JodaBeanUtils.notNull(payReceive, "payReceive");
@@ -471,8 +471,8 @@ public final class ExpandedSwapLeg
 
     private SwapLegType type;
     private PayReceive payReceive;
-    private List<PaymentPeriod> paymentPeriods = ImmutableList.of();
-    private List<PaymentEvent> paymentEvents = ImmutableList.of();
+    private List<? extends PaymentPeriod> paymentPeriods = ImmutableList.of();
+    private List<? extends PaymentEvent> paymentEvents = ImmutableList.of();
 
     /**
      * Restricted constructor.
@@ -519,10 +519,10 @@ public final class ExpandedSwapLeg
           this.payReceive = (PayReceive) newValue;
           break;
         case -1674414612:  // paymentPeriods
-          this.paymentPeriods = (List<PaymentPeriod>) newValue;
+          this.paymentPeriods = (List<? extends PaymentPeriod>) newValue;
           break;
         case 1031856831:  // paymentEvents
-          this.paymentEvents = (List<PaymentEvent>) newValue;
+          this.paymentEvents = (List<? extends PaymentEvent>) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -607,7 +607,7 @@ public final class ExpandedSwapLeg
      * @param paymentPeriods  the new value, not empty
      * @return this, for chaining, not null
      */
-    public Builder paymentPeriods(List<PaymentPeriod> paymentPeriods) {
+    public Builder paymentPeriods(List<? extends PaymentPeriod> paymentPeriods) {
       JodaBeanUtils.notEmpty(paymentPeriods, "paymentPeriods");
       this.paymentPeriods = paymentPeriods;
       return this;
@@ -630,7 +630,7 @@ public final class ExpandedSwapLeg
      * @param paymentEvents  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder paymentEvents(List<PaymentEvent> paymentEvents) {
+    public Builder paymentEvents(List<? extends PaymentEvent> paymentEvents) {
       JodaBeanUtils.notNull(paymentEvents, "paymentEvents");
       this.paymentEvents = paymentEvents;
       return this;

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RateCalculationSwapLeg.java
@@ -169,7 +169,7 @@ public final class RateCalculationSwapLeg
     return ExpandedSwapLeg.builder()
         .type(getType())
         .payReceive(payReceive)
-        .paymentPeriods(ImmutableList.copyOf(payPeriods))  // copyOf changes generics of list without an actual copy
+        .paymentPeriods(payPeriods)
         .paymentEvents(notionalSchedule.createEvents(payPeriods, getStartDate()))
         .build();
   }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RatePeriodSwapLeg.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/RatePeriodSwapLeg.java
@@ -254,7 +254,7 @@ public final class RatePeriodSwapLeg
     return ExpandedSwapLeg.builder()
         .type(type)
         .payReceive(payReceive)
-        .paymentPeriods(ImmutableList.copyOf(adjusted))  // copyOf needed for type conversion
+        .paymentPeriods(adjusted)
         .paymentEvents(createEvents(adjusted))
         .build();
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapCrossCurrencyEnd2EndTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapCrossCurrencyEnd2EndTest.java
@@ -11,7 +11,6 @@ import static com.opengamma.strata.basics.currency.Currency.EUR;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.PRECEDING;
-import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
 import static org.testng.Assert.assertEquals;
 
@@ -44,6 +43,7 @@ import com.opengamma.strata.finance.rate.swap.NotionalSchedule;
 import com.opengamma.strata.finance.rate.swap.PaymentSchedule;
 import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.Swap;
+import com.opengamma.strata.finance.rate.swap.SwapLeg;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.pricer.impl.Legacy;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -90,7 +90,7 @@ public class SwapCrossCurrencyEnd2EndTest {
   //-----------------------------------------------------------------------
   // XCcy swap with exchange of notional
   public void test_XCcyEur3MSpreadVsUSD3M() {
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 24))
@@ -109,14 +109,13 @@ public class SwapCrossCurrencyEnd2EndTest {
             .currency(EUR)
             .build())
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(EUR_EURIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .spread(ValueSchedule.of(0.0020))
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 24))
@@ -135,7 +134,6 @@ public class SwapCrossCurrencyEnd2EndTest {
             .currency(USD)
             .build())
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -157,8 +155,7 @@ public class SwapCrossCurrencyEnd2EndTest {
 
   // XCcy swap with exchange of notional and FX Reset on the USD leg
   public void test_XCcyEur3MSpreadVsUSD3MFxReset() {
-
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 24))
@@ -177,14 +174,13 @@ public class SwapCrossCurrencyEnd2EndTest {
             .currency(EUR)
             .build())
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(EUR_EURIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .spread(ValueSchedule.of(0.0020))
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 24))
@@ -208,7 +204,6 @@ public class SwapCrossCurrencyEnd2EndTest {
                 .build())
             .build())
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapEnd2EndTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapEnd2EndTest.java
@@ -54,6 +54,7 @@ import com.opengamma.strata.finance.rate.swap.PaymentSchedule;
 import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.StubCalculation;
 import com.opengamma.strata.finance.rate.swap.Swap;
+import com.opengamma.strata.finance.rate.swap.SwapLeg;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.pricer.impl.Legacy;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -108,10 +109,10 @@ public class SwapEnd2EndTest {
 
   //-----------------------------------------------------------------------
   public void test_VanillaFixedVsLibor1mSwap() {
-    RateCalculationSwapLeg payLeg = fixedLeg(
+    SwapLeg payLeg = fixedLeg(
         LocalDate.of(2014, 9, 12), LocalDate.of(2016, 9, 12), P6M, PAY, NOTIONAL, 0.0125, null);
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -125,7 +126,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_1M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -143,9 +143,9 @@ public class SwapEnd2EndTest {
 
   //-----------------------------------------------------------------------
   public void test_VanillaFixedVsLibor3mSwap() {
-    RateCalculationSwapLeg payLeg = fixedLeg(
+    SwapLeg payLeg = fixedLeg(
         LocalDate.of(2014, 9, 12), LocalDate.of(2021, 9, 12), P6M, PAY, NOTIONAL, 0.015, null);
-    RateCalculationSwapLeg receiveLeg = iborLeg(LocalDate.of(2014, 9, 12), LocalDate.of(2021, 9, 12),
+    SwapLeg receiveLeg = iborLeg(LocalDate.of(2014, 9, 12), LocalDate.of(2021, 9, 12),
         USD_LIBOR_3M, RECEIVE, NOTIONAL, null);
     SwapTrade trade = SwapTrade.builder()
         .tradeInfo(TradeInfo.builder().tradeDate(LocalDate.of(2014, 9, 10)).build())
@@ -168,10 +168,10 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_VanillaFixedVsLibor3mSwapWithFixing() {
-    RateCalculationSwapLeg payLeg = fixedLeg(
+    SwapLeg payLeg = fixedLeg(
         LocalDate.of(2013, 9, 12), LocalDate.of(2020, 9, 12), P6M, PAY, NOTIONAL, 0.015, null);
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2013, 9, 12))
@@ -185,7 +185,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -203,7 +202,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_BasisLibor3mVsLibor6mSwapWithSpread() {
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 8, 29))
@@ -217,13 +216,12 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_6M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 8, 29))
@@ -237,7 +235,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .spread(ValueSchedule.of(0.0010))
@@ -256,7 +253,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_BasisCompoundedLibor1mVsLibor3mSwap() {
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 8, 29))
@@ -271,13 +268,12 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_1M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
         .build();
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 8, 29))
@@ -291,7 +287,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -309,10 +304,10 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_Stub3mFixed6mVsLibor3mSwap() {
-    RateCalculationSwapLeg receiveLeg = fixedLeg(
+    SwapLeg receiveLeg = fixedLeg(
         LocalDate.of(2014, 9, 12), LocalDate.of(2016, 6, 12), P6M, RECEIVE, NOTIONAL, 0.01, StubConvention.SHORT_INITIAL);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -327,7 +322,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -345,10 +339,10 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_Stub1mFixed6mVsLibor3mSwap() {
-    RateCalculationSwapLeg receiveLeg = fixedLeg(
+    SwapLeg receiveLeg = fixedLeg(
         LocalDate.of(2014, 9, 12), LocalDate.of(2016, 7, 12), P6M, RECEIVE, NOTIONAL, 0.01, StubConvention.SHORT_INITIAL);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -363,7 +357,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -381,10 +374,10 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_InterpolatedStub3mFixed6mVsLibor6mSwap() {
-    RateCalculationSwapLeg receiveLeg = fixedLeg(
+    SwapLeg receiveLeg = fixedLeg(
         LocalDate.of(2014, 9, 12), LocalDate.of(2016, 6, 12), P6M, RECEIVE, NOTIONAL, 0.01, StubConvention.SHORT_INITIAL);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -399,7 +392,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_6M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .initialStub(StubCalculation.ofIborInterpolatedRate(USD_LIBOR_3M, USD_LIBOR_6M))
@@ -418,10 +410,10 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_InterpolatedStub4mFixed6mVsLibor6mSwap() {
-    RateCalculationSwapLeg receiveLeg = fixedLeg(
+    SwapLeg receiveLeg = fixedLeg(
         LocalDate.of(2014, 9, 12), LocalDate.of(2016, 7, 12), P6M, RECEIVE, NOTIONAL, 0.01, StubConvention.SHORT_INITIAL);
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -436,7 +428,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_6M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .initialStub(StubCalculation.ofIborInterpolatedRate(USD_LIBOR_3M, USD_LIBOR_6M))
@@ -455,7 +446,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_ZeroCouponFixedVsLibor3mSwap() {
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -475,7 +466,7 @@ public class SwapEnd2EndTest {
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -491,7 +482,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -515,7 +505,7 @@ public class SwapEnd2EndTest {
       steps.add(ValueStep.of(i, stepReduction));
     }
     ValueSchedule notionalSchedule = ValueSchedule.of(100_000_000, steps);
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -534,7 +524,7 @@ public class SwapEnd2EndTest {
             .build())
         .build();
 
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -549,7 +539,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NotionalSchedule.of(USD, notionalSchedule))
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
@@ -567,7 +556,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_CompoundingOisFixed2mVsFedFund12mSwap() {
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 2, 5))
@@ -586,7 +575,7 @@ public class SwapEnd2EndTest {
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 2, 5))
@@ -618,7 +607,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_CompoundingOisFixed2mVsFedFund12mSwapWithFixing() {
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 17))
@@ -637,7 +626,7 @@ public class SwapEnd2EndTest {
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 1, 17))
@@ -669,8 +658,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   public void test_OnAASpreadVsLibor3MSwap() {
-
-    RateCalculationSwapLeg payLeg = RateCalculationSwapLeg.builder()
+    SwapLeg payLeg = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -684,13 +672,12 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(NOTIONAL)
         .calculation(IborRateCalculation.builder()
-            .dayCount(ACT_360)
             .index(USD_LIBOR_3M)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
             .build())
         .build();
 
-    RateCalculationSwapLeg receiveLeg = RateCalculationSwapLeg.builder()
+    SwapLeg receiveLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(LocalDate.of(2014, 9, 12))
@@ -724,7 +711,7 @@ public class SwapEnd2EndTest {
 
   //-------------------------------------------------------------------------
   // fixed rate leg
-  private static RateCalculationSwapLeg fixedLeg(
+  private static SwapLeg fixedLeg(
       LocalDate start,
       LocalDate end,
       Frequency frequency,
@@ -755,7 +742,7 @@ public class SwapEnd2EndTest {
   }
 
   // ibor rate leg
-  private static RateCalculationSwapLeg iborLeg(
+  private static SwapLeg iborLeg(
       LocalDate start,
       LocalDate end,
       IborIndex index,
@@ -779,7 +766,6 @@ public class SwapEnd2EndTest {
             .build())
         .notionalSchedule(notional)
         .calculation(IborRateCalculation.builder()
-            .dayCount(index.getDayCount())
             .index(index)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, index.getFixingCalendar(), BDA_P))
             .build())

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapPricePerformance.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapPricePerformance.java
@@ -8,7 +8,6 @@ package com.opengamma.strata.pricer.rate.e2e;
 import static com.opengamma.strata.basics.PayReceive.PAY;
 import static com.opengamma.strata.basics.PayReceive.RECEIVE;
 import static com.opengamma.strata.basics.currency.Currency.USD;
-import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
 import static com.opengamma.strata.basics.date.DayCounts.THIRTY_U_360;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
@@ -38,6 +37,7 @@ import com.opengamma.strata.finance.rate.swap.NotionalSchedule;
 import com.opengamma.strata.finance.rate.swap.PaymentSchedule;
 import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.Swap;
+import com.opengamma.strata.finance.rate.swap.SwapLeg;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.rate.swap.DiscountingSwapTradePricer;
@@ -74,10 +74,10 @@ public class SwapPricePerformance {
   }
 
   //-----------------------------------------------------------------------
-  private static final RateCalculationSwapLeg PAY1 = fixedLeg(
+  private static final SwapLeg PAY1 = fixedLeg(
       LocalDate.of(2014, 9, 12), LocalDate.of(2016, 9, 12), P6M, PAY, NOTIONAL, 0.0125, null);
 
-  private static final RateCalculationSwapLeg RECEIVE1 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg RECEIVE1 = RateCalculationSwapLeg.builder()
       .payReceive(RECEIVE)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2014, 9, 12))
@@ -91,7 +91,6 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_1M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .build())
@@ -110,10 +109,10 @@ public class SwapPricePerformance {
   }
 
   //-----------------------------------------------------------------------
-  private static final RateCalculationSwapLeg PAY2 = fixedLeg(
+  private static final SwapLeg PAY2 = fixedLeg(
       LocalDate.of(2014, 9, 12), LocalDate.of(2021, 9, 12), P6M, PAY, NOTIONAL, 0.015, null);
 
-  private static final RateCalculationSwapLeg RECEIVE2 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg RECEIVE2 = RateCalculationSwapLeg.builder()
       .payReceive(RECEIVE)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2014, 9, 12))
@@ -127,7 +126,6 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_3M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .build())
@@ -145,10 +143,10 @@ public class SwapPricePerformance {
   }
 
   //-------------------------------------------------------------------------
-  private static final RateCalculationSwapLeg PAY3 = fixedLeg(
+  private static final SwapLeg PAY3 = fixedLeg(
       LocalDate.of(2013, 9, 12), LocalDate.of(2020, 9, 12), P6M, PAY, NOTIONAL, 0.015, null);
 
-  private static final RateCalculationSwapLeg RECEIVE3 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg RECEIVE3 = RateCalculationSwapLeg.builder()
       .payReceive(RECEIVE)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2013, 9, 12))
@@ -162,7 +160,6 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_3M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .build())
@@ -180,7 +177,7 @@ public class SwapPricePerformance {
   }
 
   //-------------------------------------------------------------------------
-  private static final RateCalculationSwapLeg PAY4 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg PAY4 = RateCalculationSwapLeg.builder()
       .payReceive(PAY)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2014, 8, 29))
@@ -194,13 +191,12 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_6M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .build())
       .build();
 
-  private static final RateCalculationSwapLeg RECEIVE4 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg RECEIVE4 = RateCalculationSwapLeg.builder()
       .payReceive(RECEIVE)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2014, 8, 29))
@@ -214,7 +210,6 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_3M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .spread(ValueSchedule.of(0.0010))
@@ -233,7 +228,7 @@ public class SwapPricePerformance {
   }
 
   //-------------------------------------------------------------------------
-  private static final RateCalculationSwapLeg RECEIVE5 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg RECEIVE5 = RateCalculationSwapLeg.builder()
       .payReceive(RECEIVE)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2014, 8, 29))
@@ -248,13 +243,12 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_1M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .build())
       .build();
 
-  private static final RateCalculationSwapLeg PAY5 = RateCalculationSwapLeg.builder()
+  private static final SwapLeg PAY5 = RateCalculationSwapLeg.builder()
       .payReceive(PAY)
       .accrualSchedule(PeriodicSchedule.builder()
           .startDate(LocalDate.of(2014, 8, 29))
@@ -268,7 +262,6 @@ public class SwapPricePerformance {
           .build())
       .notionalSchedule(NOTIONAL)
       .calculation(IborRateCalculation.builder()
-          .dayCount(ACT_360)
           .index(USD_LIBOR_3M)
           .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, CalendarUSD.NYC, BDA_P))
           .build())
@@ -287,7 +280,7 @@ public class SwapPricePerformance {
 
   //-------------------------------------------------------------------------
   // fixed rate leg
-  private static RateCalculationSwapLeg fixedLeg(
+  private static SwapLeg fixedLeg(
       LocalDate start,
       LocalDate end,
       Frequency frequency,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
@@ -5,19 +5,21 @@
  */
 package com.opengamma.strata.pricer.rate.swap;
 
-import static com.opengamma.strata.basics.PayReceive.RECEIVE;
 import static com.opengamma.strata.basics.BuySell.BUY;
+import static com.opengamma.strata.basics.PayReceive.RECEIVE;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.strata.basics.date.Tenor.TENOR_5Y;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_6M;
 import static com.opengamma.strata.basics.index.PriceIndices.GB_RPI;
-import static com.opengamma.strata.finance.rate.swap.type.FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.finance.rate.swap.type.FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M;
+import static com.opengamma.strata.pricer.datasets.RatesProviderDataSets.MULTI_USD;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FIXED_EXPANDED_SWAP_LEG_PAY;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FIXED_EXPANDED_SWAP_LEG_PAY_USD;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_PAY_GBP;
@@ -36,8 +38,6 @@ import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_CROSS_CUR
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_INFLATION;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_TRADE;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.SWAP_TRADE_CROSS_CURRENCY;
-import static com.opengamma.strata.basics.date.Tenor.TENOR_5Y;
-import static com.opengamma.strata.pricer.datasets.RatesProviderDataSets.MULTI_USD;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -74,6 +74,7 @@ import com.opengamma.strata.finance.rate.swap.PaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.PaymentSchedule;
 import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.Swap;
+import com.opengamma.strata.finance.rate.swap.SwapLeg;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapTemplate;
 import com.opengamma.strata.finance.rate.swap.type.IborIborSwapConvention;
@@ -265,7 +266,7 @@ public class DiscountingSwapProductPricerTest {
   }
 
   public void test_parRate_inflation_periodic() {
-    RateCalculationSwapLeg fixedLeg = RateCalculationSwapLeg.builder()
+    SwapLeg fixedLeg = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(date(2014, 6, 9))
@@ -293,7 +294,7 @@ public class DiscountingSwapProductPricerTest {
         .discountCurves(RATES_GBP.getDiscountCurves())
         .build();
     double parRateComputed = pricerSwap.parRate(swap, prov);
-    RateCalculationSwapLeg fixedLegWithParRate = RateCalculationSwapLeg.builder()
+    SwapLeg fixedLegWithParRate = RateCalculationSwapLeg.builder()
         .payReceive(RECEIVE)
         .accrualSchedule(PeriodicSchedule.builder()
             .startDate(date(2014, 6, 9))

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveGammaCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveGammaCalculatorTest.java
@@ -44,6 +44,7 @@ import com.opengamma.strata.finance.rate.swap.NotionalSchedule;
 import com.opengamma.strata.finance.rate.swap.PaymentSchedule;
 import com.opengamma.strata.finance.rate.swap.RateCalculationSwapLeg;
 import com.opengamma.strata.finance.rate.swap.Swap;
+import com.opengamma.strata.finance.rate.swap.SwapLeg;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.Curves;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
@@ -181,15 +182,15 @@ public class CurveGammaCalculatorTest {
   // swap USD standard conventions- TODO: replace by a template when available
   private static Swap swapUsd(LocalDate start, LocalDate end, PayReceive payReceive,
       NotionalSchedule notional, double fixedRate) {
-    RateCalculationSwapLeg fixedLeg =
+    SwapLeg fixedLeg =
         fixedLeg(start, end, Frequency.P6M, payReceive, notional, fixedRate, StubConvention.SHORT_INITIAL);
-    RateCalculationSwapLeg iborLeg =
+    SwapLeg iborLeg =
         iborLeg(start, end, USD_LIBOR_3M, (payReceive == PAY) ? RECEIVE : PAY, notional, StubConvention.SHORT_INITIAL);
     return Swap.of(fixedLeg, iborLeg);
   }
 
   // fixed rate leg
-  private static RateCalculationSwapLeg fixedLeg(
+  private static SwapLeg fixedLeg(
       LocalDate start, LocalDate end, Frequency frequency,
       PayReceive payReceive, NotionalSchedule notional, double fixedRate, StubConvention stubConvention) {
 
@@ -215,7 +216,7 @@ public class CurveGammaCalculatorTest {
   }
 
   // fixed rate leg
-  private static RateCalculationSwapLeg iborLeg(
+  private static SwapLeg iborLeg(
       LocalDate start, LocalDate end, IborIndex index,
       PayReceive payReceive, NotionalSchedule notional, StubConvention stubConvention) {
     Frequency freq = Frequency.of(index.getTenor().getPeriod());
@@ -234,7 +235,6 @@ public class CurveGammaCalculatorTest {
             .build())
         .notionalSchedule(notional)
         .calculation(IborRateCalculation.builder()
-            .dayCount(index.getDayCount())
             .index(index)
             .fixingDateOffset(DaysAdjustment.ofBusinessDays(-2, index.getFixingCalendar(), BDA_P))
             .build())


### PR DESCRIPTION
Avoid repeating index day count
Calculation class defaults the day count from the index
Declare types are interface not concrete class
Increase types accepts by ExpandedSwapLeg factory methods