### PR TITLE
Added the Ibor-Ibor swap curve node. 

### DIFF
--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedIborSwapConventions.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedIborSwapConventions.java
@@ -27,11 +27,11 @@ import com.opengamma.strata.basics.date.HolidayCalendar;
 import com.opengamma.strata.basics.index.IborIndices;
 
 /**
- * Factory methods for market standard conventions
+ * Market standard Fixed-Ibor swap conventions.
  * <p>
  * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
  */
-public class FixedIborSwapConventions {
+public final class FixedIborSwapConventions {
 
   // GBLO+USNY calendar
   private static final HolidayCalendar GBLO_USNY = GBLO.combineWith(USNY);

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedOvernightSwapConventions.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedOvernightSwapConventions.java
@@ -24,11 +24,11 @@ import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.schedule.Frequency;
 
 /**
- * Factory methods for market standard conventions
+ * Market standard Fixed-Overnight swap conventions.
  * <p>
  * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
  */
-public class FixedOvernightSwapConventions {
+public final class FixedOvernightSwapConventions {
 
   /**
    * USD fixed vs Fed Fund OIS swap for terms less than or equal to one year.

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventions.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventions.java
@@ -5,13 +5,17 @@
  */
 package com.opengamma.strata.finance.rate.swap.type;
 
-
 import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
 import com.opengamma.strata.finance.rate.swap.CompoundingMethod;
 
-public class IborIborSwapConventions {
-  
+/**
+ * Market standard Ibor-Ibor swap conventions.
+ * <p>
+ * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
+ */
+public final class IborIborSwapConventions {
+
   /**
    * USD standard LIBOR 3M vs LIBOR 6M swap.
    * <p>
@@ -20,11 +24,12 @@ public class IborIborSwapConventions {
   public static final IborIborSwapConvention USD_LIBOR_3M_LIBOR_6M =
       IborIborSwapConvention.of(
           IborRateSwapLegConvention.builder()
-          .index(IborIndices.USD_LIBOR_3M)
-          .paymentFrequency(Frequency.P6M)
-          .compoundingMethod(CompoundingMethod.FLAT).build(),
+              .index(IborIndices.USD_LIBOR_3M)
+              .paymentFrequency(Frequency.P6M)
+              .compoundingMethod(CompoundingMethod.FLAT)
+              .build(),
           IborRateSwapLegConvention.of(IborIndices.USD_LIBOR_6M));
-  
+
   /**
    * USD standard LIBOR 1M vs LIBOR 3M swap.
    * <p>
@@ -33,9 +38,17 @@ public class IborIborSwapConventions {
   public static final IborIborSwapConvention USD_LIBOR_1M_LIBOR_3M =
       IborIborSwapConvention.of(
           IborRateSwapLegConvention.builder()
-          .index(IborIndices.USD_LIBOR_1M)
-          .paymentFrequency(Frequency.P3M)
-          .compoundingMethod(CompoundingMethod.FLAT).build(),
+              .index(IborIndices.USD_LIBOR_1M)
+              .paymentFrequency(Frequency.P3M)
+              .compoundingMethod(CompoundingMethod.FLAT)
+              .build(),
           IborRateSwapLegConvention.of(IborIndices.USD_LIBOR_3M));
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private IborIborSwapConventions() {
+  }
 
 }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventions.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventions.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap.type;
+
+
+import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.finance.rate.swap.CompoundingMethod;
+
+public class IborIborSwapConventions {
+  
+  /**
+   * USD standard LIBOR 3M vs LIBOR 6M swap.
+   * <p>
+   * The LIBOR 3M leg pays semi-annually with FLAT compounding method.
+   */
+  public static final IborIborSwapConvention USD_LIBOR_3M_LIBOR_6M =
+      IborIborSwapConvention.of(
+          IborRateSwapLegConvention.builder()
+          .index(IborIndices.USD_LIBOR_3M)
+          .paymentFrequency(Frequency.P6M)
+          .compoundingMethod(CompoundingMethod.FLAT).build(),
+          IborRateSwapLegConvention.of(IborIndices.USD_LIBOR_6M));
+  
+  /**
+   * USD standard LIBOR 1M vs LIBOR 3M swap.
+   * <p>
+   * The LIBOR 1M leg pays quarterly with FLAT compounding method.
+   */
+  public static final IborIborSwapConvention USD_LIBOR_1M_LIBOR_3M =
+      IborIborSwapConvention.of(
+          IborRateSwapLegConvention.builder()
+          .index(IborIndices.USD_LIBOR_1M)
+          .paymentFrequency(Frequency.P3M)
+          .compoundingMethod(CompoundingMethod.FLAT).build(),
+          IborRateSwapLegConvention.of(IborIndices.USD_LIBOR_3M));
+
+}

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventionsTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventionsTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.finance.rate.swap.type;
+
+import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.date.BusinessDayConvention;
+import com.opengamma.strata.basics.date.BusinessDayConventions;
+import com.opengamma.strata.basics.index.IborIndex;
+import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.finance.rate.swap.CompoundingMethod;
+
+/**
+ * Test {@link FixedIborSwapConventions}.
+ * <p>
+ * These tests  match the table 18.1 in the following guide:
+ * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
+ */
+@Test
+public class IborIborSwapConventionsTest {
+
+  @DataProvider(name = "spotLag")
+  static Object[][] data_spot_lag() {
+    return new Object[][] {
+        {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, 2},
+        {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, 2}
+    };
+  }
+
+  @Test(dataProvider = "spotLag")
+  public void test_spot_lag(IborIborSwapConvention convention, int lag) {
+    assertEquals(convention.getSpotDateOffset().getDays(), lag);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "period")
+  static Object[][] data_period() {
+    return new Object[][] {
+        {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, Frequency.P6M},
+        {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, Frequency.P3M}
+    };
+  }
+
+  @Test(dataProvider = "period")
+  public void test_period(IborIborSwapConvention convention, Frequency frequency) {
+    assertEquals(convention.getSpreadLeg().getPaymentFrequency(), frequency);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "dayCount")
+  static Object[][] data_day_count() {
+    return new Object[][] {
+        {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, CompoundingMethod.FLAT},
+        {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, CompoundingMethod.FLAT}
+    };
+  }
+
+  @Test(dataProvider = "dayCount")
+  public void test_composition(IborIborSwapConvention convention, CompoundingMethod comp) {
+    assertEquals(convention.getSpreadLeg().getCompoundingMethod(), comp);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "spreadLeg")
+  static Object[][] data_spread_leg() {
+    return new Object[][] {
+        {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, IborIndices.USD_LIBOR_3M},
+        {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, IborIndices.USD_LIBOR_1M}
+    };
+  }
+
+  @Test(dataProvider = "spreadLeg")
+  public void test_float_leg(IborIborSwapConvention convention, IborIndex index) {
+    assertEquals(convention.getSpreadLeg().getIndex(), index);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "flatLeg")
+  static Object[][] data_flat_leg() {
+    return new Object[][] {
+        {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, IborIndices.USD_LIBOR_6M},
+        {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, IborIndices.USD_LIBOR_3M}
+    };
+  }
+
+  @Test(dataProvider = "flatLeg")
+  public void test_flat_leg(IborIborSwapConvention convention, IborIndex index) {
+    assertEquals(convention.getFlatLeg().getIndex(), index);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "dayConvention")
+  static Object[][] data_day_convention() {
+    return new Object[][] {
+        {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, BusinessDayConventions.MODIFIED_FOLLOWING},
+        {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING}
+    };
+  }
+
+  @Test(dataProvider = "dayConvention")
+  public void test_day_convention(IborIborSwapConvention convention, BusinessDayConvention dayConvention) {
+    assertEquals(convention.getSpreadLeg().getAccrualBusinessDayAdjustment().getConvention(), dayConvention);
+  }
+
+  public void coverage() {
+    coverPrivateConstructor(FixedIborSwapConventions.class);
+  }
+
+}

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNode.java
@@ -6,10 +6,22 @@
 package com.opengamma.strata.market.curve.definition;
 
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
+import org.joda.beans.Bean;
 import org.joda.beans.BeanDefinition;
 import org.joda.beans.ImmutableBean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
 import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.BuySell;
@@ -21,25 +33,13 @@ import com.opengamma.strata.market.curve.DatedCurveParameterMetadata;
 import com.opengamma.strata.market.curve.TenorCurveNodeMetadata;
 import com.opengamma.strata.market.value.ValueType;
 
-import java.time.LocalDate;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-
-import org.joda.beans.Bean;
-import org.joda.beans.JodaBeanUtils;
-import org.joda.beans.MetaProperty;
-import org.joda.beans.Property;
-import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
-import org.joda.beans.impl.direct.DirectMetaBean;
-import org.joda.beans.impl.direct.DirectMetaProperty;
-import org.joda.beans.impl.direct.DirectMetaPropertyMap;
-
 /**
- * A curve node whose instrument is a Ibor-Ibor interest rate swap. The spread or market quote is on the first Ibor leg.
+ * A curve node whose instrument is a Ibor-Ibor interest rate swap.
+ * <p>
+ * The spread or market quote is on the first Ibor leg.
  */
 @BeanDefinition
-public class IborIborSwapCurveNode
+public final class IborIborSwapCurveNode
     implements CurveNode, ImmutableBean, Serializable {
 
   /**
@@ -53,7 +53,7 @@ public class IborIborSwapCurveNode
   @PropertyDefinition(validate = "notNull")
   private final ObservableKey rateKey;
   /**
-   * The spread added to the market data.
+   * The spread added to the market quote.
    */
   @PropertyDefinition
   private final double spread;
@@ -82,6 +82,7 @@ public class IborIborSwapCurveNode
     return IborIborSwapCurveNode.builder().template(template).rateKey(rateKey).spread(spread).build();
   }
 
+  //-------------------------------------------------------------------------
   @Override
   public Set<ObservableKey> requirements() {
     return ImmutableSet.of(rateKey);
@@ -134,16 +135,15 @@ public class IborIborSwapCurveNode
     return new IborIborSwapCurveNode.Builder();
   }
 
-  /**
-   * Restricted constructor.
-   * @param builder  the builder to copy from, not null
-   */
-  protected IborIborSwapCurveNode(IborIborSwapCurveNode.Builder builder) {
-    JodaBeanUtils.notNull(builder.template, "template");
-    JodaBeanUtils.notNull(builder.rateKey, "rateKey");
-    this.template = builder.template;
-    this.rateKey = builder.rateKey;
-    this.spread = builder.spread;
+  private IborIborSwapCurveNode(
+      IborIborSwapTemplate template,
+      ObservableKey rateKey,
+      double spread) {
+    JodaBeanUtils.notNull(template, "template");
+    JodaBeanUtils.notNull(rateKey, "rateKey");
+    this.template = template;
+    this.rateKey = rateKey;
+    this.spread = spread;
   }
 
   @Override
@@ -181,7 +181,7 @@ public class IborIborSwapCurveNode
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the spread added to the market data.
+   * Gets the spread added to the market quote.
    * @return the value of the property
    */
   public double getSpread() {
@@ -224,26 +224,18 @@ public class IborIborSwapCurveNode
   public String toString() {
     StringBuilder buf = new StringBuilder(128);
     buf.append("IborIborSwapCurveNode{");
-    int len = buf.length();
-    toString(buf);
-    if (buf.length() > len) {
-      buf.setLength(buf.length() - 2);
-    }
+    buf.append("template").append('=').append(getTemplate()).append(',').append(' ');
+    buf.append("rateKey").append('=').append(getRateKey()).append(',').append(' ');
+    buf.append("spread").append('=').append(JodaBeanUtils.toString(getSpread()));
     buf.append('}');
     return buf.toString();
-  }
-
-  protected void toString(StringBuilder buf) {
-    buf.append("template").append('=').append(JodaBeanUtils.toString(getTemplate())).append(',').append(' ');
-    buf.append("rateKey").append('=').append(JodaBeanUtils.toString(getRateKey())).append(',').append(' ');
-    buf.append("spread").append('=').append(JodaBeanUtils.toString(getSpread())).append(',').append(' ');
   }
 
   //-----------------------------------------------------------------------
   /**
    * The meta-bean for {@code IborIborSwapCurveNode}.
    */
-  public static class Meta extends DirectMetaBean {
+  public static final class Meta extends DirectMetaBean {
     /**
      * The singleton instance of the meta-bean.
      */
@@ -276,7 +268,7 @@ public class IborIborSwapCurveNode
     /**
      * Restricted constructor.
      */
-    protected Meta() {
+    private Meta() {
     }
 
     @Override
@@ -312,7 +304,7 @@ public class IborIborSwapCurveNode
      * The meta-property for the {@code template} property.
      * @return the meta-property, not null
      */
-    public final MetaProperty<IborIborSwapTemplate> template() {
+    public MetaProperty<IborIborSwapTemplate> template() {
       return template;
     }
 
@@ -320,7 +312,7 @@ public class IborIborSwapCurveNode
      * The meta-property for the {@code rateKey} property.
      * @return the meta-property, not null
      */
-    public final MetaProperty<ObservableKey> rateKey() {
+    public MetaProperty<ObservableKey> rateKey() {
       return rateKey;
     }
 
@@ -328,7 +320,7 @@ public class IborIborSwapCurveNode
      * The meta-property for the {@code spread} property.
      * @return the meta-property, not null
      */
-    public final MetaProperty<Double> spread() {
+    public MetaProperty<Double> spread() {
       return spread;
     }
 
@@ -361,7 +353,7 @@ public class IborIborSwapCurveNode
   /**
    * The bean-builder for {@code IborIborSwapCurveNode}.
    */
-  public static class Builder extends DirectFieldsBeanBuilder<IborIborSwapCurveNode> {
+  public static final class Builder extends DirectFieldsBeanBuilder<IborIborSwapCurveNode> {
 
     private IborIborSwapTemplate template;
     private ObservableKey rateKey;
@@ -370,14 +362,14 @@ public class IborIborSwapCurveNode
     /**
      * Restricted constructor.
      */
-    protected Builder() {
+    private Builder() {
     }
 
     /**
      * Restricted copy constructor.
      * @param beanToCopy  the bean to copy from, not null
      */
-    protected Builder(IborIborSwapCurveNode beanToCopy) {
+    private Builder(IborIborSwapCurveNode beanToCopy) {
       this.template = beanToCopy.getTemplate();
       this.rateKey = beanToCopy.getRateKey();
       this.spread = beanToCopy.getSpread();
@@ -442,7 +434,10 @@ public class IborIborSwapCurveNode
 
     @Override
     public IborIborSwapCurveNode build() {
-      return new IborIborSwapCurveNode(this);
+      return new IborIborSwapCurveNode(
+          template,
+          rateKey,
+          spread);
     }
 
     //-----------------------------------------------------------------------
@@ -469,7 +464,7 @@ public class IborIborSwapCurveNode
     }
 
     /**
-     * Sets the spread added to the market data.
+     * Sets the spread added to the market quote.
      * @param spread  the new value
      * @return this, for chaining, not null
      */
@@ -483,19 +478,11 @@ public class IborIborSwapCurveNode
     public String toString() {
       StringBuilder buf = new StringBuilder(128);
       buf.append("IborIborSwapCurveNode.Builder{");
-      int len = buf.length();
-      toString(buf);
-      if (buf.length() > len) {
-        buf.setLength(buf.length() - 2);
-      }
-      buf.append('}');
-      return buf.toString();
-    }
-
-    protected void toString(StringBuilder buf) {
       buf.append("template").append('=').append(JodaBeanUtils.toString(template)).append(',').append(' ');
       buf.append("rateKey").append('=').append(JodaBeanUtils.toString(rateKey)).append(',').append(' ');
-      buf.append("spread").append('=').append(JodaBeanUtils.toString(spread)).append(',').append(' ');
+      buf.append("spread").append('=').append(JodaBeanUtils.toString(spread));
+      buf.append('}');
+      return buf.toString();
     }
 
   }

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNode.java
@@ -6,81 +6,82 @@
 package com.opengamma.strata.market.curve.definition;
 
 import java.io.Serializable;
-import java.time.LocalDate;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
 
-import org.joda.beans.Bean;
 import org.joda.beans.BeanDefinition;
 import org.joda.beans.ImmutableBean;
-import org.joda.beans.JodaBeanUtils;
-import org.joda.beans.MetaProperty;
-import org.joda.beans.Property;
 import org.joda.beans.PropertyDefinition;
-import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
-import org.joda.beans.impl.direct.DirectMetaBean;
-import org.joda.beans.impl.direct.DirectMetaProperty;
-import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.BuySell;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ObservableValues;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
-import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapTemplate;
+import com.opengamma.strata.finance.rate.swap.type.IborIborSwapTemplate;
 import com.opengamma.strata.market.curve.DatedCurveParameterMetadata;
 import com.opengamma.strata.market.curve.TenorCurveNodeMetadata;
 import com.opengamma.strata.market.value.ValueType;
 
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
 /**
- * A curve node whose instrument is a Fixed-Ibor interest rate swap.
+ * A curve node whose instrument is a Ibor-Ibor interest rate swap. The spread or market quote is on the first Ibor leg.
  */
 @BeanDefinition
-public final class FixedIborSwapCurveNode
+public class IborIborSwapCurveNode
     implements CurveNode, ImmutableBean, Serializable {
 
   /**
    * The template for the swap associated with this node.
    */
   @PropertyDefinition(validate = "notNull")
-  private final FixedIborSwapTemplate template;
+  private final IborIborSwapTemplate template;
   /**
    * The key identifying the market data value which provides the rate.
    */
   @PropertyDefinition(validate = "notNull")
   private final ObservableKey rateKey;
   /**
-   * The spread added to the rate.
+   * The spread added to the market data.
    */
   @PropertyDefinition
   private final double spread;
 
   //-------------------------------------------------------------------------
   /**
-   * Returns a curve node for a Fixed-Ibor interest rate swap using the specified instrument template and rate.
+   * Returns a curve node for a Ibor-Ibor interest rate swap using the specified instrument template and rate.
    *
    * @param template  the template used for building the instrument for the node
    * @param rateKey  the key identifying the market rate used when building the instrument for the node
    * @return a node whose instrument is built from the template using a market rate
    */
-  public static FixedIborSwapCurveNode of(FixedIborSwapTemplate template, ObservableKey rateKey) {
-    return new FixedIborSwapCurveNode(template, rateKey, 0);
+  public static IborIborSwapCurveNode of(IborIborSwapTemplate template, ObservableKey rateKey) {
+    return IborIborSwapCurveNode.builder().template(template).rateKey(rateKey).spread(0.0d).build();
   }
 
   /**
-   * Returns a curve node for a Fixed-Ibor interest rate swap using the specified instrument template, rate key and spread.
+   * Returns a curve node for a Ibor-Ibor interest rate swap using the specified instrument template, rate key and spread.
    *
    * @param template  the template defining the node instrument
    * @param rateKey  the key identifying the market data providing the rate for the node instrument
    * @param spread  the spread amount added to the rate
    * @return a node whose instrument is built from the template using a market rate
    */
-  public static FixedIborSwapCurveNode of(FixedIborSwapTemplate template, ObservableKey rateKey, double spread) {
-    return new FixedIborSwapCurveNode(template, rateKey, spread);
+  public static IborIborSwapCurveNode of(IborIborSwapTemplate template, ObservableKey rateKey, double spread) {
+    return IborIborSwapCurveNode.builder().template(template).rateKey(rateKey).spread(spread).build();
   }
 
-  //-------------------------------------------------------------------------
   @Override
   public Set<ObservableKey> requirements() {
     return ImmutableSet.of(rateKey);
@@ -94,34 +95,30 @@ public final class FixedIborSwapCurveNode
 
   @Override
   public SwapTrade trade(LocalDate valuationDate, ObservableValues marketData) {
-    double fixedRate = marketData.getValue(rateKey) + spread;
-    return template.toTrade(valuationDate, BuySell.BUY, 1, fixedRate);
+    double marketQuote = marketData.getValue(rateKey) + spread;
+    return template.toTrade(valuationDate, BuySell.BUY, 1, marketQuote);
   }
 
   @Override
   public double initialGuess(LocalDate valuationDate, ObservableValues marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
-      return marketData.getValue(rateKey);
-    }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {
-      double approximateMaturity = template.getPeriodToStart().plus(template.getTenor()).toTotalMonths() / 12.0d;
-      return Math.exp(-approximateMaturity * marketData.getValue(rateKey));
+      return 1.0d;
     }
-    return 0d;
+    return 0.0d;
   }
 
   //------------------------- AUTOGENERATED START -------------------------
   ///CLOVER:OFF
   /**
-   * The meta-bean for {@code FixedIborSwapCurveNode}.
+   * The meta-bean for {@code IborIborSwapCurveNode}.
    * @return the meta-bean, not null
    */
-  public static FixedIborSwapCurveNode.Meta meta() {
-    return FixedIborSwapCurveNode.Meta.INSTANCE;
+  public static IborIborSwapCurveNode.Meta meta() {
+    return IborIborSwapCurveNode.Meta.INSTANCE;
   }
 
   static {
-    JodaBeanUtils.registerMetaBean(FixedIborSwapCurveNode.Meta.INSTANCE);
+    JodaBeanUtils.registerMetaBean(IborIborSwapCurveNode.Meta.INSTANCE);
   }
 
   /**
@@ -133,24 +130,25 @@ public final class FixedIborSwapCurveNode
    * Returns a builder used to create an instance of the bean.
    * @return the builder, not null
    */
-  public static FixedIborSwapCurveNode.Builder builder() {
-    return new FixedIborSwapCurveNode.Builder();
+  public static IborIborSwapCurveNode.Builder builder() {
+    return new IborIborSwapCurveNode.Builder();
   }
 
-  private FixedIborSwapCurveNode(
-      FixedIborSwapTemplate template,
-      ObservableKey rateKey,
-      double spread) {
-    JodaBeanUtils.notNull(template, "template");
-    JodaBeanUtils.notNull(rateKey, "rateKey");
-    this.template = template;
-    this.rateKey = rateKey;
-    this.spread = spread;
+  /**
+   * Restricted constructor.
+   * @param builder  the builder to copy from, not null
+   */
+  protected IborIborSwapCurveNode(IborIborSwapCurveNode.Builder builder) {
+    JodaBeanUtils.notNull(builder.template, "template");
+    JodaBeanUtils.notNull(builder.rateKey, "rateKey");
+    this.template = builder.template;
+    this.rateKey = builder.rateKey;
+    this.spread = builder.spread;
   }
 
   @Override
-  public FixedIborSwapCurveNode.Meta metaBean() {
-    return FixedIborSwapCurveNode.Meta.INSTANCE;
+  public IborIborSwapCurveNode.Meta metaBean() {
+    return IborIborSwapCurveNode.Meta.INSTANCE;
   }
 
   @Override
@@ -168,7 +166,7 @@ public final class FixedIborSwapCurveNode
    * Gets the template for the swap associated with this node.
    * @return the value of the property, not null
    */
-  public FixedIborSwapTemplate getTemplate() {
+  public IborIborSwapTemplate getTemplate() {
     return template;
   }
 
@@ -183,7 +181,7 @@ public final class FixedIborSwapCurveNode
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the spread added to the rate.
+   * Gets the spread added to the market data.
    * @return the value of the property
    */
   public double getSpread() {
@@ -205,7 +203,7 @@ public final class FixedIborSwapCurveNode
       return true;
     }
     if (obj != null && obj.getClass() == this.getClass()) {
-      FixedIborSwapCurveNode other = (FixedIborSwapCurveNode) obj;
+      IborIborSwapCurveNode other = (IborIborSwapCurveNode) obj;
       return JodaBeanUtils.equal(getTemplate(), other.getTemplate()) &&
           JodaBeanUtils.equal(getRateKey(), other.getRateKey()) &&
           JodaBeanUtils.equal(getSpread(), other.getSpread());
@@ -225,19 +223,27 @@ public final class FixedIborSwapCurveNode
   @Override
   public String toString() {
     StringBuilder buf = new StringBuilder(128);
-    buf.append("FixedIborSwapCurveNode{");
-    buf.append("template").append('=').append(getTemplate()).append(',').append(' ');
-    buf.append("rateKey").append('=').append(getRateKey()).append(',').append(' ');
-    buf.append("spread").append('=').append(JodaBeanUtils.toString(getSpread()));
+    buf.append("IborIborSwapCurveNode{");
+    int len = buf.length();
+    toString(buf);
+    if (buf.length() > len) {
+      buf.setLength(buf.length() - 2);
+    }
     buf.append('}');
     return buf.toString();
   }
 
+  protected void toString(StringBuilder buf) {
+    buf.append("template").append('=').append(JodaBeanUtils.toString(getTemplate())).append(',').append(' ');
+    buf.append("rateKey").append('=').append(JodaBeanUtils.toString(getRateKey())).append(',').append(' ');
+    buf.append("spread").append('=').append(JodaBeanUtils.toString(getSpread())).append(',').append(' ');
+  }
+
   //-----------------------------------------------------------------------
   /**
-   * The meta-bean for {@code FixedIborSwapCurveNode}.
+   * The meta-bean for {@code IborIborSwapCurveNode}.
    */
-  public static final class Meta extends DirectMetaBean {
+  public static class Meta extends DirectMetaBean {
     /**
      * The singleton instance of the meta-bean.
      */
@@ -246,18 +252,18 @@ public final class FixedIborSwapCurveNode
     /**
      * The meta-property for the {@code template} property.
      */
-    private final MetaProperty<FixedIborSwapTemplate> template = DirectMetaProperty.ofImmutable(
-        this, "template", FixedIborSwapCurveNode.class, FixedIborSwapTemplate.class);
+    private final MetaProperty<IborIborSwapTemplate> template = DirectMetaProperty.ofImmutable(
+        this, "template", IborIborSwapCurveNode.class, IborIborSwapTemplate.class);
     /**
      * The meta-property for the {@code rateKey} property.
      */
     private final MetaProperty<ObservableKey> rateKey = DirectMetaProperty.ofImmutable(
-        this, "rateKey", FixedIborSwapCurveNode.class, ObservableKey.class);
+        this, "rateKey", IborIborSwapCurveNode.class, ObservableKey.class);
     /**
      * The meta-property for the {@code spread} property.
      */
     private final MetaProperty<Double> spread = DirectMetaProperty.ofImmutable(
-        this, "spread", FixedIborSwapCurveNode.class, Double.TYPE);
+        this, "spread", IborIborSwapCurveNode.class, Double.TYPE);
     /**
      * The meta-properties.
      */
@@ -270,7 +276,7 @@ public final class FixedIborSwapCurveNode
     /**
      * Restricted constructor.
      */
-    private Meta() {
+    protected Meta() {
     }
 
     @Override
@@ -287,13 +293,13 @@ public final class FixedIborSwapCurveNode
     }
 
     @Override
-    public FixedIborSwapCurveNode.Builder builder() {
-      return new FixedIborSwapCurveNode.Builder();
+    public IborIborSwapCurveNode.Builder builder() {
+      return new IborIborSwapCurveNode.Builder();
     }
 
     @Override
-    public Class<? extends FixedIborSwapCurveNode> beanType() {
-      return FixedIborSwapCurveNode.class;
+    public Class<? extends IborIborSwapCurveNode> beanType() {
+      return IborIborSwapCurveNode.class;
     }
 
     @Override
@@ -306,7 +312,7 @@ public final class FixedIborSwapCurveNode
      * The meta-property for the {@code template} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<FixedIborSwapTemplate> template() {
+    public final MetaProperty<IborIborSwapTemplate> template() {
       return template;
     }
 
@@ -314,7 +320,7 @@ public final class FixedIborSwapCurveNode
      * The meta-property for the {@code rateKey} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<ObservableKey> rateKey() {
+    public final MetaProperty<ObservableKey> rateKey() {
       return rateKey;
     }
 
@@ -322,7 +328,7 @@ public final class FixedIborSwapCurveNode
      * The meta-property for the {@code spread} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> spread() {
+    public final MetaProperty<Double> spread() {
       return spread;
     }
 
@@ -331,11 +337,11 @@ public final class FixedIborSwapCurveNode
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
         case -1321546630:  // template
-          return ((FixedIborSwapCurveNode) bean).getTemplate();
+          return ((IborIborSwapCurveNode) bean).getTemplate();
         case 983444831:  // rateKey
-          return ((FixedIborSwapCurveNode) bean).getRateKey();
+          return ((IborIborSwapCurveNode) bean).getRateKey();
         case -895684237:  // spread
-          return ((FixedIborSwapCurveNode) bean).getSpread();
+          return ((IborIborSwapCurveNode) bean).getSpread();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -353,25 +359,25 @@ public final class FixedIborSwapCurveNode
 
   //-----------------------------------------------------------------------
   /**
-   * The bean-builder for {@code FixedIborSwapCurveNode}.
+   * The bean-builder for {@code IborIborSwapCurveNode}.
    */
-  public static final class Builder extends DirectFieldsBeanBuilder<FixedIborSwapCurveNode> {
+  public static class Builder extends DirectFieldsBeanBuilder<IborIborSwapCurveNode> {
 
-    private FixedIborSwapTemplate template;
+    private IborIborSwapTemplate template;
     private ObservableKey rateKey;
     private double spread;
 
     /**
      * Restricted constructor.
      */
-    private Builder() {
+    protected Builder() {
     }
 
     /**
      * Restricted copy constructor.
      * @param beanToCopy  the bean to copy from, not null
      */
-    private Builder(FixedIborSwapCurveNode beanToCopy) {
+    protected Builder(IborIborSwapCurveNode beanToCopy) {
       this.template = beanToCopy.getTemplate();
       this.rateKey = beanToCopy.getRateKey();
       this.spread = beanToCopy.getSpread();
@@ -396,7 +402,7 @@ public final class FixedIborSwapCurveNode
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
         case -1321546630:  // template
-          this.template = (FixedIborSwapTemplate) newValue;
+          this.template = (IborIborSwapTemplate) newValue;
           break;
         case 983444831:  // rateKey
           this.rateKey = (ObservableKey) newValue;
@@ -435,11 +441,8 @@ public final class FixedIborSwapCurveNode
     }
 
     @Override
-    public FixedIborSwapCurveNode build() {
-      return new FixedIborSwapCurveNode(
-          template,
-          rateKey,
-          spread);
+    public IborIborSwapCurveNode build() {
+      return new IborIborSwapCurveNode(this);
     }
 
     //-----------------------------------------------------------------------
@@ -448,7 +451,7 @@ public final class FixedIborSwapCurveNode
      * @param template  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder template(FixedIborSwapTemplate template) {
+    public Builder template(IborIborSwapTemplate template) {
       JodaBeanUtils.notNull(template, "template");
       this.template = template;
       return this;
@@ -466,7 +469,7 @@ public final class FixedIborSwapCurveNode
     }
 
     /**
-     * Sets the spread added to the rate.
+     * Sets the spread added to the market data.
      * @param spread  the new value
      * @return this, for chaining, not null
      */
@@ -479,12 +482,20 @@ public final class FixedIborSwapCurveNode
     @Override
     public String toString() {
       StringBuilder buf = new StringBuilder(128);
-      buf.append("FixedIborSwapCurveNode.Builder{");
-      buf.append("template").append('=').append(JodaBeanUtils.toString(template)).append(',').append(' ');
-      buf.append("rateKey").append('=').append(JodaBeanUtils.toString(rateKey)).append(',').append(' ');
-      buf.append("spread").append('=').append(JodaBeanUtils.toString(spread));
+      buf.append("IborIborSwapCurveNode.Builder{");
+      int len = buf.length();
+      toString(buf);
+      if (buf.length() > len) {
+        buf.setLength(buf.length() - 2);
+      }
       buf.append('}');
       return buf.toString();
+    }
+
+    protected void toString(StringBuilder buf) {
+      buf.append("template").append('=').append(JodaBeanUtils.toString(template)).append(',').append(' ');
+      buf.append("rateKey").append('=').append(JodaBeanUtils.toString(rateKey)).append(',').append(' ');
+      buf.append("spread").append('=').append(JodaBeanUtils.toString(spread)).append(',').append(' ');
     }
 
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/definition/FixedIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/definition/FixedIborSwapCurveNodeTest.java
@@ -43,7 +43,7 @@ public class FixedIborSwapCurveNodeTest {
       FixedIborSwapTemplate.of(TENOR_10Y, FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M);
   private static final QuoteKey QUOTE_KEY = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit1"));
   private static final double SPREAD = 0.0015;
-  
+
   private static final double TOLERANCE_DF = 1.0E-10;
 
   public void test_builder() {
@@ -104,6 +104,7 @@ public class FixedIborSwapCurveNodeTest {
     double df = Math.exp(-TENOR_10Y.get(ChronoUnit.YEARS) * rate);
     assertEquals(
         node.initialGuess(valuationDate, ObservableValues.of(QUOTE_KEY, rate), ValueType.DISCOUNT_FACTOR), df, TOLERANCE_DF);
+    assertEquals(node.initialGuess(valuationDate, ObservableValues.of(QUOTE_KEY, rate), ValueType.PRICE_INDEX), 0d);
   }
 
   public void test_metadata() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNodeTest.java
@@ -26,8 +26,6 @@ import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ObservableValues;
 import com.opengamma.strata.collect.id.StandardId;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
-import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapConventions;
-import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapTemplate;
 import com.opengamma.strata.finance.rate.swap.type.IborIborSwapConventions;
 import com.opengamma.strata.finance.rate.swap.type.IborIborSwapTemplate;
 import com.opengamma.strata.market.curve.CurveParameterMetadata;
@@ -43,7 +41,10 @@ public class IborIborSwapCurveNodeTest {
 
   private static final IborIborSwapTemplate TEMPLATE =
       IborIborSwapTemplate.of(Period.ZERO, TENOR_10Y, IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M);
+  private static final IborIborSwapTemplate TEMPLATE2 =
+      IborIborSwapTemplate.of(Period.ofMonths(1), TENOR_10Y, IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M);
   private static final QuoteKey QUOTE_KEY = QuoteKey.of(StandardId.of("OG-Ticker", "USD-BS36-10Y"));
+  private static final QuoteKey QUOTE_KEY2 = QuoteKey.of(StandardId.of("OG-Ticker", "Test"));
   private static final double SPREAD = 0.0015;
 
   public void test_builder() {
@@ -117,9 +118,7 @@ public class IborIborSwapCurveNodeTest {
   public void coverage() {
     IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     coverImmutableBean(test);
-    FixedIborSwapCurveNode test2 = FixedIborSwapCurveNode.of(
-        FixedIborSwapTemplate.of(TENOR_10Y, FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M),
-        QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2")));
+    IborIborSwapCurveNode test2 = IborIborSwapCurveNode.of(TEMPLATE2, QUOTE_KEY2, 0.1);
     coverBeanEquals(test, test2);
   }
 
@@ -127,5 +126,5 @@ public class IborIborSwapCurveNodeTest {
     IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     assertSerialization(test);
   }
-  
+
 }

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/definition/IborIborSwapCurveNodeTest.java
@@ -15,7 +15,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
+import java.time.Period;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -28,26 +28,26 @@ import com.opengamma.strata.collect.id.StandardId;
 import com.opengamma.strata.finance.rate.swap.SwapTrade;
 import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapConventions;
 import com.opengamma.strata.finance.rate.swap.type.FixedIborSwapTemplate;
+import com.opengamma.strata.finance.rate.swap.type.IborIborSwapConventions;
+import com.opengamma.strata.finance.rate.swap.type.IborIborSwapTemplate;
 import com.opengamma.strata.market.curve.CurveParameterMetadata;
 import com.opengamma.strata.market.curve.TenorCurveNodeMetadata;
 import com.opengamma.strata.market.key.QuoteKey;
 import com.opengamma.strata.market.value.ValueType;
 
 /**
- * Test {@link FixedIborSwapCurveNode}.
+ * Test {@link IborIborSwapCurveNode}.
  */
 @Test
-public class FixedIborSwapCurveNodeTest {
+public class IborIborSwapCurveNodeTest {
 
-  private static final FixedIborSwapTemplate TEMPLATE =
-      FixedIborSwapTemplate.of(TENOR_10Y, FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M);
-  private static final QuoteKey QUOTE_KEY = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit1"));
+  private static final IborIborSwapTemplate TEMPLATE =
+      IborIborSwapTemplate.of(Period.ZERO, TENOR_10Y, IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M);
+  private static final QuoteKey QUOTE_KEY = QuoteKey.of(StandardId.of("OG-Ticker", "USD-BS36-10Y"));
   private static final double SPREAD = 0.0015;
-  
-  private static final double TOLERANCE_DF = 1.0E-10;
 
   public void test_builder() {
-    FixedIborSwapCurveNode test = FixedIborSwapCurveNode.builder()
+    IborIborSwapCurveNode test = IborIborSwapCurveNode.builder()
         .template(TEMPLATE)
         .rateKey(QUOTE_KEY)
         .spread(SPREAD)
@@ -58,21 +58,21 @@ public class FixedIborSwapCurveNodeTest {
   }
 
   public void test_of_noSpread() {
-    FixedIborSwapCurveNode test = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY);
+    IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY);
     assertEquals(test.getRateKey(), QUOTE_KEY);
     assertEquals(test.getSpread(), 0.0d);
     assertEquals(test.getTemplate(), TEMPLATE);
   }
 
   public void test_of_withSpread() {
-    FixedIborSwapCurveNode test = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     assertEquals(test.getRateKey(), QUOTE_KEY);
     assertEquals(test.getSpread(), SPREAD);
     assertEquals(test.getTemplate(), TEMPLATE);
   }
 
   public void test_requirements() {
-    FixedIborSwapCurveNode test = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     Set<ObservableKey> set = test.requirements();
     Iterator<ObservableKey> itr = set.iterator();
     assertEquals(itr.next(), QUOTE_KEY);
@@ -80,7 +80,7 @@ public class FixedIborSwapCurveNodeTest {
   }
 
   public void test_trade() {
-    FixedIborSwapCurveNode node = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode node = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate tradeDate = LocalDate.of(2015, 1, 22);
     double rate = 0.125;
     SwapTrade trade = node.trade(tradeDate, ObservableValues.of(QUOTE_KEY, rate));
@@ -89,7 +89,7 @@ public class FixedIborSwapCurveNodeTest {
   }
 
   public void test_trade_differentKey() {
-    FixedIborSwapCurveNode node = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode node = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
     double rate = 0.035;
     assertThrowsIllegalArg(() -> node.trade(
@@ -97,17 +97,15 @@ public class FixedIborSwapCurveNodeTest {
   }
 
   public void test_initialGuess() {
-    FixedIborSwapCurveNode node = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode node = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
     double rate = 0.035;
-    assertEquals(node.initialGuess(valuationDate, ObservableValues.of(QUOTE_KEY, rate), ValueType.ZERO_RATE), rate);
-    double df = Math.exp(-TENOR_10Y.get(ChronoUnit.YEARS) * rate);
-    assertEquals(
-        node.initialGuess(valuationDate, ObservableValues.of(QUOTE_KEY, rate), ValueType.DISCOUNT_FACTOR), df, TOLERANCE_DF);
+    assertEquals(node.initialGuess(valuationDate, ObservableValues.of(QUOTE_KEY, rate), ValueType.ZERO_RATE), 0d);
+    assertEquals(node.initialGuess(valuationDate, ObservableValues.of(QUOTE_KEY, rate), ValueType.DISCOUNT_FACTOR), 1.0d);
   }
 
   public void test_metadata() {
-    FixedIborSwapCurveNode node = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode node = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
     CurveParameterMetadata metadata = node.metadata(valuationDate);
     // 2015-01-22 is Thursday, start is 2015-01-26, but 2025-01-26 is Sunday, so end is 2025-01-27
@@ -117,7 +115,7 @@ public class FixedIborSwapCurveNodeTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    FixedIborSwapCurveNode test = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     coverImmutableBean(test);
     FixedIborSwapCurveNode test2 = FixedIborSwapCurveNode.of(
         FixedIborSwapTemplate.of(TENOR_10Y, FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M),
@@ -126,8 +124,8 @@ public class FixedIborSwapCurveNodeTest {
   }
 
   public void test_serialization() {
-    FixedIborSwapCurveNode test = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
+    IborIborSwapCurveNode test = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     assertSerialization(test);
   }
-
+  
 }


### PR DESCRIPTION
Created Ibor-Ibor swap curve node. Important for currencies where basis swap is the most liquid instrument for some Ibor tenors (e.g. USD).
Created Ibor-ibor swap conventions with USD standard conventions. No other currencies added yet as EUR standard does not fit in this convention (needs 3 leg) and I'm not sure of the JPY composition.