### PR TITLE
Time-series should be optional

### DIFF
--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/MarketDataRatesProvider.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/MarketDataRatesProvider.java
@@ -82,7 +82,7 @@ public final class MarketDataRatesProvider
   private LocalDateDoubleTimeSeries timeSeries(Index index) {
     LocalDateDoubleTimeSeries series = marketData.getTimeSeries(IndexRateKey.of(index));
     if (series == null) {
-      throw new IllegalArgumentException("Unknown index: " + index.getName());
+      return LocalDateDoubleTimeSeries.empty();
     }
     return series;
   }

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
@@ -30,7 +30,6 @@ import com.opengamma.strata.basics.market.MarketDataKey;
 import com.opengamma.strata.basics.market.ObservableId;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.collect.result.Result;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.engine.calculation.DefaultSingleCalculationMarketData;
 import com.opengamma.strata.engine.marketdata.CalculationMarketData;
 import com.opengamma.strata.engine.marketdata.MarketDataRequirements;
@@ -58,7 +57,6 @@ import com.opengamma.strata.market.id.CurveGroupId;
 import com.opengamma.strata.market.id.ParRatesId;
 import com.opengamma.strata.market.key.DiscountFactorsKey;
 import com.opengamma.strata.market.key.IborIndexRatesKey;
-import com.opengamma.strata.market.key.IndexRateKey;
 import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.market.value.DiscountIborIndexRates;
 import com.opengamma.strata.market.value.IborIndexRates;
@@ -128,9 +126,7 @@ public class CurveGroupMarketDataFunctionTest {
         .put(discountFactorsKey, discountFactors)
         .put(forwardCurveKey, iborIndexRates)
         .build();
-    Map<ObservableKey, LocalDateDoubleTimeSeries> timeSeries =
-        ImmutableMap.of(IndexRateKey.of(IborIndices.USD_LIBOR_3M), LocalDateDoubleTimeSeries.empty());
-    CalculationMarketData calculationMarketData = new MarketDataMap(valuationDate, marketDataMap, timeSeries);
+    CalculationMarketData calculationMarketData = new MarketDataMap(valuationDate, marketDataMap, ImmutableMap.of());
     MarketDataRatesProvider ratesProvider =
         new MarketDataRatesProvider(new DefaultSingleCalculationMarketData(calculationMarketData, 0));
 
@@ -181,9 +177,7 @@ public class CurveGroupMarketDataFunctionTest {
         .put(discountFactorsKey, discountFactors)
         .put(forwardCurveKey, iborIndexRates)
         .build();
-    Map<ObservableKey, LocalDateDoubleTimeSeries> timeSeries =
-        ImmutableMap.of(IndexRateKey.of(IborIndices.USD_LIBOR_3M), LocalDateDoubleTimeSeries.empty());
-    CalculationMarketData calculationMarketData = new MarketDataMap(valuationDate, marketDataMap, timeSeries);
+    CalculationMarketData calculationMarketData = new MarketDataMap(valuationDate, marketDataMap, ImmutableMap.of());
     MarketDataRatesProvider ratesProvider =
         new MarketDataRatesProvider(new DefaultSingleCalculationMarketData(calculationMarketData, 0));
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
@@ -34,7 +34,6 @@ import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.basics.market.MarketDataKey;
-import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.value.DiscountFactors;
@@ -116,12 +115,7 @@ public final class ImmutableRatesProvider
   //-------------------------------------------------------------------------
   // finds the time-series
   private LocalDateDoubleTimeSeries timeSeries(Index index) {
-    ArgChecker.notNull(index, "index");
-    LocalDateDoubleTimeSeries series = timeSeries.get(index);
-    if (series == null) {
-      throw new IllegalArgumentException("Unknown index: " + index.getName());
-    }
-    return series;
+    return timeSeries.getOrDefault(index, LocalDateDoubleTimeSeries.empty());
   }
 
   // finds the index curve
@@ -136,8 +130,6 @@ public final class ImmutableRatesProvider
   //-------------------------------------------------------------------------
   @Override
   public double fxRate(Currency baseCurrency, Currency counterCurrency) {
-    ArgChecker.notNull(baseCurrency, "baseCurrency");
-    ArgChecker.notNull(counterCurrency, "counterCurrency");
     if (baseCurrency.equals(counterCurrency)) {
       return 1d;
     }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/RatesProviderDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/RatesProviderDataSets.java
@@ -8,10 +8,6 @@ package com.opengamma.strata.pricer.datasets;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
-import static com.opengamma.strata.basics.index.FxIndices.ECB_EUR_GBP;
-import static com.opengamma.strata.basics.index.FxIndices.ECB_EUR_USD;
-import static com.opengamma.strata.basics.index.FxIndices.WM_EUR_USD;
-import static com.opengamma.strata.basics.index.FxIndices.WM_GBP_USD;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_6M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
@@ -29,7 +25,6 @@ import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxMatrix;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveMetadata;
 import com.opengamma.strata.market.curve.CurveName;
@@ -71,19 +66,6 @@ public class RatesProviderDataSets {
   {0.0240, 0.0250, 0.0260, 0.0270, 0.0280, 0.0290, 0.0300, 0.0310};
 
   //-------------------------------------------------------------------------
-  public static final Map<Index, LocalDateDoubleTimeSeries> TIME_SERIES =
-      ImmutableMap.<Index, LocalDateDoubleTimeSeries>builder()
-          .put(USD_FED_FUND, LocalDateDoubleTimeSeries.empty())
-          .put(USD_LIBOR_3M, LocalDateDoubleTimeSeries.empty())
-          .put(USD_LIBOR_6M, LocalDateDoubleTimeSeries.empty())
-          .put(GBP_SONIA, LocalDateDoubleTimeSeries.empty())
-          .put(GBP_LIBOR_3M, LocalDateDoubleTimeSeries.empty())
-          .put(GBP_LIBOR_6M, LocalDateDoubleTimeSeries.empty())
-          .put(WM_GBP_USD, LocalDateDoubleTimeSeries.empty())
-          .put(WM_EUR_USD, LocalDateDoubleTimeSeries.empty())
-          .put(ECB_EUR_GBP, LocalDateDoubleTimeSeries.empty())
-          .put(ECB_EUR_USD, LocalDateDoubleTimeSeries.empty())
-          .build();
   public static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.LINEAR_INSTANCE;
 
   //-------------------------------------------------------------------------
@@ -114,7 +96,6 @@ public class RatesProviderDataSets {
       .fxMatrix(FX_MATRIX_USD)
       .discountCurves(USD_SINGLE_CCY_MAP)
       .indexCurves(USD_SINGLE_IND_MAP)
-      .timeSeries(TIME_SERIES)
       .build();
 
   //-------------------------------------------------------------------------
@@ -135,7 +116,6 @@ public class RatesProviderDataSets {
       .fxMatrix(FX_MATRIX_USD)
       .discountCurves(USD_MULTI_CCY_MAP)
       .indexCurves(USD_MULTI_IND_MAP)
-      .timeSeries(TIME_SERIES)
       .build();
 
   //-------------------------------------------------------------------------
@@ -168,7 +148,6 @@ public class RatesProviderDataSets {
       .fxMatrix(FX_MATRIX_GBP)
       .discountCurves(GBP_MULTI_CCY_MAP)
       .indexCurves(GBP_MULTI_IND_MAP)
-      .timeSeries(TIME_SERIES)
       .build();
 
   //-------------------------------------------------------------------------
@@ -196,7 +175,6 @@ public class RatesProviderDataSets {
       .fxMatrix(FX_MATRIX_GBP_USD)
       .discountCurves(GBP_USD_MULTI_CCY_MAP)
       .indexCurves(GBP_USD_MULTI_IND_MAP)
-      .timeSeries(TIME_SERIES)
       .build();
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/RatesProviderFxDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/RatesProviderFxDataSets.java
@@ -15,14 +15,8 @@ import java.time.LocalDate;
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.analytics.math.interpolation.Interpolator1DFactory;
 import com.opengamma.strata.basics.currency.Currency;
-import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxMatrix;
-import com.opengamma.strata.basics.date.DaysAdjustment;
-import com.opengamma.strata.basics.date.HolidayCalendars;
-import com.opengamma.strata.basics.index.FxIndex;
-import com.opengamma.strata.basics.index.ImmutableFxIndex;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveMetadata;
 import com.opengamma.strata.market.curve.Curves;
@@ -79,13 +73,6 @@ public class RatesProviderFxDataSets {
   private static final InterpolatedNodalCurve KRW_DSC =
       InterpolatedNodalCurve.of(KRW_DSC_METADATA, KRW_DSC_TIME, KRW_DSC_RATE, INTERPOLATOR);
 
-  private static final FxIndex INDEX_USD_KRW = ImmutableFxIndex.builder()
-      .name("USD/KRW")
-      .currencyPair(CurrencyPair.of(USD, KRW))
-      .fixingCalendar(HolidayCalendars.USNY)
-      .maturityDateOffset(DaysAdjustment.ofBusinessDays(2, HolidayCalendars.USNY))
-      .build();
-
   /**
    * Create a yield curve bundle with three curves.
    * One called "Discounting EUR" with a constant rate of 2.50%, one called "Discounting USD"
@@ -104,7 +91,6 @@ public class RatesProviderFxDataSets {
             .put(KRW, KRW_DSC)
             .build())
         .fxMatrix(FX_MATRIX)
-        .timeSeries(ImmutableMap.of(INDEX_USD_KRW, LocalDateDoubleTimeSeries.empty()))
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingFxResetNotionalExchangePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingFxResetNotionalExchangePricerTest.java
@@ -9,7 +9,6 @@ import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_ACT_ISDA;
-import static com.opengamma.strata.basics.index.FxIndices.WM_GBP_USD;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE_PAY_GBP;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FX_RESET_NOTIONAL_EXCHANGE_REC_USD;
 import static org.mockito.Mockito.mock;
@@ -27,7 +26,6 @@ import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.FxMatrix;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.rate.swap.FxResetNotionalExchange;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.Curves;
@@ -54,7 +52,6 @@ public class DiscountingFxResetNotionalExchangePricerTest {
   private static final double DISCOUNT_FACTOR = 0.98d;
   private static final double FX_RATE = 1.6d;
   private static final double TOLERANCE = 1.0e-10;
-  private static final LocalDateDoubleTimeSeries EMPTY_TIME_SERIES = LocalDateDoubleTimeSeries.empty();
   private static final FxMatrix FX_MATRIX = FxMatrix.of(GBP, USD, 1.6d);
 
   private static final CurveInterpolator INTERPOLATOR = Interpolator1DFactory.DOUBLE_QUADRATIC_INSTANCE;
@@ -90,7 +87,6 @@ public class DiscountingFxResetNotionalExchangePricerTest {
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP, USD, DISCOUNT_CURVE_USD))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, EMPTY_TIME_SERIES))
         .build();
     FxResetNotionalExchange[] expanded =
         new FxResetNotionalExchange[] {FX_RESET_NOTIONAL_EXCHANGE_REC_USD, FX_RESET_NOTIONAL_EXCHANGE_PAY_GBP};
@@ -123,7 +119,6 @@ public class DiscountingFxResetNotionalExchangePricerTest {
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP, USD, DISCOUNT_CURVE_USD))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, EMPTY_TIME_SERIES))
         .build();
     FxResetNotionalExchange[] expanded =
         new FxResetNotionalExchange[] {FX_RESET_NOTIONAL_EXCHANGE_REC_USD, FX_RESET_NOTIONAL_EXCHANGE_PAY_GBP};

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
@@ -8,7 +8,6 @@ package com.opengamma.strata.pricer.rate;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.index.FxIndices.WM_GBP_USD;
 import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_3M;
-import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_1M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.basics.index.OvernightIndices.EUR_EONIA;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
@@ -107,7 +106,6 @@ public class ImmutableRatesProviderParameterSensitivityTest {
           .combinedWith(POINT_ON_1).combinedWith(POINT_ON_2).combinedWith(POINT_ON_3).combinedWith(POINT_ON_4);
 
   // curve providers
-  private static final LocalDateDoubleTimeSeries TS_EMPTY = LocalDateDoubleTimeSeries.empty();
   private static final Pair<MulticurveProviderDiscount, CurveBuildingBlockBundle> MULTICURVE_USD_PAIR =
       StandardDataSetsMulticurveUSD.getCurvesUSDOisL3();
   private static final Pair<MulticurveProviderDiscount, CurveBuildingBlockBundle> MULTICURVE_EUR_PAIR =
@@ -132,12 +130,6 @@ public class ImmutableRatesProviderParameterSensitivityTest {
       .fxMatrix(FX_MATRIX)
       .discountCurves(Legacy.discountCurves(MULTICURVE))
       .indexCurves(Legacy.indexCurves(MULTICURVE))
-      .timeSeries(ImmutableMap.of(
-          EUR_EURIBOR_3M, TS_EMPTY,
-          USD_LIBOR_1M, TS_EMPTY,
-          USD_LIBOR_3M, TS_EMPTY,
-          EUR_EONIA, TS_EMPTY,
-          USD_FED_FUND, TS_EMPTY))
       .build();
 
   private static final double TOLERANCE_SENSI = 1.0E-8;
@@ -236,36 +228,30 @@ public class ImmutableRatesProviderParameterSensitivityTest {
   private static final Curve DISCOUNT_CURVE_USD_DOWN = new ConstantDiscountFactorCurve("USD-DiscountDown", USD_DSC - EPS_FD);
 
   public void pointAndParameterFx() {
-    LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.empty();
     ImmutableRatesProvider test = ImmutableRatesProvider.builder()
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP, USD, DISCOUNT_CURVE_USD))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, ts))
         .build();
     ImmutableRatesProvider test_gbp_up = ImmutableRatesProvider.builder()
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP_UP, USD, DISCOUNT_CURVE_USD))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, ts))
         .build();
     ImmutableRatesProvider test_gbp_dw = ImmutableRatesProvider.builder()
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP_DOWN, USD, DISCOUNT_CURVE_USD))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, ts))
         .build();
     ImmutableRatesProvider test_usd_up = ImmutableRatesProvider.builder()
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP, USD, DISCOUNT_CURVE_USD_UP))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, ts))
         .build();
     ImmutableRatesProvider test_usd_dw = ImmutableRatesProvider.builder()
         .valuationDate(VAL_DATE)
         .fxMatrix(FX_MATRIX)
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP, USD, DISCOUNT_CURVE_USD_DOWN))
-        .timeSeries(ImmutableMap.of(WM_GBP_USD, ts))
         .build();
     LocalDate matuirtyDate = WM_GBP_USD.calculateMaturityFromFixing(VAL_DATE);
     double maturityTime = DAY_COUNT.relativeYearFraction(VAL_DATE, matuirtyDate);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
@@ -190,7 +190,6 @@ public class ImmutableRatesProviderTest {
     ImmutableRatesProvider test2 = ImmutableRatesProvider.builder()
         .valuationDate(LocalDate.of(2014, 6, 27))
         .discountCurves(ImmutableMap.of(GBP, DISCOUNT_CURVE_GBP))
-        .timeSeries(ImmutableMap.of(USD_LIBOR_3M, LocalDateDoubleTimeSeries.empty()))
         .build();
     coverBeanEquals(test, test2);
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositProductPricerTest.java
@@ -25,7 +25,6 @@ import com.opengamma.strata.basics.BuySell;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.rate.deposit.ExpandedIborFixingDeposit;
 import com.opengamma.strata.finance.rate.deposit.IborFixingDeposit;
 import com.opengamma.strata.market.curve.Curves;
@@ -78,7 +77,6 @@ public class DiscountingIborFixingDepositProductPricerTest {
         .valuationDate(VAL_DATE)
         .discountCurves(ImmutableMap.of(EUR, dscCurve))
         .indexCurves(ImmutableMap.of(EUR_EURIBOR_6M, indexCurve))
-        .timeSeries(ImmutableMap.of(EUR_EURIBOR_6M, LocalDateDoubleTimeSeries.empty()))
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositTradePricerTest.java
@@ -23,7 +23,6 @@ import com.opengamma.strata.basics.BuySell;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.TradeInfo;
 import com.opengamma.strata.finance.rate.deposit.IborFixingDeposit;
 import com.opengamma.strata.finance.rate.deposit.IborFixingDepositTrade;
@@ -72,7 +71,6 @@ public class DiscountingIborFixingDepositTradePricerTest {
         .valuationDate(VALUATION_DATE)
         .discountCurves(ImmutableMap.of(EUR, dscCurve))
         .indexCurves(ImmutableMap.of(EUR_EURIBOR_6M, indexCurve))
-        .timeSeries(ImmutableMap.of(EUR_EURIBOR_6M, LocalDateDoubleTimeSeries.empty()))
         .build();
   }
   

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapCrossCurrencyEnd2EndTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/e2e/SwapCrossCurrencyEnd2EndTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.opengamma.analytics.financial.interestrate.datasets.StandardDataSetsMulticurveEUR;
 import com.opengamma.analytics.financial.interestrate.datasets.StandardDataSetsMulticurveUSD;
 import com.opengamma.analytics.financial.provider.curve.CurveBuildingBlockBundle;
@@ -34,7 +33,6 @@ import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.value.ValueSchedule;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.collect.tuple.Pair;
 import com.opengamma.strata.finance.TradeInfo;
 import com.opengamma.strata.finance.rate.swap.FxResetCalculation;
@@ -229,8 +227,6 @@ public class SwapCrossCurrencyEnd2EndTest {
     return DiscountingSwapTradePricer.DEFAULT;
   }
 
-  private static final LocalDateDoubleTimeSeries TS_EMPTY = LocalDateDoubleTimeSeries.empty();
-
   // rates provider
   private static RatesProvider provider() {
     return ImmutableRatesProvider.builder()
@@ -238,10 +234,6 @@ public class SwapCrossCurrencyEnd2EndTest {
         .fxMatrix(FX_MATRIX)
         .discountCurves(Legacy.discountCurves(MULTICURVE))
         .indexCurves(Legacy.indexCurves(MULTICURVE))
-        .timeSeries(ImmutableMap.of(
-            USD_LIBOR_3M, TS_EMPTY,
-            EUR_EURIBOR_3M, TS_EMPTY,
-            WM_EUR_USD, TS_EMPTY))
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/fra/DiscountingFraProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/fra/DiscountingFraProductPricerTest.java
@@ -29,7 +29,6 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DayCounts;
 import com.opengamma.strata.basics.interpolator.CurveInterpolator;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.rate.IborRateObservation;
 import com.opengamma.strata.finance.rate.RateObservation;
 import com.opengamma.strata.finance.rate.fra.ExpandedFra;
@@ -491,7 +490,6 @@ public class DiscountingFraProductPricerTest {
         .valuationDate(VAL_DATE)
         .discountCurves(ImmutableMap.of(GBP, dscCurve))
         .indexCurves(ImmutableMap.of(GBP_LIBOR_3M, indexCurve))
-        .timeSeries(ImmutableMap.of(GBP_LIBOR_3M, LocalDateDoubleTimeSeries.empty()))
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/DiscountingDeliverableSwapFutureProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/DiscountingDeliverableSwapFutureProductPricerTest.java
@@ -35,7 +35,6 @@ import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.id.StandardId;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.Security;
 import com.opengamma.strata.finance.UnitSecurity;
 import com.opengamma.strata.finance.rate.future.DeliverableSwapFuture;
@@ -80,7 +79,6 @@ public class DiscountingDeliverableSwapFutureProductPricerTest {
       .fxMatrix(FxMatrix.empty())
       .discountCurves(ImmutableMap.of(USD, USD_DSC))
       .indexCurves(ImmutableMap.of(USD_LIBOR_3M, USD_FWD3))
-      .timeSeries(ImmutableMap.of(USD_LIBOR_3M, LocalDateDoubleTimeSeries.empty()))
       .build();
   // underlying swap
   private static final NotionalSchedule UNIT_NOTIONAL = NotionalSchedule.of(USD, 1d);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/DiscountingDeliverableSwapFutureTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/future/DiscountingDeliverableSwapFutureTradePricerTest.java
@@ -36,7 +36,6 @@ import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.id.StandardId;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.finance.Security;
 import com.opengamma.strata.finance.SecurityLink;
 import com.opengamma.strata.finance.TradeInfo;
@@ -84,7 +83,6 @@ public class DiscountingDeliverableSwapFutureTradePricerTest {
       .fxMatrix(FxMatrix.empty())
       .discountCurves(ImmutableMap.of(USD, USD_DSC))
       .indexCurves(ImmutableMap.of(USD_LIBOR_3M, USD_FWD3))
-      .timeSeries(ImmutableMap.of(USD_LIBOR_3M, LocalDateDoubleTimeSeries.empty()))
       .build();
   // underlying swap
   private static final NotionalSchedule UNIT_NOTIONAL = NotionalSchedule.of(USD, 1d);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveGammaCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveGammaCalculatorTest.java
@@ -79,7 +79,6 @@ public class CurveGammaCalculatorTest {
       .valuationDate(VAL_DATE_2015_04_27)
       .discountCurves(USD_SINGLE_CCY_MAP)
       .indexCurves(USD_SINGLE_IND_MAP)
-      .timeSeries(RatesProviderDataSets.TIME_SERIES)
       .build();
   private static final Currency SINGLE_CURRENCY = Currency.USD;
   // Conventions


### PR DESCRIPTION
Products can often be priced using just a forward curve.
Make time-series optional.
Simplify tests to match.