### PR TITLE
Add known amount swap leg

### DIFF
--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/KnownAmountSwapLegTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/KnownAmountSwapLegTest.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap;
+
+import static com.opengamma.strata.basics.PayReceive.PAY;
+import static com.opengamma.strata.basics.PayReceive.RECEIVE;
+import static com.opengamma.strata.basics.currency.Currency.EUR;
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.strata.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.strata.basics.schedule.Frequency.P1M;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.finance.rate.swap.SwapLegType.FIXED;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.schedule.PeriodicSchedule;
+import com.opengamma.strata.basics.value.ValueAdjustment;
+import com.opengamma.strata.basics.value.ValueSchedule;
+import com.opengamma.strata.basics.value.ValueStep;
+
+/**
+ * Test.
+ */
+@Test
+public class KnownAmountSwapLegTest {
+
+  private static final LocalDate DATE_01_05 = date(2014, 1, 5);
+  private static final LocalDate DATE_01_06 = date(2014, 1, 6);
+  private static final LocalDate DATE_02_05 = date(2014, 2, 5);
+  private static final LocalDate DATE_02_07 = date(2014, 2, 7);
+  private static final LocalDate DATE_03_05 = date(2014, 3, 5);
+  private static final LocalDate DATE_03_07 = date(2014, 3, 7);
+  private static final LocalDate DATE_04_05 = date(2014, 4, 5);
+  private static final LocalDate DATE_04_07 = date(2014, 4, 7);
+  private static final LocalDate DATE_04_09 = date(2014, 4, 9);
+  private static final DaysAdjustment PLUS_THREE_DAYS = DaysAdjustment.ofBusinessDays(3, GBLO);
+  private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
+
+  //-------------------------------------------------------------------------
+  public void test_builder() {
+    PeriodicSchedule accrualSchedule = PeriodicSchedule.builder()
+        .startDate(DATE_01_05)
+        .endDate(DATE_04_05)
+        .frequency(P1M)
+        .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
+        .build();
+    PaymentSchedule paymentSchedule = PaymentSchedule.builder()
+        .paymentFrequency(P1M)
+        .paymentDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+        .build();
+    ValueSchedule amountSchedule = ValueSchedule.of(123d);
+    KnownAmountSwapLeg test = KnownAmountSwapLeg.builder()
+        .payReceive(PAY)
+        .accrualSchedule(accrualSchedule)
+        .paymentSchedule(paymentSchedule)
+        .amount(amountSchedule)
+        .currency(GBP)
+        .build();
+    assertEquals(test.getPayReceive(), PAY);
+    assertEquals(test.getStartDate(), DATE_01_06);
+    assertEquals(test.getEndDate(), DATE_04_07);
+    assertEquals(test.getAccrualSchedule(), accrualSchedule);
+    assertEquals(test.getPaymentSchedule(), paymentSchedule);
+    assertEquals(test.getAmount(), amountSchedule);
+    assertEquals(test.getCurrency(), GBP);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_collectIndices() {
+    KnownAmountSwapLeg test = KnownAmountSwapLeg.builder()
+        .payReceive(PAY)
+        .accrualSchedule(PeriodicSchedule.builder()
+            .startDate(DATE_01_05)
+            .endDate(DATE_04_05)
+            .frequency(P1M)
+            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
+            .build())
+        .paymentSchedule(PaymentSchedule.builder()
+            .paymentFrequency(P1M)
+            .paymentDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+            .build())
+        .amount(ValueSchedule.of(123d))
+        .currency(GBP)
+        .build();
+    ImmutableSet.Builder<Index> builder = ImmutableSet.builder();
+    test.collectIndices(builder);
+    assertEquals(builder.build(), ImmutableSet.of());
+    assertEquals(test.allIndices(), ImmutableSet.of());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_expand() {
+    // test case
+    KnownAmountSwapLeg test = KnownAmountSwapLeg.builder()
+        .payReceive(PAY)
+        .accrualSchedule(PeriodicSchedule.builder()
+            .startDate(DATE_01_05)
+            .endDate(DATE_04_05)
+            .frequency(P1M)
+            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
+            .build())
+        .paymentSchedule(PaymentSchedule.builder()
+            .paymentFrequency(P1M)
+            .paymentDateOffset(PLUS_TWO_DAYS)
+            .build())
+        .amount(ValueSchedule.builder()
+            .initialValue(123d)
+            .steps(ValueStep.of(1, ValueAdjustment.ofReplace(234d)))
+            .build())
+        .currency(GBP)
+        .build();
+    // expected
+    KnownAmountPaymentPeriod rpp1 = KnownAmountPaymentPeriod.builder()
+        .payment(Payment.ofPay(CurrencyAmount.of(GBP, 123d), DATE_02_07))
+        .startDate(DATE_01_06)
+        .endDate(DATE_02_05)
+        .unadjustedStartDate(DATE_01_05)
+        .build();
+    KnownAmountPaymentPeriod rpp2 = KnownAmountPaymentPeriod.builder()
+        .payment(Payment.ofPay(CurrencyAmount.of(GBP, 234d), DATE_03_07))
+        .startDate(DATE_02_05)
+        .endDate(DATE_03_05)
+        .build();
+    KnownAmountPaymentPeriod rpp3 = KnownAmountPaymentPeriod.builder()
+        .payment(Payment.ofPay(CurrencyAmount.of(GBP, 234d), DATE_04_09))
+        .startDate(DATE_03_05)
+        .endDate(DATE_04_07)
+        .unadjustedEndDate(DATE_04_05)
+        .build();
+    // assertion
+    assertEquals(test.expand(), ExpandedSwapLeg.builder()
+        .type(FIXED)
+        .payReceive(PAY)
+        .paymentPeriods(rpp1, rpp2, rpp3)
+        .build());
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    KnownAmountSwapLeg test = KnownAmountSwapLeg.builder()
+        .payReceive(PAY)
+        .accrualSchedule(PeriodicSchedule.builder()
+            .startDate(DATE_01_05)
+            .endDate(DATE_04_05)
+            .frequency(P1M)
+            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
+            .build())
+        .paymentSchedule(PaymentSchedule.builder()
+            .paymentFrequency(P1M)
+            .paymentDateOffset(PLUS_TWO_DAYS)
+            .build())
+        .amount(ValueSchedule.of(123d))
+        .currency(GBP)
+        .build();
+    coverImmutableBean(test);
+    KnownAmountSwapLeg test2 = KnownAmountSwapLeg.builder()
+        .payReceive(RECEIVE)
+        .accrualSchedule(PeriodicSchedule.builder()
+            .startDate(DATE_02_05)
+            .endDate(DATE_03_05)
+            .frequency(P1M)
+            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
+            .build())
+        .paymentSchedule(PaymentSchedule.builder()
+            .paymentFrequency(P1M)
+            .paymentDateOffset(PLUS_THREE_DAYS)
+            .build())
+        .amount(ValueSchedule.of(2000d))
+        .currency(EUR)
+        .build();
+    coverBeanEquals(test, test2);
+  }
+
+  public void test_serialization() {
+    KnownAmountSwapLeg test = KnownAmountSwapLeg.builder()
+        .payReceive(PAY)
+        .accrualSchedule(PeriodicSchedule.builder()
+            .startDate(DATE_01_05)
+            .endDate(DATE_04_05)
+            .frequency(P1M)
+            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
+            .build())
+        .paymentSchedule(PaymentSchedule.builder()
+            .paymentFrequency(P1M)
+            .paymentDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+            .build())
+        .amount(ValueSchedule.of(123d))
+        .currency(GBP)
+        .build();
+    assertSerialization(test);
+  }
+
+}


### PR DESCRIPTION
Known amount swap leg allows a fixed leg to be defined using amounts instead of rates. This feature is needed to parse some FpML swaps.