### PR TITLE
Fixing Pricer correction

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationDerivative.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationDerivative.java
@@ -11,7 +11,7 @@ import com.opengamma.strata.finance.Trade;
 import com.opengamma.strata.math.impl.function.Function1D;
 import com.opengamma.strata.math.impl.matrix.DoubleMatrix1D;
 import com.opengamma.strata.math.impl.matrix.DoubleMatrix2D;
-import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
  * Provides the calibration derivative.
@@ -66,7 +66,7 @@ class CalibrationDerivative
   public DoubleMatrix2D evaluate(DoubleMatrix1D x) {
     // create child provider from matrix
     double[] data = x.getData();
-    RatesProvider provider = providerGenerator.generate(data);
+    ImmutableRatesProvider provider = providerGenerator.generate(data);
     // calculate derivative for each trade using the child provider
     int size = trades.size();
     double[][] measure = new double[size][size];

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationMeasure.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationMeasure.java
@@ -7,7 +7,7 @@ package com.opengamma.strata.pricer.calibration;
 
 import com.opengamma.strata.finance.Trade;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
-import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
  * Provides access to the measures needed to perform curve calibration for a single type of trade.
@@ -37,7 +37,7 @@ public interface CalibrationMeasure<T extends Trade> {
    * @return the sensitivity
    * @throws IllegalArgumentException if the trade cannot be valued
    */
-  public abstract double value(T trade, RatesProvider provider);
+  public abstract double value(T trade, ImmutableRatesProvider provider);
 
   /**
    * Calculates the parameter sensitivities that relate to the value.
@@ -49,6 +49,6 @@ public interface CalibrationMeasure<T extends Trade> {
    * @return the sensitivity
    * @throws IllegalArgumentException if the trade cannot be valued
    */
-  public abstract CurveCurrencyParameterSensitivities sensitivities(T trade, RatesProvider provider);
+  public abstract CurveCurrencyParameterSensitivities sensitivities(T trade, ImmutableRatesProvider provider);
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationMeasures.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationMeasures.java
@@ -20,7 +20,7 @@ import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitiviti
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity;
 import com.opengamma.strata.market.sensitivity.CurveUnitParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.CurveUnitParameterSensitivity;
-import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
  * Provides access to the measures needed to perform curve calibration.
@@ -100,7 +100,7 @@ public final class CalibrationMeasures {
    * @return the sensitivity
    * @throws IllegalArgumentException if the trade cannot be valued
    */
-  public double value(Trade trade, RatesProvider provider) {
+  public double value(Trade trade, ImmutableRatesProvider provider) {
     CalibrationMeasure<Trade> measure = getMeasure(trade.getClass());
     return measure.value(trade, provider);
   }
@@ -116,7 +116,7 @@ public final class CalibrationMeasures {
    * @param curveOrder  the order of the curves
    * @return the sensitivity derivative
    */
-  public double[] derivative(Trade trade, RatesProvider provider, List<CurveParameterSize> curveOrder) {
+  public double[] derivative(Trade trade, ImmutableRatesProvider provider, List<CurveParameterSize> curveOrder) {
     CurveUnitParameterSensitivities unitSens = extractSensitivities(trade, provider);
 
     // expand to a concatenated array
@@ -131,7 +131,7 @@ public final class CalibrationMeasures {
   }
 
   // determine the curve parameter sensitivities, removing the curency
-  private CurveUnitParameterSensitivities extractSensitivities(Trade trade, RatesProvider provider) {
+  private CurveUnitParameterSensitivities extractSensitivities(Trade trade, ImmutableRatesProvider provider) {
     CalibrationMeasure<Trade> measure = getMeasure(trade.getClass());
     CurveCurrencyParameterSensitivities paramSens = measure.sensitivities(trade, provider);
     CurveUnitParameterSensitivities unitSens = CurveUnitParameterSensitivities.empty();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationValue.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationValue.java
@@ -10,7 +10,7 @@ import java.util.List;
 import com.opengamma.strata.finance.Trade;
 import com.opengamma.strata.math.impl.function.Function1D;
 import com.opengamma.strata.math.impl.matrix.DoubleMatrix1D;
-import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
  * Provides the calibration value.
@@ -57,7 +57,7 @@ class CalibrationValue
   public DoubleMatrix1D evaluate(DoubleMatrix1D x) {
     // create child provider from matrix
     double[] data = x.getData();
-    RatesProvider childProvider = providerGenerator.generate(data);
+    ImmutableRatesProvider childProvider = providerGenerator.generate(data);
     // calculate value for each trade using the child provider
     int size = trades.size();
     double[] measure = new double[size];

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/TradeCalibrationMeasure.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/TradeCalibrationMeasure.java
@@ -16,7 +16,7 @@ import com.opengamma.strata.finance.rate.fra.FraTrade;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
-import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.deposit.DiscountingIborFixingDepositProductPricer;
 import com.opengamma.strata.pricer.rate.deposit.DiscountingTermDepositProductPricer;
 import com.opengamma.strata.pricer.rate.fra.DiscountingFraProductPricer;
@@ -84,11 +84,11 @@ public class TradeCalibrationMeasure<T extends Trade>
   /**
    * The value measure.
    */
-  private final ToDoubleBiFunction<T, RatesProvider> valueFn;
+  private final ToDoubleBiFunction<T, ImmutableRatesProvider> valueFn;
   /**
    * The sensitivity measure.
    */
-  private final BiFunction<T, RatesProvider, PointSensitivities> sensitivityFn;
+  private final BiFunction<T, ImmutableRatesProvider, PointSensitivities> sensitivityFn;
 
   //-------------------------------------------------------------------------
   /**
@@ -106,8 +106,8 @@ public class TradeCalibrationMeasure<T extends Trade>
   public static <R extends Trade> TradeCalibrationMeasure<R> of(
       String name,
       Class<R> tradeType,
-      ToDoubleBiFunction<R, RatesProvider> valueFn,
-      BiFunction<R, RatesProvider, PointSensitivities> sensitivityFn) {
+      ToDoubleBiFunction<R, ImmutableRatesProvider> valueFn,
+      BiFunction<R, ImmutableRatesProvider, PointSensitivities> sensitivityFn) {
 
     return new TradeCalibrationMeasure<R>(name, tradeType, valueFn, sensitivityFn);
   }
@@ -116,8 +116,8 @@ public class TradeCalibrationMeasure<T extends Trade>
   private TradeCalibrationMeasure(
       String name,
       Class<T> tradeType,
-      ToDoubleBiFunction<T, RatesProvider> valueFn,
-      BiFunction<T, RatesProvider, PointSensitivities> sensitivityFn) {
+      ToDoubleBiFunction<T, ImmutableRatesProvider> valueFn,
+      BiFunction<T, ImmutableRatesProvider, PointSensitivities> sensitivityFn) {
 
     this.name = name;
     this.tradeType = tradeType;
@@ -133,12 +133,12 @@ public class TradeCalibrationMeasure<T extends Trade>
 
   //-------------------------------------------------------------------------
   @Override
-  public double value(T trade, RatesProvider provider) {
+  public double value(T trade, ImmutableRatesProvider provider) {
     return valueFn.applyAsDouble(trade, provider);
   }
 
   @Override
-  public CurveCurrencyParameterSensitivities sensitivities(T trade, RatesProvider provider) {
+  public CurveCurrencyParameterSensitivities sensitivities(T trade, ImmutableRatesProvider provider) {
     PointSensitivities pts = sensitivityFn.apply(trade, provider);
     return provider.curveParameterSensitivity(pts);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/deposit/DiscountingIborFixingDepositTradePricer.java
@@ -10,12 +10,13 @@ import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.finance.rate.deposit.IborFixingDepositProduct;
 import com.opengamma.strata.finance.rate.deposit.IborFixingDepositTrade;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
-import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
  * The methods associated to the pricing of Ibor fixing deposit trades by discounting.
  * <p>
- * This function provides the ability to price a {@link IborFixingDepositTrade}.
+ * This function provides the ability to price a {@link IborFixingDepositTrade}. Those trades are synthetic trades
+ * which are used for curve calibration purposes; they should not be used as actual trades.
  */
 public class DiscountingIborFixingDepositTradePricer {
 
@@ -49,7 +50,7 @@ public class DiscountingIborFixingDepositTradePricer {
    * @param provider  the rates provider
    * @return the present value of the product
    */
-  public CurrencyAmount presentValue(IborFixingDepositTrade trade, RatesProvider provider) {
+  public CurrencyAmount presentValue(IborFixingDepositTrade trade, ImmutableRatesProvider provider) {
     return productPricer.presentValue(trade.getProduct(), provider);
   }
 
@@ -63,7 +64,7 @@ public class DiscountingIborFixingDepositTradePricer {
    * @param provider  the rates provider
    * @return the point sensitivity of the present value
    */
-  public PointSensitivities presentValueSensitivity(IborFixingDepositTrade trade, RatesProvider provider) {
+  public PointSensitivities presentValueSensitivity(IborFixingDepositTrade trade, ImmutableRatesProvider provider) {
     return productPricer.presentValueSensitivity(trade.getProduct(), provider);
   }
 
@@ -75,7 +76,7 @@ public class DiscountingIborFixingDepositTradePricer {
    * @param provider  the rates provider
    * @return the par spread
    */
-  public double parSpread(IborFixingDepositTrade trade, RatesProvider provider) {
+  public double parSpread(IborFixingDepositTrade trade, ImmutableRatesProvider provider) {
     return productPricer.parSpread(trade.getProduct(), provider);
   }
 
@@ -86,7 +87,7 @@ public class DiscountingIborFixingDepositTradePricer {
    * @param provider  the rates provider
    * @return the par spread curve sensitivity
    */
-  public PointSensitivities parSpreadSensitivity(IborFixingDepositTrade trade, RatesProvider provider) {
+  public PointSensitivities parSpreadSensitivity(IborFixingDepositTrade trade, ImmutableRatesProvider provider) {
     return productPricer.parSpreadSensitivity(trade.getProduct(), provider);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationMeasuresTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationMeasuresTest.java
@@ -15,7 +15,7 @@ import com.opengamma.strata.finance.rate.deposit.IborFixingDepositTrade;
 import com.opengamma.strata.finance.rate.deposit.TermDepositTrade;
 import com.opengamma.strata.finance.rate.fra.FraTrade;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
-import com.opengamma.strata.pricer.rate.SimpleRatesProvider;
+import com.opengamma.strata.pricer.rate.datasets.ImmutableRatesProviderSimpleData;
 import com.opengamma.strata.pricer.rate.swap.SwapDummyData;
 
 /**
@@ -53,7 +53,7 @@ public class CalibrationMeasuresTest {
 
   public void test_measureNotKnown() {
     CalibrationMeasures test = CalibrationMeasures.of(TradeCalibrationMeasure.FRA_PAR_SPREAD);
-    assertThrowsIllegalArg(() -> test.value(SwapDummyData.SWAP_TRADE, new SimpleRatesProvider()));
+    assertThrowsIllegalArg(() -> test.value(SwapDummyData.SWAP_TRADE, ImmutableRatesProviderSimpleData.IMM_PROV_EUR_FIX));
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/datasets/ImmutableRatesProviderSimpleData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/datasets/ImmutableRatesProviderSimpleData.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.rate.datasets;
+
+import static com.opengamma.strata.basics.currency.Currency.EUR;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_6M;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.interpolator.CurveInterpolator;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.math.impl.interpolation.Interpolator1DFactory;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
+
+/**
+ * Simple instances of ImmutableRateProvider to be used in tests.
+ */
+public class ImmutableRatesProviderSimpleData {
+  
+  public static final LocalDate VAL_DATE = LocalDate.of(2014, 1, 16);  
+
+  public static final ImmutableRatesProvider IMM_PROV_EUR_NOFIX;
+  public static final ImmutableRatesProvider IMM_PROV_EUR_FIX;
+  static {
+    CurveInterpolator interp = Interpolator1DFactory.DOUBLE_QUADRATIC_INSTANCE;
+    double[] time_eur = new double[] {0.0, 0.1, 0.25, 0.5, 0.75, 1.0, 2.0};
+    double[] rate_eur = new double[] {0.0160, 0.0165, 0.0155, 0.0155, 0.0155, 0.0150, 0.0140};
+    InterpolatedNodalCurve dscCurve =
+        InterpolatedNodalCurve.of(Curves.zeroRates("EUR-Discount", ACT_365F), time_eur, rate_eur, interp);
+    double[] time_index = new double[] {0.0, 0.25, 0.5, 1.0};
+    double[] rate_index = new double[] {0.0180, 0.0180, 0.0175, 0.0165};
+    InterpolatedNodalCurve indexCurve =
+        InterpolatedNodalCurve.of(Curves.zeroRates("EUR-EURIBOR6M", ACT_365F), time_index, rate_index, interp);
+    IMM_PROV_EUR_NOFIX = ImmutableRatesProvider.builder()
+        .valuationDate(VAL_DATE)
+        .discountCurves(ImmutableMap.of(EUR, dscCurve))
+        .indexCurves(ImmutableMap.of(EUR_EURIBOR_6M, indexCurve))
+        .build();
+    Map<Index, LocalDateDoubleTimeSeries> ts = new HashMap<>();
+    LocalDateDoubleTimeSeries tsE6 = LocalDateDoubleTimeSeries.builder()
+        .put(EUR_EURIBOR_6M.calculateFixingFromEffective(VAL_DATE), 0.012345).build();
+    ts.put(EUR_EURIBOR_6M, tsE6);
+    IMM_PROV_EUR_FIX = ImmutableRatesProvider.builder()
+        .valuationDate(VAL_DATE)
+        .discountCurves(ImmutableMap.of(EUR, dscCurve))
+        .indexCurves(ImmutableMap.of(EUR_EURIBOR_6M, indexCurve))
+        .timeSeries(ts)
+        .build();
+  }
+
+}


### PR DESCRIPTION
Change the IborFixingDepositPricer pricer so it does not use the time series. The synthetic IborFixingDeposit represent a way to introduce the fixing to come in the curve calibration process. Using the TS for that purpose would cancel the reason for which the synthetic instrument was introduced.
Change the curve calibration classes to refer to ImmutableRatesProvider.