### PR TITLE
Fixed coupon bond: provider and pricer

### DIFF
--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/bond/FixedCouponBondTrade.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/bond/FixedCouponBondTrade.java
@@ -23,6 +23,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.id.LinkResolver;
 import com.opengamma.strata.collect.id.StandardId;
 import com.opengamma.strata.finance.SecurityLink;
@@ -60,6 +61,16 @@ public final class FixedCouponBondTrade
    */
   @PropertyDefinition
   private final long quantity;
+  /**
+   * The upfront fee payment of the bond trade.
+   * <p>
+   * The payment sign should be compatible with the product quantity, 
+   * thus the payment is negative for positive quantity and positive for negative quantity.
+   * <p>
+   * Typically the date of this payment is the same as the settlement date in {@code tradeInfo}.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final Payment payment;
 
   //-------------------------------------------------------------------------
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -104,11 +115,14 @@ public final class FixedCouponBondTrade
   private FixedCouponBondTrade(
       TradeInfo tradeInfo,
       SecurityLink<FixedCouponBond> securityLink,
-      long quantity) {
+      long quantity,
+      Payment payment) {
     JodaBeanUtils.notNull(securityLink, "securityLink");
+    JodaBeanUtils.notNull(payment, "payment");
     this.tradeInfo = tradeInfo;
     this.securityLink = securityLink;
     this.quantity = quantity;
+    this.payment = payment;
   }
 
   @Override
@@ -164,6 +178,20 @@ public final class FixedCouponBondTrade
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the upfront fee payment of the bond trade.
+   * <p>
+   * The payment sign should be compatible with the product quantity,
+   * thus the payment is negative for positive quantity and positive for negative quantity.
+   * <p>
+   * Typically the date of this payment is the same as the settlement date in {@code tradeInfo}.
+   * @return the value of the property, not null
+   */
+  public Payment getPayment() {
+    return payment;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Returns a builder that allows this bean to be mutated.
    * @return the mutable builder, not null
    */
@@ -180,7 +208,8 @@ public final class FixedCouponBondTrade
       FixedCouponBondTrade other = (FixedCouponBondTrade) obj;
       return JodaBeanUtils.equal(getTradeInfo(), other.getTradeInfo()) &&
           JodaBeanUtils.equal(getSecurityLink(), other.getSecurityLink()) &&
-          (getQuantity() == other.getQuantity());
+          (getQuantity() == other.getQuantity()) &&
+          JodaBeanUtils.equal(getPayment(), other.getPayment());
     }
     return false;
   }
@@ -191,16 +220,18 @@ public final class FixedCouponBondTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(getTradeInfo());
     hash = hash * 31 + JodaBeanUtils.hashCode(getSecurityLink());
     hash = hash * 31 + JodaBeanUtils.hashCode(getQuantity());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getPayment());
     return hash;
   }
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(128);
+    StringBuilder buf = new StringBuilder(160);
     buf.append("FixedCouponBondTrade{");
     buf.append("tradeInfo").append('=').append(getTradeInfo()).append(',').append(' ');
     buf.append("securityLink").append('=').append(getSecurityLink()).append(',').append(' ');
-    buf.append("quantity").append('=').append(JodaBeanUtils.toString(getQuantity()));
+    buf.append("quantity").append('=').append(getQuantity()).append(',').append(' ');
+    buf.append("payment").append('=').append(JodaBeanUtils.toString(getPayment()));
     buf.append('}');
     return buf.toString();
   }
@@ -232,13 +263,19 @@ public final class FixedCouponBondTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", FixedCouponBondTrade.class, Long.TYPE);
     /**
+     * The meta-property for the {@code payment} property.
+     */
+    private final MetaProperty<Payment> payment = DirectMetaProperty.ofImmutable(
+        this, "payment", FixedCouponBondTrade.class, Payment.class);
+    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "tradeInfo",
         "securityLink",
-        "quantity");
+        "quantity",
+        "payment");
 
     /**
      * Restricted constructor.
@@ -255,6 +292,8 @@ public final class FixedCouponBondTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
+        case -786681338:  // payment
+          return payment;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -299,6 +338,14 @@ public final class FixedCouponBondTrade
       return quantity;
     }
 
+    /**
+     * The meta-property for the {@code payment} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Payment> payment() {
+      return payment;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
@@ -309,6 +356,8 @@ public final class FixedCouponBondTrade
           return ((FixedCouponBondTrade) bean).getSecurityLink();
         case -1285004149:  // quantity
           return ((FixedCouponBondTrade) bean).getQuantity();
+        case -786681338:  // payment
+          return ((FixedCouponBondTrade) bean).getPayment();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -333,6 +382,7 @@ public final class FixedCouponBondTrade
     private TradeInfo tradeInfo;
     private SecurityLink<FixedCouponBond> securityLink;
     private long quantity;
+    private Payment payment;
 
     /**
      * Restricted constructor.
@@ -349,6 +399,7 @@ public final class FixedCouponBondTrade
       this.tradeInfo = beanToCopy.getTradeInfo();
       this.securityLink = beanToCopy.getSecurityLink();
       this.quantity = beanToCopy.getQuantity();
+      this.payment = beanToCopy.getPayment();
     }
 
     //-----------------------------------------------------------------------
@@ -361,6 +412,8 @@ public final class FixedCouponBondTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
+        case -786681338:  // payment
+          return payment;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -378,6 +431,9 @@ public final class FixedCouponBondTrade
           break;
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
+          break;
+        case -786681338:  // payment
+          this.payment = (Payment) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -414,7 +470,8 @@ public final class FixedCouponBondTrade
       return new FixedCouponBondTrade(
           tradeInfo,
           securityLink,
-          quantity);
+          quantity,
+          payment);
     }
 
     //-----------------------------------------------------------------------
@@ -456,14 +513,31 @@ public final class FixedCouponBondTrade
       return this;
     }
 
+    /**
+     * Sets the upfront fee payment of the bond trade.
+     * <p>
+     * The payment sign should be compatible with the product quantity,
+     * thus the payment is negative for positive quantity and positive for negative quantity.
+     * <p>
+     * Typically the date of this payment is the same as the settlement date in {@code tradeInfo}.
+     * @param payment  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder payment(Payment payment) {
+      JodaBeanUtils.notNull(payment, "payment");
+      this.payment = payment;
+      return this;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(128);
+      StringBuilder buf = new StringBuilder(160);
       buf.append("FixedCouponBondTrade.Builder{");
       buf.append("tradeInfo").append('=').append(JodaBeanUtils.toString(tradeInfo)).append(',').append(' ');
       buf.append("securityLink").append('=').append(JodaBeanUtils.toString(securityLink)).append(',').append(' ');
-      buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity));
+      buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
+      buf.append("payment").append('=').append(JodaBeanUtils.toString(payment));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/bond/FixedCouponBondTradeTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/bond/FixedCouponBondTradeTest.java
@@ -10,7 +10,6 @@ import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
-import static com.opengamma.strata.collect.TestHelper.date;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -18,6 +17,8 @@ import java.time.LocalDate;
 import org.testng.annotations.Test;
 
 import com.google.common.reflect.TypeToken;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.BusinessDayConventions;
 import com.opengamma.strata.basics.date.DayCount;
@@ -43,9 +44,11 @@ import com.opengamma.strata.finance.UnitSecurity;
 public class FixedCouponBondTradeTest {
 
   private static final StandardId SECURITY_ID = StandardId.of("OG-Ticker", "GOVT1-BOND1");
+  private static final LocalDate TRADE_DATE = LocalDate.of(2015, 3, 25);
+  private static final LocalDate SETTLEMENT_DATE = LocalDate.of(2015, 3, 30);
   private static final TradeInfo TRADE_INFO = TradeInfo.builder()
-      .tradeDate(date(2015, 3, 25))
-      .settlementDate(date(2015, 3, 30))
+      .tradeDate(TRADE_DATE)
+      .settlementDate(SETTLEMENT_DATE)
       .build();
   private static final long QUANTITY = 10;
 
@@ -74,6 +77,8 @@ public class FixedCouponBondTradeTest {
       .build();
   private static final Security<FixedCouponBond> BOND_SECURITY =
       UnitSecurity.builder(PRODUCT).standardId(SECURITY_ID).build();
+  private static final Payment UPFRONT_PAYMENT = Payment.of(
+      CurrencyAmount.of(EUR, -NOTIONAL * QUANTITY * 0.99), SETTLEMENT_DATE);
 
   private static final SecurityLink<FixedCouponBond> SECURITY_LINK_RESOLVED = SecurityLink.resolved(BOND_SECURITY);
   private static final SecurityLink<FixedCouponBond> SECURITY_LINK_RESOLVABLE =
@@ -94,12 +99,14 @@ public class FixedCouponBondTradeTest {
         .securityLink(SECURITY_LINK_RESOLVED)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     assertEquals(test.getProduct(), PRODUCT);
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getQuantity(), QUANTITY);
     assertEquals(test.getSecurity(), BOND_SECURITY);
     assertEquals(test.getSecurityLink(), SECURITY_LINK_RESOLVED);
+    assertEquals(test.getPayment(), UPFRONT_PAYMENT);
   }
 
   public void test_builder_resolvable() {
@@ -107,6 +114,7 @@ public class FixedCouponBondTradeTest {
         .securityLink(SECURITY_LINK_RESOLVABLE)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getQuantity(), QUANTITY);
@@ -121,6 +129,7 @@ public class FixedCouponBondTradeTest {
         .securityLink(SECURITY_LINK_RESOLVED)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     assertEquals(base.resolveLinks(RESOLVER), base);
   }
@@ -130,11 +139,13 @@ public class FixedCouponBondTradeTest {
         .securityLink(SECURITY_LINK_RESOLVABLE)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     FixedCouponBondTrade expected = FixedCouponBondTrade.builder()
         .securityLink(SECURITY_LINK_RESOLVED)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     assertEquals(base.resolveLinks(RESOLVER), expected);
   }
@@ -145,6 +156,7 @@ public class FixedCouponBondTradeTest {
         .securityLink(SECURITY_LINK_RESOLVED)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     coverImmutableBean(test1);
     FixedCouponBondTrade test2 = FixedCouponBondTrade.builder()
@@ -152,6 +164,7 @@ public class FixedCouponBondTradeTest {
             .standardId(StandardId.of("Ticker", "GOV1-BND1"))
             .build()))
         .quantity(100L)
+        .payment(Payment.of(CurrencyAmount.of(EUR, -NOTIONAL * QUANTITY * 0.99), SETTLEMENT_DATE))
         .build();
     coverBeanEquals(test1, test2);
   }
@@ -161,6 +174,7 @@ public class FixedCouponBondTradeTest {
         .securityLink(SECURITY_LINK_RESOLVED)
         .tradeInfo(TRADE_INFO)
         .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT)
         .build();
     assertSerialization(test);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/bond/DiscountingFixedCouponBondPaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/bond/DiscountingFixedCouponBondPaymentPeriodPricer.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.impl.bond;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.time.LocalDate;
+
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondPaymentPeriod;
+import com.opengamma.strata.market.explain.ExplainKey;
+import com.opengamma.strata.market.explain.ExplainMapBuilder;
+import com.opengamma.strata.market.sensitivity.IssuerCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.sensitivity.ZeroRateSensitivity;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+
+/**
+ * Pricer implementation for bond payment periods based on a fixed coupon.
+ * <p>
+ * This pricer performs discounting of the fixed coupon payment.
+ */
+public class DiscountingFixedCouponBondPaymentPeriodPricer {
+
+  /**
+   * Default implementation.
+   */
+  public static final DiscountingFixedCouponBondPaymentPeriodPricer DEFAULT =
+      new DiscountingFixedCouponBondPaymentPeriodPricer();
+
+  /**
+   * Creates an instance.
+   */
+  public DiscountingFixedCouponBondPaymentPeriodPricer() {
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the present value of a single fixed coupon payment period.
+   * <p>
+   * The amount is expressed in the currency of the period.
+   * This returns the value of the period with discounting.
+   * <p>
+   * The payment date of the period should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @return the present value of the period
+   */
+  public double presentValue(FixedCouponBondPaymentPeriod period, IssuerCurveDiscountFactors discountFactors) {
+
+    if (period.getPaymentDate().isBefore(discountFactors.getValuationDate())) {
+      return 0d;
+    }
+    double df = discountFactors.discountFactor(period.getPaymentDate());
+    return period.getFixedRate() * period.getNotional() * period.getYearFraction() * df;
+  }
+
+  /**
+   * Calculates the present value of a single fixed coupon payment period with z-spread.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * The amount is expressed in the currency of the period.
+   * This returns the value of the period with discounting.
+   * <p>
+   * The payment date of the period should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value of the period
+   */
+  public double presentValueWithSpread(
+      FixedCouponBondPaymentPeriod period,
+      IssuerCurveDiscountFactors discountFactors,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    if (period.getPaymentDate().isBefore(discountFactors.getValuationDate())) {
+      return 0d;
+    }
+    double df = discountFactors.getDiscountFactors()
+        .discountFactorWithSpread(period.getPaymentDate(), zSpread, periodic, periodsPerYear);
+    return period.getFixedRate() * period.getNotional() * period.getYearFraction() * df;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the future value of a single fixed coupon payment period.
+   * <p>
+   * The amount is expressed in the currency of the period.
+   * This returns the value of the period with discounting.
+   * <p>
+   * The payment date of the period should not be in the past.
+   * The result of this method for payment dates in the past is undefined.
+   * <p>
+   * The future value is z-spread independent. 
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @return the present value of the period
+   */
+  public double futureValue(FixedCouponBondPaymentPeriod period, IssuerCurveDiscountFactors discountFactors) {
+
+    if (period.getPaymentDate().isBefore(discountFactors.getValuationDate())) {
+      return 0d;
+    }
+    return period.getFixedRate() * period.getNotional() * period.getYearFraction();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the present value sensitivity of a single fixed coupon payment period.
+   * <p>
+   * The present value sensitivity of the period is the sensitivity of the present value to
+   * the underlying curves.
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @return the present value curve sensitivity of the period
+   */
+  public PointSensitivityBuilder presentValueSensitivity(
+      FixedCouponBondPaymentPeriod period,
+      IssuerCurveDiscountFactors discountFactors) {
+
+    if (period.getPaymentDate().isBefore(discountFactors.getValuationDate())) {
+      return PointSensitivityBuilder.none();
+    }
+    IssuerCurveZeroRateSensitivity dscSensi = discountFactors.zeroRatePointSensitivity(period.getPaymentDate());
+    return dscSensi.multipliedBy(period.getFixedRate() * period.getNotional() * period.getYearFraction());
+  }
+
+  /**
+   * Calculates the present value sensitivity of a single fixed coupon payment period with z-spread.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * The present value sensitivity of the period is the sensitivity of the present value to
+   * the underlying curves.
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value curve sensitivity of the period
+   */
+  public PointSensitivityBuilder presentValueSensitivityWithSpread(
+      FixedCouponBondPaymentPeriod period,
+      IssuerCurveDiscountFactors discountFactors,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    if (period.getPaymentDate().isBefore(discountFactors.getValuationDate())) {
+      return PointSensitivityBuilder.none();
+    }
+    ZeroRateSensitivity zeroSensi = discountFactors.getDiscountFactors().zeroRatePointSensitivityWithSpread(
+        period.getPaymentDate(), zSpread, periodic, periodsPerYear);
+    IssuerCurveZeroRateSensitivity dscSensi =
+        IssuerCurveZeroRateSensitivity.of(zeroSensi, discountFactors.getLegalEntityGroup());
+    return dscSensi.multipliedBy(period.getFixedRate() * period.getNotional() * period.getYearFraction());
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the future value sensitivity of a single fixed coupon payment period.
+   * <p>
+   * The future value sensitivity of the period is the sensitivity of the future value to
+   * the underlying curves.
+   * <p>
+   * The future value sensitivity is zero and z-spread independent for the fixed payment. 
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @return the future value curve sensitivity of the period
+   */
+  public PointSensitivityBuilder futureValueSensitivity(
+      FixedCouponBondPaymentPeriod period,
+      IssuerCurveDiscountFactors discountFactors) {
+
+    return PointSensitivityBuilder.none();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Explains the present value of a single fixed coupon payment period.
+   * <p>
+   * This adds information to the {@link ExplainMapBuilder} to aid understanding of the calculation.
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @param builder  the builder to populate
+   */
+  public void explainPresentValue(
+      FixedCouponBondPaymentPeriod period,
+      IssuerCurveDiscountFactors discountFactors,
+      ExplainMapBuilder builder) {
+
+    Currency currency = period.getCurrency();
+    LocalDate paymentDate = period.getPaymentDate();
+    explainBasics(period, builder, currency, paymentDate);
+    if (paymentDate.isBefore(discountFactors.getValuationDate())) {
+      builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.zero(currency));
+      builder.put(ExplainKey.PRESENT_VALUE, CurrencyAmount.zero(currency));
+    } else {
+      builder.put(ExplainKey.DISCOUNT_FACTOR, discountFactors.discountFactor(paymentDate));
+      builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.of(currency, futureValue(period, discountFactors)));
+      builder.put(ExplainKey.PRESENT_VALUE, CurrencyAmount.of(currency, presentValue(period, discountFactors)));
+    }
+  }
+
+  /**
+   * Explains the present value of a single fixed coupon payment period with z-spread.
+   * <p>
+   * This adds information to the {@link ExplainMapBuilder} to aid understanding of the calculation.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * 
+   * @param period  the period to price
+   * @param discountFactors  the discount factor provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @param builder  the builder to populate
+   */
+  public void explainPresentValueWithSpread(
+      FixedCouponBondPaymentPeriod period,
+      IssuerCurveDiscountFactors discountFactors,
+      ExplainMapBuilder builder,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    Currency currency = period.getCurrency();
+    LocalDate paymentDate = period.getPaymentDate();
+    explainBasics(period, builder, currency, paymentDate);
+    if (paymentDate.isBefore(discountFactors.getValuationDate())) {
+      builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.zero(currency));
+      builder.put(ExplainKey.PRESENT_VALUE, CurrencyAmount.zero(currency));
+    } else {
+      builder.put(ExplainKey.DISCOUNT_FACTOR,
+          discountFactors.getDiscountFactors().discountFactorWithSpread(paymentDate, zSpread, periodic, periodsPerYear));
+      builder.put(ExplainKey.FUTURE_VALUE, CurrencyAmount.of(currency, futureValue(period, discountFactors)));
+      builder.put(ExplainKey.PRESENT_VALUE,
+          CurrencyAmount.of(currency, presentValueWithSpread(period, discountFactors, zSpread, periodic, periodsPerYear)));
+    }
+  }
+
+  // common parts of explain
+  private void explainBasics(FixedCouponBondPaymentPeriod period, ExplainMapBuilder builder, Currency currency,
+      LocalDate paymentDate) {
+    builder.put(ExplainKey.ENTRY_TYPE, "FixedCouponBondPaymentPeriod");
+    builder.put(ExplainKey.PAYMENT_DATE, paymentDate);
+    builder.put(ExplainKey.PAYMENT_CURRENCY, currency);
+    builder.put(ExplainKey.START_DATE, period.getStartDate());
+    builder.put(ExplainKey.UNADJUSTED_START_DATE, period.getUnadjustedStartDate());
+    builder.put(ExplainKey.END_DATE, period.getEndDate());
+    builder.put(ExplainKey.ACCRUAL_DAYS, (int) DAYS.between(period.getStartDate(), period.getEndDate()));
+    builder.put(ExplainKey.UNADJUSTED_END_DATE, period.getUnadjustedEndDate());
+  }
+
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/LegalEntityDiscountingProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/LegalEntityDiscountingProvider.java
@@ -1,0 +1,738 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutablePreBuild;
+import org.joda.beans.ImmutableValidator;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.sensitivity.IssuerCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
+import com.opengamma.strata.market.sensitivity.PointSensitivity;
+import com.opengamma.strata.market.sensitivity.RepoCurveZeroRateSensitivity;
+import com.opengamma.strata.market.value.BondGroup;
+import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+import com.opengamma.strata.market.value.LegalEntityGroup;
+import com.opengamma.strata.market.value.RepoCurveDiscountFactors;
+
+/**
+ * The discounting factors provider, used to calculate analytic measures. 
+ * <p>
+ * The primary usage of this provider is to price bonds issued by a legal entity. 
+ * This includes discount factors of repo curves and issuer curves. 
+ */
+@BeanDefinition
+public final class LegalEntityDiscountingProvider
+    implements ImmutableBean, Serializable {
+
+  /**
+   * The valuation date.
+   * All curves and other data items in this provider are calibrated for this date.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final LocalDate valuationDate;
+
+  /**
+   * The bond group map.
+   * <p>
+   * This map is used to convert the {@link StandardId} that identifies the bond to
+   * the associated bond group in order to lookup a repo curve.
+   * <p>
+   * See {@link LegalEntityDiscountingProvider#repoCurveDiscountFactors(StandardId, StandardId, Currency)}.
+   */
+  @PropertyDefinition(validate = "notNull", get = "private")
+  private final ImmutableMap<StandardId, BondGroup> bondMap;
+  /**
+   * The repo curves, defaulted to an empty map.
+   * The curve data, predicting the future, associated with each bond group and currency.
+   */
+  @PropertyDefinition(validate = "notNull", get = "private")
+  private final ImmutableMap<Pair<BondGroup, Currency>, DiscountFactors> repoCurves;
+
+  /**
+   * The legal entity group map.
+   * <p>
+   * This map is used to convert the {@link StandardId} that identifies the legal entity to
+   * the associated legal entity group in order to lookup an issuer curve.
+   * <p>
+   * See {@link LegalEntityDiscountingProvider#issuerCurveDiscountFactors(StandardId, Currency)}.
+   */
+  @PropertyDefinition(validate = "notEmpty", get = "private")
+  private final ImmutableMap<StandardId, LegalEntityGroup> legalEntityMap;
+  /**
+   * The issuer curves.
+   * The curve data, predicting the future, associated with each legal entity group and currency.
+   */
+  @PropertyDefinition(validate = "notEmpty", get = "private")
+  private final ImmutableMap<Pair<LegalEntityGroup, Currency>, DiscountFactors> issuerCurves;
+
+  //-------------------------------------------------------------------------
+  @ImmutablePreBuild
+  private static void preBuild(Builder builder) {
+    if (builder.valuationDate == null && !builder.issuerCurves.isEmpty()) {
+      builder.valuationDate = builder.issuerCurves.values().iterator().next().getValuationDate();
+    }
+  }
+
+  @ImmutableValidator
+  private void validate() {
+    for (Entry<Pair<BondGroup, Currency>, DiscountFactors> entry : repoCurves.entrySet()) {
+      if (!entry.getValue().getValuationDate().isEqual(valuationDate)) {
+        throw new IllegalArgumentException("Invalid valuation date for the curve: " + entry.getValue().getCurveName());
+      }
+      if (!bondMap.containsValue(entry.getKey().getFirst())) {
+        throw new IllegalArgumentException("No map to the bond group from ID: " + entry.getKey().getFirst());
+      }
+    }
+    for (Entry<Pair<LegalEntityGroup, Currency>, DiscountFactors> entry : issuerCurves.entrySet()) {
+      if (!entry.getValue().getValuationDate().isEqual(valuationDate)) {
+        throw new IllegalArgumentException("Invalid valuation date for the curve: " + entry.getValue().getCurveName());
+      }
+      if (!legalEntityMap.containsValue(entry.getKey().getFirst())) {
+        throw new IllegalArgumentException("No map to the legal entity group from ID: " + entry.getKey().getFirst());
+      }
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the discount factors of a repo curve for standard IDs and a currency.
+   * <p>
+   * If the bond standard ID is matched in a BondGroup, the relevant DiscountFactors is returned, 
+   * if not the issuer standard ID is checked and the relevant DiscountFactors is returned; 
+   * if both the bond and the issuer ID are not in any BondGroup, an error is thrown.
+   * <p>
+   * If the valuation date is on or after the specified date, the discount factor is 1.
+   * 
+   * @param securityID  the standard ID of security to get the discount factors for
+   * @param issuerID  the standard ID of legal entity to get the discount factors for
+   * @param currency  the currency to get the discount factors for
+   * @return the discount factors 
+   * @throws IllegalArgumentException if the discount factors are not available
+   */
+  public RepoCurveDiscountFactors repoCurveDiscountFactors(StandardId securityID, StandardId issuerID, Currency currency) {
+    BondGroup bondGroup = bondMap.get(securityID);
+    if (bondGroup == null) {
+      bondGroup = bondMap.get(issuerID);
+      if (bondGroup == null) {
+        throw new IllegalArgumentException("Unable to find map for ID: " + securityID + ", " + issuerID);
+      }
+    }
+    return repoCurveDiscountFactors(bondGroup, currency);
+  }
+
+  // lookup the discount factors for the bond group
+  private RepoCurveDiscountFactors repoCurveDiscountFactors(BondGroup bondGroup, Currency currency) {
+    DiscountFactors discountFactors = repoCurves.get(Pair.of(bondGroup, currency));
+    if (discountFactors == null) {
+      throw new IllegalArgumentException("Unable to find repo curve: " + bondGroup + ", " + currency);
+    }
+    return RepoCurveDiscountFactors.of(discountFactors, bondGroup);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the discount factors of an issuer curve for a standard ID and a currency.
+   * <p>
+   * If the valuation date is on or after the specified date, the discount factor is 1.
+   * 
+   * @param standardId  the standard ID to get the discount factors for
+   * @param currency  the currency to get the discount factors for
+   * @return the discount factors 
+   * @throws IllegalArgumentException if the discount factors are not available
+   */
+  public IssuerCurveDiscountFactors issuerCurveDiscountFactors(StandardId standardId, Currency currency) {
+    LegalEntityGroup legalEntityGroup = legalEntityMap.get(standardId);
+    if (legalEntityGroup == null) {
+      throw new IllegalArgumentException("Unable to find map for ID: " + standardId);
+    }
+    return issuerCurveDiscountFactors(legalEntityGroup, currency);
+  }
+
+  // lookup the discount factors for the legal entity group
+  private IssuerCurveDiscountFactors issuerCurveDiscountFactors(LegalEntityGroup legalEntityGroup, Currency currency) {
+    DiscountFactors discountFactors = issuerCurves.get(Pair.of(legalEntityGroup, currency));
+    if (discountFactors == null) {
+      throw new IllegalArgumentException("Unable to find issuer curve: " + legalEntityGroup + ", " + currency);
+    }
+    return IssuerCurveDiscountFactors.of(discountFactors, legalEntityGroup);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Computes the parameter sensitivity.
+   * <p>
+   * This computes the {@link CurveCurrencyParameterSensitivities} associated with the {@link PointSensitivities}.
+   * This corresponds to the projection of the point sensitivity to the curve internal parameters representation.
+   * <p>
+   * The sensitivities handled here are {@link RepoCurveZeroRateSensitivity} and {@link IssuerCurveZeroRateSensitivity}. 
+   * For the other sensitivity objects, use {@link RatesProvider} instead. 
+   * 
+   * @param pointSensitivities  the point sensitivity
+   * @return the sensitivity to the curve parameters
+   */
+  public CurveCurrencyParameterSensitivities curveParameterSensitivity(PointSensitivities pointSensitivities) {
+    CurveCurrencyParameterSensitivities sens = CurveCurrencyParameterSensitivities.empty();
+    for (PointSensitivity point : pointSensitivities.getSensitivities()) {
+      if (point instanceof RepoCurveZeroRateSensitivity) {
+        RepoCurveZeroRateSensitivity pt = (RepoCurveZeroRateSensitivity) point;
+        RepoCurveDiscountFactors factors = repoCurveDiscountFactors(pt.getBondGroup(), pt.getCurveCurrency());
+        sens = sens.combinedWith(factors.curveParameterSensitivity(pt));
+      } else if (point instanceof IssuerCurveZeroRateSensitivity) {
+        IssuerCurveZeroRateSensitivity pt = (IssuerCurveZeroRateSensitivity) point;
+        IssuerCurveDiscountFactors factors = issuerCurveDiscountFactors(pt.getLegalEntityGroup(), pt.getCurveCurrency());
+        sens = sens.combinedWith(factors.curveParameterSensitivity(pt));
+      }
+    }
+    return sens;
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code LegalEntityDiscountingProvider}.
+   * @return the meta-bean, not null
+   */
+  public static LegalEntityDiscountingProvider.Meta meta() {
+    return LegalEntityDiscountingProvider.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(LegalEntityDiscountingProvider.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static LegalEntityDiscountingProvider.Builder builder() {
+    return new LegalEntityDiscountingProvider.Builder();
+  }
+
+  private LegalEntityDiscountingProvider(
+      LocalDate valuationDate,
+      Map<StandardId, BondGroup> bondMap,
+      Map<Pair<BondGroup, Currency>, DiscountFactors> repoCurves,
+      Map<StandardId, LegalEntityGroup> legalEntityMap,
+      Map<Pair<LegalEntityGroup, Currency>, DiscountFactors> issuerCurves) {
+    JodaBeanUtils.notNull(valuationDate, "valuationDate");
+    JodaBeanUtils.notNull(bondMap, "bondMap");
+    JodaBeanUtils.notNull(repoCurves, "repoCurves");
+    JodaBeanUtils.notEmpty(legalEntityMap, "legalEntityMap");
+    JodaBeanUtils.notEmpty(issuerCurves, "issuerCurves");
+    this.valuationDate = valuationDate;
+    this.bondMap = ImmutableMap.copyOf(bondMap);
+    this.repoCurves = ImmutableMap.copyOf(repoCurves);
+    this.legalEntityMap = ImmutableMap.copyOf(legalEntityMap);
+    this.issuerCurves = ImmutableMap.copyOf(issuerCurves);
+    validate();
+  }
+
+  @Override
+  public LegalEntityDiscountingProvider.Meta metaBean() {
+    return LegalEntityDiscountingProvider.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the valuation date.
+   * All curves and other data items in this provider are calibrated for this date.
+   * @return the value of the property, not null
+   */
+  public LocalDate getValuationDate() {
+    return valuationDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the bond group map.
+   * <p>
+   * This map is used to convert the {@link StandardId} that identifies the bond to
+   * the associated bond group in order to lookup a repo curve.
+   * <p>
+   * See {@link LegalEntityDiscountingProvider#repoCurveDiscountFactors(StandardId, StandardId, Currency)}.
+   * @return the value of the property, not null
+   */
+  private ImmutableMap<StandardId, BondGroup> getBondMap() {
+    return bondMap;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the repo curves, defaulted to an empty map.
+   * The curve data, predicting the future, associated with each bond group and currency.
+   * @return the value of the property, not null
+   */
+  private ImmutableMap<Pair<BondGroup, Currency>, DiscountFactors> getRepoCurves() {
+    return repoCurves;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the legal entity group map.
+   * <p>
+   * This map is used to convert the {@link StandardId} that identifies the legal entity to
+   * the associated legal entity group in order to lookup an issuer curve.
+   * <p>
+   * See {@link LegalEntityDiscountingProvider#issuerCurveDiscountFactors(StandardId, Currency)}.
+   * @return the value of the property, not empty
+   */
+  private ImmutableMap<StandardId, LegalEntityGroup> getLegalEntityMap() {
+    return legalEntityMap;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the issuer curves.
+   * The curve data, predicting the future, associated with each legal entity group and currency.
+   * @return the value of the property, not empty
+   */
+  private ImmutableMap<Pair<LegalEntityGroup, Currency>, DiscountFactors> getIssuerCurves() {
+    return issuerCurves;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      LegalEntityDiscountingProvider other = (LegalEntityDiscountingProvider) obj;
+      return JodaBeanUtils.equal(getValuationDate(), other.getValuationDate()) &&
+          JodaBeanUtils.equal(getBondMap(), other.getBondMap()) &&
+          JodaBeanUtils.equal(getRepoCurves(), other.getRepoCurves()) &&
+          JodaBeanUtils.equal(getLegalEntityMap(), other.getLegalEntityMap()) &&
+          JodaBeanUtils.equal(getIssuerCurves(), other.getIssuerCurves());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(getValuationDate());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getBondMap());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getRepoCurves());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getLegalEntityMap());
+    hash = hash * 31 + JodaBeanUtils.hashCode(getIssuerCurves());
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(192);
+    buf.append("LegalEntityDiscountingProvider{");
+    buf.append("valuationDate").append('=').append(getValuationDate()).append(',').append(' ');
+    buf.append("bondMap").append('=').append(getBondMap()).append(',').append(' ');
+    buf.append("repoCurves").append('=').append(getRepoCurves()).append(',').append(' ');
+    buf.append("legalEntityMap").append('=').append(getLegalEntityMap()).append(',').append(' ');
+    buf.append("issuerCurves").append('=').append(JodaBeanUtils.toString(getIssuerCurves()));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code LegalEntityDiscountingProvider}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code valuationDate} property.
+     */
+    private final MetaProperty<LocalDate> valuationDate = DirectMetaProperty.ofImmutable(
+        this, "valuationDate", LegalEntityDiscountingProvider.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code bondMap} property.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    private final MetaProperty<ImmutableMap<StandardId, BondGroup>> bondMap = DirectMetaProperty.ofImmutable(
+        this, "bondMap", LegalEntityDiscountingProvider.class, (Class) ImmutableMap.class);
+    /**
+     * The meta-property for the {@code repoCurves} property.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    private final MetaProperty<ImmutableMap<Pair<BondGroup, Currency>, DiscountFactors>> repoCurves = DirectMetaProperty.ofImmutable(
+        this, "repoCurves", LegalEntityDiscountingProvider.class, (Class) ImmutableMap.class);
+    /**
+     * The meta-property for the {@code legalEntityMap} property.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    private final MetaProperty<ImmutableMap<StandardId, LegalEntityGroup>> legalEntityMap = DirectMetaProperty.ofImmutable(
+        this, "legalEntityMap", LegalEntityDiscountingProvider.class, (Class) ImmutableMap.class);
+    /**
+     * The meta-property for the {@code issuerCurves} property.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    private final MetaProperty<ImmutableMap<Pair<LegalEntityGroup, Currency>, DiscountFactors>> issuerCurves = DirectMetaProperty.ofImmutable(
+        this, "issuerCurves", LegalEntityDiscountingProvider.class, (Class) ImmutableMap.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "valuationDate",
+        "bondMap",
+        "repoCurves",
+        "legalEntityMap",
+        "issuerCurves");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 113107279:  // valuationDate
+          return valuationDate;
+        case 63526809:  // bondMap
+          return bondMap;
+        case 587630454:  // repoCurves
+          return repoCurves;
+        case 1085102016:  // legalEntityMap
+          return legalEntityMap;
+        case -1909076611:  // issuerCurves
+          return issuerCurves;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public LegalEntityDiscountingProvider.Builder builder() {
+      return new LegalEntityDiscountingProvider.Builder();
+    }
+
+    @Override
+    public Class<? extends LegalEntityDiscountingProvider> beanType() {
+      return LegalEntityDiscountingProvider.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code valuationDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> valuationDate() {
+      return valuationDate;
+    }
+
+    /**
+     * The meta-property for the {@code bondMap} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ImmutableMap<StandardId, BondGroup>> bondMap() {
+      return bondMap;
+    }
+
+    /**
+     * The meta-property for the {@code repoCurves} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ImmutableMap<Pair<BondGroup, Currency>, DiscountFactors>> repoCurves() {
+      return repoCurves;
+    }
+
+    /**
+     * The meta-property for the {@code legalEntityMap} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ImmutableMap<StandardId, LegalEntityGroup>> legalEntityMap() {
+      return legalEntityMap;
+    }
+
+    /**
+     * The meta-property for the {@code issuerCurves} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ImmutableMap<Pair<LegalEntityGroup, Currency>, DiscountFactors>> issuerCurves() {
+      return issuerCurves;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 113107279:  // valuationDate
+          return ((LegalEntityDiscountingProvider) bean).getValuationDate();
+        case 63526809:  // bondMap
+          return ((LegalEntityDiscountingProvider) bean).getBondMap();
+        case 587630454:  // repoCurves
+          return ((LegalEntityDiscountingProvider) bean).getRepoCurves();
+        case 1085102016:  // legalEntityMap
+          return ((LegalEntityDiscountingProvider) bean).getLegalEntityMap();
+        case -1909076611:  // issuerCurves
+          return ((LegalEntityDiscountingProvider) bean).getIssuerCurves();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code LegalEntityDiscountingProvider}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<LegalEntityDiscountingProvider> {
+
+    private LocalDate valuationDate;
+    private Map<StandardId, BondGroup> bondMap = ImmutableMap.of();
+    private Map<Pair<BondGroup, Currency>, DiscountFactors> repoCurves = ImmutableMap.of();
+    private Map<StandardId, LegalEntityGroup> legalEntityMap = ImmutableMap.of();
+    private Map<Pair<LegalEntityGroup, Currency>, DiscountFactors> issuerCurves = ImmutableMap.of();
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(LegalEntityDiscountingProvider beanToCopy) {
+      this.valuationDate = beanToCopy.getValuationDate();
+      this.bondMap = beanToCopy.getBondMap();
+      this.repoCurves = beanToCopy.getRepoCurves();
+      this.legalEntityMap = beanToCopy.getLegalEntityMap();
+      this.issuerCurves = beanToCopy.getIssuerCurves();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 113107279:  // valuationDate
+          return valuationDate;
+        case 63526809:  // bondMap
+          return bondMap;
+        case 587630454:  // repoCurves
+          return repoCurves;
+        case 1085102016:  // legalEntityMap
+          return legalEntityMap;
+        case -1909076611:  // issuerCurves
+          return issuerCurves;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 113107279:  // valuationDate
+          this.valuationDate = (LocalDate) newValue;
+          break;
+        case 63526809:  // bondMap
+          this.bondMap = (Map<StandardId, BondGroup>) newValue;
+          break;
+        case 587630454:  // repoCurves
+          this.repoCurves = (Map<Pair<BondGroup, Currency>, DiscountFactors>) newValue;
+          break;
+        case 1085102016:  // legalEntityMap
+          this.legalEntityMap = (Map<StandardId, LegalEntityGroup>) newValue;
+          break;
+        case -1909076611:  // issuerCurves
+          this.issuerCurves = (Map<Pair<LegalEntityGroup, Currency>, DiscountFactors>) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public LegalEntityDiscountingProvider build() {
+      preBuild(this);
+      return new LegalEntityDiscountingProvider(
+          valuationDate,
+          bondMap,
+          repoCurves,
+          legalEntityMap,
+          issuerCurves);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the valuation date.
+     * All curves and other data items in this provider are calibrated for this date.
+     * @param valuationDate  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder valuationDate(LocalDate valuationDate) {
+      JodaBeanUtils.notNull(valuationDate, "valuationDate");
+      this.valuationDate = valuationDate;
+      return this;
+    }
+
+    /**
+     * Sets the bond group map.
+     * <p>
+     * This map is used to convert the {@link StandardId} that identifies the bond to
+     * the associated bond group in order to lookup a repo curve.
+     * <p>
+     * See {@link LegalEntityDiscountingProvider#repoCurveDiscountFactors(StandardId, StandardId, Currency)}.
+     * @param bondMap  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder bondMap(Map<StandardId, BondGroup> bondMap) {
+      JodaBeanUtils.notNull(bondMap, "bondMap");
+      this.bondMap = bondMap;
+      return this;
+    }
+
+    /**
+     * Sets the repo curves, defaulted to an empty map.
+     * The curve data, predicting the future, associated with each bond group and currency.
+     * @param repoCurves  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder repoCurves(Map<Pair<BondGroup, Currency>, DiscountFactors> repoCurves) {
+      JodaBeanUtils.notNull(repoCurves, "repoCurves");
+      this.repoCurves = repoCurves;
+      return this;
+    }
+
+    /**
+     * Sets the legal entity group map.
+     * <p>
+     * This map is used to convert the {@link StandardId} that identifies the legal entity to
+     * the associated legal entity group in order to lookup an issuer curve.
+     * <p>
+     * See {@link LegalEntityDiscountingProvider#issuerCurveDiscountFactors(StandardId, Currency)}.
+     * @param legalEntityMap  the new value, not empty
+     * @return this, for chaining, not null
+     */
+    public Builder legalEntityMap(Map<StandardId, LegalEntityGroup> legalEntityMap) {
+      JodaBeanUtils.notEmpty(legalEntityMap, "legalEntityMap");
+      this.legalEntityMap = legalEntityMap;
+      return this;
+    }
+
+    /**
+     * Sets the issuer curves.
+     * The curve data, predicting the future, associated with each legal entity group and currency.
+     * @param issuerCurves  the new value, not empty
+     * @return this, for chaining, not null
+     */
+    public Builder issuerCurves(Map<Pair<LegalEntityGroup, Currency>, DiscountFactors> issuerCurves) {
+      JodaBeanUtils.notEmpty(issuerCurves, "issuerCurves");
+      this.issuerCurves = issuerCurves;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(192);
+      buf.append("LegalEntityDiscountingProvider.Builder{");
+      buf.append("valuationDate").append('=').append(JodaBeanUtils.toString(valuationDate)).append(',').append(' ');
+      buf.append("bondMap").append('=').append(JodaBeanUtils.toString(bondMap)).append(',').append(' ');
+      buf.append("repoCurves").append('=').append(JodaBeanUtils.toString(repoCurves)).append(',').append(' ');
+      buf.append("legalEntityMap").append('=').append(JodaBeanUtils.toString(legalEntityMap)).append(',').append(' ');
+      buf.append("issuerCurves").append('=').append(JodaBeanUtils.toString(issuerCurves));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondProductPricer.java
@@ -1,0 +1,959 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate.bond;
+
+import java.time.LocalDate;
+
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.schedule.Schedule;
+import com.opengamma.strata.basics.schedule.SchedulePeriod;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.finance.Security;
+import com.opengamma.strata.finance.rate.bond.ExpandedFixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondPaymentPeriod;
+import com.opengamma.strata.finance.rate.bond.YieldConvention;
+import com.opengamma.strata.market.sensitivity.IssuerCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.sensitivity.RepoCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.ZeroRateSensitivity;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+import com.opengamma.strata.market.value.RepoCurveDiscountFactors;
+import com.opengamma.strata.math.impl.function.Function1D;
+import com.opengamma.strata.math.impl.rootfinding.BracketRoot;
+import com.opengamma.strata.math.impl.rootfinding.BrentSingleRootFinder;
+import com.opengamma.strata.math.impl.rootfinding.RealSingleRootFinder;
+import com.opengamma.strata.pricer.DiscountingPaymentPricer;
+import com.opengamma.strata.pricer.impl.bond.DiscountingFixedCouponBondPaymentPeriodPricer;
+import com.opengamma.strata.pricer.rate.LegalEntityDiscountingProvider;
+
+/**
+ * Pricer for for rate fixed coupon bond products.
+ * <p>
+ * This function provides the ability to price a {@link FixedCouponBond}.
+ */
+public class DiscountingFixedCouponBondProductPricer {
+
+  /**
+   * Default implementation.
+   */
+  public static final DiscountingFixedCouponBondProductPricer DEFAULT = new DiscountingFixedCouponBondProductPricer(
+      DiscountingFixedCouponBondPaymentPeriodPricer.DEFAULT,
+      DiscountingPaymentPricer.DEFAULT);
+
+  /**
+   * The root finder.
+   */
+  private static final RealSingleRootFinder ROOT_FINDER = new BrentSingleRootFinder();
+  /**
+   * Brackets a root.
+   */
+  private static final BracketRoot ROOT_BRACKETER = new BracketRoot();
+
+  /**
+   * Pricer for {@link Payment}.
+   */
+  private final DiscountingPaymentPricer nominalPricer;
+  /**
+   * Pricer for {@link FixedCouponBondPaymentPeriod}.
+   */
+  private final DiscountingFixedCouponBondPaymentPeriodPricer periodPricer;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param periodPricer  the pricer for {@link FixedCouponBondPaymentPeriod}
+   * @param nominalPricer  the pricer for {@link Payment}
+   */
+  public DiscountingFixedCouponBondProductPricer(
+      DiscountingFixedCouponBondPaymentPeriodPricer periodPricer,
+      DiscountingPaymentPricer nominalPricer) {
+
+    this.nominalPricer = ArgChecker.notNull(nominalPricer, "nominalPricer");
+    this.periodPricer = ArgChecker.notNull(periodPricer, "periodPricer");
+  }
+
+  //-------------------------------------------------------------------------
+
+  /**
+   * Calculates the present value of the fixed coupon bond product.
+   * <p>
+   * The present value of the product is the value on the valuation date.
+   * The result is expressed using the payment currency of the bond.
+   * <p>
+   * Coupon payments of the product are considered based on the valuation date. 
+   * 
+   * @param product  the product to price
+   * @param provider  the rates provider
+   * @return the present value of the fixed coupon bond product
+   */
+  public CurrencyAmount presentValue(FixedCouponBond product, LegalEntityDiscountingProvider provider) {
+    return presentValue(product, provider, provider.getValuationDate());
+  }
+
+  // calculate the present value
+  CurrencyAmount presentValue(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider,
+      LocalDate referenceDate) {
+
+    ExpandedFixedCouponBond expanded = product.expand();
+    IssuerCurveDiscountFactors discountFactors = provider.issuerCurveDiscountFactors(
+        product.getLegalEntityId(), product.getCurrency());
+    CurrencyAmount pvNominal =
+        nominalPricer.presentValue(expanded.getNominalPayment(), discountFactors.getDiscountFactors());
+    CurrencyAmount pvCoupon =
+        presentValueCoupon(expanded, discountFactors, referenceDate, product.getExCouponPeriod().getDays() != 0);
+    return pvNominal.plus(pvCoupon);
+  }
+
+  /**
+   * Calculates the present value of the fixed coupon bond product with z-spread. 
+   * <p>
+   * The present value of the product is the value on the valuation date.
+   * The result is expressed using the payment currency of the bond.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or
+   * periodic compounded rates of the issuer discounting curve. 
+   * 
+   * @param product  the product to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value of the fixed coupon bond product
+   */
+  public CurrencyAmount presentValueWithZSpread(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    return presentValueWithZSpread(product, provider, zSpread, periodic, periodsPerYear, provider.getValuationDate());
+  }
+
+  // calculate the present value
+  CurrencyAmount presentValueWithZSpread(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear,
+      LocalDate referenceDate) {
+
+    ExpandedFixedCouponBond expanded = product.expand();
+    IssuerCurveDiscountFactors discountFactors = provider.issuerCurveDiscountFactors(
+        product.getLegalEntityId(), product.getCurrency());
+    CurrencyAmount pvNominal = nominalPricer.presentValue(
+        expanded.getNominalPayment(), discountFactors.getDiscountFactors(), zSpread, periodic, periodsPerYear);
+    boolean isExCoupon = product.getExCouponPeriod().getDays() != 0;
+    CurrencyAmount pvCoupon = presentValueCouponFromZSpread(
+        expanded, discountFactors, zSpread, periodic, periodsPerYear, referenceDate, isExCoupon);
+    return pvNominal.plus(pvCoupon);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the dirty price of the fixed coupon bond.
+   * <p>
+   * The fixed coupon bond is represented as {@link Security} where standard ID of the bond is stored.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @return the dirty price of the fixed coupon bond security
+   */
+  public double dirtyPriceFromCurves(Security<FixedCouponBond> security, LegalEntityDiscountingProvider provider) {
+    FixedCouponBond product = security.getProduct();
+    LocalDate settlementDate = product.getSettlementDateOffset().adjust(provider.getValuationDate());
+    return dirtyPriceFromCurves(security, provider, settlementDate);
+  }
+
+  /**
+   * Calculates the dirty price of the fixed coupon bond under the specified settlement date.
+   * <p>
+   * The fixed coupon bond is represented as {@link Security} where standard ID of the bond is stored.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @param settlementDate  the settlement date
+   * @return the dirty price of the fixed coupon bond security
+   */
+  public double dirtyPriceFromCurves(
+      Security<FixedCouponBond> security,
+      LegalEntityDiscountingProvider provider,
+      LocalDate settlementDate) {
+
+    FixedCouponBond product = security.getProduct();
+    CurrencyAmount pv = presentValue(product, provider, settlementDate);
+    StandardId securityId = security.getStandardId();
+    StandardId legalEntityId = product.getLegalEntityId();
+    double df = provider.repoCurveDiscountFactors(
+        securityId, legalEntityId, product.getCurrency()).discountFactor(settlementDate);
+    double notional = product.getNotional();
+    return pv.getAmount() / df / notional;
+  }
+
+  /**
+   * Calculates the dirty price of the fixed coupon bond with z-spread.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * The fixed coupon bond is represented as {@link Security} where standard ID of the bond is stored.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the dirty price of the fixed coupon bond security
+   */
+  public double dirtyPriceFromCurvesWithZSpread(
+      Security<FixedCouponBond> security,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    FixedCouponBond product = security.getProduct();
+    LocalDate settlementDate = product.getSettlementDateOffset().adjust(provider.getValuationDate());
+    return dirtyPriceFromCurvesWithZSpread(security, provider, zSpread, periodic, periodsPerYear, settlementDate);
+  }
+
+  /**
+   * Calculates the dirty price of the fixed coupon bond under the specified settlement date with z-spread.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * The fixed coupon bond is represented as {@link Security} where standard ID of the bond is stored.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @param settlementDate  the settlement date
+   * @return the dirty price of the fixed coupon bond security
+   */
+  public double dirtyPriceFromCurvesWithZSpread(
+      Security<FixedCouponBond> security,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear,
+      LocalDate settlementDate) {
+
+    FixedCouponBond product = security.getProduct();
+    CurrencyAmount pv = presentValueWithZSpread(product, provider, zSpread, periodic, periodsPerYear, settlementDate);
+    StandardId securityId = security.getStandardId();
+    StandardId legalEntityId = product.getLegalEntityId();
+    double df = provider.repoCurveDiscountFactors(
+        securityId, legalEntityId, product.getCurrency()).discountFactor(settlementDate);
+    double notional = product.getNotional();
+    return pv.getAmount() / df / notional;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the dirty price of the fixed coupon bond from its settlement date and clean price.
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param cleanPrice  the clean price
+   * @return the present value of the fixed coupon bond product
+   */
+  public double dirtyPriceFromCleanPrice(FixedCouponBond product, LocalDate settlementDate, double cleanPrice) {
+    double notional = product.getNotional();
+    double accruedInterest = accruedInterest(product, settlementDate);
+    return cleanPrice + accruedInterest / notional;
+  }
+
+  /**
+   * Calculates the clean price of the fixed coupon bond from its settlement date and dirty price.
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param dirtyPrice  the dirty price
+   * @return the present value of the fixed coupon bond product
+   */
+  public double cleanPriceFromDirtyPrice(FixedCouponBond product, LocalDate settlementDate, double dirtyPrice) {
+    double notional = product.getNotional();
+    double accruedInterest = accruedInterest(product, settlementDate);
+    return dirtyPrice - accruedInterest / notional;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the z-spread of the fixed coupon bond from curves and dirty price.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve associated to the bond (Issuer Entity)
+   * to match the dirty price.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @param dirtyPrice  the dirtyPrice
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the z-spread of the fixed coupon bond security
+   */
+  public double zSpreadFromCurvesAndDirtyPrice(
+      Security<FixedCouponBond> security,
+      LegalEntityDiscountingProvider provider,
+      double dirtyPrice,
+      boolean periodic,
+      int periodsPerYear) {
+
+    final Function1D<Double, Double> residual = new Function1D<Double, Double>() {
+      @Override
+      public Double evaluate(final Double z) {
+        return dirtyPriceFromCurvesWithZSpread(security, provider, z, periodic, periodsPerYear) - dirtyPrice;
+      }
+    };
+    double[] range = ROOT_BRACKETER.getBracketedPoints(residual, -0.01, 0.01); // Starting range is [-1%, 1%]
+    return ROOT_FINDER.getRoot(residual, range[0], range[1]);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the present value sensitivity of the fixed coupon bond product.
+   * <p>
+   * The present value sensitivity of the product is the sensitivity of the present value to
+   * the underlying curves.
+   * 
+   * @param product  the product to price
+   * @param provider  the rates provider
+   * @return the present value curve sensitivity of the product
+   */
+  public PointSensitivityBuilder presentValueSensitivity(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider) {
+    return presentValueSensitivity(product, provider, provider.getValuationDate());
+  }
+
+  // calculate the present value sensitivity
+  PointSensitivityBuilder presentValueSensitivity(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider,
+      LocalDate referenceDate) {
+
+    ExpandedFixedCouponBond expanded = product.expand();
+    IssuerCurveDiscountFactors discountFactors = provider.issuerCurveDiscountFactors(
+        product.getLegalEntityId(), product.getCurrency());
+    PointSensitivityBuilder pvNominal = presentValueSensitivityNominal(expanded, discountFactors);
+    PointSensitivityBuilder pvCoupon = presentValueSensitivityCoupon(
+        expanded, discountFactors, referenceDate, product.getExCouponPeriod().getDays() != 0);
+    return pvNominal.combinedWith(pvCoupon);
+  }
+
+  /**
+   * Calculates the present value sensitivity of the fixed coupon bond with z-spread.
+   * <p>
+   * The present value sensitivity of the product is the sensitivity of the present value to
+   * the underlying curves.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or
+   * periodic compounded rates of the issuer discounting curve. 
+   * 
+   * @param product  the product to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value curve sensitivity of the product
+   */
+  public PointSensitivityBuilder presentValueSensitivityWithZSpread(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    return presentValueSensitivityWithZSpread(
+        product, provider, zSpread, periodic, periodsPerYear, provider.getValuationDate());
+  }
+
+  // calculate the present value sensitivity
+  PointSensitivityBuilder presentValueSensitivityWithZSpread(
+      FixedCouponBond product,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear,
+      LocalDate referenceDate) {
+
+    ExpandedFixedCouponBond expanded = product.expand();
+    IssuerCurveDiscountFactors discountFactors = provider.issuerCurveDiscountFactors(
+        product.getLegalEntityId(), product.getCurrency());
+    PointSensitivityBuilder pvNominal = presentValueSensitivityNominalFromZSpread(
+        expanded, discountFactors, zSpread, periodic, periodsPerYear);
+    boolean isExCoupon = product.getExCouponPeriod().getDays() != 0;
+    PointSensitivityBuilder pvCoupon = presentValueSensitivityCouponFromZSpread(
+        expanded, discountFactors, zSpread, periodic, periodsPerYear, referenceDate, isExCoupon);
+    return pvNominal.combinedWith(pvCoupon);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the dirty price sensitivity of the fixed coupon bond product.
+   * <p>
+   * The dirty price sensitivity of the security is the sensitivity of the present value to
+   * the underlying curves.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @return the dirty price value curve sensitivity of the security
+   */
+  public PointSensitivityBuilder dirtyPriceSensitivity(
+      Security<FixedCouponBond> security,
+      LegalEntityDiscountingProvider provider) {
+
+    FixedCouponBond product = security.getProduct();
+    LocalDate settlementDate = product.getSettlementDateOffset().adjust(provider.getValuationDate());
+    StandardId securityId = security.getStandardId();
+    StandardId legalEntityId = product.getLegalEntityId();
+    RepoCurveDiscountFactors discountFactors =
+        provider.repoCurveDiscountFactors(securityId, legalEntityId, product.getCurrency());
+    double df = discountFactors.discountFactor(settlementDate);
+    CurrencyAmount pv = presentValue(product, provider);
+    double notional = product.getNotional();
+    PointSensitivityBuilder pvSensi = presentValueSensitivity(product, provider).multipliedBy(1d / df / notional);
+    RepoCurveZeroRateSensitivity dfSensi = discountFactors.zeroRatePointSensitivity(settlementDate)
+        .multipliedBy(-pv.getAmount() / df / df / notional);
+    return pvSensi.combinedWith(dfSensi);
+  }
+
+  /**
+   * Calculates the dirty price sensitivity of the fixed coupon bond with z-spread.
+   * <p>
+   * The dirty price sensitivity of the security is the sensitivity of the present value to
+   * the underlying curves.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * 
+   * @param security  the security to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the dirty price curve sensitivity of the security
+   */
+  public PointSensitivityBuilder dirtyPriceSensitivityWithZspread(
+      Security<FixedCouponBond> security,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    FixedCouponBond product = security.getProduct();
+    LocalDate settlementDate = product.getSettlementDateOffset().adjust(provider.getValuationDate());
+    StandardId securityId = security.getStandardId();
+    StandardId legalEntityId = product.getLegalEntityId();
+    RepoCurveDiscountFactors discountFactors =
+        provider.repoCurveDiscountFactors(securityId, legalEntityId, product.getCurrency());
+    double df = discountFactors.discountFactor(settlementDate);
+    CurrencyAmount pv = presentValueWithZSpread(product, provider, zSpread, periodic, periodsPerYear);
+    double notional = product.getNotional();
+    PointSensitivityBuilder pvSensi = presentValueSensitivityWithZSpread(
+        product, provider, zSpread, periodic, periodsPerYear).multipliedBy(1d / df / notional);
+    RepoCurveZeroRateSensitivity dfSensi = discountFactors.zeroRatePointSensitivity(settlementDate)
+        .multipliedBy(-pv.getAmount() / df / df / notional);
+    return pvSensi.combinedWith(dfSensi);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the accrued interest of the fixed coupon bond with the specified settlement date.
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @return the accrued interest of the product 
+   */
+  public double accruedInterest(FixedCouponBond product, LocalDate settlementDate) {
+    Schedule scheduleAdjusted = product.getPeriodicSchedule().createSchedule();
+    Schedule scheduleUnadjusted = scheduleAdjusted.toUnadjusted();
+    if (scheduleUnadjusted.getPeriods().get(0).getStartDate().isAfter(settlementDate)) {
+      return 0d;
+    }
+    double notional = product.getNotional();
+    int couponIndex = couponIndex(scheduleUnadjusted, settlementDate);
+    SchedulePeriod schedulePeriod = scheduleUnadjusted.getPeriod(couponIndex);
+    LocalDate previousAccrualDate = schedulePeriod.getStartDate();
+    LocalDate paymentDate = scheduleAdjusted.getPeriod(couponIndex).getEndDate();
+    double fixedRate = product.getFixedRate();
+    double accruedInterest = product.getDayCount()
+        .yearFraction(previousAccrualDate, settlementDate, scheduleUnadjusted) * fixedRate * notional;
+    DaysAdjustment exCouponDays = product.getExCouponPeriod();
+    double result = 0d;
+    if (exCouponDays.getDays() != 0 && settlementDate.isAfter(exCouponDays.adjust(paymentDate))) {
+      result = accruedInterest - notional * fixedRate *
+          schedulePeriod.yearFraction(product.getDayCount(), scheduleUnadjusted);
+    } else {
+      result = accruedInterest;
+    }
+    return result;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the dirty price of the fixed coupon bond from yield.
+   * <p>
+   * The yield must be fractional.
+   * The dirty price is computed for {@link YieldConvention}, and the result is expressed in fraction. 
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param yield  the yield
+   * @return the dirty price of the product 
+   */
+  public double dirtyPriceFromYield(FixedCouponBond product, LocalDate settlementDate, double yield) {
+    ExpandedFixedCouponBond expanded = product.expand();
+    ImmutableList<FixedCouponBondPaymentPeriod> payments = expanded.getPeriodicPayments();
+    int nCoupon = payments.size() - couponIndex(payments, settlementDate);
+    YieldConvention yieldConvention = product.getYieldConvention();
+    if (nCoupon == 1) {
+      if (yieldConvention.equals(YieldConvention.US_STREET) || yieldConvention.equals(YieldConvention.GERMAN_BONDS)) {
+        FixedCouponBondPaymentPeriod payment = payments.get(payments.size() - 1);
+        return (1d + payment.getFixedRate() * payment.getYearFraction()) /
+            (1d + factorToNextCoupon(product, expanded, settlementDate) * yield /
+                ((double) product.getPeriodicSchedule().getFrequency().eventsPerYear()));
+      }
+    }
+    if ((yieldConvention.equals(YieldConvention.US_STREET)) ||
+        (yieldConvention.equals(YieldConvention.UK_BUMP_DMO)) ||
+        (yieldConvention.equals(YieldConvention.GERMAN_BONDS))) {
+      return dirtyPriceFromYieldStandard(product, expanded, settlementDate, yield);
+    }
+    if (yieldConvention.equals(YieldConvention.JAPAN_SIMPLE)) {
+      LocalDate maturityDate = product.getPeriodicSchedule().getEndDate();
+      if (settlementDate.isAfter(maturityDate)) {
+        return 0d;
+      }
+      double maturity = product.getDayCount().relativeYearFraction(settlementDate, maturityDate);
+      double cleanPrice = (1d + product.getFixedRate() * maturity) / (1d + yield * maturity);
+      return dirtyPriceFromCleanPrice(product, settlementDate, cleanPrice);
+    }
+    throw new UnsupportedOperationException("The convention " + yieldConvention.name() + " is not supported.");
+  }
+
+  private double dirtyPriceFromYieldStandard(FixedCouponBond product, ExpandedFixedCouponBond expanded,
+      LocalDate settlementDate, double yield) {
+    int nbCoupon = expanded.getPeriodicPayments().size();
+    double factorOnPeriod = 1 + yield / ((double) product.getPeriodicSchedule().getFrequency().eventsPerYear());
+    double fixedRate = product.getFixedRate();
+    double pvAtFirstCoupon = 0;
+    int pow = 0;
+    for (int loopcpn = 0; loopcpn < nbCoupon; loopcpn++) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(loopcpn);
+      if ((product.getExCouponPeriod().getDays() != 0 && !settlementDate.isAfter(payment.getDetachmentDate())) ||
+          (product.getExCouponPeriod().getDays() == 0 && payment.getPaymentDate().isAfter(settlementDate))) {
+        pvAtFirstCoupon += fixedRate * payment.getYearFraction() / Math.pow(factorOnPeriod, pow);
+        ++pow;
+      }
+    }
+    pvAtFirstCoupon += 1d / Math.pow(factorOnPeriod, pow - 1);
+    return pvAtFirstCoupon * Math.pow(factorOnPeriod, -factorToNextCoupon(product, expanded, settlementDate));
+  }
+
+  /**
+   * Calculates the yield of the fixed coupon bond product from dirty price.
+   * <p>
+   * The dirty price must be fractional. 
+   * If the analytic formula is not available, the yield is computed by solving
+   * a root-finding problem with {@link #dirtyPriceFromYield(FixedCouponBond, LocalDate, double)}.  
+   * The result is also expressed in fraction. 
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param dirtyPrice  the dirty price
+   * @return the yield of the product 
+   */
+  public double yieldFromDirtyPrice(FixedCouponBond product, LocalDate settlementDate, double dirtyPrice) {
+    if (product.getYieldConvention().equals(YieldConvention.JAPAN_SIMPLE)) {
+      double cleanPrice = cleanPriceFromDirtyPrice(product, settlementDate, dirtyPrice);
+      LocalDate maturityDate = product.getPeriodicSchedule().getEndDate();
+      double maturity = product.getDayCount().relativeYearFraction(settlementDate, maturityDate);
+      return (product.getFixedRate() + (1d - cleanPrice) / maturity) / cleanPrice;
+    }
+
+    final Function1D<Double, Double> priceResidual = new Function1D<Double, Double>() {
+      @Override
+      public Double evaluate(final Double y) {
+        return dirtyPriceFromYield(product, settlementDate, y) - dirtyPrice;
+      }
+    };
+    double[] range = ROOT_BRACKETER.getBracketedPoints(priceResidual, 0.00, 0.20);
+    double yield = ROOT_FINDER.getRoot(priceResidual, range[0], range[1]);
+    return yield;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the modified duration of the fixed coupon bond product from yield.
+   * <p>
+   * The modified duration is defined as the minus of the first derivative of dirty price
+   * with respect to yield, divided by the dirty price. 
+   * <p>
+   * The input yield must be fractional. The dirty price and its derivative are
+   * computed for {@link YieldConvention}, and the result is expressed in fraction. 
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param yield  the yield
+   * @return the modified duration of the product 
+   */
+  public double modifiedDurationFromYield(FixedCouponBond product, LocalDate settlementDate, double yield) {
+    ExpandedFixedCouponBond expanded = product.expand();
+    ImmutableList<FixedCouponBondPaymentPeriod> payments = expanded.getPeriodicPayments();
+    int nCoupon = payments.size() - couponIndex(payments, settlementDate);
+    YieldConvention yieldConvention = product.getYieldConvention();
+    if (nCoupon == 1) {
+      if (yieldConvention.equals(YieldConvention.US_STREET) || yieldConvention.equals(YieldConvention.GERMAN_BONDS)) {
+        double couponPerYear = product.getPeriodicSchedule().getFrequency().eventsPerYear();
+        double factor = factorToNextCoupon(product, expanded, settlementDate);
+        return factor / couponPerYear / (1d + factor * yield / couponPerYear);
+      }
+    }
+    if (yieldConvention.equals(YieldConvention.US_STREET) ||
+        yieldConvention.equals(YieldConvention.UK_BUMP_DMO) ||
+        yieldConvention.equals(YieldConvention.GERMAN_BONDS)) {
+      return modifiedDurationFromYieldStandard(product, expanded, settlementDate, yield);
+    }
+    if (yieldConvention.equals(YieldConvention.JAPAN_SIMPLE)) {
+      LocalDate maturityDate = product.getPeriodicSchedule().getEndDate();
+      if (settlementDate.isAfter(maturityDate)) {
+        return 0d;
+      }
+      double maturity = product.getDayCount().relativeYearFraction(settlementDate, maturityDate);
+      double num = 1d + product.getFixedRate() * maturity;
+      double den = 1d + yield * maturity;
+      double dirtyPrice = dirtyPriceFromCleanPrice(product, settlementDate, num / den);
+      return num * maturity / den / den / dirtyPrice;
+    }
+    throw new UnsupportedOperationException("The convention " + yieldConvention.name() + " is not supported.");
+  }
+
+  private double modifiedDurationFromYieldStandard(FixedCouponBond product, ExpandedFixedCouponBond expanded,
+      LocalDate settlementDate, double yield) {
+    int nbCoupon = expanded.getPeriodicPayments().size();
+    double couponPerYear = product.getPeriodicSchedule().getFrequency().eventsPerYear();
+    double factorToNextCoupon = factorToNextCoupon(product, expanded, settlementDate);
+    double factorOnPeriod = 1 + yield / couponPerYear;
+    double nominal = product.getNotional();
+    double fixedRate = product.getFixedRate();
+    double mdAtFirstCoupon = 0d;
+    double pvAtFirstCoupon = 0d;
+    int pow = 0;
+    for (int loopcpn = 0; loopcpn < nbCoupon; loopcpn++) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(loopcpn);
+      if ((product.getExCouponPeriod().getDays() != 0 && !settlementDate.isAfter(payment.getDetachmentDate())) ||
+          (product.getExCouponPeriod().getDays() == 0 && payment.getPaymentDate().isAfter(settlementDate))) {
+        mdAtFirstCoupon += payment.getYearFraction() / Math.pow(factorOnPeriod, pow + 1) *
+            (pow + factorToNextCoupon) / couponPerYear;
+        pvAtFirstCoupon += payment.getYearFraction() / Math.pow(factorOnPeriod, pow);
+        ++pow;
+      }
+    }
+    mdAtFirstCoupon *= fixedRate * nominal;
+    pvAtFirstCoupon *= fixedRate * nominal;
+    mdAtFirstCoupon += nominal / Math.pow(factorOnPeriod, pow) * (pow - 1 + factorToNextCoupon) /
+        couponPerYear;
+    pvAtFirstCoupon += nominal / Math.pow(factorOnPeriod, pow - 1);
+    double md = mdAtFirstCoupon / pvAtFirstCoupon;
+    return md;
+  }
+
+  /**
+   * Calculates the Macaulay duration of the fixed coupon bond product from yield.
+   * <p>
+   * Macaulay defined an alternative way of weighting the future cash flows. 
+   * <p>
+   * The input yield must be fractional. The dirty price and its derivative are
+   * computed for {@link YieldConvention}, and the result is expressed in fraction. 
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param yield  the yield
+   * @return the modified duration of the product 
+   */
+  public double macaulayDurationFromYield(FixedCouponBond product, LocalDate settlementDate, double yield) {
+    ExpandedFixedCouponBond expanded = product.expand();
+    ImmutableList<FixedCouponBondPaymentPeriod> payments = expanded.getPeriodicPayments();
+    int nCoupon = payments.size() - couponIndex(payments, settlementDate);
+    YieldConvention yieldConvention = product.getYieldConvention();
+    if ((yieldConvention.equals(YieldConvention.US_STREET)) && (nCoupon == 1)) {
+      return factorToNextCoupon(product, expanded, settlementDate) /
+          product.getPeriodicSchedule().getFrequency().eventsPerYear();
+    }
+    if ((yieldConvention.equals(YieldConvention.US_STREET)) ||
+        (yieldConvention.equals(YieldConvention.UK_BUMP_DMO)) ||
+        (yieldConvention.equals(YieldConvention.GERMAN_BONDS))) {
+      return modifiedDurationFromYield(product, settlementDate, yield) *
+          (1d + yield / product.getPeriodicSchedule().getFrequency().eventsPerYear());
+    }
+    throw new UnsupportedOperationException("The convention " + yieldConvention.name() + " is not supported.");
+  }
+
+  /**
+   * Calculates the convexity of the fixed coupon bond product from yield.
+   * <p>
+   * The convexity is defined as the second derivative of dirty price with respect
+   * to yield, divided by the dirty price. 
+   * <p>
+   * The input yield must be fractional. The dirty price and its derivative are
+   * computed for {@link YieldConvention}, and the result is expressed in fraction. 
+   * 
+   * @param product  the product to price
+   * @param settlementDate  the settlement date
+   * @param yield  the yield
+   * @return the convexity of the product 
+   */
+  public double convexityFromYield(FixedCouponBond product, LocalDate settlementDate, double yield) {
+    ExpandedFixedCouponBond expanded = product.expand();
+    ImmutableList<FixedCouponBondPaymentPeriod> payments = expanded.getPeriodicPayments();
+    int nCoupon = payments.size() - couponIndex(payments, settlementDate);
+    YieldConvention yieldConvention = product.getYieldConvention();
+    if (nCoupon == 1) {
+      if (yieldConvention.equals(YieldConvention.US_STREET) || yieldConvention.equals(YieldConvention.GERMAN_BONDS)) {
+        double couponPerYear = product.getPeriodicSchedule().getFrequency().eventsPerYear();
+        double factorToNextCoupon = factorToNextCoupon(product, expanded, settlementDate);
+        double timeToPay = factorToNextCoupon / couponPerYear;
+        double disc = (1d + factorToNextCoupon * yield / couponPerYear);
+        return 2d * timeToPay * timeToPay / (disc * disc);
+      }
+    }
+    if (yieldConvention.equals(YieldConvention.US_STREET) || yieldConvention.equals(YieldConvention.UK_BUMP_DMO) ||
+        yieldConvention.equals(YieldConvention.GERMAN_BONDS)) {
+      return convexityFromYieldStandard(product, expanded, settlementDate, yield);
+    }
+    if (yieldConvention.equals(YieldConvention.JAPAN_SIMPLE)) {
+      LocalDate maturityDate = product.getPeriodicSchedule().getEndDate();
+      if (settlementDate.isAfter(maturityDate)) {
+        return 0d;
+      }
+      double maturity = product.getDayCount().relativeYearFraction(settlementDate, maturityDate);
+      double num = 1d + product.getFixedRate() * maturity;
+      double den = 1d + yield * maturity;
+      double dirtyPrice = dirtyPriceFromCleanPrice(product, settlementDate, num / den);
+      return 2d * num * Math.pow(maturity, 2) * Math.pow(den, -3) / dirtyPrice;
+    }
+    throw new UnsupportedOperationException("The convention " + yieldConvention.name() + " is not supported.");
+  }
+
+  // assumes notional and coupon rate are constant across the payments. 
+  private double convexityFromYieldStandard(FixedCouponBond product, ExpandedFixedCouponBond expanded,
+      LocalDate settlementDate, double yield) {
+    int nbCoupon = expanded.getPeriodicPayments().size();
+    double couponPerYear = product.getPeriodicSchedule().getFrequency().eventsPerYear();
+    double factorToNextCoupon = factorToNextCoupon(product, expanded, settlementDate);
+    double factorOnPeriod = 1 + yield / couponPerYear;
+    double nominal = product.getNotional();
+    double fixedRate = product.getFixedRate();
+    double cvAtFirstCoupon = 0;
+    double pvAtFirstCoupon = 0;
+    int pow = 0;
+    for (int loopcpn = 0; loopcpn < nbCoupon; loopcpn++) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(loopcpn);
+      if ((product.getExCouponPeriod().getDays() != 0 && !settlementDate.isAfter(payment.getDetachmentDate())) ||
+          (product.getExCouponPeriod().getDays() == 0 && payment.getPaymentDate().isAfter(settlementDate))) {
+        cvAtFirstCoupon += payment.getYearFraction() / Math.pow(factorOnPeriod, pow + 2) *
+            (pow + factorToNextCoupon) * (pow + factorToNextCoupon + 1);
+        pvAtFirstCoupon += payment.getYearFraction() / Math.pow(factorOnPeriod, pow);
+        ++pow;
+      }
+    }
+    cvAtFirstCoupon *= fixedRate * nominal / (couponPerYear * couponPerYear);
+    pvAtFirstCoupon *= fixedRate * nominal;
+    cvAtFirstCoupon += nominal / Math.pow(factorOnPeriod, pow + 1) * (pow - 1 + factorToNextCoupon) *
+        (pow + factorToNextCoupon) / (couponPerYear * couponPerYear);
+    pvAtFirstCoupon += nominal / Math.pow(factorOnPeriod, pow - 1);
+    final double pv = pvAtFirstCoupon * Math.pow(factorOnPeriod, -factorToNextCoupon);
+    final double cv = cvAtFirstCoupon * Math.pow(factorOnPeriod, -factorToNextCoupon) / pv;
+    return cv;
+  }
+
+  //-------------------------------------------------------------------------
+  private double factorToNextCoupon(FixedCouponBond product, ExpandedFixedCouponBond expanded, LocalDate settlementDate) {
+    if (expanded.getPeriodicPayments().get(0).getStartDate().isAfter(settlementDate)) {
+      return 0d;
+    }
+    int couponIndex = couponIndex(expanded.getPeriodicPayments(), settlementDate);
+    double factorSpot = accruedInterest(product, settlementDate) / product.getFixedRate() / product.getNotional();
+    double factorPeriod = expanded.getPeriodicPayments().get(couponIndex).getYearFraction();
+    return (factorPeriod - factorSpot) / factorPeriod;
+  }
+
+  private int couponIndex(Schedule schedule, LocalDate date) {
+    int nbCoupon = schedule.getPeriods().size();
+    int couponIndex = 0;
+    for (int loopcpn = 0; loopcpn < nbCoupon; ++loopcpn) {
+      if (schedule.getPeriods().get(loopcpn).getEndDate().isAfter(date)) {
+        couponIndex = loopcpn;
+        break;
+      }
+    }
+    return couponIndex;
+  }
+
+  private int couponIndex(ImmutableList<FixedCouponBondPaymentPeriod> list, LocalDate date) {
+    int nbCoupon = list.size();
+    int couponIndex = 0;
+    for (int loopcpn = 0; loopcpn < nbCoupon; ++loopcpn) {
+      if (list.get(loopcpn).getEndDate().isAfter(date)) {
+        couponIndex = loopcpn;
+        break;
+      }
+    }
+    return couponIndex;
+  }
+
+  //-------------------------------------------------------------------------
+  private CurrencyAmount presentValueCoupon(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors,
+      LocalDate referenceDate,
+      boolean exCoupon) {
+    double total = 0d;
+    for (FixedCouponBondPaymentPeriod period : product.getPeriodicPayments()) {
+      if ((exCoupon && period.getDetachmentDate().isAfter(referenceDate)) ||
+          (!exCoupon && period.getPaymentDate().isAfter(referenceDate))) {
+        total += periodPricer.presentValue(period, discountFactors);
+      }
+    }
+    return CurrencyAmount.of(product.getCurrency(), total);
+  }
+
+  private CurrencyAmount presentValueCouponFromZSpread(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear,
+      LocalDate referenceDate,
+      boolean exCoupon) {
+    double total = 0d;
+    for (FixedCouponBondPaymentPeriod period : product.getPeriodicPayments()) {
+      if ((exCoupon && period.getDetachmentDate().isAfter(referenceDate)) ||
+          (!exCoupon && period.getPaymentDate().isAfter(referenceDate))) {
+        total += periodPricer.presentValueWithSpread(period, discountFactors, zSpread, periodic, periodsPerYear);
+      }
+    }
+    return CurrencyAmount.of(product.getCurrency(), total);
+  }
+
+  //-------------------------------------------------------------------------
+  private PointSensitivityBuilder presentValueSensitivityCoupon(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors,
+      LocalDate referenceDate,
+      boolean exCoupon) {
+    PointSensitivityBuilder builder = PointSensitivityBuilder.none();
+    for (FixedCouponBondPaymentPeriod period : product.getPeriodicPayments()) {
+      if ((exCoupon && period.getDetachmentDate().isAfter(referenceDate)) ||
+          (!exCoupon && period.getPaymentDate().isAfter(referenceDate))) {
+        builder = builder.combinedWith(periodPricer.presentValueSensitivity(period, discountFactors));
+      }
+    }
+    return builder;
+  }
+
+  private PointSensitivityBuilder presentValueSensitivityCouponFromZSpread(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear,
+      LocalDate referenceDate,
+      boolean exCoupon) {
+    PointSensitivityBuilder builder = PointSensitivityBuilder.none();
+    for (FixedCouponBondPaymentPeriod period : product.getPeriodicPayments()) {
+      if ((exCoupon && period.getDetachmentDate().isAfter(referenceDate)) ||
+          (!exCoupon && period.getPaymentDate().isAfter(referenceDate))) {
+        builder = builder.combinedWith(
+            periodPricer.presentValueSensitivityWithSpread(period, discountFactors, zSpread, periodic, periodsPerYear));
+      }
+    }
+    return builder;
+  }
+
+  private PointSensitivityBuilder presentValueSensitivityNominal(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors) {
+    Payment nominal = product.getNominalPayment();
+    PointSensitivityBuilder pt = nominalPricer.presentValueSensitivity(nominal, discountFactors.getDiscountFactors());
+    if (pt instanceof ZeroRateSensitivity) {
+      return IssuerCurveZeroRateSensitivity.of((ZeroRateSensitivity) pt, discountFactors.getLegalEntityGroup());
+    }
+    return pt; // NoPointSensitivity
+  }
+
+  private PointSensitivityBuilder presentValueSensitivityNominalFromZSpread(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+    Payment nominal = product.getNominalPayment();
+    PointSensitivityBuilder pt = nominalPricer.presentValueSensitivity(
+        nominal, discountFactors.getDiscountFactors(), zSpread, periodic, periodsPerYear);
+    if (pt instanceof ZeroRateSensitivity) {
+      return IssuerCurveZeroRateSensitivity.of((ZeroRateSensitivity) pt, discountFactors.getLegalEntityGroup());
+    }
+    return pt; // NoPointSensitivity
+  }
+
+  //-------------------------------------------------------------------------
+  // compute pv of coupon payment(s) s.t. referenceDate1 < coupon <= referenceDate2
+  double presentValueCoupon(
+      ExpandedFixedCouponBond product,
+      IssuerCurveDiscountFactors discountFactors,
+      LocalDate referenceDate1,
+      LocalDate referenceDate2,
+      boolean exCoupon) {
+    double pvDiff = 0d;
+    for (FixedCouponBondPaymentPeriod period : product.getPeriodicPayments()) {
+      if ((exCoupon && period.getDetachmentDate().isAfter(referenceDate1) && !period.getDetachmentDate().isAfter(referenceDate2)) ||
+          (!exCoupon && period.getPaymentDate().isAfter(referenceDate1) && !period.getPaymentDate().isAfter(referenceDate2))) {
+        pvDiff += periodPricer.presentValue(period, discountFactors);
+      }
+    }
+    return pvDiff;
+  }
+
+  // compute pv of coupon payment(s) s.t. referenceDate1 < coupon <= referenceDate2
+  double presentValueCouponWithZSpread(
+      ExpandedFixedCouponBond expanded,
+      IssuerCurveDiscountFactors discountFactors,
+      LocalDate referenceDate1,
+      LocalDate referenceDate2,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear,
+      boolean exCoupon) {
+    double pvDiff = 0d;
+    for (FixedCouponBondPaymentPeriod period : expanded.getPeriodicPayments()) {
+      if ((exCoupon && period.getDetachmentDate().isAfter(referenceDate1) && !period.getDetachmentDate().isAfter(referenceDate2)) ||
+          (!exCoupon && period.getPaymentDate().isAfter(referenceDate1) && !period.getPaymentDate().isAfter(referenceDate2))) {
+        pvDiff += periodPricer.presentValueWithSpread(
+            period, discountFactors, zSpread, periodic, periodsPerYear);
+      }
+    }
+    return pvDiff;
+  }
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondTradePricer.java
@@ -1,0 +1,317 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate.bond;
+
+import java.time.LocalDate;
+
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.finance.Security;
+import com.opengamma.strata.finance.rate.bond.ExpandedFixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondTrade;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.sensitivity.RepoCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.ZeroRateSensitivity;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+import com.opengamma.strata.market.value.RepoCurveDiscountFactors;
+import com.opengamma.strata.pricer.DiscountingPaymentPricer;
+import com.opengamma.strata.pricer.rate.LegalEntityDiscountingProvider;
+
+/**
+ * Pricer for for rate fixed coupon bond trades.
+ * <p>
+ * This function provides the ability to price a {@link FixedCouponBondTrade}.
+ */
+public class DiscountingFixedCouponBondTradePricer {
+
+  /**
+   * Default implementation.
+   */
+  public static final DiscountingFixedCouponBondTradePricer DEFAULT = new DiscountingFixedCouponBondTradePricer(
+      DiscountingFixedCouponBondProductPricer.DEFAULT,
+      DiscountingPaymentPricer.DEFAULT);
+
+  /**
+   * Pricer for {@link FixedCouponBond}.
+   */
+  private final DiscountingFixedCouponBondProductPricer productPricer;
+  /**
+   * Pricer for {@link Payment}.
+   */
+  private final DiscountingPaymentPricer paymentPricer;
+
+  /**
+   * Creates an instance.
+   * 
+   * @param productPricer  the pricer for {@link FixedCouponBond}
+   * @param paymentPricer  the pricer for {@link Payment}
+  */
+  public DiscountingFixedCouponBondTradePricer(
+      DiscountingFixedCouponBondProductPricer productPricer,
+      DiscountingPaymentPricer paymentPricer) {
+
+    this.productPricer = ArgChecker.notNull(productPricer, "productPricer");
+    this.paymentPricer = ArgChecker.notNull(paymentPricer, "paymentPricer");
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the present value of the fixed coupon bond trade.
+   * <p>
+   * The present value of the trade is the value on the valuation date.
+   * The result is expressed using the payment currency of the bond.
+   * <p>
+   * Coupon payments of the underlying product are considered based on the settlement date of the trade. 
+   * 
+   * @param trade  the trade to price
+   * @param provider  the rates provider
+   * @return the present value of the fixed coupon bond trade
+   */
+  public CurrencyAmount presentValue(FixedCouponBondTrade trade, LegalEntityDiscountingProvider provider) {
+    LocalDate settlementDate = trade.getTradeInfo().getSettlementDate().get();
+    CurrencyAmount pvProduct = productPricer.presentValue(trade.getProduct(), provider, settlementDate);
+    return presentValueFromProductPresentValue(trade, provider, pvProduct);
+  }
+
+  /**
+   * Calculates the present value of the fixed coupon bond trade with z-spread.
+   * <p>
+   * The present value of the trade is the value on the valuation date.
+   * The result is expressed using the payment currency of the bond.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * Coupon payments of the underlying product are considered based on the settlement date of the trade. 
+   * 
+   * @param trade  the trade to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value of the fixed coupon bond trade
+   */
+  public CurrencyAmount presentValueWithZSpread(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    LocalDate settlementDate = trade.getTradeInfo().getSettlementDate().get();
+    CurrencyAmount pvProduct = productPricer.presentValueWithZSpread(
+        trade.getProduct(), provider, zSpread, periodic, periodsPerYear, settlementDate);
+    return presentValueFromProductPresentValue(trade, provider, pvProduct);
+  }
+
+  private CurrencyAmount presentValueFromProductPresentValue(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider,
+      CurrencyAmount productPresentValue) {
+    CurrencyAmount pvProduct = productPresentValue.multipliedBy(trade.getQuantity());
+    CurrencyAmount pvPayment = presentValuePayment(trade, provider);
+    return pvProduct.plus(pvPayment);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the present value of the fixed coupon bond trade from the clean price of the underlying product.
+   * <p>
+   * The present value of the trade is the value on the valuation date.
+   * The result is expressed using the payment currency of the bond.
+   * <p>
+   * Coupon payments of the underlying product are considered based on the settlement date of the trade. 
+   * 
+   * @param trade  the trade to price
+   * @param provider  the rates provider
+   * @param cleanPrice  the clean price
+   * @return the present value of the fixed coupon bond trade
+   */
+  public CurrencyAmount presentValueFromCleanPrice(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider,
+      double cleanPrice) {
+
+    Security<FixedCouponBond> security = trade.getSecurity();
+    FixedCouponBond product = security.getProduct();
+    LocalDate standardSettlementDate = product.getSettlementDateOffset().adjust(provider.getValuationDate());
+    LocalDate tradeSettlementDate = trade.getTradeInfo().getSettlementDate().get();
+    StandardId securityId = security.getStandardId();
+    StandardId legalEntityId = product.getLegalEntityId();
+    Currency currency = product.getCurrency();
+    double df = provider.repoCurveDiscountFactors(securityId, legalEntityId, currency).discountFactor(standardSettlementDate);
+    double pvStandard =
+        (cleanPrice * product.getNotional() + productPricer.accruedInterest(product, standardSettlementDate)) * df;
+    if (standardSettlementDate.isEqual(tradeSettlementDate)) {
+      return presentValueFromProductPresentValue(trade, provider, CurrencyAmount.of(currency, pvStandard));
+    }
+    // check coupon payment between two settlement dates
+    IssuerCurveDiscountFactors discountFactors = provider.issuerCurveDiscountFactors(legalEntityId, currency);
+    ExpandedFixedCouponBond expanded = product.expand();
+    boolean exCoupon = product.getExCouponPeriod().getDays() != 0;
+    double pvDiff = 0d;
+    if (standardSettlementDate.isAfter(tradeSettlementDate)) {
+      pvDiff = productPricer.presentValueCoupon(
+          expanded, discountFactors, tradeSettlementDate, standardSettlementDate, exCoupon);
+    } else {
+      pvDiff = -productPricer.presentValueCoupon(
+          expanded, discountFactors, standardSettlementDate, tradeSettlementDate, exCoupon);
+    }
+    return presentValueFromProductPresentValue(trade, provider, CurrencyAmount.of(currency, pvStandard + pvDiff));
+  }
+
+  /**
+   * Calculates the present value of the fixed coupon bond trade with z-spread from the
+   * clean price of the underlying product.
+   * <p>
+   * The present value of the trade is the value on the valuation date.
+   * The result is expressed using the payment currency of the bond.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * Coupon payments of the underlying product are considered based on the settlement date of the trade. 
+   * 
+   * @param trade  the trade to price
+   * @param provider  the rates provider
+   * @param cleanPrice  the clean price
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value of the fixed coupon bond trade
+   */
+  public CurrencyAmount presentValueFromCleanPriceWithZSpread(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider,
+      double cleanPrice,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    Security<FixedCouponBond> security = trade.getSecurity();
+    FixedCouponBond product = security.getProduct();
+    LocalDate standardSettlementDate = product.getSettlementDateOffset().adjust(provider.getValuationDate());
+    LocalDate tradeSettlementDate = trade.getTradeInfo().getSettlementDate().get();
+    StandardId securityId = security.getStandardId();
+    StandardId legalEntityId = product.getLegalEntityId();
+    Currency currency = product.getCurrency();
+    double df = provider.repoCurveDiscountFactors(securityId, legalEntityId, currency).discountFactor(
+        standardSettlementDate);
+    double pvStandard =
+        (cleanPrice * product.getNotional() + productPricer.accruedInterest(product, standardSettlementDate)) * df;
+    if (standardSettlementDate.isEqual(tradeSettlementDate)) {
+      return presentValueFromProductPresentValue(trade, provider, CurrencyAmount.of(currency, pvStandard));
+    }
+    // check coupon payment between two settlement dates
+    IssuerCurveDiscountFactors discountFactors = provider.issuerCurveDiscountFactors(legalEntityId, currency);
+    ExpandedFixedCouponBond expanded = product.expand();
+    boolean exCoupon = product.getExCouponPeriod().getDays() != 0;
+    double pvDiff = 0d;
+    if (standardSettlementDate.isAfter(tradeSettlementDate)) {
+      pvDiff = productPricer.presentValueCouponWithZSpread(
+          expanded, discountFactors, tradeSettlementDate, standardSettlementDate, zSpread, periodic, periodsPerYear, exCoupon);
+    } else {
+      pvDiff = -productPricer.presentValueCouponWithZSpread(
+          expanded, discountFactors, standardSettlementDate, tradeSettlementDate, zSpread, periodic, periodsPerYear, exCoupon);
+    }
+    return presentValueFromProductPresentValue(trade, provider, CurrencyAmount.of(currency, pvStandard + pvDiff));
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the present value sensitivity of the fixed coupon bond trade.
+   * <p>
+   * The present value sensitivity of the trade is the sensitivity of the present value to
+   * the underlying curves.
+   * <p>
+   * Coupon payments of the underlying product are considered based on the settlement date of the trade. 
+   * 
+   * @param trade  the trade to price
+   * @param provider  the rates provider
+   * @return the present value curve sensitivity of the trade
+   */
+  public PointSensitivityBuilder presentValueSensitivity(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider) {
+
+    LocalDate settlementDate = trade.getTradeInfo().getSettlementDate().get();
+    PointSensitivityBuilder sensiProduct = productPricer.presentValueSensitivity(
+        trade.getProduct(), provider, settlementDate);
+    return presnetValueSensitivityFromProductPresentValueSensitivity(trade, provider, sensiProduct);
+  }
+
+  /**
+   * Calculates the present value sensitivity of the fixed coupon bond trade with z-spread.
+   * <p>
+   * The present value sensitivity of the trade is the sensitivity of the present value to
+   * the underlying curves.
+   * <p>
+   * The z-spread is a parallel shift applied to continuously compounded rates or periodic
+   * compounded rates of the discounting curve.
+   * <p>
+   * Coupon payments of the underlying product are considered based on the settlement date of the trade. 
+   * 
+   * @param trade  the trade to price
+   * @param provider  the rates provider
+   * @param zSpread  the z-spread
+   * @param periodic  if true, the spread is added to periodic compounded rates,
+   *  if false, the spread is added to continuously compounded rates
+   * @param periodsPerYear  the number of periods per year
+   * @return the present value curve sensitivity of the trade
+   */
+  public PointSensitivityBuilder presentValueSensitivityWithZSpread(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider,
+      double zSpread,
+      boolean periodic,
+      int periodsPerYear) {
+
+    LocalDate settlementDate = trade.getTradeInfo().getSettlementDate().get();
+    PointSensitivityBuilder sensiProduct = productPricer.presentValueSensitivityWithZSpread(
+        trade.getProduct(), provider, zSpread, periodic, periodsPerYear, settlementDate);
+    return presnetValueSensitivityFromProductPresentValueSensitivity(trade, provider, sensiProduct);
+  }
+
+  private PointSensitivityBuilder presnetValueSensitivityFromProductPresentValueSensitivity(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider,
+      PointSensitivityBuilder productPresnetValueSensitivity) {
+
+    PointSensitivityBuilder sensiProduct = productPresnetValueSensitivity.multipliedBy(trade.getQuantity());
+    PointSensitivityBuilder sensiPayment = presentValueSensitivityPayment(trade, provider);
+    return sensiProduct.combinedWith(sensiPayment);
+  }
+
+  //-------------------------------------------------------------------------
+  private CurrencyAmount presentValuePayment(FixedCouponBondTrade trade, LegalEntityDiscountingProvider provider) {
+    FixedCouponBond product = trade.getProduct();
+    RepoCurveDiscountFactors discountFactors = provider.repoCurveDiscountFactors(
+        product.getLegalEntityId(), trade.getSecurity().getStandardId(), product.getCurrency());
+    return paymentPricer.presentValue(trade.getPayment(), discountFactors.getDiscountFactors());
+  }
+
+  private PointSensitivityBuilder presentValueSensitivityPayment(
+      FixedCouponBondTrade trade,
+      LegalEntityDiscountingProvider provider) {
+
+    FixedCouponBond product = trade.getProduct();
+    RepoCurveDiscountFactors discountFactors = provider.repoCurveDiscountFactors(
+        product.getLegalEntityId(), trade.getSecurity().getStandardId(), product.getCurrency());
+    PointSensitivityBuilder pt = paymentPricer.presentValueSensitivity(
+        trade.getPayment(), discountFactors.getDiscountFactors());
+    if (pt instanceof ZeroRateSensitivity) {
+      return RepoCurveZeroRateSensitivity.of((ZeroRateSensitivity) pt, discountFactors.getBondGroup());
+    }
+    return pt; // NoPointSensitivity
+  }
+
+}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/bond/DiscountingFixedCouponBondPaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/bond/DiscountingFixedCouponBondPaymentPeriodPricerTest.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.impl.bond;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.currency.Currency.USD;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.interpolator.CurveInterpolator;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondPaymentPeriod;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.explain.ExplainKey;
+import com.opengamma.strata.market.explain.ExplainMap;
+import com.opengamma.strata.market.explain.ExplainMapBuilder;
+import com.opengamma.strata.market.sensitivity.IssuerCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+import com.opengamma.strata.market.value.LegalEntityGroup;
+import com.opengamma.strata.market.value.ZeroRateDiscountFactors;
+import com.opengamma.strata.math.impl.interpolation.Interpolator1DFactory;
+
+/**
+ * Test {@link DiscountingFixedCouponBondPaymentPeriodPricer}.
+ */
+@Test
+public class DiscountingFixedCouponBondPaymentPeriodPricerTest {
+
+  // issuer curves
+  private static final LocalDate VALUATION = date(2015, 1, 28);
+  private static final LocalDate VALUATION_AFTER = date(2015, 8, 28);
+  private static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.LINEAR_INSTANCE;
+  private static final CurveName NAME = CurveName.of("TestCurve");
+  private static final CurveMetadata METADATA = Curves.zeroRates(NAME, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE =
+      InterpolatedNodalCurve.of(METADATA, DoubleArray.of(0, 10), DoubleArray.of(0.1, 0.18), INTERPOLATOR);
+  private static final DiscountFactors DSC_FACTORS = ZeroRateDiscountFactors.of(GBP, VALUATION, CURVE);
+  private static final DiscountFactors DSC_FACTORS_AFTER = ZeroRateDiscountFactors.of(GBP, VALUATION_AFTER, CURVE);
+  private static final LegalEntityGroup GROUP = LegalEntityGroup.of("ISSUER1");
+  private static final IssuerCurveDiscountFactors ISSUER_CURVE = IssuerCurveDiscountFactors.of(DSC_FACTORS, GROUP);
+  private static final IssuerCurveDiscountFactors ISSUER_CURVE_AFTER =
+      IssuerCurveDiscountFactors.of(DSC_FACTORS_AFTER, GROUP);
+  // coupon payment
+  private static final LocalDate START = LocalDate.of(2015, 2, 2);
+  private static final LocalDate END = LocalDate.of(2015, 8, 2);
+  private static final LocalDate START_ADJUSTED = LocalDate.of(2015, 2, 2);
+  private static final LocalDate END_ADJUSTED = LocalDate.of(2015, 8, 3);
+  private static final double FIXED_RATE = 0.025;
+  private static final double NOTIONAL = 1.0e7;
+  private static final double YEAR_FRACTION = 0.51;
+  private static final FixedCouponBondPaymentPeriod PAYMENT_PERIOD = FixedCouponBondPaymentPeriod.builder()
+      .currency(USD)
+      .startDate(START_ADJUSTED)
+      .unadjustedStartDate(START)
+      .endDate(END_ADJUSTED)
+      .unadjustedEndDate(END)
+      .notional(NOTIONAL)
+      .fixedRate(FIXED_RATE)
+      .yearFraction(YEAR_FRACTION)
+      .build();
+  /// z-spread
+  private static final double Z_SPREAD = 0.02;
+  private static final int PERIOD_PER_YEAR = 4;
+
+  private static final DiscountingFixedCouponBondPaymentPeriodPricer PRICER =
+      DiscountingFixedCouponBondPaymentPeriodPricer.DEFAULT;
+  private static final double TOL = 1.0e-12;
+
+  //-------------------------------------------------------------------------
+  public void test_presentValue() {
+    double computed = PRICER.presentValue(PAYMENT_PERIOD, ISSUER_CURVE);
+    double expected = FIXED_RATE * NOTIONAL * YEAR_FRACTION * DSC_FACTORS.discountFactor(END_ADJUSTED);
+    assertEquals(computed, expected);
+  }
+
+  public void test_presentValueWithSpread() {
+    double computed = PRICER.presentValueWithSpread(PAYMENT_PERIOD, ISSUER_CURVE, Z_SPREAD, true, PERIOD_PER_YEAR);
+    double expected = FIXED_RATE * NOTIONAL * YEAR_FRACTION *
+        DSC_FACTORS.discountFactorWithSpread(END_ADJUSTED, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed, expected);
+  }
+
+  public void test_futureValue() {
+    double computed = PRICER.futureValue(PAYMENT_PERIOD, ISSUER_CURVE);
+    double expected = FIXED_RATE * NOTIONAL * YEAR_FRACTION;
+    assertEquals(computed, expected);
+  }
+
+  public void test_presentValue_past() {
+    double computed = PRICER.presentValue(PAYMENT_PERIOD, ISSUER_CURVE_AFTER);
+    assertEquals(computed, 0d);
+  }
+
+  public void test_presentValueWithSpread_past() {
+    double computed = PRICER.presentValueWithSpread(PAYMENT_PERIOD, ISSUER_CURVE_AFTER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed, 0d);
+  }
+
+  public void test_futureValue_past() {
+    double computed = PRICER.futureValue(PAYMENT_PERIOD, ISSUER_CURVE_AFTER);
+    assertEquals(computed, 0d);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueSensitivity() {
+    PointSensitivityBuilder computed = PRICER.presentValueSensitivity(PAYMENT_PERIOD, ISSUER_CURVE);
+    PointSensitivityBuilder expected = IssuerCurveZeroRateSensitivity.of(
+        DSC_FACTORS.zeroRatePointSensitivity(END_ADJUSTED).multipliedBy(FIXED_RATE * NOTIONAL * YEAR_FRACTION), GROUP);
+    assertEquals(computed, expected);
+  }
+
+  public void test_presentValueSensitivityWithSpread() {
+    PointSensitivityBuilder computed = PRICER.presentValueSensitivityWithSpread(
+        PAYMENT_PERIOD, ISSUER_CURVE, Z_SPREAD, true, PERIOD_PER_YEAR);
+    PointSensitivityBuilder expected = IssuerCurveZeroRateSensitivity.of(
+        DSC_FACTORS.zeroRatePointSensitivityWithSpread(END_ADJUSTED, Z_SPREAD, true, PERIOD_PER_YEAR)
+            .multipliedBy(FIXED_RATE * NOTIONAL * YEAR_FRACTION), GROUP);
+    assertEquals(computed, expected);
+  }
+
+  public void test_futureValueSensitivity() {
+    PointSensitivityBuilder computed = PRICER.futureValueSensitivity(PAYMENT_PERIOD, ISSUER_CURVE);
+    assertEquals(computed, PointSensitivityBuilder.none());
+  }
+
+  public void test_presentValueSensitivity_past() {
+    PointSensitivityBuilder computed = PRICER.presentValueSensitivity(PAYMENT_PERIOD, ISSUER_CURVE_AFTER);
+    assertEquals(computed, PointSensitivityBuilder.none());
+  }
+
+  public void test_presentValueSensitivityWithSpread_past() {
+    PointSensitivityBuilder computed =
+        PRICER.presentValueSensitivityWithSpread(PAYMENT_PERIOD, ISSUER_CURVE_AFTER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed, PointSensitivityBuilder.none());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_explainPresentValue() {
+    ExplainMapBuilder builder = ExplainMap.builder();
+    PRICER.explainPresentValue(PAYMENT_PERIOD, ISSUER_CURVE, builder);
+    ExplainMap explain = builder.build();
+    assertEquals(explain.get(ExplainKey.ENTRY_TYPE).get(), "FixedCouponBondPaymentPeriod");
+    assertEquals(explain.get(ExplainKey.PAYMENT_DATE).get(), PAYMENT_PERIOD.getPaymentDate());
+    assertEquals(explain.get(ExplainKey.PAYMENT_CURRENCY).get(), PAYMENT_PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.START_DATE).get(), START_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_START_DATE).get(), START);
+    assertEquals(explain.get(ExplainKey.END_DATE).get(), END_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_END_DATE).get(), END);
+    assertEquals(explain.get(ExplainKey.ACCRUAL_DAYS).get().intValue(),
+        (int) DAYS.between(START_ADJUSTED, END_ADJUSTED));
+    assertEquals(explain.get(ExplainKey.DISCOUNT_FACTOR).get(), DSC_FACTORS.discountFactor(END_ADJUSTED));
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getAmount(),
+        FIXED_RATE * NOTIONAL * YEAR_FRACTION, NOTIONAL * TOL);
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getAmount(),
+        FIXED_RATE * NOTIONAL * YEAR_FRACTION * DSC_FACTORS.discountFactor(END_ADJUSTED), NOTIONAL * TOL);
+  }
+
+  public void test_explainPresentValue_past() {
+    ExplainMapBuilder builder = ExplainMap.builder();
+    PRICER.explainPresentValue(PAYMENT_PERIOD, ISSUER_CURVE_AFTER, builder);
+    ExplainMap explain = builder.build();
+    assertEquals(explain.get(ExplainKey.ENTRY_TYPE).get(), "FixedCouponBondPaymentPeriod");
+    assertEquals(explain.get(ExplainKey.PAYMENT_DATE).get(), PAYMENT_PERIOD.getPaymentDate());
+    assertEquals(explain.get(ExplainKey.PAYMENT_CURRENCY).get(), PAYMENT_PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.START_DATE).get(), START_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_START_DATE).get(), START);
+    assertEquals(explain.get(ExplainKey.END_DATE).get(), END_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_END_DATE).get(), END);
+    assertEquals(explain.get(ExplainKey.ACCRUAL_DAYS).get().intValue(),
+        (int) DAYS.between(START_ADJUSTED, END_ADJUSTED));
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getAmount(), 0d, NOTIONAL * TOL);
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getAmount(), 0d, NOTIONAL * TOL);
+  }
+
+  public void test_explainPresentValueWithSpread() {
+    ExplainMapBuilder builder = ExplainMap.builder();
+    PRICER.explainPresentValueWithSpread(PAYMENT_PERIOD, ISSUER_CURVE, builder, Z_SPREAD, true, PERIOD_PER_YEAR);
+    ExplainMap explain = builder.build();
+    assertEquals(explain.get(ExplainKey.ENTRY_TYPE).get(), "FixedCouponBondPaymentPeriod");
+    assertEquals(explain.get(ExplainKey.PAYMENT_DATE).get(), PAYMENT_PERIOD.getPaymentDate());
+    assertEquals(explain.get(ExplainKey.PAYMENT_CURRENCY).get(), PAYMENT_PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.START_DATE).get(), START_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_START_DATE).get(), START);
+    assertEquals(explain.get(ExplainKey.END_DATE).get(), END_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_END_DATE).get(), END);
+    assertEquals(explain.get(ExplainKey.ACCRUAL_DAYS).get().intValue(),
+        (int) DAYS.between(START_ADJUSTED, END_ADJUSTED));
+    assertEquals(explain.get(ExplainKey.DISCOUNT_FACTOR).get(),
+        DSC_FACTORS.discountFactorWithSpread(END_ADJUSTED, Z_SPREAD, true, PERIOD_PER_YEAR));
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getAmount(),
+        FIXED_RATE * NOTIONAL * YEAR_FRACTION, NOTIONAL * TOL);
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getAmount(), FIXED_RATE * NOTIONAL * YEAR_FRACTION *
+        DSC_FACTORS.discountFactorWithSpread(END_ADJUSTED, Z_SPREAD, true, PERIOD_PER_YEAR), NOTIONAL * TOL);
+  }
+
+  public void test_explainPresentValueWithSpread_past() {
+    ExplainMapBuilder builder = ExplainMap.builder();
+    PRICER.explainPresentValueWithSpread(PAYMENT_PERIOD, ISSUER_CURVE_AFTER, builder, Z_SPREAD, true, PERIOD_PER_YEAR);
+    ExplainMap explain = builder.build();
+    assertEquals(explain.get(ExplainKey.ENTRY_TYPE).get(), "FixedCouponBondPaymentPeriod");
+    assertEquals(explain.get(ExplainKey.PAYMENT_DATE).get(), PAYMENT_PERIOD.getPaymentDate());
+    assertEquals(explain.get(ExplainKey.PAYMENT_CURRENCY).get(), PAYMENT_PERIOD.getCurrency());
+    assertEquals(explain.get(ExplainKey.START_DATE).get(), START_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_START_DATE).get(), START);
+    assertEquals(explain.get(ExplainKey.END_DATE).get(), END_ADJUSTED);
+    assertEquals(explain.get(ExplainKey.UNADJUSTED_END_DATE).get(), END);
+    assertEquals(explain.get(ExplainKey.ACCRUAL_DAYS).get().intValue(),
+        (int) DAYS.between(START_ADJUSTED, END_ADJUSTED));
+    assertEquals(explain.get(ExplainKey.FUTURE_VALUE).get().getAmount(), 0d, NOTIONAL * TOL);
+    assertEquals(explain.get(ExplainKey.PRESENT_VALUE).get().getAmount(), 0d, NOTIONAL * TOL);
+  }
+
+}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/LegalEntityDiscountingProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/LegalEntityDiscountingProviderTest.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.currency.Currency.USD;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.interpolator.CurveInterpolator;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.sensitivity.IssuerCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
+import com.opengamma.strata.market.sensitivity.RepoCurveZeroRateSensitivity;
+import com.opengamma.strata.market.sensitivity.ZeroRateSensitivity;
+import com.opengamma.strata.market.value.BondGroup;
+import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+import com.opengamma.strata.market.value.LegalEntityGroup;
+import com.opengamma.strata.market.value.RepoCurveDiscountFactors;
+import com.opengamma.strata.market.value.ZeroRateDiscountFactors;
+import com.opengamma.strata.math.impl.interpolation.Interpolator1DFactory;
+
+/**
+ * Test {@link LegalEntityDiscountingProvider}.
+ */
+@Test
+public class LegalEntityDiscountingProviderTest {
+
+  private static final LocalDate DATE = date(2015, 6, 4);
+  private static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.LINEAR_INSTANCE;
+
+  private static final CurveName NAME_REPO = CurveName.of("TestRepoCurve");
+  private static final CurveMetadata METADATA_REPO = Curves.zeroRates(NAME_REPO, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE_REPO =
+      InterpolatedNodalCurve.of(METADATA_REPO, DoubleArray.of(0, 10), DoubleArray.of(1, 2), INTERPOLATOR);
+  private static final DiscountFactors DSC_FACTORS_REPO = ZeroRateDiscountFactors.of(GBP, DATE, CURVE_REPO);
+  private static final BondGroup GROUP_REPO_SECURITY = BondGroup.of("ISSUER1 BND 5Y");
+  private static final BondGroup GROUP_REPO_ISSUER = BondGroup.of("ISSUER1");
+  private static final StandardId ID_SECURITY = StandardId.of("OG-Ticker", "Bond-5Y");
+
+  private static final CurveName NAME_ISSUER = CurveName.of("TestIssuerCurve");
+  private static final CurveMetadata METADATA_ISSUER = Curves.zeroRates(NAME_ISSUER, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE_ISSUER =
+      InterpolatedNodalCurve.of(METADATA_ISSUER, DoubleArray.of(0, 15), DoubleArray.of(1, 2.5), INTERPOLATOR);
+  private static final DiscountFactors DSC_FACTORS_ISSUER = ZeroRateDiscountFactors.of(GBP, DATE, CURVE_ISSUER);
+  private static final LegalEntityGroup GROUP_ISSUER = LegalEntityGroup.of("ISSUER1");
+  private static final StandardId ID_ISSUER = StandardId.of("OG-Ticker", "Issuer-1");
+
+  //-------------------------------------------------------------------------
+  public void test_builder() {
+    LegalEntityDiscountingProvider test = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_SECURITY, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, GROUP_REPO_SECURITY))
+        .valuationDate(DATE)
+        .build();
+    assertEquals(
+        test.issuerCurveDiscountFactors(ID_ISSUER, GBP),
+        IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
+    assertEquals(test.repoCurveDiscountFactors(ID_SECURITY, ID_ISSUER, GBP),
+        RepoCurveDiscountFactors.of(DSC_FACTORS_REPO, GROUP_REPO_SECURITY));
+    assertEquals(test.getValuationDate(), DATE);
+  }
+
+  public void test_builder_noValuationDate() {
+    LegalEntityDiscountingProvider test = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_ISSUER, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_ISSUER, GROUP_REPO_ISSUER))
+        .build();
+    assertEquals(
+        test.issuerCurveDiscountFactors(ID_ISSUER, GBP),
+        IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
+    assertEquals(test.repoCurveDiscountFactors(ID_SECURITY, ID_ISSUER, GBP),
+        RepoCurveDiscountFactors.of(DSC_FACTORS_REPO, GROUP_REPO_ISSUER));
+    assertEquals(test.getValuationDate(), DATE);
+
+  }
+
+  public void test_builder_noRepoRate() {
+    LegalEntityDiscountingProvider test = LegalEntityDiscountingProvider.builder()
+        .legalEntityMap(ImmutableMap.of(ID_ISSUER, GROUP_ISSUER))
+        .issuerCurves(ImmutableMap.of(Pair.of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .build();
+    assertEquals(
+        test.issuerCurveDiscountFactors(ID_ISSUER, GBP),
+        IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
+    assertEquals(test.getValuationDate(), DATE);
+  }
+
+  public void test_builder_fail() {
+    // no relevant map for repo curve
+    assertThrowsIllegalArg(() -> LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_ISSUER, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_ISSUER, BondGroup.of("ISSUER2 BND 5Y")))
+        .build());
+    // no relevant map for issuer curve
+    assertThrowsIllegalArg(() -> LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, LegalEntityGroup.of("ISSUER2")))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_ISSUER, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_ISSUER, GROUP_REPO_ISSUER))
+        .build());
+    // issuer curve is missing
+    assertThrowsIllegalArg(() -> LegalEntityDiscountingProvider.builder()
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_SECURITY, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, GROUP_REPO_SECURITY))
+        .valuationDate(DATE)
+        .build());
+    // issuer curve and valuation date are missing
+    assertThrowsIllegalArg(() -> LegalEntityDiscountingProvider.builder()
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_SECURITY, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, GROUP_REPO_SECURITY))
+        .build());
+    // issuer curve date is different from valuation date
+    DiscountFactors dscFactorIssuer = ZeroRateDiscountFactors.of(GBP, date(2015, 6, 14), CURVE_ISSUER);
+    assertThrowsIllegalArg(() -> LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), dscFactorIssuer))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_SECURITY, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, GROUP_REPO_SECURITY))
+        .valuationDate(DATE)
+        .build());
+    // repo curve rate is different from valuation date
+    DiscountFactors dscFactorRepo = ZeroRateDiscountFactors.of(GBP, date(2015, 6, 14), CURVE_REPO);
+    assertThrowsIllegalArg(() -> LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_SECURITY, GBP), dscFactorRepo))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, GROUP_REPO_SECURITY))
+        .valuationDate(DATE)
+        .build());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_discountFactor_notFound() {
+    StandardId issuerId = StandardId.of("OG-Ticker", "Issuer-2");
+    LegalEntityGroup issuerGroup = LegalEntityGroup.of("ISSUER2");
+    BondGroup bondGroup = BondGroup.of("ISSUER2 BND 5Y");
+    StandardId securityId = StandardId.of("OG-Ticker", "Issuer-2-bond-5Y");
+    LegalEntityDiscountingProvider test = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER, issuerId, issuerGroup))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_SECURITY, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, GROUP_REPO_SECURITY, issuerId, bondGroup))
+        .valuationDate(DATE)
+        .build();
+    assertThrowsIllegalArg(() -> test.issuerCurveDiscountFactors(ID_ISSUER, USD));
+    assertThrowsIllegalArg(() -> test.issuerCurveDiscountFactors(StandardId.of("OG-Ticker", "foo"), GBP));
+    assertThrowsIllegalArg(() -> test.issuerCurveDiscountFactors(issuerId, GBP));
+    assertThrowsIllegalArg(() -> test.repoCurveDiscountFactors(ID_SECURITY, ID_ISSUER, USD));
+    assertThrowsIllegalArg(() -> test.repoCurveDiscountFactors(
+        StandardId.of("OG-Ticker", "foo-bond"), StandardId.of("OG-Ticker", "foo"), GBP));
+    assertThrowsIllegalArg(() -> test.repoCurveDiscountFactors(securityId, issuerId, GBP));
+  }
+
+  public void test_curveParameterSensitivity() {
+    LegalEntityDiscountingProvider test = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_ISSUER, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_ISSUER, GROUP_REPO_ISSUER))
+        .valuationDate(DATE)
+        .build();
+    LocalDate refDate = date(2018, 11, 24);
+    IssuerCurveZeroRateSensitivity sensi1 = test.issuerCurveDiscountFactors(ID_ISSUER, GBP)
+        .zeroRatePointSensitivity(refDate, GBP);
+    RepoCurveZeroRateSensitivity sensi2 = test.repoCurveDiscountFactors(ID_SECURITY, ID_ISSUER, GBP)
+        .zeroRatePointSensitivity(refDate, GBP);
+    PointSensitivities sensi = PointSensitivities.of(sensi1, sensi2);
+    CurveCurrencyParameterSensitivities computed = test.curveParameterSensitivity(sensi);
+    CurveCurrencyParameterSensitivities expected =
+        DSC_FACTORS_ISSUER.curveParameterSensitivity(sensi1.createZeroRateSensitivity()).combinedWith(
+            DSC_FACTORS_REPO.curveParameterSensitivity(sensi2.createZeroRateSensitivity()));
+    assertTrue(computed.equalWithTolerance(expected, 1.0e-12));
+  }
+
+  public void test_curveParameterSensitivity_noSensi() {
+    LegalEntityDiscountingProvider test = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_ISSUER, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_ISSUER, GROUP_REPO_ISSUER))
+        .valuationDate(DATE)
+        .build();
+    ZeroRateSensitivity sensi = ZeroRateSensitivity.of(USD, date(2018, 11, 24), 25d);
+    CurveCurrencyParameterSensitivities computed = test.curveParameterSensitivity(sensi.build());
+    assertEquals(computed, CurveCurrencyParameterSensitivities.empty());
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    LegalEntityDiscountingProvider test1 = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), DSC_FACTORS_ISSUER))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ID_ISSUER, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO_ISSUER, GBP), DSC_FACTORS_REPO))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_ISSUER, GROUP_REPO_ISSUER))
+        .build();
+    coverImmutableBean(test1);
+    LocalDate val = date(2015, 6, 14);
+    DiscountFactors dscFactorIssuer = ZeroRateDiscountFactors.of(GBP, val, CURVE_ISSUER);
+    DiscountFactors dscFactorRepo = ZeroRateDiscountFactors.of(GBP, val, CURVE_REPO);
+    LegalEntityDiscountingProvider test2 = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, GBP), dscFactorIssuer))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(StandardId.of("OG-Ticker", "foo"), GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(BondGroup.of("ISSUER2 BND 5Y"), GBP), dscFactorRepo))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(ID_SECURITY, BondGroup.of("ISSUER2 BND 5Y")))
+        .build();
+    coverBeanEquals(test1, test2);
+  }
+
+}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondProductPricerTest.java
@@ -1,0 +1,797 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate.bond;
+
+import static com.opengamma.strata.basics.currency.Currency.EUR;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.joda.beans.MetaProperty;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
+import com.opengamma.strata.basics.date.BusinessDayConventions;
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.HolidayCalendar;
+import com.opengamma.strata.basics.date.HolidayCalendars;
+import com.opengamma.strata.basics.interpolator.CurveInterpolator;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.PeriodicSchedule;
+import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.finance.Security;
+import com.opengamma.strata.finance.UnitSecurity;
+import com.opengamma.strata.finance.rate.bond.ExpandedFixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondPaymentPeriod;
+import com.opengamma.strata.finance.rate.bond.YieldConvention;
+import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.curve.NodalCurve;
+import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.value.BondGroup;
+import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.IssuerCurveDiscountFactors;
+import com.opengamma.strata.market.value.LegalEntityGroup;
+import com.opengamma.strata.market.value.ZeroRateDiscountFactors;
+import com.opengamma.strata.math.impl.interpolation.Interpolator1DFactory;
+import com.opengamma.strata.pricer.DiscountingPaymentPricer;
+import com.opengamma.strata.pricer.impl.bond.DiscountingFixedCouponBondPaymentPeriodPricer;
+import com.opengamma.strata.pricer.rate.LegalEntityDiscountingProvider;
+
+/**
+ * Test
+ */
+@Test
+public class DiscountingFixedCouponBondProductPricerTest {
+  // fixed coupon bond
+  private static final StandardId SECURITY_ID = StandardId.of("OG-Ticker", "GOVT1-BOND1");
+  private static final StandardId ISSUER_ID = StandardId.of("OG-Ticker", "GOVT1");
+  private static final LocalDate VALUATION = date(2016, 4, 25);
+  private static final YieldConvention YIELD_CONVENTION = YieldConvention.GERMAN_BONDS;
+  private static final double NOTIONAL = 1.0e7;
+  private static final double FIXED_RATE = 0.015;
+  private static final HolidayCalendar EUR_CALENDAR = HolidayCalendars.EUTA;
+  private static final DaysAdjustment DATE_OFFSET = DaysAdjustment.ofBusinessDays(3, EUR_CALENDAR);
+  private static final DayCount DAY_COUNT = DayCounts.ACT_365F;
+  private static final LocalDate START_DATE = LocalDate.of(2015, 4, 12);
+  private static final LocalDate END_DATE = LocalDate.of(2025, 4, 12);
+  private static final BusinessDayAdjustment BUSINESS_ADJUST =
+      BusinessDayAdjustment.of(BusinessDayConventions.MODIFIED_FOLLOWING, EUR_CALENDAR);
+  private static final PeriodicSchedule PERIOD_SCHEDULE = PeriodicSchedule.of(
+      START_DATE, END_DATE, Frequency.P6M, BUSINESS_ADJUST, StubConvention.SHORT_INITIAL, false);
+  private static final DaysAdjustment EX_COUPON = DaysAdjustment.ofBusinessDays(-5, EUR_CALENDAR, BUSINESS_ADJUST);
+  /** nonzero ex-coupon period */
+  private static final FixedCouponBond PRODUCT = FixedCouponBond.builder()
+      .dayCount(DAY_COUNT)
+      .fixedRate(FIXED_RATE)
+      .legalEntityId(ISSUER_ID)
+      .currency(EUR)
+      .notional(NOTIONAL)
+      .periodicSchedule(PERIOD_SCHEDULE)
+      .settlementDateOffset(DATE_OFFSET)
+      .yieldConvention(YIELD_CONVENTION)
+      .exCouponPeriod(EX_COUPON)
+      .build();
+  private static final Security<FixedCouponBond> BOND_SECURITY =
+      UnitSecurity.builder(PRODUCT).standardId(SECURITY_ID).build();
+  /** no ex-coupon period */
+  private static final FixedCouponBond PRODUCT_NO_EXCOUPON = FixedCouponBond.builder()
+      .dayCount(DAY_COUNT)
+      .fixedRate(FIXED_RATE)
+      .legalEntityId(ISSUER_ID)
+      .currency(EUR)
+      .notional(NOTIONAL)
+      .periodicSchedule(PERIOD_SCHEDULE)
+      .settlementDateOffset(DATE_OFFSET)
+      .yieldConvention(YIELD_CONVENTION)
+      .build();
+
+  // rates provider
+  private static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.LINEAR_INSTANCE;
+  private static final CurveName NAME_REPO = CurveName.of("TestRepoCurve");
+  private static final CurveMetadata METADATA_REPO = Curves.zeroRates(NAME_REPO, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE_REPO = InterpolatedNodalCurve.of(
+      METADATA_REPO, DoubleArray.of(0.1, 2.0, 10.0), DoubleArray.of(0.05, 0.06, 0.09), INTERPOLATOR);
+  private static final DiscountFactors DSC_FACTORS_REPO = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO);
+  private static final BondGroup GROUP_REPO = BondGroup.of("GOVT1 BOND1");
+  private static final CurveName NAME_ISSUER = CurveName.of("TestIssuerCurve");
+  private static final CurveMetadata METADATA_ISSUER = Curves.zeroRates(NAME_ISSUER, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE_ISSUER = InterpolatedNodalCurve.of(
+      METADATA_ISSUER, DoubleArray.of(0.2, 9.0, 15.0), DoubleArray.of(0.03, 0.05, 0.13), INTERPOLATOR);
+  private static final DiscountFactors DSC_FACTORS_ISSUER = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_ISSUER);
+  private static final LegalEntityGroup GROUP_ISSUER = LegalEntityGroup.of("GOVT1");
+  private static final LegalEntityDiscountingProvider PROVIDER = LegalEntityDiscountingProvider.builder()
+      .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+          Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, EUR), DSC_FACTORS_ISSUER))
+      .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ISSUER_ID, GROUP_ISSUER))
+      .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+          Pair.<BondGroup, Currency>of(GROUP_REPO, EUR), DSC_FACTORS_REPO))
+      .bondMap(ImmutableMap.<StandardId, BondGroup>of(SECURITY_ID, GROUP_REPO))
+      .valuationDate(VALUATION)
+      .build();
+
+  // pricers
+  private static final DiscountingFixedCouponBondProductPricer PRICER = DiscountingFixedCouponBondProductPricer.DEFAULT;
+  private static final DiscountingPaymentPricer PRICER_NOMINAL = DiscountingPaymentPricer.DEFAULT;
+  private static final DiscountingFixedCouponBondPaymentPeriodPricer PRICER_COUPON =
+      DiscountingFixedCouponBondPaymentPeriodPricer.DEFAULT;
+
+  private static final double Z_SPREAD = 0.035;
+  private static final int PERIOD_PER_YEAR = 4;
+  private static final double TOL = 1.0e-12;
+  private static final double EPS = 1.0e-6;
+
+  //-------------------------------------------------------------------------
+  public void test_presentValue() {
+    CurrencyAmount computed = PRICER.presentValue(PRODUCT, PROVIDER);
+    ExpandedFixedCouponBond expanded = PRODUCT.expand();
+    CurrencyAmount expected = PRICER_NOMINAL.presentValue(expanded.getNominalPayment(), DSC_FACTORS_ISSUER);
+    int size = expanded.getPeriodicPayments().size();
+    double pvCupon = 0d;
+    for (int i = 2; i < size; ++i) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(i);
+      pvCupon += PRICER_COUPON.presentValue(payment, IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
+    }
+    expected = expected.plus(pvCupon);
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueWithZSpread_continuous() {
+    CurrencyAmount computed = PRICER.presentValueWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, false, 0);
+    ExpandedFixedCouponBond expanded = PRODUCT.expand();
+    CurrencyAmount expected = PRICER_NOMINAL.presentValue(
+        expanded.getNominalPayment(), DSC_FACTORS_ISSUER, Z_SPREAD, false, 0);
+    int size = expanded.getPeriodicPayments().size();
+    double pvcCupon = 0d;
+    for (int i = 2; i < size; ++i) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(i);
+      pvcCupon += PRICER_COUPON.presentValueWithSpread(
+          payment, IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER), Z_SPREAD, false, 0);
+    }
+    expected = expected.plus(pvcCupon);
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueWithZSpread_periodic() {
+    CurrencyAmount computed = PRICER.presentValueWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    ExpandedFixedCouponBond expanded = PRODUCT.expand();
+    CurrencyAmount expected = PRICER_NOMINAL.presentValue(
+        expanded.getNominalPayment(), DSC_FACTORS_ISSUER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    int size = expanded.getPeriodicPayments().size();
+    double pvcCupon = 0d;
+    for (int i = 2; i < size; ++i) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(i);
+      pvcCupon += PRICER_COUPON.presentValueWithSpread(
+          payment, IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER), Z_SPREAD, true, PERIOD_PER_YEAR);
+    }
+    expected = expected.plus(pvcCupon);
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValue_noExcoupon() {
+    CurrencyAmount computed = PRICER.presentValue(PRODUCT_NO_EXCOUPON, PROVIDER);
+    ExpandedFixedCouponBond expanded = PRODUCT.expand();
+    CurrencyAmount expected = PRICER_NOMINAL.presentValue(expanded.getNominalPayment(), DSC_FACTORS_ISSUER);
+    int size = expanded.getPeriodicPayments().size();
+    double pvcCupon = 0d;
+    for (int i = 2; i < size; ++i) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(i);
+      pvcCupon += PRICER_COUPON.presentValue(payment, IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
+    }
+    expected = expected.plus(pvcCupon);
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueWithZSpread_continuous_noExcoupon() {
+    CurrencyAmount computed = PRICER.presentValueWithZSpread(PRODUCT_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0);
+    ExpandedFixedCouponBond expanded = PRODUCT.expand();
+    CurrencyAmount expected = PRICER_NOMINAL.presentValue(
+        expanded.getNominalPayment(), DSC_FACTORS_ISSUER, Z_SPREAD, false, 0);
+    int size = expanded.getPeriodicPayments().size();
+    double pvcCupon = 0d;
+    for (int i = 2; i < size; ++i) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(i);
+      pvcCupon += PRICER_COUPON.presentValueWithSpread(
+          payment, IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER), Z_SPREAD, false, 0);
+    }
+    expected = expected.plus(pvcCupon);
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueWithZSpread_periodic_noExcoupon() {
+    CurrencyAmount computed = PRICER.presentValueWithZSpread(PRODUCT_NO_EXCOUPON, PROVIDER, Z_SPREAD, true,
+        PERIOD_PER_YEAR);
+    ExpandedFixedCouponBond expanded = PRODUCT.expand();
+    CurrencyAmount expected = PRICER_NOMINAL.presentValue(
+        expanded.getNominalPayment(), DSC_FACTORS_ISSUER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    int size = expanded.getPeriodicPayments().size();
+    double pvcCupon = 0d;
+    for (int i = 2; i < size; ++i) {
+      FixedCouponBondPaymentPeriod payment = expanded.getPeriodicPayments().get(i);
+      pvcCupon += PRICER_COUPON.presentValueWithSpread(
+          payment, IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER), Z_SPREAD, true, PERIOD_PER_YEAR);
+    }
+    expected = expected.plus(pvcCupon);
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected.getAmount(), NOTIONAL * TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_dirtyPriceFromCurves() {
+    double computed = PRICER.dirtyPriceFromCurves(BOND_SECURITY, PROVIDER);
+    CurrencyAmount pv = PRICER.presentValue(PRODUCT, PROVIDER);
+    LocalDate settlement = DATE_OFFSET.adjust(VALUATION);
+    double df = DSC_FACTORS_REPO.discountFactor(settlement);
+    assertEquals(computed, pv.getAmount() / df / NOTIONAL);
+  }
+
+  public void test_dirtyPriceFromCurvesWithZSpread_continuous() {
+    double computed = PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, PROVIDER, Z_SPREAD, false, 0);
+    CurrencyAmount pv = PRICER.presentValueWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, false, 0);
+    LocalDate settlement = DATE_OFFSET.adjust(VALUATION);
+    double df = DSC_FACTORS_REPO.discountFactor(settlement);
+    assertEquals(computed, pv.getAmount() / df / NOTIONAL);
+  }
+
+  public void test_dirtyPriceFromCurvesWithZSpread_periodic() {
+    double computed = PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount pv = PRICER.presentValueWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    LocalDate settlement = DATE_OFFSET.adjust(VALUATION);
+    double df = DSC_FACTORS_REPO.discountFactor(settlement);
+    assertEquals(computed, pv.getAmount() / df / NOTIONAL);
+  }
+
+  public void test_dirtyPriceFromCleanPrice_cleanPriceFromDirtyPrice() {
+    double dirtyPrice = PRICER.dirtyPriceFromCurves(BOND_SECURITY, PROVIDER);
+    LocalDate settlement = DATE_OFFSET.adjust(VALUATION);
+    double cleanPrice = PRICER.cleanPriceFromDirtyPrice(PRODUCT, settlement, dirtyPrice);
+    double accruedInterest = PRICER.accruedInterest(PRODUCT, settlement);
+    assertEquals(cleanPrice, dirtyPrice - accruedInterest / NOTIONAL, NOTIONAL * TOL);
+    double dirtyPriceRe = PRICER.dirtyPriceFromCleanPrice(PRODUCT, settlement, cleanPrice);
+    assertEquals(dirtyPriceRe, dirtyPrice, TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_zSpreadFromCurvesAndPV_continuous() {
+    double dirtyPrice = PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, PROVIDER, Z_SPREAD, false, 0);
+    double computed = PRICER.zSpreadFromCurvesAndDirtyPrice(BOND_SECURITY, PROVIDER, dirtyPrice, false, 0);
+    assertEquals(computed, Z_SPREAD, TOL);
+  }
+
+  public void test_zSpreadFromCurvesAndPV_periodic() {
+    double dirtyPrice = PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    double computed = PRICER.zSpreadFromCurvesAndDirtyPrice(BOND_SECURITY, PROVIDER, dirtyPrice, true, PERIOD_PER_YEAR);
+    assertEquals(computed, Z_SPREAD, TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueSensitivity() {
+    PointSensitivityBuilder point = PRICER.presentValueSensitivity(PRODUCT, PROVIDER);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(PROVIDER, (p) -> PRICER.presentValue(PRODUCT, (p)), EPS);
+    assertTrue(computed.equalWithTolerance(expected, 30d * NOTIONAL * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_continuous() {
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, false, 0);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(
+        PROVIDER, (p) -> PRICER.presentValueWithZSpread(PRODUCT, (p), Z_SPREAD, false, 0), EPS);
+    assertTrue(computed.equalWithTolerance(expected, 20d * NOTIONAL * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_periodic() {
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityWithZSpread(
+        PRODUCT, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(
+        PROVIDER, (p) -> PRICER.presentValueWithZSpread(PRODUCT, (p), Z_SPREAD, true, PERIOD_PER_YEAR), EPS);
+    assertTrue(computed.equalWithTolerance(expected, 20d * NOTIONAL * EPS));
+  }
+
+  public void test_presentValueProductSensitivity_noExcoupon() {
+    PointSensitivityBuilder point = PRICER.presentValueSensitivity(PRODUCT_NO_EXCOUPON, PROVIDER);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(
+        PROVIDER, (p) -> PRICER.presentValue(PRODUCT_NO_EXCOUPON, (p)), EPS);
+    assertTrue(computed.equalWithTolerance(expected, 30d * NOTIONAL * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_continuous_noExcoupon() {
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityWithZSpread(
+        PRODUCT_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(
+        PROVIDER, (p) -> PRICER.presentValueWithZSpread(PRODUCT_NO_EXCOUPON, (p), Z_SPREAD, false, 0), EPS);
+    assertTrue(computed.equalWithTolerance(expected, 20d * NOTIONAL * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_periodic_noExcoupon() {
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityWithZSpread(
+        PRODUCT_NO_EXCOUPON, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(PROVIDER,
+        (p) -> PRICER.presentValueWithZSpread(PRODUCT_NO_EXCOUPON, (p), Z_SPREAD, true, PERIOD_PER_YEAR), EPS);
+    assertTrue(computed.equalWithTolerance(expected, 20d * NOTIONAL * EPS));
+  }
+
+  public void test_dirtyPriceSensitivity() {
+    PointSensitivityBuilder point = PRICER.dirtyPriceSensitivity(BOND_SECURITY, PROVIDER);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(
+        PROVIDER, (p) -> CurrencyAmount.of(EUR, PRICER.dirtyPriceFromCurves(BOND_SECURITY, (p))), EPS);
+    assertTrue(computed.equalWithTolerance(expected, NOTIONAL * EPS));
+  }
+
+  public void test_dirtyPriceSensitivityWithZspread_continuous() {
+    PointSensitivityBuilder point = PRICER.dirtyPriceSensitivityWithZspread(BOND_SECURITY, PROVIDER, Z_SPREAD, false, 0);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(PROVIDER, (p) ->
+        CurrencyAmount.of(EUR, PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, (p), Z_SPREAD, false, 0)), EPS);
+    assertTrue(computed.equalWithTolerance(expected, NOTIONAL * EPS));
+  }
+
+  public void test_dirtyPriceSensitivityWithZspread_periodic() {
+    PointSensitivityBuilder point = PRICER.dirtyPriceSensitivityWithZspread(
+        BOND_SECURITY, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurveCurrencyParameterSensitivities computed = PROVIDER.curveParameterSensitivity(point.build());
+    CurveCurrencyParameterSensitivities expected = sensitivity(PROVIDER, (p) -> CurrencyAmount.of(
+        EUR, PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, (p), Z_SPREAD, true, PERIOD_PER_YEAR)), EPS);
+    assertTrue(computed.equalWithTolerance(expected, NOTIONAL * EPS));
+  }
+
+  private CurveCurrencyParameterSensitivities sensitivity(
+      LegalEntityDiscountingProvider provider,
+      Function<LegalEntityDiscountingProvider, CurrencyAmount> valueFn, double shift) {
+
+    CurrencyAmount valueInit = valueFn.apply(provider);
+    CurveCurrencyParameterSensitivities discounting = sensitivity(
+        provider, valueFn, LegalEntityDiscountingProvider.meta().repoCurves(), valueInit, shift);
+    CurveCurrencyParameterSensitivities forward = sensitivity(
+        provider, valueFn, LegalEntityDiscountingProvider.meta().issuerCurves(), valueInit, shift);
+    return discounting.combinedWith(forward);
+  }
+
+  private <T> CurveCurrencyParameterSensitivities sensitivity(
+      LegalEntityDiscountingProvider provider,
+      Function<LegalEntityDiscountingProvider, CurrencyAmount> valueFn,
+      MetaProperty<ImmutableMap<Pair<T, Currency>, DiscountFactors>> metaProperty,
+      CurrencyAmount valueInit,
+      double shift) {
+
+    ImmutableMap<Pair<T, Currency>, DiscountFactors> baseCurves = metaProperty.get(provider);
+    CurveCurrencyParameterSensitivities result = CurveCurrencyParameterSensitivities.empty();
+    for (Pair<T, Currency> key : baseCurves.keySet()) {
+      DiscountFactors discountFactors = baseCurves.get(key);
+      // Assume underlying object is ZeroRateDiscountFactors 
+      NodalCurve curveInt = (NodalCurve) ((ZeroRateDiscountFactors) discountFactors).getCurve();
+      DoubleArray sensitivity = DoubleArray.of(curveInt.getXValues().size(), i -> {
+        Curve dscBumped = bumpedCurve(curveInt, i, shift);
+        Map<Pair<T, Currency>, DiscountFactors> mapBumped = new HashMap<>(baseCurves);
+        mapBumped.put(key, ZeroRateDiscountFactors.of(
+            discountFactors.getCurrency(), discountFactors.getValuationDate(), dscBumped));
+        LegalEntityDiscountingProvider providerDscBumped = provider.toBuilder().set(metaProperty, mapBumped).build();
+        return (valueFn.apply(providerDscBumped).getAmount() - valueInit.getAmount()) / shift;
+      });
+      CurveMetadata metadata = curveInt.getMetadata();
+      result = result.combinedWith(
+          CurveCurrencyParameterSensitivity.of(metadata, valueInit.getCurrency(), sensitivity));
+    }
+    return result;
+  }
+
+  private NodalCurve bumpedCurve(NodalCurve curveInt, int loopnode, double shift) {
+    DoubleArray yValues = curveInt.getYValues();
+    return curveInt.withYValues(yValues.with(loopnode, yValues.get(loopnode) + shift));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_accruedInterest() {
+    // settle before start
+    LocalDate settleDate1 = START_DATE.minusDays(5);
+    double accruedInterest1 = PRICER.accruedInterest(PRODUCT, settleDate1);
+    assertEquals(accruedInterest1, 0d);
+    // settle between endDate and endDate -lag
+    LocalDate settleDate2 = date(2015, 10, 8);
+    double accruedInterest2 = PRICER.accruedInterest(PRODUCT, settleDate2);
+    assertEquals(accruedInterest2, -4.0 / 365.0 * FIXED_RATE * NOTIONAL, EPS);
+    // normal
+    LocalDate settleDate3 = date(2015, 4, 18); // not adjusted
+    FixedCouponBond product = FixedCouponBond.builder()
+        .dayCount(DAY_COUNT)
+        .fixedRate(FIXED_RATE)
+        .legalEntityId(ISSUER_ID)
+        .currency(EUR)
+        .notional(NOTIONAL)
+        .periodicSchedule(PERIOD_SCHEDULE)
+        .settlementDateOffset(DATE_OFFSET)
+        .yieldConvention(YIELD_CONVENTION)
+        .exCouponPeriod(DaysAdjustment.NONE)
+        .build();
+    double accruedInterest3 = PRICER.accruedInterest(product, settleDate3);
+    assertEquals(accruedInterest3, 6.0 / 365.0 * FIXED_RATE * NOTIONAL, EPS);
+  }
+
+  //-------------------------------------------------------------------------
+  /* US Street convention */
+  private static final LocalDate START_US = date(2006, 11, 15);
+  private static final LocalDate END_US = START_US.plusYears(10);
+  private static final PeriodicSchedule SCHEDULE_US = PeriodicSchedule.of(START_US, END_US, Frequency.P6M,
+      BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, HolidayCalendars.SAT_SUN),
+      StubConvention.SHORT_INITIAL, false);
+  private static final FixedCouponBond PRODUCT_US = FixedCouponBond.builder()
+      .dayCount(DayCounts.ACT_ACT_ICMA)
+      .fixedRate(0.04625)
+      .legalEntityId(ISSUER_ID)
+      .currency(Currency.USD)
+      .notional(100)
+      .periodicSchedule(SCHEDULE_US)
+      .settlementDateOffset(DaysAdjustment.ofBusinessDays(3, HolidayCalendars.SAT_SUN))
+      .yieldConvention(YieldConvention.US_STREET)
+      .exCouponPeriod(DaysAdjustment.NONE)
+      .build();
+  private static final LocalDate VALUATION_US = date(2011, 8, 18);
+  private static final LocalDate SETTLEMENT_US = PRODUCT_US.getSettlementDateOffset().adjust(VALUATION_US);
+  private static final LocalDate VALUATION_LAST_US = date(2016, 6, 3);
+  private static final LocalDate SETTLEMENT_LAST_US = PRODUCT_US.getSettlementDateOffset().adjust(VALUATION_LAST_US);
+  private static final double YIELD_US = 0.04;
+
+  public void dirtyPriceFromYieldUS() {
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
+    assertEquals(dirtyPrice, 1.0417352500524246, TOL); // 2.x.
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_US, SETTLEMENT_US, dirtyPrice);
+    assertEquals(yield, YIELD_US, TOL);
+  }
+
+  public void dirtyPriceFromYieldUSLastPeriod() {
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US);
+    assertEquals(dirtyPrice, 1.005635683760684, TOL); // 2.x.
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_US, SETTLEMENT_LAST_US, dirtyPrice);
+    assertEquals(yield, YIELD_US, TOL);
+  }
+
+  public void modifiedDurationFromYieldUS() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void modifiedDurationFromYieldUSLastPeriod() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldUS() {
+    double computed = PRICER.convexityFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldUSLastPeriod() {
+    double computed = PRICER.convexityFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void macaulayDurationFromYieldUS() {
+    double duration = PRICER.macaulayDurationFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
+    assertEquals(duration, 4.6575232098896215, TOL); // 2.x.
+  }
+
+  public void macaulayDurationFromYieldUSLastPeriod() {
+    double duration = PRICER.macaulayDurationFromYield(PRODUCT_US, SETTLEMENT_LAST_US, YIELD_US);
+    assertEquals(duration, 0.43478260869565216, TOL); // 2.x.
+  }
+
+  /* UK BUMP/DMO convention */
+  private static final LocalDate START_UK = date(2002, 9, 7);
+  private static final LocalDate END_UK = START_UK.plusYears(12);
+  private static final PeriodicSchedule SCHEDULE_UK = PeriodicSchedule.of(START_UK, END_UK, Frequency.P6M,
+      BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, HolidayCalendars.SAT_SUN),
+      StubConvention.SHORT_INITIAL, false);
+  private static final FixedCouponBond PRODUCT_UK = FixedCouponBond.builder()
+      .dayCount(DayCounts.ACT_ACT_ICMA)
+      .fixedRate(0.05)
+      .legalEntityId(ISSUER_ID)
+      .currency(Currency.GBP)
+      .notional(100)
+      .periodicSchedule(SCHEDULE_UK)
+      .settlementDateOffset(DaysAdjustment.ofBusinessDays(1, HolidayCalendars.SAT_SUN))
+      .yieldConvention(YieldConvention.UK_BUMP_DMO)
+      .exCouponPeriod(DaysAdjustment.ofCalendarDays(-7,
+          BusinessDayAdjustment.of(BusinessDayConventions.PRECEDING, HolidayCalendars.SAT_SUN)))
+      .build();
+  private static final LocalDate VALUATION_UK = date(2011, 9, 2);
+  private static final LocalDate SETTLEMENT_UK = PRODUCT_UK.getSettlementDateOffset().adjust(VALUATION_UK);
+  private static final LocalDate VALUATION_LAST_UK = date(2014, 6, 3);
+  private static final LocalDate SETTLEMENT_LAST_UK = PRODUCT_UK.getSettlementDateOffset().adjust(VALUATION_LAST_UK);
+  private static final double YIELD_UK = 0.04;
+
+  public void dirtyPriceFromYieldUK() {
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK);
+    assertEquals(dirtyPrice, 1.0277859038905428, TOL); // 2.x.
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_UK, SETTLEMENT_UK, dirtyPrice);
+    assertEquals(yield, YIELD_UK, TOL);
+  }
+
+  public void dirtyPriceFromYieldUKLastPeriod() {
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK);
+    assertEquals(dirtyPrice, 1.0145736043763598, TOL); // 2.x.
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_UK, SETTLEMENT_LAST_UK, dirtyPrice);
+    assertEquals(yield, YIELD_UK, TOL);
+  }
+
+  public void modifiedDurationFromYieldUK() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void modifiedDurationFromYieldUKLastPeriod() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldUK() {
+    double computed = PRICER.convexityFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldUKLastPeriod() {
+    double computed = PRICER.convexityFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void macaulayDurationFromYieldUK() {
+    double duration = PRICER.macaulayDurationFromYield(PRODUCT_UK, SETTLEMENT_UK, YIELD_UK);
+    assertEquals(duration, 2.8312260658609163, TOL); // 2.x.
+  }
+
+  public void macaulayDurationFromYieldUKLastPeriod() {
+    double duration = PRICER.macaulayDurationFromYield(PRODUCT_UK, SETTLEMENT_LAST_UK, YIELD_UK);
+    assertEquals(duration, 0.25815217391304346, TOL); // 2.x.
+  }
+
+  /* German bond convention */
+  private static final LocalDate START_GER = date(2002, 9, 7);
+  private static final LocalDate END_GER = START_GER.plusYears(12);
+  private static final PeriodicSchedule SCHEDULE_GER = PeriodicSchedule.of(START_GER, END_GER, Frequency.P12M,
+      BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, HolidayCalendars.SAT_SUN),
+      StubConvention.SHORT_INITIAL, false);
+  private static final FixedCouponBond PRODUCT_GER = FixedCouponBond.builder()
+      .dayCount(DayCounts.ACT_ACT_ICMA)
+      .fixedRate(0.05)
+      .legalEntityId(ISSUER_ID)
+      .currency(Currency.EUR)
+      .notional(100)
+      .periodicSchedule(SCHEDULE_GER)
+      .settlementDateOffset(DaysAdjustment.ofBusinessDays(3, HolidayCalendars.SAT_SUN))
+      .yieldConvention(YieldConvention.GERMAN_BONDS)
+      .exCouponPeriod(DaysAdjustment.NONE)
+      .build();
+  private static final LocalDate VALUATION_GER = date(2011, 9, 2);
+  private static final LocalDate SETTLEMENT_GER = PRODUCT_GER.getSettlementDateOffset().adjust(VALUATION_GER);
+  private static final LocalDate VALUATION_LAST_GER = date(2014, 6, 3);
+  private static final LocalDate SETTLEMENT_LAST_GER = PRODUCT_GER.getSettlementDateOffset().adjust(VALUATION_LAST_GER);
+  private static final double YIELD_GER = 0.04;
+
+  public void dirtyPriceFromYieldGerman() {
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER);
+    assertEquals(dirtyPrice, 1.027750910332271, TOL); // 2.x.
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_GER, SETTLEMENT_GER, dirtyPrice);
+    assertEquals(yield, YIELD_GER, TOL);
+  }
+
+  public void dirtyPriceFromYieldGermanLastPeriod() {
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER);
+    assertEquals(dirtyPrice, 1.039406595790844, TOL); // 2.x.
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_GER, SETTLEMENT_LAST_GER, dirtyPrice);
+    assertEquals(yield, YIELD_GER, TOL);
+  }
+
+  public void modifiedDurationFromYieldGER() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void modifiedDurationFromYieldGERLastPeriod() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldGER() {
+    double computed = PRICER.convexityFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldGERLastPeriod() {
+    double computed = PRICER.convexityFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void macaulayDurationFromYieldGER() {
+    double duration = PRICER.macaulayDurationFromYield(PRODUCT_GER, SETTLEMENT_GER, YIELD_GER);
+    assertEquals(duration, 2.861462874541554, TOL); // 2.x.
+  }
+
+  public void macaulayDurationFromYieldGERLastPeriod() {
+    double duration = PRICER.macaulayDurationFromYield(PRODUCT_GER, SETTLEMENT_LAST_GER, YIELD_GER);
+    assertEquals(duration, 0.26231286613148186, TOL); // 2.x.
+  }
+
+  /* Japan simple convention */
+  private static final LocalDate START_JP = date(2015, 9, 20);
+  private static final LocalDate END_JP = START_JP.plusYears(10);
+  private static final PeriodicSchedule SCHEDULE_JP = PeriodicSchedule.of(START_JP, END_JP, Frequency.P6M,
+      BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, HolidayCalendars.JPTO),
+      StubConvention.SHORT_INITIAL, false);
+  private static final double RATE_JP = 0.004;
+  private static final FixedCouponBond PRODUCT_JP = FixedCouponBond.builder()
+      .dayCount(DayCounts.NL_365)
+      .fixedRate(RATE_JP)
+      .legalEntityId(ISSUER_ID)
+      .currency(Currency.JPY)
+      .notional(100)
+      .periodicSchedule(SCHEDULE_JP)
+      .settlementDateOffset(DaysAdjustment.ofBusinessDays(3, HolidayCalendars.JPTO))
+      .yieldConvention(YieldConvention.JAPAN_SIMPLE)
+      .exCouponPeriod(DaysAdjustment.NONE)
+      .build();
+  private static final LocalDate VALUATION_JP = date(2015, 9, 24);
+  private static final LocalDate SETTLEMENT_JP = PRODUCT_JP.getSettlementDateOffset().adjust(VALUATION_JP);
+  private static final LocalDate VALUATION_LAST_JP = date(2025, 6, 3);
+  private static final LocalDate SETTLEMENT_LAST_JP = PRODUCT_JP.getSettlementDateOffset().adjust(VALUATION_LAST_JP);
+  private static final LocalDate VALUATION_ENDED_JP = date(2026, 8, 3);
+  private static final LocalDate SETTLEMENT_ENDED_JP = PRODUCT_JP.getSettlementDateOffset().adjust(VALUATION_ENDED_JP);
+  private static final double YIELD_JP = 0.00321;
+
+  public void dirtyPriceFromYieldJP() {
+    double computed = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP);
+    double maturity = DayCounts.NL_365.relativeYearFraction(SETTLEMENT_JP, END_JP);
+    double expected = PRICER.dirtyPriceFromCleanPrice(
+        PRODUCT_JP, SETTLEMENT_JP, (1d + RATE_JP * maturity) / (1d + YIELD_JP * maturity));
+    assertEquals(computed, expected, TOL);
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_JP, SETTLEMENT_JP, computed);
+    assertEquals(yield, YIELD_JP, TOL);
+  }
+
+  public void dirtyPriceFromYieldJPLastPeriod() {
+    double computed = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP);
+    double maturity = DayCounts.NL_365.relativeYearFraction(SETTLEMENT_LAST_JP, END_JP);
+    double expected = PRICER.dirtyPriceFromCleanPrice(
+        PRODUCT_JP, SETTLEMENT_LAST_JP, (1d + RATE_JP * maturity) / (1d + YIELD_JP * maturity));
+    assertEquals(computed, expected, TOL);
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_JP, SETTLEMENT_LAST_JP, computed);
+    assertEquals(yield, YIELD_JP, TOL);
+  }
+
+  public void dirtyPriceFromYieldJPEnded() {
+    double computed = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_ENDED_JP, YIELD_JP);
+    assertEquals(computed, 0d, TOL);
+  }
+
+  public void modifiedDurationFromYielddJP() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void modifiedDurationFromYieldJPLastPeriod() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP);
+    double price = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP);
+    double priceUp = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP + EPS);
+    double priceDw = PRICER.dirtyPriceFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP - EPS);
+    double expected = 0.5 * (priceDw - priceUp) / price / EPS;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void modifiedDurationFromYielddJPEnded() {
+    double computed = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_ENDED_JP, YIELD_JP);
+    assertEquals(computed, 0d, EPS);
+  }
+
+  public void convexityFromYieldJP() {
+    double computed = PRICER.convexityFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldJPLastPeriod() {
+    double computed = PRICER.convexityFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP);
+    double duration = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP);
+    double durationUp = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP + EPS);
+    double durationDw = PRICER.modifiedDurationFromYield(PRODUCT_JP, SETTLEMENT_LAST_JP, YIELD_JP - EPS);
+    double expected = 0.5 * (durationDw - durationUp) / EPS + duration * duration;
+    assertEquals(computed, expected, EPS);
+  }
+
+  public void convexityFromYieldJPEnded() {
+    double computed = PRICER.convexityFromYield(PRODUCT_JP, SETTLEMENT_ENDED_JP, YIELD_JP);
+    assertEquals(computed, 0d, EPS);
+  }
+
+  public void macaulayDurationFromYieldYieldJP() {
+    assertThrows(() -> PRICER.macaulayDurationFromYield(PRODUCT_JP, SETTLEMENT_JP, YIELD_JP),
+        UnsupportedOperationException.class, "The convention JAPAN_SIMPLE is not supported.");
+  }
+
+}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/bond/DiscountingFixedCouponBondTradePricerTest.java
@@ -1,0 +1,1093 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate.bond;
+
+import static com.opengamma.strata.basics.currency.Currency.EUR;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.joda.beans.MetaProperty;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
+import com.opengamma.strata.basics.date.BusinessDayConventions;
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.HolidayCalendar;
+import com.opengamma.strata.basics.date.HolidayCalendars;
+import com.opengamma.strata.basics.interpolator.CurveInterpolator;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.PeriodicSchedule;
+import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.finance.Security;
+import com.opengamma.strata.finance.SecurityLink;
+import com.opengamma.strata.finance.TradeInfo;
+import com.opengamma.strata.finance.UnitSecurity;
+import com.opengamma.strata.finance.rate.bond.ExpandedFixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBond;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondPaymentPeriod;
+import com.opengamma.strata.finance.rate.bond.FixedCouponBondTrade;
+import com.opengamma.strata.finance.rate.bond.YieldConvention;
+import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.curve.NodalCurve;
+import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.value.BondGroup;
+import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.LegalEntityGroup;
+import com.opengamma.strata.market.value.ZeroRateDiscountFactors;
+import com.opengamma.strata.math.impl.interpolation.Interpolator1DFactory;
+import com.opengamma.strata.pricer.DiscountingPaymentPricer;
+import com.opengamma.strata.pricer.impl.bond.DiscountingFixedCouponBondPaymentPeriodPricer;
+import com.opengamma.strata.pricer.rate.LegalEntityDiscountingProvider;
+
+/**
+ * Test {@link DiscountingFixedCouponBondTradePricer}.
+ */
+@Test
+public class DiscountingFixedCouponBondTradePricerTest {
+  // fixed coupon bond
+  private static final StandardId SECURITY_ID = StandardId.of("OG-Ticker", "GOVT1-BOND1");
+  private static final StandardId ISSUER_ID = StandardId.of("OG-Ticker", "GOVT1");
+  private static final LocalDate SETTLEMENT = date(2016, 4, 29); // after coupon date
+  private static final LocalDate VALUATION = date(2016, 4, 25);
+  private static final LocalDate TRADE_BEFORE = date(2016, 3, 18);
+  private static final LocalDate SETTLE_BEFORE = date(2016, 3, 22); // before coupon date
+  private static final LocalDate TRADE_ON_COUPON = date(2016, 4, 8);
+  private static final LocalDate SETTLE_ON_COUPON = date(2016, 4, 12); // coupon date
+  private static final LocalDate TRADE_BTWN_DETACHMENT_COUPON = date(2016, 4, 5);
+  private static final LocalDate SETTLE_BTWN_DETACHMENT_COUPON = date(2016, 4, 8); // between detachment date and coupon date
+  private static final LocalDate TRADE_ON_DETACHMENT = date(2016, 4, 4);
+  private static final LocalDate SETTLE_ON_DETACHMENT = date(2016, 4, 7); // detachment date
+  private static final TradeInfo TRADE_INFO = TradeInfo.builder()
+      .tradeDate(VALUATION)
+      .settlementDate(SETTLEMENT)
+      .build();
+  private static final TradeInfo TRADE_INFO_BEFORE = TradeInfo.builder()
+      .tradeDate(TRADE_BEFORE)
+      .settlementDate(SETTLE_BEFORE)
+      .build();
+  private static final TradeInfo TRADE_INFO_ON_COUPON = TradeInfo.builder()
+      .tradeDate(TRADE_ON_COUPON)
+      .settlementDate(SETTLE_ON_COUPON)
+      .build();
+  private static final TradeInfo TRADE_INFO_BTWN_DETACHMENT_COUPON = TradeInfo.builder()
+      .tradeDate(TRADE_BTWN_DETACHMENT_COUPON)
+      .settlementDate(SETTLE_BTWN_DETACHMENT_COUPON)
+      .build();
+  private static final TradeInfo TRADE_INFO_ON_DETACHMENT = TradeInfo.builder()
+      .tradeDate(TRADE_ON_DETACHMENT)
+      .settlementDate(SETTLE_ON_DETACHMENT)
+      .build();
+  private static final long QUANTITY = 15L;
+  private static final YieldConvention YIELD_CONVENTION = YieldConvention.GERMAN_BONDS;
+  private static final double NOTIONAL = 1.0e7;
+  private static final double FIXED_RATE = 0.015;
+  private static final HolidayCalendar EUR_CALENDAR = HolidayCalendars.EUTA;
+  private static final DaysAdjustment DATE_OFFSET = DaysAdjustment.ofBusinessDays(3, EUR_CALENDAR);
+  private static final DayCount DAY_COUNT = DayCounts.ACT_365F;
+  private static final LocalDate START_DATE = LocalDate.of(2015, 4, 12);
+  private static final LocalDate END_DATE = LocalDate.of(2025, 4, 12);
+  private static final BusinessDayAdjustment BUSINESS_ADJUST =
+      BusinessDayAdjustment.of(BusinessDayConventions.MODIFIED_FOLLOWING, EUR_CALENDAR);
+  private static final PeriodicSchedule PERIOD_SCHEDULE = PeriodicSchedule.of(
+      START_DATE, END_DATE, Frequency.P6M, BUSINESS_ADJUST, StubConvention.SHORT_INITIAL, false);
+  private static final DaysAdjustment EX_COUPON = DaysAdjustment.ofCalendarDays(-5, BUSINESS_ADJUST);
+  private static final FixedCouponBond PRODUCT = FixedCouponBond.builder()
+      .dayCount(DAY_COUNT)
+      .fixedRate(FIXED_RATE)
+      .legalEntityId(ISSUER_ID)
+      .currency(EUR)
+      .notional(NOTIONAL)
+      .periodicSchedule(PERIOD_SCHEDULE)
+      .settlementDateOffset(DATE_OFFSET)
+      .yieldConvention(YIELD_CONVENTION)
+      .exCouponPeriod(EX_COUPON)
+      .build();
+  private static final Security<FixedCouponBond> BOND_SECURITY =
+      UnitSecurity.builder(PRODUCT).standardId(SECURITY_ID).build();
+  private static final SecurityLink<FixedCouponBond> SECURITY_LINK = SecurityLink.resolved(BOND_SECURITY);
+  private static final Payment UPFRONT_PAYMENT = Payment.of(CurrencyAmount.of(EUR, -QUANTITY * NOTIONAL * 0.99), SETTLEMENT);
+  private static final Payment UPFRONT_PAYMENT_ZERO = Payment.of(CurrencyAmount.of(EUR, 0d), SETTLE_BEFORE);
+  /** nonzero ex-coupon period */
+  private static final FixedCouponBondTrade TRADE = FixedCouponBondTrade.builder()
+      .securityLink(SECURITY_LINK)
+      .tradeInfo(TRADE_INFO)
+      .quantity(QUANTITY)
+      .payment(UPFRONT_PAYMENT)
+      .build();
+  private static final FixedCouponBond PRODUCT_NO_EXCOUPON = FixedCouponBond.builder()
+      .dayCount(DAY_COUNT)
+      .fixedRate(FIXED_RATE)
+      .legalEntityId(ISSUER_ID)
+      .currency(EUR)
+      .notional(NOTIONAL)
+      .periodicSchedule(PERIOD_SCHEDULE)
+      .settlementDateOffset(DATE_OFFSET)
+      .yieldConvention(YIELD_CONVENTION)
+      .build();
+  private static final Security<FixedCouponBond> BOND_SECURITY_NO_EXCOUPON =
+      UnitSecurity.builder(PRODUCT_NO_EXCOUPON).standardId(SECURITY_ID).build();
+  private static final SecurityLink<FixedCouponBond> SECURITY_LINK_NO_EXCOUPON =
+      SecurityLink.resolved(BOND_SECURITY_NO_EXCOUPON);
+  /** no ex-coupon period */
+  private static final FixedCouponBondTrade TRADE_NO_EXCOUPON = FixedCouponBondTrade.builder()
+      .securityLink(SECURITY_LINK_NO_EXCOUPON)
+      .tradeInfo(TRADE_INFO)
+      .quantity(QUANTITY)
+      .payment(UPFRONT_PAYMENT)
+      .build();
+
+  // rates provider
+  private static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.LINEAR_INSTANCE;
+  private static final CurveName NAME_REPO = CurveName.of("TestRepoCurve");
+  private static final CurveMetadata METADATA_REPO = Curves.zeroRates(NAME_REPO, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE_REPO = InterpolatedNodalCurve.of(
+      METADATA_REPO, DoubleArray.of(0.1, 2.0, 10.0), DoubleArray.of(0.05, 0.06, 0.09), INTERPOLATOR);
+  private static final BondGroup GROUP_REPO = BondGroup.of("GOVT1 BOND1");
+  private static final CurveName NAME_ISSUER = CurveName.of("TestIssuerCurve");
+  private static final CurveMetadata METADATA_ISSUER = Curves.zeroRates(NAME_ISSUER, ACT_365F);
+  private static final InterpolatedNodalCurve CURVE_ISSUER = InterpolatedNodalCurve.of(
+      METADATA_ISSUER, DoubleArray.of(0.2, 9.0, 15.0), DoubleArray.of(0.03, 0.05, 0.13), INTERPOLATOR);
+  private static final LegalEntityGroup GROUP_ISSUER = LegalEntityGroup.of("GOVT1");
+  private static final LegalEntityDiscountingProvider PROVIDER = createRatesProvider(VALUATION);
+  private static final LegalEntityDiscountingProvider PROVIDER_BEFORE = createRatesProvider(TRADE_BEFORE);
+
+  // pricers
+  private static final DiscountingFixedCouponBondTradePricer TRADE_PRICER = DiscountingFixedCouponBondTradePricer.DEFAULT;
+  private static final DiscountingFixedCouponBondProductPricer PRODUCT_PRICER =
+      DiscountingFixedCouponBondProductPricer.DEFAULT;
+  private static final DiscountingPaymentPricer PRICER_NOMINAL = DiscountingPaymentPricer.DEFAULT;
+  private static final DiscountingFixedCouponBondPaymentPeriodPricer COUPON_PRICER =
+      DiscountingFixedCouponBondPaymentPeriodPricer.DEFAULT;
+
+  private static final double Z_SPREAD = 0.035;
+  private static final int PERIOD_PER_YEAR = 4;
+  private static final double TOL = 1.0e-12;
+  private static final double EPS = 1.0e-6;
+
+  public void test_presentValue() {
+    CurrencyAmount computedTrade = TRADE_PRICER.presentValue(TRADE, PROVIDER);
+    CurrencyAmount computedProduct = PRODUCT_PRICER.presentValue(PRODUCT, PROVIDER, SETTLEMENT);
+    CurrencyAmount pvPayment =
+        PRICER_NOMINAL.presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO));
+    assertEquals(computedTrade.getAmount(),
+        computedProduct.multipliedBy(QUANTITY).plus(pvPayment).getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueWithZSpread_continuous() {
+    CurrencyAmount computedTrade = TRADE_PRICER.presentValueWithZSpread(TRADE, PROVIDER, Z_SPREAD, false, 0);
+    CurrencyAmount computedProduct =
+        PRODUCT_PRICER.presentValueWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, false, 0, SETTLEMENT);
+    CurrencyAmount pvPayment =
+        PRICER_NOMINAL.presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO));
+    assertEquals(computedTrade.getAmount(),
+        computedProduct.multipliedBy(QUANTITY).plus(pvPayment).getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueWithZSpread_periodic() {
+    CurrencyAmount computedTrade =
+        TRADE_PRICER.presentValueWithZSpread(TRADE, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount computedProduct =
+        PRODUCT_PRICER.presentValueWithZSpread(PRODUCT, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR, SETTLEMENT);
+    CurrencyAmount pvPayment =
+        PRICER_NOMINAL.presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO));
+    assertEquals(computedTrade.getAmount(),
+        computedProduct.multipliedBy(QUANTITY).plus(pvPayment).getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValue_noExcoupon() {
+    CurrencyAmount computedTrade = TRADE_PRICER.presentValue(TRADE_NO_EXCOUPON, PROVIDER);
+    CurrencyAmount computedProduct = PRODUCT_PRICER.presentValue(PRODUCT_NO_EXCOUPON, PROVIDER, SETTLEMENT);
+    CurrencyAmount pvPayment =
+        PRICER_NOMINAL.presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO));
+    assertEquals(computedTrade.getAmount(),
+        computedProduct.multipliedBy(QUANTITY).plus(pvPayment).getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueWithZSpread_continuous_noExcoupon() {
+    CurrencyAmount computedTrade =
+        TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0);
+    CurrencyAmount computedProduct =
+        PRODUCT_PRICER.presentValueWithZSpread(PRODUCT_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0, SETTLEMENT);
+    CurrencyAmount pvPayment =
+        PRICER_NOMINAL.presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO));
+    assertEquals(computedTrade.getAmount(),
+        computedProduct.multipliedBy(QUANTITY).plus(pvPayment).getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueWithZSpread_periodic_noExcoupon() {
+    CurrencyAmount computedTrade =
+        TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount computedProduct =
+        PRODUCT_PRICER.presentValueWithZSpread(PRODUCT_NO_EXCOUPON, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR,
+            SETTLEMENT);
+    CurrencyAmount pvPayment =
+        PRICER_NOMINAL.presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO));
+    assertEquals(computedTrade.getAmount(),
+        computedProduct.multipliedBy(QUANTITY).plus(pvPayment).getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValue_dateLogic() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeAfter = TRADE_PRICER.presentValue(tradeAfter, PROVIDER_BEFORE);
+    // settle before detachment date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeBefore = TRADE_PRICER.presentValue(tradeBefore, PROVIDER_BEFORE);
+    FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT.expand(), SETTLE_BEFORE, SETTLEMENT);
+    double pvExtra = COUPON_PRICER.presentValue(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR));
+    assertEquals(computedTradeBefore.getAmount(), computedTradeAfter.plus(pvExtra * QUANTITY).getAmount(),
+        NOTIONAL * QUANTITY * TOL);
+    // settle on detachment date
+    FixedCouponBondTrade tradeOnDetachment = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_ON_DETACHMENT)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeOnDetachment = TRADE_PRICER.presentValue(tradeOnDetachment, PROVIDER_BEFORE);
+    assertEquals(computedTradeOnDetachment.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+    // settle between detachment date and coupon date
+    FixedCouponBondTrade tradeBtwnDetachmentCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BTWN_DETACHMENT_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeBtwnDetachmentCoupon =
+        TRADE_PRICER.presentValue(tradeBtwnDetachmentCoupon, PROVIDER_BEFORE);
+    assertEquals(computedTradeBtwnDetachmentCoupon.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValue_dateLogic_pastSettle() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeAfter = TRADE_PRICER.presentValue(tradeAfter, PROVIDER);
+    // settle before detachment date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeBefore = TRADE_PRICER.presentValue(tradeBefore, PROVIDER);
+    assertEquals(computedTradeBefore.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+    // settle on detachment date
+    FixedCouponBondTrade tradeOnDetachment = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_ON_DETACHMENT)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeOnDetachment = TRADE_PRICER.presentValue(tradeOnDetachment, PROVIDER);
+    assertEquals(computedTradeOnDetachment.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+    // settle between detachment date and coupon date
+    FixedCouponBondTrade tradeBtwnDetachmentCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BTWN_DETACHMENT_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeBtwnDetachmentCoupon =
+        TRADE_PRICER.presentValue(tradeBtwnDetachmentCoupon, PROVIDER);
+    assertEquals(computedTradeBtwnDetachmentCoupon.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValue_dateLogic_noExcoupon() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeAfter = TRADE_PRICER.presentValue(tradeAfter, PROVIDER_BEFORE);
+    // settle before coupon date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeBefore = TRADE_PRICER.presentValue(tradeBefore, PROVIDER_BEFORE);
+    FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT_NO_EXCOUPON.expand(), SETTLE_BEFORE, SETTLEMENT);
+    double pvExtra = COUPON_PRICER.presentValue(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR));
+    assertEquals(computedTradeBefore.getAmount(), computedTradeAfter.plus(pvExtra * QUANTITY).getAmount(),
+        NOTIONAL * QUANTITY * TOL);
+    // settle on coupon date
+    FixedCouponBondTrade tradeOnCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_ON_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeOnCoupon = TRADE_PRICER.presentValue(tradeOnCoupon, PROVIDER_BEFORE);
+    assertEquals(computedTradeOnCoupon.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValue_dateLogic_pastSettle_noExcoupon() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeAfter = TRADE_PRICER.presentValue(tradeAfter, PROVIDER);
+    // settle before coupon date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeBefore = TRADE_PRICER.presentValue(tradeBefore, PROVIDER);
+    assertEquals(computedTradeBefore.getAmount(), computedTradeAfter.getAmount(),
+        NOTIONAL * QUANTITY * TOL);
+    // settle on coupon date
+    FixedCouponBondTrade tradeOnCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_ON_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computedTradeOnCoupon = TRADE_PRICER.presentValue(tradeOnCoupon, PROVIDER);
+    assertEquals(computedTradeOnCoupon.getAmount(), computedTradeAfter.getAmount(), NOTIONAL * QUANTITY * TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueFromCleanPrice() {
+    double cleanPrice = 0.985;
+    CurrencyAmount computed = TRADE_PRICER.presentValueFromCleanPrice(TRADE, PROVIDER, cleanPrice);
+    LocalDate standardSettlement = PRODUCT.getSettlementDateOffset().adjust(VALUATION);
+    double df = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO).discountFactor(standardSettlement);
+    double accruedInterest = PRODUCT_PRICER.accruedInterest(PRODUCT, standardSettlement);
+    double pvPayment = PRICER_NOMINAL
+        .presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO)).getAmount();
+    double expected = QUANTITY * (cleanPrice * df * NOTIONAL + accruedInterest * df) + pvPayment;
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected, NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_continuous() {
+    double cleanPrice = 0.985;
+    CurrencyAmount computed = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE, PROVIDER, cleanPrice, Z_SPREAD, false, 0);
+    LocalDate standardSettlement = PRODUCT.getSettlementDateOffset().adjust(VALUATION);
+    double df = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO).discountFactor(standardSettlement);
+    double accruedInterest = PRODUCT_PRICER.accruedInterest(PRODUCT, standardSettlement);
+    double pvPayment = PRICER_NOMINAL
+        .presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO)).getAmount();
+    double expected = QUANTITY * (cleanPrice * df * NOTIONAL + accruedInterest * df) + pvPayment;
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected, NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_periodic() {
+    double cleanPrice = 0.985;
+    CurrencyAmount computed = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE, PROVIDER, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    LocalDate standardSettlement = PRODUCT.getSettlementDateOffset().adjust(VALUATION);
+    double df = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO).discountFactor(standardSettlement);
+    double accruedInterest = PRODUCT_PRICER.accruedInterest(PRODUCT, standardSettlement);
+    double pvPayment = PRICER_NOMINAL
+        .presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO)).getAmount();
+    double expected = QUANTITY * (cleanPrice * df * NOTIONAL + accruedInterest * df) + pvPayment;
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected, NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueFromCleanPrice_noExcoupon() {
+    double cleanPrice = 0.985;
+    CurrencyAmount computed = TRADE_PRICER.presentValueFromCleanPrice(TRADE_NO_EXCOUPON, PROVIDER, cleanPrice);
+    LocalDate standardSettlement = PRODUCT_NO_EXCOUPON.getSettlementDateOffset().adjust(VALUATION);
+    double df = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO).discountFactor(standardSettlement);
+    double accruedInterest = PRODUCT_PRICER.accruedInterest(PRODUCT_NO_EXCOUPON, standardSettlement);
+    double pvPayment = PRICER_NOMINAL
+        .presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO)).getAmount();
+    double expected = QUANTITY * (cleanPrice * df * NOTIONAL + accruedInterest * df) + pvPayment;
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected, NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_continuous_noExcoupon() {
+    double cleanPrice = 0.985;
+    CurrencyAmount computed = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE_NO_EXCOUPON, PROVIDER, cleanPrice, Z_SPREAD, false, 0);
+    LocalDate standardSettlement = PRODUCT_NO_EXCOUPON.getSettlementDateOffset().adjust(VALUATION);
+    double df = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO).discountFactor(standardSettlement);
+    double accruedInterest = PRODUCT_PRICER.accruedInterest(PRODUCT_NO_EXCOUPON, standardSettlement);
+    double pvPayment = PRICER_NOMINAL
+        .presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO)).getAmount();
+    double expected = QUANTITY * (cleanPrice * df * NOTIONAL + accruedInterest * df) + pvPayment;
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected, NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_periodic_noExcoupon() {
+    double cleanPrice = 0.985;
+    CurrencyAmount computed = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE_NO_EXCOUPON, PROVIDER, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    LocalDate standardSettlement = PRODUCT_NO_EXCOUPON.getSettlementDateOffset().adjust(VALUATION);
+    double df = ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO).discountFactor(standardSettlement);
+    double accruedInterest = PRODUCT_PRICER.accruedInterest(PRODUCT_NO_EXCOUPON, standardSettlement);
+    double pvPayment = PRICER_NOMINAL
+        .presentValue(UPFRONT_PAYMENT, ZeroRateDiscountFactors.of(EUR, VALUATION, CURVE_REPO)).getAmount();
+    double expected = QUANTITY * (cleanPrice * df * NOTIONAL + accruedInterest * df) + pvPayment;
+    assertEquals(computed.getCurrency(), EUR);
+    assertEquals(computed.getAmount(), expected, NOTIONAL * QUANTITY * TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueFromCleanPrice_dateLogic() {
+    double cleanPrice = 0.985;
+    FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT.expand(), SETTLE_BEFORE, SETTLEMENT);
+    // trade settlement < detachment date < standard settlement
+    LocalDate valuation1 = SETTLE_ON_DETACHMENT.minusDays(1);
+    TradeInfo tradeInfo1 = TradeInfo.builder()
+        .tradeDate(valuation1)
+        .settlementDate(valuation1)
+        .build();
+    FixedCouponBondTrade trade1 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(tradeInfo1)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    LegalEntityDiscountingProvider provider1 = createRatesProvider(valuation1);
+    LocalDate standardSettlement1 = PRODUCT.getSettlementDateOffset().adjust(valuation1);
+    double df1 = ZeroRateDiscountFactors.of(EUR, valuation1, CURVE_REPO).discountFactor(standardSettlement1);
+    double accruedInterest1 = PRODUCT_PRICER.accruedInterest(PRODUCT, standardSettlement1);
+    double basePv1 = cleanPrice * df1 * NOTIONAL + accruedInterest1 * df1;
+    double pvExtra1 = COUPON_PRICER.presentValue(periodExtra, provider1.issuerCurveDiscountFactors(ISSUER_ID, EUR));
+    double pvExtra1Continuous = COUPON_PRICER.presentValueWithSpread(
+        periodExtra, provider1.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, false, 0);
+    double pvExtra1Periodic = COUPON_PRICER.presentValueWithSpread(
+        periodExtra, provider1.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount computed1 = TRADE_PRICER.presentValueFromCleanPrice(trade1, provider1, cleanPrice);
+    CurrencyAmount computed1Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade1, provider1, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed1Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade1, provider1, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed1.getAmount(), QUANTITY * (basePv1 + pvExtra1), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed1Continuous.getAmount(), QUANTITY * (basePv1 + pvExtra1Continuous), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed1Periodic.getAmount(), QUANTITY * (basePv1 + pvExtra1Periodic), NOTIONAL * QUANTITY * TOL);
+    // detachment date < trade settlement < standard settlement
+    TradeInfo tradeInfo2 = TradeInfo.builder()
+        .tradeDate(valuation1)
+        .settlementDate(SETTLE_ON_DETACHMENT.plusDays(2))
+        .build();
+    FixedCouponBondTrade trade2 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(tradeInfo2)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed2 = TRADE_PRICER.presentValueFromCleanPrice(trade2, provider1, cleanPrice);
+    CurrencyAmount computed2Continuous =
+        TRADE_PRICER.presentValueFromCleanPriceWithZSpread(trade2, provider1, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed2Periodic =
+        TRADE_PRICER.presentValueFromCleanPriceWithZSpread(trade2, provider1, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed2.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed2Continuous.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed2Periodic.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    // detachment date < standard settlement < trade settlement
+    TradeInfo tradeInfo3 = TradeInfo.builder()
+        .tradeDate(valuation1)
+        .settlementDate(SETTLE_ON_DETACHMENT.plusDays(7))
+        .build();
+    FixedCouponBondTrade trade3 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(tradeInfo3)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed3 = TRADE_PRICER.presentValueFromCleanPrice(trade3, provider1, cleanPrice);
+    CurrencyAmount computed3Continuous =
+        TRADE_PRICER.presentValueFromCleanPriceWithZSpread(trade3, provider1, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed3Periodic =
+        TRADE_PRICER.presentValueFromCleanPriceWithZSpread(trade3, provider1, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed3.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed3Continuous.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed3Periodic.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+
+    // standard settlement < detachment date < trade settlement
+    LocalDate settlement4 = SETTLE_ON_DETACHMENT.plusDays(1);
+    TradeInfo tradeInfo4 = TradeInfo.builder()
+        .tradeDate(TRADE_BEFORE)
+        .settlementDate(settlement4)
+        .build();
+    FixedCouponBondTrade trade4 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(tradeInfo4)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    LocalDate standardSettlement4 = PRODUCT.getSettlementDateOffset().adjust(TRADE_BEFORE);
+    double df4 = ZeroRateDiscountFactors.of(EUR, TRADE_BEFORE, CURVE_REPO).discountFactor(standardSettlement4);
+    double accruedInterest4 = PRODUCT_PRICER.accruedInterest(PRODUCT, standardSettlement4);
+    double basePv4 = cleanPrice * df4 * NOTIONAL + accruedInterest4 * df4;
+    double pvExtra4 = COUPON_PRICER.presentValue(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR));
+    double pvExtra4Continuous = COUPON_PRICER.presentValueWithSpread(
+        periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, false, 0);
+    double pvExtra4Periodic = COUPON_PRICER.presentValueWithSpread(
+        periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount computed4 = TRADE_PRICER.presentValueFromCleanPrice(trade4, PROVIDER_BEFORE, cleanPrice);
+    CurrencyAmount computed4Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade4, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed4Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade4, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed4.getAmount(), QUANTITY * (basePv4 - pvExtra4), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed4Continuous.getAmount(), QUANTITY * (basePv4 - pvExtra4Continuous), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed4Periodic.getAmount(), QUANTITY * (basePv4 - pvExtra4Periodic), NOTIONAL * QUANTITY * TOL);
+    // standard settlement < trade settlement < detachment date
+    TradeInfo tradeInfo5 = TradeInfo.builder()
+        .tradeDate(TRADE_BEFORE)
+        .settlementDate(TRADE_BEFORE.plusDays(7))
+        .build();
+    FixedCouponBondTrade trade5 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(tradeInfo5)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed5 = TRADE_PRICER.presentValueFromCleanPrice(trade5, PROVIDER_BEFORE, cleanPrice);
+    CurrencyAmount computed5Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade5, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed5Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade5, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed5.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed5Continuous.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed5Periodic.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    // trade settlement < standard settlement < detachment date
+    FixedCouponBondTrade trade6 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed6 = TRADE_PRICER.presentValueFromCleanPrice(trade6, PROVIDER_BEFORE, cleanPrice);
+    CurrencyAmount computed6Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade6, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed6Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade6, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed6.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed6Continuous.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed6Periodic.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+  }
+
+  public void test_presentValueFromCleanPrice_dateLogic_noExcoupon() {
+    double cleanPrice = 0.985;
+    FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT_NO_EXCOUPON.expand(), SETTLE_BEFORE, SETTLEMENT);
+    // trade settlement < coupon date < standard settlement
+    LocalDate valuation1 = SETTLE_ON_COUPON.minusDays(1);
+    TradeInfo tradeInfo1 = TradeInfo.builder()
+        .tradeDate(valuation1)
+        .settlementDate(valuation1)
+        .build();
+    FixedCouponBondTrade trade1 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(tradeInfo1)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    LegalEntityDiscountingProvider provider1 = createRatesProvider(valuation1);
+    LocalDate standardSettlement1 = PRODUCT_NO_EXCOUPON.getSettlementDateOffset().adjust(valuation1);
+    double df1 = ZeroRateDiscountFactors.of(EUR, valuation1, CURVE_REPO).discountFactor(standardSettlement1);
+    double accruedInterest1 = PRODUCT_PRICER.accruedInterest(PRODUCT_NO_EXCOUPON, standardSettlement1);
+    double basePv1 = cleanPrice * df1 * NOTIONAL + accruedInterest1 * df1;
+    double pvExtra1 = COUPON_PRICER.presentValue(periodExtra, provider1.issuerCurveDiscountFactors(ISSUER_ID, EUR));
+    double pvExtra1Continuous = COUPON_PRICER.presentValueWithSpread(
+        periodExtra, provider1.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, false, 0);
+    double pvExtra1Periodic = COUPON_PRICER.presentValueWithSpread(
+        periodExtra, provider1.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount computed1 = TRADE_PRICER.presentValueFromCleanPrice(trade1, provider1, cleanPrice);
+    CurrencyAmount computed1Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade1, provider1, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed1Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade1, provider1, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed1.getAmount(), QUANTITY * (basePv1 + pvExtra1), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed1Continuous.getAmount(), QUANTITY * (basePv1 + pvExtra1Continuous), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed1Periodic.getAmount(), QUANTITY * (basePv1 + pvExtra1Periodic), NOTIONAL * QUANTITY * TOL);
+    // coupon date < trade settlement < standard settlement
+    TradeInfo tradeInfo2 = TradeInfo.builder()
+        .tradeDate(valuation1)
+        .settlementDate(SETTLE_ON_COUPON.plusDays(2))
+        .build();
+    FixedCouponBondTrade trade2 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(tradeInfo2)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed2 = TRADE_PRICER.presentValueFromCleanPrice(trade2, provider1, cleanPrice);
+    CurrencyAmount computed2Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade2, provider1, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed2Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade2, provider1, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed2.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed2Continuous.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed2Periodic.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    // coupon date < standard settlement < trade settlement
+    TradeInfo tradeInfo3 = TradeInfo.builder()
+        .tradeDate(valuation1)
+        .settlementDate(SETTLE_ON_COUPON.plusDays(7))
+        .build();
+    FixedCouponBondTrade trade3 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(tradeInfo3)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed3 = TRADE_PRICER.presentValueFromCleanPrice(trade3, provider1, cleanPrice);
+    CurrencyAmount computed3Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade3, provider1, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed3Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade3, provider1, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed3.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed3Continuous.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed3Periodic.getAmount(), QUANTITY * basePv1, NOTIONAL * QUANTITY * TOL);
+
+    // standard settlement < coupon date < trade settlement
+    LocalDate settlement4 = SETTLE_ON_COUPON.plusDays(1);
+    TradeInfo tradeInfo4 = TradeInfo.builder()
+        .tradeDate(TRADE_BEFORE)
+        .settlementDate(settlement4)
+        .build();
+    FixedCouponBondTrade trade4 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(tradeInfo4)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    LocalDate standardSettlement4 = PRODUCT_NO_EXCOUPON.getSettlementDateOffset().adjust(TRADE_BEFORE);
+    double df4 = ZeroRateDiscountFactors.of(EUR, TRADE_BEFORE, CURVE_REPO).discountFactor(standardSettlement4);
+    double accruedInterest4 = PRODUCT_PRICER.accruedInterest(PRODUCT_NO_EXCOUPON, standardSettlement4);
+    double basePv4 = cleanPrice * df4 * NOTIONAL + accruedInterest4 * df4;
+    double pvExtra4 = COUPON_PRICER.presentValue(periodExtra,
+        PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR));
+    double pvExtra4Continuous = COUPON_PRICER.presentValueWithSpread(periodExtra,
+        PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, false, 0);
+    double pvExtra4Periodic = COUPON_PRICER.presentValueWithSpread(periodExtra,
+        PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR), Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount computed4 = TRADE_PRICER.presentValueFromCleanPrice(trade4, PROVIDER_BEFORE, cleanPrice);
+    CurrencyAmount computed4Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade4, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed4Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade4, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed4.getAmount(), QUANTITY * (basePv4 - pvExtra4), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed4Continuous.getAmount(), QUANTITY * (basePv4 - pvExtra4Continuous), NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed4Periodic.getAmount(), QUANTITY * (basePv4 - pvExtra4Periodic), NOTIONAL * QUANTITY * TOL);
+    // standard settlement < trade settlement < coupon date
+    TradeInfo tradeInfo5 = TradeInfo.builder()
+        .tradeDate(TRADE_BEFORE)
+        .settlementDate(TRADE_BEFORE.plusDays(7))
+        .build();
+    FixedCouponBondTrade trade5 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(tradeInfo5)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed5 = TRADE_PRICER.presentValueFromCleanPrice(trade5, PROVIDER_BEFORE, cleanPrice);
+    CurrencyAmount computed5Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade5, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed5Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade5, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed5.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed5Continuous.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed5Periodic.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    // trade settlement < standard settlement < coupon date
+    FixedCouponBondTrade trade6 = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    CurrencyAmount computed6 = TRADE_PRICER.presentValueFromCleanPrice(trade6, PROVIDER_BEFORE, cleanPrice);
+    CurrencyAmount computed6Continuous = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade6, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, false, 0);
+    CurrencyAmount computed6Periodic = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        trade6, PROVIDER_BEFORE, cleanPrice, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(computed6.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed6Continuous.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+    assertEquals(computed6Periodic.getAmount(), QUANTITY * basePv4, NOTIONAL * QUANTITY * TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueFromCleanPrice_coherency() {
+    double priceDirty = PRODUCT_PRICER.dirtyPriceFromCurves(BOND_SECURITY, PROVIDER);
+    LocalDate standardSettlementDate = PRODUCT.getSettlementDateOffset().adjust(PROVIDER.getValuationDate());
+    double priceCleanComputed = PRODUCT_PRICER.cleanPriceFromDirtyPrice(PRODUCT, standardSettlementDate, priceDirty);
+    CurrencyAmount pvCleanPrice = TRADE_PRICER.presentValueFromCleanPrice(TRADE, PROVIDER, priceCleanComputed);
+    CurrencyAmount pvCurves = TRADE_PRICER.presentValue(TRADE, PROVIDER);
+    assertEquals(pvCleanPrice.getAmount(), pvCurves.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_continuous_coherency() {
+    double priceDirty = PRODUCT_PRICER.dirtyPriceFromCurvesWithZSpread(BOND_SECURITY, PROVIDER, Z_SPREAD, false, 0);
+    LocalDate standardSettlementDate = PRODUCT.getSettlementDateOffset().adjust(PROVIDER.getValuationDate());
+    double priceCleanComputed = PRODUCT_PRICER.cleanPriceFromDirtyPrice(PRODUCT, standardSettlementDate, priceDirty);
+    CurrencyAmount pvCleanPrice = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE, PROVIDER, priceCleanComputed, Z_SPREAD, false, 0);
+    CurrencyAmount pvCurves = TRADE_PRICER.presentValueWithZSpread(TRADE, PROVIDER, Z_SPREAD, false, 0);
+    assertEquals(pvCleanPrice.getAmount(), pvCurves.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_periodic_coherency() {
+    double priceDirty = PRODUCT_PRICER.dirtyPriceFromCurvesWithZSpread(
+        BOND_SECURITY, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    LocalDate standardSettlementDate = PRODUCT.getSettlementDateOffset().adjust(PROVIDER.getValuationDate());
+    double priceCleanComputed = PRODUCT_PRICER.cleanPriceFromDirtyPrice(PRODUCT, standardSettlementDate, priceDirty);
+    CurrencyAmount pvCleanPrice = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE, PROVIDER, priceCleanComputed, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount pvCurves = TRADE_PRICER.presentValueWithZSpread(TRADE, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(pvCleanPrice.getAmount(), pvCurves.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueFromCleanPrice_noExcoupon_coherency() {
+    double priceDirty = PRODUCT_PRICER.dirtyPriceFromCurves(BOND_SECURITY_NO_EXCOUPON, PROVIDER);
+    LocalDate standardSettlementDate = PRODUCT.getSettlementDateOffset().adjust(PROVIDER.getValuationDate());
+    double priceCleanComputed = PRODUCT_PRICER.cleanPriceFromDirtyPrice(PRODUCT, standardSettlementDate, priceDirty);
+    CurrencyAmount pvCleanPrice = TRADE_PRICER.presentValueFromCleanPrice(
+        TRADE_NO_EXCOUPON, PROVIDER, priceCleanComputed);
+    CurrencyAmount pvCurves = TRADE_PRICER.presentValue(TRADE_NO_EXCOUPON, PROVIDER);
+    assertEquals(pvCleanPrice.getAmount(), pvCurves.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_continuous_noExcoupon_coherency() {
+    double priceDirty = PRODUCT_PRICER.dirtyPriceFromCurvesWithZSpread(
+        BOND_SECURITY_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0);
+    LocalDate standardSettlementDate = PRODUCT.getSettlementDateOffset().adjust(PROVIDER.getValuationDate());
+    double priceCleanComputed = PRODUCT_PRICER.cleanPriceFromDirtyPrice(PRODUCT, standardSettlementDate, priceDirty);
+    CurrencyAmount pvCleanPrice = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE_NO_EXCOUPON, PROVIDER, priceCleanComputed, Z_SPREAD, false, 0);
+    CurrencyAmount pvCurves = TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0);
+    assertEquals(pvCleanPrice.getAmount(), pvCurves.getAmount(), NOTIONAL * TOL);
+  }
+
+  public void test_presentValueFromCleanPriceWithZSpread_periodic_noExcoupon_coherency() {
+    double priceDirty = PRODUCT_PRICER.dirtyPriceFromCurvesWithZSpread(
+        BOND_SECURITY_NO_EXCOUPON, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    LocalDate standardSettlementDate = PRODUCT.getSettlementDateOffset().adjust(PROVIDER.getValuationDate());
+    double priceCleanComputed = PRODUCT_PRICER.cleanPriceFromDirtyPrice(PRODUCT, standardSettlementDate, priceDirty);
+    CurrencyAmount pvCleanPrice = TRADE_PRICER.presentValueFromCleanPriceWithZSpread(
+        TRADE_NO_EXCOUPON, PROVIDER, priceCleanComputed, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurrencyAmount pvCurves = TRADE_PRICER.presentValueWithZSpread(
+        TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    assertEquals(pvCleanPrice.getAmount(), pvCurves.getAmount(), NOTIONAL * TOL);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueSensitivity() {
+    PointSensitivityBuilder pointTrade = TRADE_PRICER.presentValueSensitivity(TRADE, PROVIDER);
+    CurveCurrencyParameterSensitivities computedTrade = PROVIDER.curveParameterSensitivity(pointTrade.build());
+    CurveCurrencyParameterSensitivities expectedTrade = sensitivity(PROVIDER,
+        (p) -> TRADE_PRICER.presentValue(TRADE, (p)), EPS);
+    assertTrue(computedTrade.equalWithTolerance(expectedTrade, 30d * NOTIONAL * QUANTITY * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_continuous() {
+    PointSensitivityBuilder pointTrade =
+        TRADE_PRICER.presentValueSensitivityWithZSpread(TRADE, PROVIDER, Z_SPREAD, false, 0);
+    CurveCurrencyParameterSensitivities computedTrade = PROVIDER.curveParameterSensitivity(pointTrade.build());
+    CurveCurrencyParameterSensitivities expectedTrade = sensitivity(
+        PROVIDER, (p) -> TRADE_PRICER.presentValueWithZSpread(TRADE, (p), Z_SPREAD, false, 0), EPS);
+    assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_periodic() {
+    PointSensitivityBuilder pointTrade =
+        TRADE_PRICER.presentValueSensitivityWithZSpread(TRADE, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurveCurrencyParameterSensitivities computedTrade = PROVIDER.curveParameterSensitivity(pointTrade.build());
+    CurveCurrencyParameterSensitivities expectedTrade = sensitivity(
+        PROVIDER, (p) -> TRADE_PRICER.presentValueWithZSpread(TRADE, (p), Z_SPREAD, true, PERIOD_PER_YEAR), EPS);
+    assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
+  }
+
+  public void test_presentValueProductSensitivity_noExcoupon() {
+    PointSensitivityBuilder pointTrade = TRADE_PRICER.presentValueSensitivity(TRADE_NO_EXCOUPON, PROVIDER);
+    CurveCurrencyParameterSensitivities computedTrade = PROVIDER.curveParameterSensitivity(pointTrade.build());
+    CurveCurrencyParameterSensitivities expectedTrade = sensitivity(
+        PROVIDER, (p) -> TRADE_PRICER.presentValue(TRADE_NO_EXCOUPON, (p)), EPS);
+    assertTrue(computedTrade.equalWithTolerance(expectedTrade, 30d * NOTIONAL * QUANTITY * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_continuous_noExcoupon() {
+    PointSensitivityBuilder pointTrade =
+        TRADE_PRICER.presentValueSensitivityWithZSpread(TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, false, 0);
+    CurveCurrencyParameterSensitivities computedTrade = PROVIDER.curveParameterSensitivity(pointTrade.build());
+    CurveCurrencyParameterSensitivities expectedTrade = sensitivity(
+        PROVIDER, (p) -> TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, (p), Z_SPREAD, false, 0), EPS);
+    assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
+  }
+
+  public void test_presentValueSensitivityWithZSpread_periodic_noExcoupon() {
+    PointSensitivityBuilder pointTrade = TRADE_PRICER.presentValueSensitivityWithZSpread(
+        TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, true, PERIOD_PER_YEAR);
+    CurveCurrencyParameterSensitivities computedTrade = PROVIDER.curveParameterSensitivity(pointTrade.build());
+    CurveCurrencyParameterSensitivities expectedTrade = sensitivity(PROVIDER,
+        (p) -> TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, (p), Z_SPREAD, true, PERIOD_PER_YEAR), EPS);
+    assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_presentValueSensitivity_dateLogic() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER.presentValueSensitivity(tradeAfter, PROVIDER_BEFORE).build();
+    // settle before detachment date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeBefore = TRADE_PRICER.presentValueSensitivity(tradeBefore, PROVIDER_BEFORE).build();
+    FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT.expand(), SETTLE_BEFORE, SETTLEMENT);
+    PointSensitivities sensiExtra = COUPON_PRICER
+        .presentValueSensitivity(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR)).build();
+    assertTrue(computedTradeBefore.normalized().equalWithTolerance(
+        computedTradeAfter.combinedWith(sensiExtra.multipliedBy(QUANTITY)).normalized(), NOTIONAL * QUANTITY * TOL));
+    // settle on detachment date
+    FixedCouponBondTrade tradeOnDetachment = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_ON_DETACHMENT)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeOnDetachment =
+        TRADE_PRICER.presentValueSensitivity(tradeOnDetachment, PROVIDER_BEFORE).build();
+    assertTrue(computedTradeOnDetachment.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+    // settle between detachment date and coupon date
+    FixedCouponBondTrade tradeBtwnDetachmentCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BTWN_DETACHMENT_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeBtwnDetachmentCoupon =
+        TRADE_PRICER.presentValueSensitivity(tradeBtwnDetachmentCoupon, PROVIDER_BEFORE).build();
+    assertTrue(computedTradeBtwnDetachmentCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+  }
+
+  public void test_presentValueSensitivity_dateLogic_pastSettle() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER.presentValueSensitivity(tradeAfter, PROVIDER).build();
+    // settle before detachment date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeBefore = TRADE_PRICER.presentValueSensitivity(tradeBefore, PROVIDER).build();
+    assertTrue(computedTradeBefore.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+    // settle on detachment date
+    FixedCouponBondTrade tradeOnDetachment = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_ON_DETACHMENT)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeOnDetachment =
+        TRADE_PRICER.presentValueSensitivity(tradeOnDetachment, PROVIDER).build();
+    assertTrue(computedTradeOnDetachment.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+    // settle between detachment date and coupon date
+    FixedCouponBondTrade tradeBtwnDetachmentCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK)
+        .tradeInfo(TRADE_INFO_BTWN_DETACHMENT_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeBtwnDetachmentCoupon =
+        TRADE_PRICER.presentValueSensitivity(tradeBtwnDetachmentCoupon, PROVIDER).build();
+    assertTrue(computedTradeBtwnDetachmentCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+  }
+
+  public void test_presentValueSensitivity_dateLogic_noExcoupon() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER.presentValueSensitivity(tradeAfter, PROVIDER_BEFORE).build();
+    // settle before coupon date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeBefore = TRADE_PRICER.presentValueSensitivity(tradeBefore, PROVIDER_BEFORE).build();
+    FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT_NO_EXCOUPON.expand(), SETTLE_BEFORE, SETTLEMENT);
+    PointSensitivities sensiExtra = COUPON_PRICER
+        .presentValueSensitivity(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR)).build();
+    assertTrue(computedTradeBefore.normalized().equalWithTolerance(
+        computedTradeAfter.combinedWith(sensiExtra.multipliedBy(QUANTITY)).normalized(), NOTIONAL * QUANTITY * TOL));
+    // settle on coupon date
+    FixedCouponBondTrade tradeOnCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_ON_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeOnCoupon = TRADE_PRICER.presentValueSensitivity(tradeOnCoupon, PROVIDER_BEFORE)
+        .build();
+    assertTrue(computedTradeOnCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+  }
+
+  public void test_presentValueSensitivity_dateLogic_pastSettle_noExcoupon() {
+    FixedCouponBondTrade tradeAfter = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER.presentValueSensitivity(tradeAfter, PROVIDER).build();
+    // settle before coupon date
+    FixedCouponBondTrade tradeBefore = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_BEFORE)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeBefore = TRADE_PRICER.presentValueSensitivity(tradeBefore, PROVIDER).build();
+    assertTrue(computedTradeBefore.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+    // settle on coupon date
+    FixedCouponBondTrade tradeOnCoupon = FixedCouponBondTrade.builder()
+        .securityLink(SECURITY_LINK_NO_EXCOUPON)
+        .tradeInfo(TRADE_INFO_ON_COUPON)
+        .quantity(QUANTITY)
+        .payment(UPFRONT_PAYMENT_ZERO)
+        .build();
+    PointSensitivities computedTradeOnCoupon = TRADE_PRICER.presentValueSensitivity(tradeOnCoupon, PROVIDER).build();
+    assertTrue(computedTradeOnCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
+  }
+
+  //-------------------------------------------------------------------------
+  private CurveCurrencyParameterSensitivities sensitivity(
+      LegalEntityDiscountingProvider provider,
+      Function<LegalEntityDiscountingProvider, CurrencyAmount> valueFn, double shift) {
+
+    CurrencyAmount valueInit = valueFn.apply(provider);
+    CurveCurrencyParameterSensitivities discounting = sensitivity(
+        provider, valueFn, LegalEntityDiscountingProvider.meta().repoCurves(), valueInit, shift);
+    CurveCurrencyParameterSensitivities forward = sensitivity(
+        provider, valueFn, LegalEntityDiscountingProvider.meta().issuerCurves(), valueInit, shift);
+    return discounting.combinedWith(forward);
+  }
+
+  private <T> CurveCurrencyParameterSensitivities sensitivity(
+      LegalEntityDiscountingProvider provider,
+      Function<LegalEntityDiscountingProvider, CurrencyAmount> valueFn,
+      MetaProperty<ImmutableMap<Pair<T, Currency>, DiscountFactors>> metaProperty,
+      CurrencyAmount valueInit,
+      double shift) {
+
+    ImmutableMap<Pair<T, Currency>, DiscountFactors> baseCurves = metaProperty.get(provider);
+    CurveCurrencyParameterSensitivities result = CurveCurrencyParameterSensitivities.empty();
+    for (Pair<T, Currency> key : baseCurves.keySet()) {
+      DiscountFactors discountFactors = baseCurves.get(key);
+      // Assume underlying object is ZeroRateDiscountFactors 
+      NodalCurve curveInt = (NodalCurve) ((ZeroRateDiscountFactors) discountFactors).getCurve();
+      int nbNodePoint = curveInt.getXValues().size();
+      DoubleArray sensitivity = DoubleArray.of(nbNodePoint, i -> {
+        Curve dscBumped = bumpedCurve(curveInt, i, shift);
+        Map<Pair<T, Currency>, DiscountFactors> mapBumped = new HashMap<>(baseCurves);
+        mapBumped.put(key, ZeroRateDiscountFactors.of(
+            discountFactors.getCurrency(), discountFactors.getValuationDate(), dscBumped));
+        LegalEntityDiscountingProvider providerDscBumped = provider.toBuilder().set(metaProperty, mapBumped).build();
+        return (valueFn.apply(providerDscBumped).getAmount() - valueInit.getAmount()) / shift;
+      });
+      CurveMetadata metadata = curveInt.getMetadata();
+      result = result.combinedWith(
+          CurveCurrencyParameterSensitivity.of(metadata, valueInit.getCurrency(), sensitivity));
+    }
+    return result;
+  }
+
+  private NodalCurve bumpedCurve(NodalCurve curveInt, int loopnode, double shift) {
+    DoubleArray yValues = curveInt.getYValues();
+    return curveInt.withYValues(yValues.with(loopnode, yValues.get(loopnode) + shift));
+  }
+
+  private static LegalEntityDiscountingProvider createRatesProvider(LocalDate valuationDate) {
+    DiscountFactors dscRepo = ZeroRateDiscountFactors.of(EUR, valuationDate, CURVE_REPO);
+    DiscountFactors dscIssuer = ZeroRateDiscountFactors.of(EUR, valuationDate, CURVE_ISSUER);
+    LegalEntityDiscountingProvider provider = LegalEntityDiscountingProvider.builder()
+        .issuerCurves(ImmutableMap.<Pair<LegalEntityGroup, Currency>, DiscountFactors>of(
+            Pair.<LegalEntityGroup, Currency>of(GROUP_ISSUER, EUR), dscIssuer))
+        .legalEntityMap(ImmutableMap.<StandardId, LegalEntityGroup>of(ISSUER_ID, GROUP_ISSUER))
+        .repoCurves(ImmutableMap.<Pair<BondGroup, Currency>, DiscountFactors>of(
+            Pair.<BondGroup, Currency>of(GROUP_REPO, EUR), dscRepo))
+        .bondMap(ImmutableMap.<StandardId, BondGroup>of(SECURITY_ID, GROUP_REPO))
+        .valuationDate(valuationDate)
+        .build();
+    return provider;
+  }
+
+  private FixedCouponBondPaymentPeriod findPeriod(ExpandedFixedCouponBond bond, LocalDate date1, LocalDate date2) {
+    ImmutableList<FixedCouponBondPaymentPeriod> list = bond.getPeriodicPayments();
+    for (FixedCouponBondPaymentPeriod period : list) {
+      if (period.getDetachmentDate().equals(period.getPaymentDate())) {
+        if (period.getPaymentDate().isAfter(date1) && period.getPaymentDate().isBefore(date2)) {
+          return period;
+        }
+      } else {
+        if (period.getDetachmentDate().isAfter(date1) && period.getDetachmentDate().isBefore(date2)) {
+          return period;
+        }
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
* Added bond-specific rate provider, **LegalEntityDiscountingProvider**, which produces two types of discount factors **repoCurveDiscountFactors** and **IssuerCurveDiscountFactors**. 
* Added bond pricer, **DiscountingFixedCouponBondTradePricer**, where each coupon payment is computed by **DiscountingFixedCouponBondPaymentPeriodPricer**. 
* Dirty price and its derivative computation from yield is tested against 2.x
* This work closes #421 
* This work closes #186 
* This work closes #187 