### PR TITLE
Refactor expression parsing in report templates

### DIFF
--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/BeanTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/BeanTokenEvaluator.java
@@ -27,7 +27,7 @@ import com.opengamma.strata.market.amount.LegAmounts;
  * <p>
  * For example, the bean {@link LegAmounts} has a single property named {@code amounts} containing a list of
  * {@link LegAmount} instances. The following expressions are equivalent and both return the first amount in the
- * list:
+ * list. {@code LegInitialNotional} is a measure that produces {@code LegAmounts}.
  * <pre>
  *   Measures.LegInitialNotional.0
  *   Measures.LegInitialNotional.amounts.0

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/BeanTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/BeanTokenEvaluator.java
@@ -5,20 +5,40 @@
  */
 package com.opengamma.strata.report.framework.expression;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import org.joda.beans.Bean;
 
-import com.opengamma.strata.collect.Messages;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.opengamma.strata.market.amount.LegAmount;
+import com.opengamma.strata.market.amount.LegAmounts;
 
 /**
  * Evaluates a token against a bean to produce another object.
+ * <p>
+ * The token must be the name of one of the properties of the bean and the result is the value of the property.
+ * <p>
+ * There is special handling of beans with a single property. The name of the property can be omitted from
+ * the expression if the bean only has one property.
+ * <p>
+ * For example, the bean {@link LegAmounts} has a single property named {@code amounts} containing a list of
+ * {@link LegAmount} instances. The following expressions are equivalent and both return the first amount in the
+ * list:
+ * <pre>
+ *   Measures.LegInitialNotional.0
+ *   Measures.LegInitialNotional.amounts.0
+ * </pre>
+ * <p>
+ * If the token matches the property then the default behaviour applies; the property value is returned and
+ * the remaining tokens do not include the property token. If the token doesn't match the property, the property value
+ * is returned but the token isn't consumed. i.e. the remaining tokens returned from {@link #evaluate} include
+ * the first token.
  */
-public class BeanTokenEvaluator
-    extends TokenEvaluator<Bean> {
+public class BeanTokenEvaluator extends TokenEvaluator<Bean> {
 
   @Override
   public Class<Bean> getTargetType() {
@@ -27,22 +47,46 @@ public class BeanTokenEvaluator
 
   @Override
   public Set<String> tokens(Bean bean) {
-    return bean.propertyNames();
+    if (bean.propertyNames().size() == 1) {
+      String singlePropertyName = Iterables.getOnlyElement(bean.propertyNames());
+      Object propertyValue = bean.property(singlePropertyName).get();
+      Set<String> valueTokens = ValuePathEvaluator.tokens(propertyValue);
+
+      return ImmutableSet.<String>builder()
+          .add(singlePropertyName)
+          .addAll(valueTokens)
+          .build();
+    } else {
+      return bean.propertyNames();
+    }
   }
 
   @Override
-  public Result<?> evaluate(Bean bean, String token) {
+  public EvaluationResult evaluate(Bean bean, String firstToken, List<String> remainingTokens) {
     Optional<String> propertyName = bean.propertyNames().stream()
-        .filter(p -> p.toLowerCase().equals(token))
+        .filter(p -> p.equalsIgnoreCase(firstToken))
         .findFirst();
 
     if (propertyName.isPresent()) {
       Object propertyValue = bean.property(propertyName.get()).get();
+
       return propertyValue != null ?
-          Result.success(propertyValue) :
-          Result.failure(FailureReason.INVALID_INPUT, Messages.format("No value available for property '{}'", token));
+          EvaluationResult.success(propertyValue, remainingTokens) :
+          EvaluationResult.failure("No value available for property '{}'", firstToken);
     }
-    return invalidTokenFailure(bean, token);
+    // The bean has a single property which doesn't match the token.
+    // Return the property value without consuming any tokens.
+    // This allows skipping over properties when the bean only has a single property.
+    if (bean.propertyNames().size() == 1) {
+      String singlePropertyName = Iterables.getOnlyElement(bean.propertyNames());
+      Object propertyValue = bean.property(singlePropertyName).get();
+      List<String> tokens = ImmutableList.<String>builder().add(firstToken).addAll(remainingTokens).build();
+
+      return propertyValue != null ?
+          EvaluationResult.success(propertyValue, tokens) :
+          EvaluationResult.failure("No value available for property '{}'", firstToken);
+    }
+    return invalidTokenFailure(bean, firstToken);
   }
 
 }

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurrencyAmountTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurrencyAmountTokenEvaluator.java
@@ -5,15 +5,15 @@
  */
 package com.opengamma.strata.report.framework.expression;
 
+import java.util.List;
+
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
-import com.opengamma.strata.collect.result.Result;
 
 /**
  * Evaluates a token against a currency amount.
  */
-public class CurrencyAmountTokenEvaluator
-    extends TokenEvaluator<CurrencyAmount> {
+public class CurrencyAmountTokenEvaluator extends TokenEvaluator<CurrencyAmount> {
 
   private final String CURRENCY_FIELD = "currency";
   private final String AMOUNT_FIELD = "amount";
@@ -24,20 +24,20 @@ public class CurrencyAmountTokenEvaluator
   }
 
   @Override
-  public ImmutableSet<String> tokens(CurrencyAmount amount) {
+  public ImmutableSet<String>tokens(CurrencyAmount amount) {
     return ImmutableSet.of(CURRENCY_FIELD, AMOUNT_FIELD);
   }
 
   @Override
-  public Result<?> evaluate(CurrencyAmount amount, String token) {
-    if (token.equals(CURRENCY_FIELD)) {
-      return Result.success(amount.getCurrency());
+  public EvaluationResult evaluate(CurrencyAmount amount, String firstToken, List<String> remainingTokens) {
+    if (firstToken.equalsIgnoreCase(CURRENCY_FIELD)) {
+      return EvaluationResult.success(amount.getCurrency(), remainingTokens);
     }
-    if (token.equals(AMOUNT_FIELD)) {
+    if (firstToken.equalsIgnoreCase(AMOUNT_FIELD)) {
       // Can be rendered directly - retains the currency for formatting purposes
-      return Result.success(amount);
+      return EvaluationResult.success(amount, remainingTokens);
     }
-    return invalidTokenFailure(amount, token);
+    return invalidTokenFailure(amount, firstToken);
   }
 
 }

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurrencyAmountTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurrencyAmountTokenEvaluator.java
@@ -24,7 +24,7 @@ public class CurrencyAmountTokenEvaluator extends TokenEvaluator<CurrencyAmount>
   }
 
   @Override
-  public ImmutableSet<String>tokens(CurrencyAmount amount) {
+  public ImmutableSet<String> tokens(CurrencyAmount amount) {
     return ImmutableSet.of(CURRENCY_FIELD, AMOUNT_FIELD);
   }
 

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurveCurrencyParameterSensitivitiesTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurveCurrencyParameterSensitivitiesTokenEvaluator.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity;
 
@@ -24,7 +23,7 @@ import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity
  * lower case before matching.
  */
 public class CurveCurrencyParameterSensitivitiesTokenEvaluator
-    extends TokenEvaluator<CurveCurrencyParameterSensitivities> {
+        extends TokenEvaluator<CurveCurrencyParameterSensitivities> {
 
   @Override
   public Class<?> getTargetType() {
@@ -39,18 +38,23 @@ public class CurveCurrencyParameterSensitivitiesTokenEvaluator
   }
 
   @Override
-  public Result<?> evaluate(CurveCurrencyParameterSensitivities sensitivities, String token) {
+  public EvaluationResult evaluate(
+      CurveCurrencyParameterSensitivities sensitivities,
+      String firstToken,
+      List<String> remainingTokens) {
+
     List<CurveCurrencyParameterSensitivity> matchingSensitivities = sensitivities.getSensitivities().stream()
-        .filter(sensitivity -> matchesToken(sensitivity, token))
+        .filter(sensitivity -> matchesToken(sensitivity, firstToken))
         .collect(toImmutableList());
 
     switch (matchingSensitivities.size()) {
       case 0:
-        return invalidTokenFailure(sensitivities, token);
+        return invalidTokenFailure(sensitivities, firstToken);
       case 1:
-        return Result.success(matchingSensitivities.get(0));
+        return EvaluationResult.success(matchingSensitivities.get(0), remainingTokens);
+
       default:
-        return Result.success(CurveCurrencyParameterSensitivities.of(matchingSensitivities));
+        return EvaluationResult.success(CurveCurrencyParameterSensitivities.of(matchingSensitivities), remainingTokens);
     }
   }
 
@@ -63,7 +67,7 @@ public class CurveCurrencyParameterSensitivitiesTokenEvaluator
   }
 
   private boolean matchesToken(CurveCurrencyParameterSensitivity sensitivity, String token) {
-    return token.equals(sensitivity.getCurrency().getCode().toLowerCase()) ||
-        token.equals(sensitivity.getCurveName().toString().toLowerCase());
+    return token.equalsIgnoreCase(sensitivity.getCurrency().getCode()) ||
+        token.equalsIgnoreCase(sensitivity.getCurveName().toString());
   }
 }

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurveCurrencyParameterSensitivityTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/CurveCurrencyParameterSensitivityTokenEvaluator.java
@@ -5,10 +5,10 @@
  */
 package com.opengamma.strata.report.framework.expression;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity;
 
 /**
@@ -19,8 +19,7 @@ import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity
  * evaluator is to continue returning the same sensitivity object as long as the tokens are
  * consistent with the fields on this object.
  */
-public class CurveCurrencyParameterSensitivityTokenEvaluator
-    extends TokenEvaluator<CurveCurrencyParameterSensitivity> {
+public class CurveCurrencyParameterSensitivityTokenEvaluator extends TokenEvaluator<CurveCurrencyParameterSensitivity> {
 
   @Override
   public Class<?> getTargetType() {
@@ -35,12 +34,16 @@ public class CurveCurrencyParameterSensitivityTokenEvaluator
   }
 
   @Override
-  public Result<?> evaluate(CurveCurrencyParameterSensitivity sensitivity, String token) {
-    if (token.equals(sensitivity.getCurrency().getCode().toLowerCase()) ||
-        token.equals(sensitivity.getCurveName().toString().toLowerCase())) {
-      return Result.success(sensitivity);
+  public EvaluationResult evaluate(
+      CurveCurrencyParameterSensitivity sensitivity,
+      String firstToken,
+      List<String> remainingTokens) {
+
+    if (firstToken.equalsIgnoreCase(sensitivity.getCurrency().getCode()) ||
+        firstToken.equalsIgnoreCase(sensitivity.getCurveName().toString())) {
+      return EvaluationResult.success(sensitivity, remainingTokens);
     } else {
-      return invalidTokenFailure(sensitivity, token);
+      return invalidTokenFailure(sensitivity, firstToken);
     }
   }
 

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/EvaluationResult.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/EvaluationResult.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * <p>
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.report.framework.expression;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.collect.Messages;
+import com.opengamma.strata.collect.result.FailureReason;
+import com.opengamma.strata.collect.result.Result;
+
+/**
+ * The result of a {@link TokenEvaluator} evaluating an expression against an object.
+ * <p>
+ * The result contains the result of the evaluation and the remaining tokens in the expression.
+ */
+class EvaluationResult {
+
+  /** The result of evaluating the expression against the object. */
+  private final Result<?> result;
+
+  /** The tokens remaining in the expression after evaluation. */
+  private final List<String> remainingTokens;
+
+  EvaluationResult(Result<?> result, List<String> remainingTokens) {
+    this.result = result;
+    this.remainingTokens = remainingTokens;
+  }
+
+  /**
+   * Returns the result of evaluating the expression against the object.
+   *
+   * @return the result of evaluating the expression against the object
+   */
+  Result<?> getResult() {
+    return result;
+  }
+
+  /**
+   * Returns the tokens remaining in the expression after evaluation.
+   *
+   * @return the tokens remaining in the expression after evaluation
+   */
+  List<String> getRemainingTokens() {
+    return remainingTokens;
+  }
+
+  /**
+   * Returns true if evaluation of the whole expression is complete.
+   * <p>
+   * This occurs if the evaluation failed or all tokens in the expression have been consumed.
+   *
+   * @return returns true if evaluation of the whole expression is complete
+   */
+  boolean isComplete() {
+    return getResult().isFailure() || getRemainingTokens().isEmpty();
+  }
+
+  /**
+   * Creates the result of successfully evaluating a token against an object.
+   *
+   * @param value  the result of evaluating the expression against the object
+   * @param remainingTokens  the tokens remaining in the expression after evaluation
+   * @return the result of successfully evaluating a token against an object
+   */
+  static EvaluationResult success(Object value, List<String> remainingTokens) {
+    return new EvaluationResult(Result.success(value), remainingTokens);
+  }
+
+  /**
+   * Creates a result for an unsuccessful evaluation of an expression.
+   *
+   * @param message  the error message
+   * @param messageValues  values substituted into the error message. See {@link Messages#format(String, Object...)}
+   *   for details
+   * @return the result of an unsuccessful evaluation of an expression
+   */
+  static EvaluationResult failure(String message, Object... messageValues) {
+    String msg = Messages.format(message, messageValues);
+    return new EvaluationResult(Result.failure(FailureReason.INVALID_INPUT, msg), ImmutableList.of());
+  }
+
+  /**
+   * Creates the result of evaluating a token against an object.
+   *
+   * @param result  the result of evaluating the expression against the object
+   * @param remainingTokens  the tokens remaining in the expression after evaluation
+   * @return the result of evaluating a token against an object
+   */
+  static EvaluationResult of(Result<?> result, List<String> remainingTokens) {
+    return new EvaluationResult(result, remainingTokens);
+  }
+}

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/MapTokenEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/MapTokenEvaluator.java
@@ -5,17 +5,15 @@
  */
 package com.opengamma.strata.report.framework.expression;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.opengamma.strata.collect.result.Result;
-
 /**
  * Evaluates a token against a map.
  */
-public class MapTokenEvaluator
-    extends TokenEvaluator<Map<?, ?>> {
+public class MapTokenEvaluator extends TokenEvaluator<Map<?, ?>> {
 
   @Override
   public Class<?> getTargetType() {
@@ -30,13 +28,11 @@ public class MapTokenEvaluator
   }
 
   @Override
-  public Result<?> evaluate(Map<?, ?> map, String token) {
-    for (Object key : map.keySet()) {
-      if (token.equals(key.toString().toLowerCase())) {
-        return Result.success(map.get(key));
-      }
-    }
-    return invalidTokenFailure(map, token);
+  public EvaluationResult evaluate(Map<?, ?> map, String firstToken, List<String> remainingTokens) {
+    return map.entrySet().stream()
+        .filter(e -> firstToken.equalsIgnoreCase(e.getKey().toString()))
+        .findFirst()
+        .map(e -> EvaluationResult.success(e.getValue(), remainingTokens))
+        .orElse(invalidTokenFailure(map, firstToken));
   }
-
 }

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/ResultsRow.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/ResultsRow.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * <p>
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.report.framework.expression;
+
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
+import java.util.List;
+import java.util.Set;
+
+import com.opengamma.strata.collect.result.FailureReason;
+import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.collect.type.TypedString;
+import com.opengamma.strata.engine.Column;
+import com.opengamma.strata.engine.config.Measure;
+import com.opengamma.strata.finance.Product;
+import com.opengamma.strata.finance.ProductTrade;
+import com.opengamma.strata.finance.SecurityTrade;
+import com.opengamma.strata.finance.Trade;
+import com.opengamma.strata.function.StandardComponents;
+import com.opengamma.strata.report.ReportCalculationResults;
+
+/**
+ * Wraps a set of {@link ReportCalculationResults} and exposes the contents of a single row.
+ */
+class ResultsRow {
+
+  /** The results used to generate a report. */
+  private final ReportCalculationResults results;
+
+  /** The index of the row in the result whose data is exposed by this object. */
+  private final int rowIndex;
+
+  /**
+   * Returns a new instance exposing the data from a single row in the results.
+   *
+   * @param results  the results used to generate a report
+   * @param rowIndex  the index of the row in the result whose data is exposed by this object
+   */
+  ResultsRow(ReportCalculationResults results, int rowIndex) {
+    this.results = results;
+    this.rowIndex = rowIndex;
+  }
+
+  /**
+   * Returns the trade from the row.
+   *
+   * @return the trade from the row
+   */
+  Trade getTrade() {
+    return results.getTrades().get(rowIndex);
+  }
+
+  /**
+   * Returns the product from the row.
+   * <p>
+   * This returns a successful result where the row's trade implements {@link ProductTrade}.
+   *
+   * @return the product from the row
+   */
+  Result<Product> getProduct() {
+    Trade trade = getTrade();
+
+    if (trade instanceof ProductTrade) {
+      return Result.success(((ProductTrade<?>) trade).getProduct());
+    }
+    if (trade instanceof SecurityTrade) {
+      return Result.success(((SecurityTrade<?>) trade).getProduct());
+    }
+    return Result.failure(FailureReason.INVALID_INPUT, "Trade does not contain a product");
+  }
+
+  /**
+   * Returns the result of calculating the named measure for the trade in the row.
+   *
+   * @param measureName  the name of the measure
+   * @return the result of calculating the named measure for the trade in the row
+   */
+  Result<?> getResult(String measureName) {
+    try {
+      Column column = Column.of(Measure.of(measureName));
+      int columnIndex = results.getColumns().indexOf(column);
+      return columnIndex == -1 ?
+          Result.failure(
+              FailureReason.INVALID_INPUT,
+              "Measure not found in results: '{}'. Valid measure names: {}",
+              measureName,
+              measureNames(results.getTrades().get(rowIndex))) :
+          results.getCalculationResults().get(rowIndex, columnIndex);
+    } catch (IllegalArgumentException ex) {
+      return Result.failure(
+          FailureReason.INVALID_INPUT,
+          "Invalid measure name: '{}'. Valid measure names: {}",
+          measureName,
+          measureNames(results.getTrades().get(rowIndex)));
+    }
+  }
+
+  // TODO The pricing rules should be an argument, not hard-coded to be the standard rules
+  private static List<String> measureNames(Trade trade) {
+    Set<Measure> validMeasures = StandardComponents.pricingRules().configuredMeasures(trade);
+    return validMeasures.stream()
+        .map(TypedString::toString)
+        .sorted()
+        .collect(toImmutableList());
+  }
+}

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/RootEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/RootEvaluator.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * <p>
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.report.framework.expression;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Evaluator that evaluates the first token in the expression.
+ * <p>
+ * The supported values for the first token are enumerated in {@link ValueRootType}.
+ */
+class RootEvaluator extends TokenEvaluator<ResultsRow> {
+
+  /** The single shared instance of this class. */
+  static final RootEvaluator INSTANCE = new RootEvaluator();
+
+  private static final ImmutableSet<String> TOKENS = ImmutableSet.of(
+      ValueRootType.MEASURES.token(),
+      ValueRootType.TRADE.token(),
+      ValueRootType.PRODUCT.token());
+
+  @Override
+  public Class<?> getTargetType() {
+    // This isn't used because the root parser has special treatment
+    return ResultsRow.class;
+  }
+
+  @Override
+  public Set<String> tokens(ResultsRow target) {
+    return TOKENS;
+  }
+
+  @Override
+  public EvaluationResult evaluate(ResultsRow resultsRow, String firstToken, List<String> remainingTokens) {
+    ValueRootType rootType = ValueRootType.parseToken(firstToken);
+
+    switch (rootType) {
+      case MEASURES:
+        return remainingTokens.isEmpty() ?
+            EvaluationResult.failure("A measure name must be specified when selecting a measure") :
+            EvaluationResult.of(resultsRow.getResult(remainingTokens.get(0)),
+                                remainingTokens.subList(1, remainingTokens.size()));
+      case PRODUCT:
+        return EvaluationResult.of(resultsRow.getProduct(), remainingTokens);
+      case TRADE:
+        return EvaluationResult.success(resultsRow.getTrade(), remainingTokens);
+      default:
+        throw new IllegalArgumentException("Unknown root token '" + rootType.token() + "'");
+    }
+  }
+}

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/ValuePathEvaluator.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/expression/ValuePathEvaluator.java
@@ -7,32 +7,21 @@ package com.opengamma.strata.report.framework.expression;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.IntFunction;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
-import org.joda.beans.Bean;
-
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Ordering;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.index.IborIndex;
-import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
-import com.opengamma.strata.collect.type.TypedString;
-import com.opengamma.strata.engine.Column;
 import com.opengamma.strata.engine.config.Measure;
-import com.opengamma.strata.finance.ProductTrade;
-import com.opengamma.strata.finance.SecurityTrade;
-import com.opengamma.strata.finance.Trade;
 import com.opengamma.strata.finance.rate.fra.Fra;
 import com.opengamma.strata.finance.rate.fra.FraTrade;
-import com.opengamma.strata.function.StandardComponents;
 import com.opengamma.strata.report.ReportCalculationResults;
 
 /**
@@ -63,8 +52,8 @@ public class ValuePathEvaluator {
 
   //-------------------------------------------------------------------------
   /**
-   * Gets the measure encoded in a value path, if present. 
-   * 
+   * Gets the measure encoded in a value path, if present.
+   *
    * @param valuePath  the value path
    * @return the measure, if present
    */
@@ -85,73 +74,60 @@ public class ValuePathEvaluator {
 
   /**
    * Evaluates a value path against a set of results, returning the resolved result for each trade.
-   * 
+   *
    * @param valuePath  the value path
    * @param results  the calculation results
    * @return the list of resolved results for each trade
    */
+  @SuppressWarnings("unchecked")
   public static List<Result<?>> evaluate(String valuePath, ReportCalculationResults results) {
     List<String> tokens = tokenize(valuePath);
-    IntFunction<Result<?>> rootResultSupplier;
-    // The first token is Measure, Product or Trade. It is consumed by this method
-    List<String> remainingTokens = tokens.subList(1, tokens.size());
 
-    try {
-      ValueRootType rootType = ValueRootType.parseToken(tokens.get(0));
-
-      switch (rootType) {
-        case MEASURES:
-          rootResultSupplier = getMeasureSupplier(remainingTokens, results);
-          // The second token after "Measure" is the measure name which is consumed by the measure supplier
-          remainingTokens = remainingTokens.subList(1, remainingTokens.size());
-          break;
-        case PRODUCT:
-          rootResultSupplier = getProductSupplier(results);
-          break;
-        case TRADE:
-          rootResultSupplier = getTradeSupplier(results);
-          break;
-        default:
-          throw new IllegalArgumentException(Messages.format("Unsupported root: {}", rootType.token()));
-      }
-    } catch (Exception ex) {
-      rootResultSupplier = i -> Result.failure(FailureReason.INVALID_INPUT, ex.getMessage());
+    if (tokens.size() < 1) {
+      return Collections.nCopies(
+          results.getTrades().size(),
+          Result.failure(FailureReason.INVALID_INPUT, "Column expressions must not be empty"));
     }
-    // This is necessary to make the compiler happy
-    List<String> finalRemainingTokens = remainingTokens;
+    TokenEvaluator rootEvaluator = RootEvaluator.INSTANCE;
 
-    return IntStream.range(0, results.getCalculationResults().getRowCount())
-        .mapToObj(rootResultSupplier)
-        .map(r -> evaluate(r, finalRemainingTokens))
-        .collect(toImmutableList());
+    int rowCount = results.getCalculationResults().getRowCount();
+    // javac 8u40 won't compile this if the call to collect() is chained after the call to mapToObj()
+    // but it works fine if the intermediate stream is assigned to a local variable. Compiler bug?
+    Stream<Result<?>> resultStream = IntStream.range(0, rowCount)
+        .mapToObj(rowIndex -> evaluate(tokens, rootEvaluator, new ResultsRow(results, rowIndex)));
+    return resultStream.collect(toImmutableList());
+  }
+
+  // Tokens always has at least one token
+  private static Result<?> evaluate(List<String> tokens, TokenEvaluator<Object> evaluator, Object target) {
+    EvaluationResult evaluationResult = evaluator.evaluate(target, tokens.get(0), tokens.subList(1, tokens.size()));
+
+    if (evaluationResult.isComplete()) {
+      return evaluationResult.getResult();
+    }
+    Object value = evaluationResult.getResult().getValue();
+    Optional<TokenEvaluator<Object>> nextEvaluator = getEvaluator(value.getClass());
+
+    return nextEvaluator.isPresent() ?
+        evaluate(evaluationResult.getRemainingTokens(), nextEvaluator.get(), value) :
+        noEvaluatorResult(value);
+  }
+
+  private static Result<?> noEvaluatorResult(Object value) {
+    return Result.failure(
+        FailureReason.INVALID_INPUT,
+        "No evaluator available for objects of type {}",
+        value.getClass().getName());
   }
 
   /**
    * Gets the supported tokens on the given object.
-   * 
+   *
    * @param object  the object for which to return the valid tokens
    * @return the tokens
    */
   public static Set<String> tokens(Object object) {
-    // This must mirror the main evaluate method implementation
-    Object evalObject = object;
-    Set<String> tokens = new HashSet<>();
-    Optional<TokenEvaluator<Object>> evaluator = getEvaluator(evalObject.getClass());
-
-    if (evalObject instanceof Bean && !isTypeSpecificEvaluator(evaluator)) {
-      Bean bean = (Bean) evalObject;
-
-      if (bean.propertyNames().size() == 1) {
-        String onlyProperty = Iterables.getOnlyElement(bean.propertyNames());
-        tokens.add(onlyProperty);
-        evalObject = bean.property(onlyProperty).get();
-        evaluator = getEvaluator(evalObject.getClass());
-      }
-    }
-    if (evaluator.isPresent()) {
-      tokens.addAll(evaluator.get().tokens(evalObject));
-    }
-    return tokens;
+    return getEvaluator(object.getClass()).map(evaluator -> evaluator.tokens(object)).orElse(ImmutableSet.of());
   }
 
   //-------------------------------------------------------------------------
@@ -161,145 +137,15 @@ public class ValuePathEvaluator {
     return ImmutableList.copyOf(tokens);
   }
 
-  /**
-   * Returns a function whose input is the index of a trade in the results and whose return value contains
-   * the trade's product.
-   * <p>
-   * If the trade is not a {@link ProductTrade} a failure result is returned.
-   *
-   * @param results  calculation results containing the trades for which the calculations were performed
-   * @return a function whose input is the index of a trade in the results and whose return value contains
-   *   the trade's product
-   */
-  private static IntFunction<Result<?>> getProductSupplier(ReportCalculationResults results) {
-    return i -> {
-      Trade trade = results.getTrades().get(i);
-      if (trade instanceof ProductTrade) {
-        return Result.success(((ProductTrade<?>) trade).getProduct());
-      }
-      if (trade instanceof SecurityTrade) {
-        return Result.success(((SecurityTrade<?>) trade).getProduct());
-      }
-      return Result.failure(FailureReason.INVALID_INPUT, "Trade does not contain a product");
-    };
-  }
-
-  /**
-   * Returns a function whose input is the index of a trade in the results and whose return value contains the trade.
-   *
-   * @param results  calculation results containing the trades for which the calculations were performed
-   * @return a function whose input is the index of a trade in the results and whose return value contains the trade
-   */
-  private static IntFunction<Result<?>> getTradeSupplier(ReportCalculationResults results) {
-    return i -> Result.success(results.getTrades().get(i));
-  }
-
-  /**
-   * Returns a function whose input is the index of a trade in the results and whose return value contains
-   * the calculated value for a measure.
-   *
-   * @param results  calculation results containing the trades for which the calculations were performed
-   * @return a function whose input is the index of a trade in the results and whose return value contains
-   *   the calculated value for a measure
-   */
-  private static IntFunction<Result<?>> getMeasureSupplier(List<String> tokens, ReportCalculationResults results) {
-    if (tokens.isEmpty() || Strings.nullToEmpty(tokens.get(0)).trim().isEmpty()) {
-      return i -> {
-        Trade trade = results.getTrades().get(i);
-        Set<Measure> validMeasures = StandardComponents.pricingRules().configuredMeasures(trade);
-        List<String> measureNames = validMeasures.stream()
-            .map(TypedString::toString)
-            .collect(toImmutableList());
-        measureNames.sort(Ordering.natural());
-        return Result.failure(FailureReason.INVALID_INPUT, "No measure specified. Use one of: {}", validMeasures);
-      };
-    }
-    String measureToken = tokens.get(0);
-    Measure measure;
-
-    try {
-      measure = Measure.of(measureToken);
-    } catch (Exception ex) {
-      return i -> Result.failure(FailureReason.INVALID_INPUT, "Invalid measure name: {}", measureToken);
-    }
-    Column requiredColumn = Column.of(measure);
-    int columnIdx = results.getColumns().indexOf(requiredColumn);
-
-    if (columnIdx == -1) {
-      return i -> Result.failure(FailureReason.INVALID_INPUT, "Measure not present: {}", measure);
-    }
-    return i -> results.getCalculationResults().get(i, columnIdx);
-  }
-
-  /**
-   * Evaluates an expression to extract a value from an object.
-   * <p>
-   * For example, if the root value is a {@link Fra} and the expression is '{@code index.name}', the tokens will be
-   * {@code ['index', 'name']} and this method will call:
-   * <ul>
-   *   <li>{@code Fra.getIndex()}, returning an {@code IborIndex}</li>
-   *   <li>{@code IborIndex.getName()} returning the index name</li>
-   * </ul>
-   * The return value of this method will be the index name.
-   *
-   * @param rootObject  the object against which the expression is evaluated
-   * @param tokens  the individual tokens making up the expression
-   * @return the result of evaluating the expression against the object
-   */
-  static private Result<?> evaluate(Result<?> rootObject, List<String> tokens) {
-    Result<?> result = rootObject;
-
-    for (String token : tokens) {
-      if (result.isFailure()) {
-        return result;
-      }
-      Object value = result.getValue();
-      Optional<TokenEvaluator<Object>> evaluator = getEvaluator(value.getClass());
-
-      if (!evaluator.isPresent()) {
-        return Result.failure(
-            FailureReason.INVALID_INPUT,
-            "Failed to evaluate value. Path: {}. No evaluator found for type {}",
-            String.join(PATH_SEPARATOR, tokens),
-            value.getClass().getSimpleName());
-      }
-      if (value instanceof Bean && !isTypeSpecificEvaluator(evaluator)) {
-        Bean bean = (Bean) value;
-
-        if (bean.propertyNames().size() == 1 && !evaluator.get().tokens(bean).contains(token)) {
-          // Allow single properties to be skipped over in the value path
-          String singlePropertyName = Iterables.getOnlyElement(bean.propertyNames());
-          value = bean.property(singlePropertyName).get();
-          evaluator = getEvaluator(value.getClass());
-
-          if (!evaluator.isPresent()) {
-            return Result.failure(
-                FailureReason.INVALID_INPUT,
-                "Failed to evaluate value. Path: {}. No evaluator found for type {}",
-                String.join(PATH_SEPARATOR, tokens),
-                value.getClass().getSimpleName());
-          }
-        }
-      }
-      result = evaluator.get().evaluate(value, token.toLowerCase());
-    }
-    return result;
-  }
-
   @SuppressWarnings("unchecked")
-  private static Optional<TokenEvaluator<Object>> getEvaluator(Class<?> targetClazz) {
+  private static Optional<TokenEvaluator<Object>> getEvaluator(Class<?> targetClass) {
     return EVALUATORS.stream()
-        .filter(e -> e.getTargetType().isAssignableFrom(targetClazz))
+        .filter(e -> e.getTargetType().isAssignableFrom(targetClass))
         .map(e -> (TokenEvaluator<Object>) e)
         .findFirst();
   }
 
-  private static boolean isTypeSpecificEvaluator(Optional<TokenEvaluator<Object>> evaluator) {
-    return evaluator.isPresent() && !Bean.class.equals(evaluator.get().getTargetType());
-  }
-
   //-------------------------------------------------------------------------
-  // restricted constrctor
   private ValuePathEvaluator() {
   }
 

--- a/modules/report/src/main/java/com/opengamma/strata/report/framework/format/UnsupportedValueFormatter.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/framework/format/UnsupportedValueFormatter.java
@@ -37,14 +37,13 @@ class UnsupportedValueFormatter
   @Override
   public String formatForDisplay(Object object) {
     Set<String> validTokens = ValuePathEvaluator.tokens(object);
+
     if (validTokens.isEmpty()) {
-      return Messages.format("<{}> - drilling into this type is not supported",
-          object.getClass().getSimpleName());
+      return Messages.format("<{}> - drilling into this type is not supported", object.getClass().getSimpleName());
     } else {
       List<String> orderedTokens = new ArrayList<>(validTokens);
       orderedTokens.sort(null);
-      return Messages.format("<{}> - drill down using a field: {}",
-          object.getClass().getSimpleName(), orderedTokens);
+      return Messages.format("<{}> - drill down using a field: {}", object.getClass().getSimpleName(), orderedTokens);
     }
   }
 

--- a/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/BeanTokenEvaluatorTest.java
+++ b/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/BeanTokenEvaluatorTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * <p>
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.report.framework.expression;
+
+import static com.opengamma.strata.basics.BuySell.BUY;
+import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
+import static com.opengamma.strata.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
+import static com.opengamma.strata.collect.TestHelper.date;
+
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.PayReceive;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.finance.rate.fra.Fra;
+import com.opengamma.strata.finance.rate.swap.SwapLegType;
+import com.opengamma.strata.market.amount.LegAmounts;
+import com.opengamma.strata.market.amount.SwapLegAmount;
+
+@Test
+public class BeanTokenEvaluatorTest {
+
+  public void evaluate() {
+    Bean bean = bean();
+    BeanTokenEvaluator evaluator = new BeanTokenEvaluator();
+
+    EvaluationResult notional1 = evaluator.evaluate(bean, "notional", ImmutableList.of());
+    assertThat(notional1.getResult()).hasValue(1_000_000d);
+
+    EvaluationResult notional2 = evaluator.evaluate(bean, "Notional", ImmutableList.of());
+    assertThat(notional2.getResult()).hasValue(1_000_000d);
+  }
+
+  public void tokens() {
+    Bean bean = bean();
+    BeanTokenEvaluator evaluator = new BeanTokenEvaluator();
+
+    Set<String> tokens = evaluator.tokens(bean);
+    ImmutableSet<String> expectedTokens = ImmutableSet.of(
+        "buySell",
+        "currency",
+        "notional",
+        "startDate",
+        "endDate",
+        "businessDayAdjustment",
+        "paymentDate",
+        "fixedRate",
+        "index",
+        "indexInterpolated",
+        "fixingDateOffset",
+        "dayCount",
+        "discounting");
+
+    assertThat(tokens).isEqualTo(expectedTokens);
+  }
+
+  /**
+   * Tests evaluating a bean with a single property. There are 2 different expected behaviours:
+   *
+   * 1) If the token matches the property, the property value is returned and the token is consumed. This is the same
+   *    as the normal bean behaviour.
+   * 2) If the token doesn't match the property it is assumed to match something on the property's value. In this
+   *    case the property value is returned and no tokens are consumed.
+   */
+  public void evaluateSingleProperty() {
+    SwapLegAmount amount = SwapLegAmount.builder()
+        .amount(CurrencyAmount.of(Currency.AUD, 7))
+        .payReceive(PayReceive.PAY)
+        .type(SwapLegType.FIXED)
+        .currency(Currency.AUD)
+        .build();
+    LegAmounts amounts = LegAmounts.of(amount);
+    BeanTokenEvaluator evaluator = new BeanTokenEvaluator();
+
+    EvaluationResult result1 = evaluator.evaluate(amounts, "amounts", ImmutableList.of("foo", "bar"));
+    assertThat(result1.getResult()).hasValue(ImmutableList.of(amount));
+    assertThat(result1.getRemainingTokens()).isEqualTo(ImmutableList.of("foo", "bar"));
+
+    EvaluationResult result2 = evaluator.evaluate(amounts, "baz", ImmutableList.of("foo", "bar"));
+    assertThat(result2.getResult()).hasValue(ImmutableList.of(amount));
+    assertThat(result2.getRemainingTokens()).isEqualTo(ImmutableList.of("baz", "foo", "bar"));
+  }
+
+  /**
+   * Tests the tokens() method when the bean has a single property. The tokens should include the single property
+   * name plus the tokens of the property value.
+   */
+  public void tokensSingleProperty() {
+    SwapLegAmount amount = SwapLegAmount.builder()
+        .amount(CurrencyAmount.of(Currency.AUD, 7))
+        .payReceive(PayReceive.PAY)
+        .type(SwapLegType.FIXED)
+        .currency(Currency.AUD)
+        .build();
+    LegAmounts amounts = LegAmounts.of(amount);
+    BeanTokenEvaluator evaluator = new BeanTokenEvaluator();
+
+    Set<String> tokens = evaluator.tokens(amounts);
+    assertThat(tokens).isEqualTo(ImmutableSet.of("amounts", "0", "aud", "pay", "fixed"));
+  }
+
+  private static Bean bean() {
+    return Fra.builder()
+        .buySell(BUY)
+        .notional(1_000_000)
+        .startDate(date(2015, 8, 5))
+        .endDate(date(2015, 11, 5))
+        .businessDayAdjustment(BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO))
+        .paymentDate(DaysAdjustment.ofBusinessDays(2, GBLO).toAdjustedDate(date(2015, 8, 5)))
+        .fixedRate(0.25d)
+        .index(GBP_LIBOR_3M)
+        .build();
+  }
+}

--- a/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/CurveCurrencyParameterSensitivitiesTokenEvaluatorTest.java
+++ b/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/CurveCurrencyParameterSensitivitiesTokenEvaluatorTest.java
@@ -6,15 +6,14 @@
 package com.opengamma.strata.report.framework.expression;
 
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.curve.DefaultCurveMetadata;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.CurveCurrencyParameterSensitivity;
@@ -55,21 +54,21 @@ public class CurveCurrencyParameterSensitivitiesTokenEvaluatorTest {
     CurveCurrencyParameterSensitivitiesTokenEvaluator evaluator = new CurveCurrencyParameterSensitivitiesTokenEvaluator();
 
     CurveCurrencyParameterSensitivities expected1 = CurveCurrencyParameterSensitivities.of(sensitivity1, sensitivity3);
-    Result<?> result1 = evaluator.evaluate(sensitivities, "aud");
-    assertThat(result1).isSuccess();
-    CurveCurrencyParameterSensitivities result1Value = (CurveCurrencyParameterSensitivities) result1.getValue();
+    EvaluationResult result1 = evaluator.evaluate(sensitivities, "aud", ImmutableList.of());
+    assertThat(result1.getResult()).isSuccess();
+    CurveCurrencyParameterSensitivities result1Value = (CurveCurrencyParameterSensitivities) result1.getResult().getValue();
     assertThat(result1Value.getSensitivities()).containsAll(expected1.getSensitivities());
 
     CurveCurrencyParameterSensitivities expected2 = CurveCurrencyParameterSensitivities.of(sensitivity2, sensitivity3);
-    Result<?> result2 = evaluator.evaluate(sensitivities, "curve2");
-    assertThat(result2).isSuccess();
-    CurveCurrencyParameterSensitivities result2Value = (CurveCurrencyParameterSensitivities) result2.getValue();
+    EvaluationResult result2 = evaluator.evaluate(sensitivities, "curve2", ImmutableList.of());
+    assertThat(result2.getResult()).isSuccess();
+    CurveCurrencyParameterSensitivities result2Value = (CurveCurrencyParameterSensitivities) result2.getResult().getValue();
     assertThat(result2Value.getSensitivities()).containsAll(expected2.getSensitivities());
 
-    Result<?> result3 = evaluator.evaluate(sensitivities, "chf");
-    assertThat(result3).hasValue(sensitivity2);
+    EvaluationResult result3 = evaluator.evaluate(sensitivities, "chf", ImmutableList.of());
+    assertThat(result3.getResult()).hasValue(sensitivity2);
 
-    Result<?> result4 = evaluator.evaluate(sensitivities, "usd");
-    assertThat(result4).isFailure();
+    EvaluationResult result4 = evaluator.evaluate(sensitivities, "usd", ImmutableList.of());
+    assertThat(result4.getResult()).isFailure();
   }
 }

--- a/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/TradeTokenEvaluatorTest.java
+++ b/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/TradeTokenEvaluatorTest.java
@@ -6,15 +6,14 @@
 package com.opengamma.strata.report.framework.expression;
 
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.collect.id.StandardId;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.finance.SecurityLink;
 import com.opengamma.strata.finance.Trade;
 import com.opengamma.strata.finance.TradeInfo;
@@ -49,26 +48,26 @@ public class TradeTokenEvaluatorTest {
     TradeTokenEvaluator evaluator = new TradeTokenEvaluator();
     Trade trade = trade();
 
-    Result<?> quantity = evaluator.evaluate(trade, "quantity");
-    assertThat(quantity).hasValue(123L);
+    EvaluationResult quantity = evaluator.evaluate(trade, "quantity", ImmutableList.of());
+    assertThat(quantity.getResult()).hasValue(123L);
 
-    Result<?> initialPrice = evaluator.evaluate(trade, "initialPrice");
-    assertThat(initialPrice).hasValue(456d);
+    EvaluationResult initialPrice = evaluator.evaluate(trade, "initialPrice", ImmutableList.of());
+    assertThat(initialPrice.getResult()).hasValue(456d);
 
     // Check that property name isn't case sensitive
-    Result<?> initialPrice2 = evaluator.evaluate(trade, "initialprice");
-    assertThat(initialPrice2).hasValue(456d);
+    EvaluationResult initialPrice2 = evaluator.evaluate(trade, "initialprice", ImmutableList.of());
+    assertThat(initialPrice2.getResult()).hasValue(456d);
 
-    Result<?> counterparty = evaluator.evaluate(trade, "counterparty");
-    assertThat(counterparty).hasValue(StandardId.of("cpty", "a"));
+    EvaluationResult counterparty = evaluator.evaluate(trade, "counterparty", ImmutableList.of());
+    assertThat(counterparty.getResult()).hasValue(StandardId.of("cpty", "a"));
 
     // Optional property with no value
-    Result<?> tradeTime = evaluator.evaluate(trade, "tradeTime");
-    assertThat(tradeTime).isFailure();
+    EvaluationResult tradeTime = evaluator.evaluate(trade, "tradeTime", ImmutableList.of());
+    assertThat(tradeTime.getResult()).isFailure();
 
     // Unknown property
-    Result<?> foo = evaluator.evaluate(trade, "foo");
-    assertThat(foo).isFailure();
+    EvaluationResult foo = evaluator.evaluate(trade, "foo", ImmutableList.of());
+    assertThat(foo.getResult()).isFailure();
   }
 
   private static Trade trade() {


### PR DESCRIPTION
This PR refactors the parsing of expressions in report templates. The key changes are:

* The first token in an expression is parsed by a `TokenEvaluator` implementation instead of being handled as a special case.
* `TokenEvaluator` is now able to consume a variable number of tokens allowing greater flexibility
* Hard-coded special cases for handling beans with a single property have been removed from the framework. This logic is now in `BeanTokenEvaluator`
