### PR TITLE
Enhance extended enum to support parsing

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyDataLoader.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyDataLoader.java
@@ -75,10 +75,10 @@ final class CurrencyDataLoader {
       if (Currency.REGEX_FORMAT.matcher(currencyCode).matches()) {
         PropertySet properties = entry.getValue();
         boolean isHistoric =
-            (properties.keys().contains("historic") && Boolean.parseBoolean(properties.getValue("historic")));
+            (properties.keys().contains("historic") && Boolean.parseBoolean(properties.value("historic")));
         if (isHistoric == loadHistoric) {
-          Integer minorUnits = Integer.parseInt(properties.getValue("minorUnitDigits"));
-          String triangulationCurrency = properties.getValue("triangulationCurrency");
+          Integer minorUnits = Integer.parseInt(properties.value("minorUnitDigits"));
+          String triangulationCurrency = properties.value("triangulationCurrency");
           builder.put(currencyCode, new Currency(currencyCode, minorUnits, triangulationCurrency));
         }
       }
@@ -115,7 +115,7 @@ final class CurrencyDataLoader {
       if (CurrencyPair.REGEX_FORMAT.matcher(pairStr).matches()) {
         CurrencyPair pair = CurrencyPair.parse(pairStr);
         PropertySet properties = entry.getValue();
-        Integer rateDigits = Integer.parseInt(properties.getValue("rateDigits"));
+        Integer rateDigits = Integer.parseInt(properties.value("rateDigits"));
         builder.put(pair, rateDigits);
       }
     }
@@ -132,8 +132,8 @@ final class CurrencyDataLoader {
     try {
       Stream<ResourceLocator> resourceLocators = ResourceLocator.streamOfClasspathResources(CURRENCY_DATA_INI);
       IniFile ini = IniFile.ofChained(resourceLocators.map(ResourceLocator::getCharSource));
-      PropertySet section = ini.getSection("marketConventionPriority");
-      String list = section.getValue("ordering");
+      PropertySet section = ini.section("marketConventionPriority");
+      String list = section.value("ordering");
       // The currency ordering is defined as a comma-separated list
       List<Currency> currencies = Arrays.stream(list.split(","))
           .map(String::trim)

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/IniFile.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/IniFile.java
@@ -134,16 +134,16 @@ public final class IniFile {
     Map<String, PropertySet> builder = new LinkedHashMap<>();
     for (IniFile file : files) {
       // remove everything from lower priority files if not chaining
-      if (Boolean.parseBoolean(file.getSection(CHAIN_SECTION).getValue(CHAIN_NEXT)) == false) {
+      if (Boolean.parseBoolean(file.section(CHAIN_SECTION).value(CHAIN_NEXT)) == false) {
         builder.clear();
       } else {
         // remove sections from lower priority files
-        builder.keySet().removeAll(file.getSection(CHAIN_SECTION).getValueList(CHAIN_REMOVE));
+        builder.keySet().removeAll(file.section(CHAIN_SECTION).valueList(CHAIN_REMOVE));
       }
       // add entries, replacing existing data
       for (String sectionName : file.asMap().keySet()) {
         if (!sectionName.equals(CHAIN_SECTION)) {
-          builder.merge(sectionName, file.getSection(sectionName), PropertySet::combinedWith);
+          builder.merge(sectionName, file.section(sectionName), PropertySet::combinedWith);
         }
       }
     }
@@ -152,8 +152,8 @@ public final class IniFile {
 
   // sort by priority, lowest first
   private static int compareByReversePriority(IniFile a, IniFile b) {
-    int priority1 = Integer.parseInt(a.getSection(CHAIN_SECTION).getValue(PRIORITY));
-    int priority2 = Integer.parseInt(b.getSection(CHAIN_SECTION).getValue(PRIORITY));
+    int priority1 = Integer.parseInt(a.section(CHAIN_SECTION).value(PRIORITY));
+    int priority2 = Integer.parseInt(b.section(CHAIN_SECTION).value(PRIORITY));
     return Integer.compare(priority1, priority2);
   }
 
@@ -208,11 +208,11 @@ public final class IniFile {
 
   //-------------------------------------------------------------------------
   /**
-   * Returns the set of keys of this INI file.
+   * Returns the set of sections of this INI file.
    * 
-   * @return the set of keys
+   * @return the set of sections
    */
-  public ImmutableSet<String> keys() {
+  public ImmutableSet<String> sections() {
     return sectionMap.keySet();
   }
 
@@ -249,7 +249,7 @@ public final class IniFile {
    * @return the INI file section
    * @throws IllegalArgumentException if the section does not exist
    */
-  public PropertySet getSection(String name) {
+  public PropertySet section(String name) {
     ArgChecker.notNull(name, "name");
     if (contains(name) == false) {
       throw new IllegalArgumentException("Unknown INI file section: " + name);

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/PropertySet.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/PropertySet.java
@@ -12,6 +12,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
@@ -104,14 +105,29 @@ public final class PropertySet {
   }
 
   /**
-   * Returns the property set as a map.
+   * Returns the property set as a multimap.
    * <p>
    * The iteration order of the map matches that of the input data.
    * 
    * @return the key-value map
    */
-  public ImmutableListMultimap<String, String> asMap() {
+  public ImmutableListMultimap<String, String> asMultimap() {
     return keyValueMap;
+  }
+
+  /**
+   * Returns the property set as a map, throwing an exception if any key has multiple values.
+   * <p>
+   * The iteration order of the map matches that of the input data.
+   * 
+   * @return the key-value map
+   */
+  public ImmutableMap<String, String> asMap() {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    for (String key : keys()) {
+      builder.put(key, value(key));
+    }
+    return builder.build();
   }
 
   //-------------------------------------------------------------------------
@@ -145,7 +161,7 @@ public final class PropertySet {
    * @return the value
    * @throws IllegalArgumentException if the key does not exist, or if more than one value is associated
    */
-  public String getValue(String key) {
+  public String value(String key) {
     ArgChecker.notNull(key, "key");
     ImmutableList<String> values = keyValueMap.get(key);
     if (values.size() == 0) {
@@ -168,7 +184,7 @@ public final class PropertySet {
    * @param key  the key name
    * @return the list of values associated with the key
    */
-  public ImmutableList<String> getValueList(String key) {
+  public ImmutableList<String> valueList(String key) {
     ArgChecker.notNull(key, "key");
     return MoreObjects.firstNonNull(keyValueMap.get(key), ImmutableList.<String>of());
   }
@@ -191,9 +207,9 @@ public final class PropertySet {
       return other;
     }
     ListMultimap<String, String> map = ArrayListMultimap.create(keyValueMap);
-    for (String key : other.asMap().keySet()) {
+    for (String key : other.asMultimap().keySet()) {
       map.removeAll(key);
-      map.putAll(key, other.getValueList(key));
+      map.putAll(key, other.valueList(key));
     }
     return new PropertySet(ImmutableListMultimap.copyOf(map));
   }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/named/ExtendedEnum.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/named/ExtendedEnum.java
@@ -18,7 +18,9 @@ import org.joda.convert.RenameHandler;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.io.IniFile;
 import com.opengamma.strata.collect.io.PropertiesFile;
 import com.opengamma.strata.collect.io.PropertySet;
@@ -44,7 +46,7 @@ import com.opengamma.strata.collect.io.ResourceLocator;
  * A 'chain' section includes a 'priority' value to specify the order to load the files.
  * The 'chainNextFile' and 'chainRemoveSections' keys provide fine grained control.
  * <p>
- * Two sections control the loading of extended enum providers - 'providers' and 'alternates'.
+ * Three sections control the loading of additional information.
  * <p>
  * The 'providers' section contains a number of properties, one for each provider.
  * The key is the full class name of the provider.
@@ -55,6 +57,15 @@ import com.opengamma.strata.collect.io.ResourceLocator;
  * The 'alternates' section contains a number of properties, one for each alternate name.
  * The key is the alternate name, the value is the standard name.
  * Alternate names are used when looking up an extended enum.
+ * <p>
+ * The 'externals' sections contains a number of properties intended to allow external enum names to be mapped.
+ * Unlike 'alternates', which are always included, 'externals' are only included when requested.
+ * There may be multiple external <i>groups</i> to handle different external providers of data.
+ * For example, the mapping used by FpML may differ from that used by Bloomberg.
+ * <p>
+ * Each 'externals' section has a name of the form 'externals.XXX', where 'XXX' is the name of the group.
+ * Each property line in the section is of the same format as the 'alternates' section.
+ * It maps the external name to the standard name.
  * <p>
  * It is intended that this class is used as a helper class to load the configuration
  * and manage the map of names to instances. It should be created and used by the author
@@ -72,19 +83,29 @@ public final class ExtendedEnum<T extends Named> {
    * Section name used for alternates.
    */
   private static final String ALTERNATES_SECTION = "alternates";
+  /**
+   * Section name used for externals.
+   */
+  private static final String EXTERNALS_SECTION = "externals.";
 
   /**
    * The enum type.
    */
   private final Class<T> type;
   /**
-   * The lookup functions.
+   * The lookup functions defining the standard names.
    */
   private final ImmutableList<NamedLookup<T>> lookups;
   /**
    * The map of alternate names.
    */
-  private final ImmutableMap<String, String> alternates;
+  private final ImmutableMap<String, String> alternateNames;
+  /**
+   * The map of external names, keyed by the group name.
+   * The first map holds groups of external names.
+   * The inner map holds the mapping from external name to our name.
+   */
+  private final ImmutableMap<String, ImmutableMap<String, String>> externalNames;
 
   //-------------------------------------------------------------------------
   /**
@@ -100,7 +121,6 @@ public final class ExtendedEnum<T extends Named> {
    * @return the extended enum
    */
   public static <R extends Named> ExtendedEnum<R> of(Class<R> type) {
-    ArgChecker.notNull(type, "type");
     try {
       // load all matching files
       String name = type.getName().replace('.', '/') + ".ini";
@@ -109,14 +129,15 @@ public final class ExtendedEnum<T extends Named> {
       // parse files
       ImmutableList<NamedLookup<R>> lookups = parseProviders(config, type);
       ImmutableMap<String, String> alternateNames = parseAlternates(config);
-      return new ExtendedEnum<>(type, lookups, alternateNames);
+      ImmutableMap<String, ImmutableMap<String, String>> externalNames = parseExternals(config);
+      return new ExtendedEnum<>(type, lookups, alternateNames, externalNames);
 
     } catch (RuntimeException ex) {
       // logging used because this is loaded in a static variable
       Logger logger = Logger.getLogger(ExtendedEnum.class.getName());
       logger.severe("Failed to load ExtendedEnum for " + type + ": " + Throwables.getStackTraceAsString(ex));
       // return an empty instance to avoid ExceptionInInitializerError
-      return new ExtendedEnum<>(type, ImmutableList.of(), ImmutableMap.of());
+      return new ExtendedEnum<>(type, ImmutableList.of(), ImmutableMap.of(), ImmutableMap.of());
     }
   }
 
@@ -129,7 +150,7 @@ public final class ExtendedEnum<T extends Named> {
     if (!config.contains(PROVIDERS_SECTION)) {
       return ImmutableList.of();
     }
-    PropertySet section = config.getSection(PROVIDERS_SECTION);
+    PropertySet section = config.section(PROVIDERS_SECTION);
     ImmutableList.Builder<NamedLookup<R>> builder = ImmutableList.builder();
     for (String key : section.keys()) {
       Class<?> cls;
@@ -138,7 +159,7 @@ public final class ExtendedEnum<T extends Named> {
       } catch (Exception ex) {
         throw new IllegalArgumentException("Unable to find enum provider class: " + key, ex);
       }
-      String value = section.getValue(key);
+      String value = section.value(key);
       if (value.equals("constants")) {
         // extract public static final constants
         builder.add(parseConstants(enumType, cls));
@@ -212,10 +233,17 @@ public final class ExtendedEnum<T extends Named> {
     if (!config.contains(ALTERNATES_SECTION)) {
       return ImmutableMap.of();
     }
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    PropertySet section = config.getSection(ALTERNATES_SECTION);
-    for (String key : section.keys()) {
-      builder.put(key, section.getValue(key));
+    return config.section(ALTERNATES_SECTION).asMap();
+  }
+
+  // parses the external names.
+  private static ImmutableMap<String, ImmutableMap<String, String>> parseExternals(IniFile config) {
+    ImmutableMap.Builder<String, ImmutableMap<String, String>> builder = ImmutableMap.builder();
+    for (String sectionName : config.sections()) {
+      if (sectionName.startsWith(EXTERNALS_SECTION)) {
+        String group = sectionName.substring(EXTERNALS_SECTION.length());
+        builder.put(group, config.section(sectionName).asMap());
+      }
     }
     return builder.build();
   }
@@ -226,15 +254,19 @@ public final class ExtendedEnum<T extends Named> {
    * 
    * @param type  the enum type
    * @param lookups  the lookup functions to find instances
-   * @param alternates  the map of alternate name to standard name
+   * @param alternateNames  the map of alternate name to standard name
+   * @param externalNames  the map of external name groups
    */
-  private ExtendedEnum(Class<T> type, ImmutableList<NamedLookup<T>> lookups, ImmutableMap<String, String> alternates) {
-    ArgChecker.notNull(type, "type");
-    ArgChecker.notNull(alternates, "alternates");
-    ArgChecker.notNull(lookups, "lookups");
-    this.type = type;
-    this.lookups = lookups;
-    this.alternates = alternates;
+  private ExtendedEnum(
+      Class<T> type,
+      ImmutableList<NamedLookup<T>> lookups,
+      ImmutableMap<String, String> alternateNames,
+      ImmutableMap<String, ImmutableMap<String, String>> externalNames) {
+
+    this.type = ArgChecker.notNull(type, "type");
+    this.lookups = ArgChecker.notNull(lookups, "lookups");
+    this.alternateNames = ArgChecker.notNull(alternateNames, "alternateNames");
+    this.externalNames = ArgChecker.notNull(externalNames, "externalNames");
   }
 
   //-------------------------------------------------------------------------
@@ -247,10 +279,10 @@ public final class ExtendedEnum<T extends Named> {
    * 
    * @param name  the enum name to return
    * @return the named enum
+   * @throws IllegalArgumentException if the name is not found
    */
   public T lookup(String name) {
-    ArgChecker.notNull(name, "name");
-    String standardName = alternates.getOrDefault(name, name);
+    String standardName = alternateNames.getOrDefault(name, name);
     for (NamedLookup<T> lookup : lookups) {
       T instance = lookup.lookup(standardName);
       if (instance != null) {
@@ -271,6 +303,7 @@ public final class ExtendedEnum<T extends Named> {
    * @param subtype  the enum subtype to match
    * @param name  the enum name to return
    * @return the named enum
+   * @throws IllegalArgumentException if the name is not found or has the wrong type
    */
   public <S extends T> S lookup(String name, Class<S> subtype) {
     T result = lookup(name);
@@ -311,13 +344,157 @@ public final class ExtendedEnum<T extends Named> {
    * @return the map of alternate names
    */
   public ImmutableMap<String, String> alternateNames() {
-    return alternates;
+    return alternateNames;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns the set of groups that have external names defined.
+   * <p>
+   * External names are used to map names used by external systems to the standard name used here.
+   * There can be multiple groups of mappings to external systems,
+   * For example, the mapping used by FpML may differ from that used by Bloomberg.
+   * 
+   * @return the set of groups that have external names
+   */
+  public ImmutableSet<String> externalNameGroups() {
+    return externalNames.keySet();
+  }
+
+  /**
+   * Returns the mapping of external names to standard names for a group.
+   * <p>
+   * External names are used to map names used by external systems to the standard name used here.
+   * There can be multiple groups of mappings to external systems,
+   * For example, the mapping used by FpML may differ from that used by Bloomberg.
+   * <p>
+   * The result provides mapping between the external name and the standard name.
+   * 
+   * @param group  the group name to find external names for
+   * @return the map of external names for the group
+   * @throws IllegalArgumentException if the group is not found
+   */
+  public ExternalEnumNames<T> externalNames(String group) {
+    ImmutableMap<String, String> externals = externalNames.get(group);
+    if (externals == null) {
+      throw new IllegalArgumentException(type.getSimpleName() + " group not found: " + group);
+    }
+    return new ExternalEnumNames<T>(this, group, externals);
   }
 
   //-------------------------------------------------------------------------
   @Override
   public String toString() {
     return "ExtendedEnum[" + type.getSimpleName() + "]";
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Maps names used by external systems to the standard name used here.
+   * <p>
+   * A frequent problem in parsing external file formats is converting enum values.
+   * This class provides a suitable mapping, allowing multiple external names to map to one standard name.
+   * <p>
+   * A single instance represents the mapping for a single external group.
+   * This allows the mapping for different groups to differ.
+   * For example, the mapping used by FpML may differ from that used by Bloomberg.
+   * <p>
+   * Instances of this class are configured via INI files and provided via {@link ExtendedEnum}.
+   * 
+   * @param <T>  the type of the enum
+   */
+  public static class ExternalEnumNames<T extends Named> {
+
+    private ExtendedEnum<T> extendedEnum;
+    private String group;
+    private ImmutableMap<String, String> externalNames;
+
+    private ExternalEnumNames(ExtendedEnum<T> extendedEnum, String group, ImmutableMap<String, String> externalNames) {
+      this.extendedEnum = extendedEnum;
+      this.group = group;
+      this.externalNames = externalNames;
+    }
+
+    /**
+     * Looks up an instance by name.
+     * <p>
+     * This finds the instance matching the specified name.
+     * Instances may have alternate names (aliases), thus the returned instance
+     * may have a name other than that requested.
+     * 
+     * @param name  the enum name to return
+     * @return the named enum
+     * @throws IllegalArgumentException if the name is not found
+     */
+    public T lookup(String name) {
+      String standardName = externalNames.getOrDefault(name, name);
+      try {
+        return extendedEnum.lookup(standardName);
+      } catch (IllegalArgumentException ex) {
+        throw new IllegalArgumentException(Messages.format(
+            "{}:{} unable to find external name: {}", extendedEnum.type.getSimpleName(), group, name));
+      }
+    }
+
+    /**
+     * Looks up an instance by name and type.
+     * <p>
+     * This finds the instance matching the specified name, ensuring it is of the specified type.
+     * Instances may have alternate names (aliases), thus the returned instance
+     * may have a name other than that requested.
+     * 
+     * @param <S>  the enum subtype
+     * @param subtype  the enum subtype to match
+     * @param name  the enum name to return
+     * @return the named enum
+     * @throws IllegalArgumentException if the name is not found or has the wrong type
+     */
+    public <S extends T> S lookup(String name, Class<S> subtype) {
+      T result = lookup(name);
+      if (!subtype.isInstance(result)) {
+        throw new IllegalArgumentException(Messages.format(
+            "{}:{} external name found but did not match expected type: {}", extendedEnum.type.getSimpleName(), group, name));
+      }
+      return subtype.cast(result);
+    }
+
+    /**
+     * Returns the complete map of external name to standard name.
+     * <p>
+     * The map is keyed by the external name.
+     * 
+     * @return the map of external names
+     */
+    public ImmutableMap<String, String> externalNames() {
+      return externalNames;
+    }
+
+    /**
+     * Looks up the external name given a standard enum instance.
+     * <p>
+     * This searches the map of external names and returns the first matching entry
+     * that maps to the given standard name.
+     * 
+     * @param namedEnum  the named enum to find an external name for
+     * @return the external name
+     * @throws IllegalArgumentException if there is no external name
+     */
+    public String reverseLookup(T namedEnum) {
+      String name = namedEnum.getName();
+      for (Entry<String, String> entry : externalNames.entrySet()) {
+        if (entry.getValue().equals(name)) {
+          return entry.getKey();
+        }
+      }
+      throw new IllegalArgumentException(Messages.format(
+          "{}:{} external name not found for standard name: {}", extendedEnum.type.getSimpleName(), group, name));
+    }
+
+    //-------------------------------------------------------------------------
+    @Override
+    public String toString() {
+      return "ExternalEnumNames[" + extendedEnum.type.getSimpleName() + ":" + group + "]";
+    }
   }
 
 }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/IniFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/IniFileTest.java
@@ -92,33 +92,33 @@ public class IniFileTest {
         ImmutableMap.of("section", PropertySet.of(keyValues1), "name", PropertySet.of(keyValues2)));
 
     assertEquals(test.contains("section"), true);
-    assertEquals(test.getSection("section"), PropertySet.of(keyValues1));
-    assertEquals(test.getSection("section").contains("a"), true);
-    assertEquals(test.getSection("section").getValue("a"), "x");
-    assertEquals(test.getSection("section").getValueList("a"), ImmutableList.of("x"));
-    assertEquals(test.getSection("section").contains("b"), true);
-    assertEquals(test.getSection("section").getValue("b"), "y");
-    assertEquals(test.getSection("section").getValueList("b"), ImmutableList.of("y"));
-    assertEquals(test.getSection("section").contains("c"), false);
-    assertEquals(test.getSection("section").keys(), ImmutableSet.of("a", "b"));
-    assertEquals(test.getSection("section").asMap(), ImmutableListMultimap.of("a", "x", "b", "y"));
+    assertEquals(test.section("section"), PropertySet.of(keyValues1));
+    assertEquals(test.section("section").contains("a"), true);
+    assertEquals(test.section("section").value("a"), "x");
+    assertEquals(test.section("section").valueList("a"), ImmutableList.of("x"));
+    assertEquals(test.section("section").contains("b"), true);
+    assertEquals(test.section("section").value("b"), "y");
+    assertEquals(test.section("section").valueList("b"), ImmutableList.of("y"));
+    assertEquals(test.section("section").contains("c"), false);
+    assertEquals(test.section("section").keys(), ImmutableSet.of("a", "b"));
+    assertEquals(test.section("section").asMultimap(), ImmutableListMultimap.of("a", "x", "b", "y"));
 
     assertEquals(test.contains("name"), true);
-    assertEquals(test.getSection("name"), PropertySet.of(keyValues2));
-    assertEquals(test.getSection("name").contains("a"), true);
-    assertEquals(test.getSection("name").getValue("a"), "m");
-    assertEquals(test.getSection("name").getValueList("a"), ImmutableList.of("m"));
-    assertEquals(test.getSection("name").contains("b"), true);
-    assertEquals(test.getSection("name").getValue("b"), "n");
-    assertEquals(test.getSection("name").getValueList("b"), ImmutableList.of("n"));
-    assertEquals(test.getSection("name").contains("c"), false);
-    assertEquals(test.getSection("name").keys(), ImmutableSet.of("a", "b"));
-    assertEquals(test.getSection("name").asMap(), ImmutableListMultimap.of("a", "m", "b", "n"));
+    assertEquals(test.section("name"), PropertySet.of(keyValues2));
+    assertEquals(test.section("name").contains("a"), true);
+    assertEquals(test.section("name").value("a"), "m");
+    assertEquals(test.section("name").valueList("a"), ImmutableList.of("m"));
+    assertEquals(test.section("name").contains("b"), true);
+    assertEquals(test.section("name").value("b"), "n");
+    assertEquals(test.section("name").valueList("b"), ImmutableList.of("n"));
+    assertEquals(test.section("name").contains("c"), false);
+    assertEquals(test.section("name").keys(), ImmutableSet.of("a", "b"));
+    assertEquals(test.section("name").asMultimap(), ImmutableListMultimap.of("a", "m", "b", "n"));
 
     assertEquals(test.contains("unknown"), false);
-    assertThrowsIllegalArg(() -> test.getSection("unknown"));
-    assertEquals(test.getSection("section").getValueList("unknown"), ImmutableList.of());
-    assertThrowsIllegalArg(() -> test.getSection("section").getValue("unknown"));
+    assertThrowsIllegalArg(() -> test.section("unknown"));
+    assertEquals(test.section("section").valueList("unknown"), ImmutableList.of());
+    assertThrowsIllegalArg(() -> test.section("section").value("unknown"));
     assertEquals(test.toString(), "{section={a=[x], b=[y]}, name={a=[m], b=[n]}}");
   }
 
@@ -129,13 +129,13 @@ public class IniFileTest {
     keyValues1.put("a", "y");
     assertEquals(test.asMap(), ImmutableMap.of("section", PropertySet.of(keyValues1)));
 
-    assertEquals(test.getSection("section"), PropertySet.of(keyValues1));
-    assertEquals(test.getSection("section").contains("a"), true);
-    assertThrowsIllegalArg(() -> test.getSection("section").getValue("a"));
-    assertEquals(test.getSection("section").getValueList("a"), ImmutableList.of("x", "y"));
-    assertEquals(test.getSection("section").contains("b"), false);
-    assertEquals(test.getSection("section").keys(), ImmutableSet.of("a"));
-    assertEquals(test.getSection("section").asMap(), ImmutableListMultimap.of("a", "x", "a", "y"));
+    assertEquals(test.section("section"), PropertySet.of(keyValues1));
+    assertEquals(test.section("section").contains("a"), true);
+    assertThrowsIllegalArg(() -> test.section("section").value("a"));
+    assertEquals(test.section("section").valueList("a"), ImmutableList.of("x", "y"));
+    assertEquals(test.section("section").contains("b"), false);
+    assertEquals(test.section("section").keys(), ImmutableSet.of("a"));
+    assertEquals(test.section("section").asMultimap(), ImmutableListMultimap.of("a", "x", "a", "y"));
     assertEquals(test.toString(), "{section={a=[x, y]}}");
   }
 
@@ -245,12 +245,12 @@ public class IniFileTest {
     IniFile a2 = IniFile.of(CharSource.wrap(INI1));
     IniFile b = IniFile.of(CharSource.wrap(INI2));
 
-    assertEquals(a1.getSection("name").equals(a1.getSection("name")), true);
-    assertEquals(a1.getSection("name").equals(a2.getSection("name")), true);
-    assertEquals(a1.getSection("name").equals(b.getSection("section")), false);
-    assertEquals(a1.getSection("name").equals(null), false);
-    assertEquals(a1.getSection("name").equals(""), false);
-    assertEquals(a1.getSection("name").hashCode(), a2.getSection("name").hashCode());
+    assertEquals(a1.section("name").equals(a1.section("name")), true);
+    assertEquals(a1.section("name").equals(a2.section("name")), true);
+    assertEquals(a1.section("name").equals(b.section("section")), false);
+    assertEquals(a1.section("name").equals(null), false);
+    assertEquals(a1.section("name").equals(""), false);
+    assertEquals(a1.section("name").hashCode(), a2.section("name").hashCode());
   }
 
 }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertySetTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertySetTest.java
@@ -30,8 +30,8 @@ public class PropertySetTest {
 
     assertEquals(test.isEmpty(), true);
     assertEquals(test.contains("unknown"), false);
-    assertEquals(test.getValueList("unknown"), ImmutableList.of());
-    assertThrowsIllegalArg(() -> test.getValue("unknown"));
+    assertEquals(test.valueList("unknown"), ImmutableList.of());
+    assertThrowsIllegalArg(() -> test.value("unknown"));
     assertEquals(test.toString(), "{}");
   }
 
@@ -41,17 +41,18 @@ public class PropertySetTest {
 
     assertEquals(test.isEmpty(), false);
     assertEquals(test.contains("a"), true);
-    assertEquals(test.getValue("a"), "x");
-    assertEquals(test.getValueList("a"), ImmutableList.of("x"));
+    assertEquals(test.value("a"), "x");
+    assertEquals(test.valueList("a"), ImmutableList.of("x"));
     assertEquals(test.contains("b"), true);
-    assertEquals(test.getValue("b"), "y");
-    assertEquals(test.getValueList("b"), ImmutableList.of("y"));
+    assertEquals(test.value("b"), "y");
+    assertEquals(test.valueList("b"), ImmutableList.of("y"));
     assertEquals(test.contains("c"), false);
     assertEquals(test.keys(), ImmutableSet.of("a", "b"));
-    assertEquals(test.asMap(), ImmutableListMultimap.of("a", "x", "b", "y"));
-    assertEquals(test.getValueList("unknown"), ImmutableSet.of());
+    assertEquals(test.asMap(), ImmutableMap.of("a", "x", "b", "y"));
+    assertEquals(test.asMultimap(), ImmutableListMultimap.of("a", "x", "b", "y"));
+    assertEquals(test.valueList("unknown"), ImmutableSet.of());
 
-    assertThrowsIllegalArg(() -> test.getValue("unknown"));
+    assertThrowsIllegalArg(() -> test.value("unknown"));
     assertEquals(test.toString(), "{a=[x], b=[y]}");
   }
 
@@ -61,17 +62,18 @@ public class PropertySetTest {
 
     assertEquals(test.isEmpty(), false);
     assertEquals(test.contains("a"), true);
-    assertThrowsIllegalArg(() -> test.getValue("a"));
-    assertEquals(test.getValueList("a"), ImmutableList.of("x", "y"));
+    assertThrowsIllegalArg(() -> test.value("a"));
+    assertEquals(test.valueList("a"), ImmutableList.of("x", "y"));
     assertEquals(test.contains("b"), true);
-    assertEquals(test.getValue("b"), "z");
-    assertEquals(test.getValueList("b"), ImmutableList.of("z"));
+    assertEquals(test.value("b"), "z");
+    assertEquals(test.valueList("b"), ImmutableList.of("z"));
     assertEquals(test.contains("c"), false);
     assertEquals(test.keys(), ImmutableSet.of("a", "b"));
-    assertEquals(test.asMap(), ImmutableListMultimap.of("a", "x", "a", "y", "b", "z"));
-    assertEquals(test.getValueList("unknown"), ImmutableSet.of());
+    assertEquals(test.asMultimap(), ImmutableListMultimap.of("a", "x", "a", "y", "b", "z"));
+    assertEquals(test.valueList("unknown"), ImmutableSet.of());
 
-    assertThrowsIllegalArg(() -> test.getValue("unknown"));
+    assertThrowsIllegalArg(() -> test.asMap());
+    assertThrowsIllegalArg(() -> test.value("unknown"));
     assertEquals(test.toString(), "{a=[x, y], b=[z]}");
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/named/ExtendedEnumTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/named/ExtendedEnumTest.java
@@ -14,6 +14,8 @@ import java.util.logging.Logger;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.collect.named.ExtendedEnum.ExternalEnumNames;
 
 /**
  * Test {@link ExtendedEnum}.
@@ -39,16 +41,42 @@ public class ExtendedEnumTest {
     assertEquals(test.lookup("Other", OtherSampleNameds.class), OtherSampleNameds.OTHER);
     assertEquals(test.lookup("Another1"), SampleNamedInstanceLookup1.ANOTHER1);
     assertEquals(test.lookup("Another2"), SampleNamedInstanceLookup2.ANOTHER2);
+    assertEquals(test.alternateNames(), ImmutableMap.of("Alternate", "Standard"));
     assertThrowsIllegalArg(() -> test.lookup("Rubbish"));
     assertThrowsIllegalArg(() -> test.lookup(null));
     assertThrowsIllegalArg(() -> test.lookup("Other", MoreSampleNameds.class));
     assertEquals(test.toString(), "ExtendedEnum[SampleNamed]");
   }
 
+  public void test_enum_SampleNamed_externals() {
+    ExtendedEnum<SampleNamed> test = ExtendedEnum.of(SampleNamed.class);
+    assertEquals(test.externalNameGroups(), ImmutableSet.of("Foo", "Bar"));
+    assertThrowsIllegalArg(() -> test.externalNames("Rubbish"));
+    ExternalEnumNames<SampleNamed> fooExternals = test.externalNames("Foo");
+    assertEquals(fooExternals.lookup("Foo1"), SampleNameds.STANDARD);
+    assertEquals(fooExternals.lookup("Foo1", SampleNamed.class), SampleNameds.STANDARD);
+    assertEquals(fooExternals.lookup("Foo1", SampleNamed.class), SampleNameds.STANDARD);
+    assertEquals(fooExternals.externalNames(), ImmutableMap.of("Foo1", "Standard"));
+    assertThrowsIllegalArg(() -> fooExternals.lookup("Rubbish"));
+    assertThrowsIllegalArg(() -> fooExternals.lookup(null));
+    assertThrowsIllegalArg(() -> fooExternals.lookup("Other", MoreSampleNameds.class));
+    assertEquals(fooExternals.toString(), "ExternalEnumNames[SampleNamed:Foo]");
+
+    ExternalEnumNames<SampleNamed> barExternals = test.externalNames("Bar");
+    assertEquals(barExternals.lookup("Foo1"), MoreSampleNameds.MORE);
+    assertEquals(barExternals.lookup("Foo2"), SampleNameds.STANDARD);
+    assertEquals(barExternals.reverseLookup(MoreSampleNameds.MORE), "Foo1");
+    assertEquals(barExternals.reverseLookup(SampleNameds.STANDARD), "Foo2");
+    assertThrowsIllegalArg(() -> barExternals.reverseLookup(OtherSampleNameds.OTHER));
+    assertEquals(barExternals.externalNames(), ImmutableMap.of("Foo1", "More", "Foo2", "Standard"));
+    assertEquals(barExternals.toString(), "ExternalEnumNames[SampleNamed:Bar]");
+  }
+
   public void test_enum_SampleOther() {
     ExtendedEnum<SampleOther> test = ExtendedEnum.of(SampleOther.class);
     assertEquals(test.lookupAll(), ImmutableMap.of());
     assertEquals(test.alternateNames(), ImmutableMap.of());
+    assertEquals(test.externalNameGroups(), ImmutableSet.of());
     assertThrowsIllegalArg(() -> test.lookup("Rubbish"));
     assertThrowsIllegalArg(() -> test.lookup(null));
     assertEquals(test.toString(), "ExtendedEnum[SampleOther]");

--- a/modules/collect/src/test/resources/com/opengamma/strata/collect/named/SampleNamed.ini
+++ b/modules/collect/src/test/resources/com/opengamma/strata/collect/named/SampleNamed.ini
@@ -11,3 +11,10 @@ com.opengamma.strata.collect.named.SampleNamedInstanceLookup2 = instance
 
 [alternates]
 Alternate = Standard
+
+[externals.Foo]
+Foo1 = Standard
+
+[externals.Bar]
+Foo1 = More
+Foo2 = Standard

--- a/modules/report-beta/src/main/java/com/opengamma/strata/report/MasterReportTemplateIniLoader.java
+++ b/modules/report-beta/src/main/java/com/opengamma/strata/report/MasterReportTemplateIniLoader.java
@@ -25,13 +25,13 @@ public class MasterReportTemplateIniLoader {
 
   @SuppressWarnings("unchecked")
   public ReportTemplate load(IniFile iniFile) {
-    String settingsSectionKey = iniFile.keys().stream()
+    String settingsSectionKey = iniFile.sections().stream()
         .filter(k -> k.toLowerCase().equals(ReportTemplateIniLoader.SETTINGS_SECTION))
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException(
             Messages.format("Report template INI file must contain a {} section", ReportTemplateIniLoader.SETTINGS_SECTION)));
-    PropertySet settingsSection = iniFile.getSection(settingsSectionKey);
-    String reportType = settingsSection.getValue(ReportTemplateIniLoader.SETTINGS_REPORT_TYPE);
+    PropertySet settingsSection = iniFile.section(settingsSectionKey);
+    String reportType = settingsSection.value(ReportTemplateIniLoader.SETTINGS_REPORT_TYPE);
     ReportTemplateIniLoader<ReportTemplate> iniLoader = (ReportTemplateIniLoader<ReportTemplate>) LOADERS.stream()
         .filter(loader -> loader.getReportType().toLowerCase().equals(reportType.toLowerCase()))
         .findFirst()

--- a/modules/report-beta/src/main/java/com/opengamma/strata/report/trade/TradeReportTemplateIniLoader.java
+++ b/modules/report-beta/src/main/java/com/opengamma/strata/report/trade/TradeReportTemplateIniLoader.java
@@ -37,11 +37,11 @@ public class TradeReportTemplateIniLoader implements ReportTemplateIniLoader<Tra
   @Override
   public TradeReportTemplate load(IniFile iniFile) {
     List<TradeReportColumn> reportColumns = new ArrayList<TradeReportColumn>();
-    for (String columnName : iniFile.keys()) {
+    for (String columnName : iniFile.sections()) {
       if (columnName.toLowerCase().equals(SETTINGS_SECTION)) {
         continue;
       }
-      PropertySet properties = iniFile.getSection(columnName);
+      PropertySet properties = iniFile.section(columnName);
       reportColumns.add(parseColumn(columnName, properties));
     }
     return TradeReportTemplate.builder()
@@ -54,10 +54,10 @@ public class TradeReportTemplateIniLoader implements ReportTemplateIniLoader<Tra
     columnBuilder.header(columnName);
 
     if (properties.contains(VALUE_PROPERTY)) {
-      columnBuilder.value(properties.getValue(VALUE_PROPERTY));
+      columnBuilder.value(properties.value(VALUE_PROPERTY));
     }
     if (properties.contains(IGNORE_FAILURES_PROPERTY)) {
-      String ignoreFailuresValue = properties.getValue(IGNORE_FAILURES_PROPERTY);
+      String ignoreFailuresValue = properties.value(IGNORE_FAILURES_PROPERTY);
       boolean ignoresFailure = Boolean.valueOf(ignoreFailuresValue);
       columnBuilder.ignoreFailures(ignoresFailure);
     }


### PR DESCRIPTION
Support concept of external names.
Allow multiple groups of external names, ideal for parsing.
Adjust `PropertySet` and `IniFile` to use same short method naming convention as `CsvFile`.