### PR TITLE
 Leg Pricer: Added par spread for payment with FLAT compounding

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingKnownAmountPaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DiscountingKnownAmountPaymentPeriodPricer.java
@@ -75,6 +75,11 @@ public class DiscountingKnownAmountPaymentPeriodPricer
     return fv * (partialDays / totalDays);
   }
 
+  @Override
+  public double pvbp(KnownAmountPaymentPeriod period, RatesProvider provider) {
+    throw new UnsupportedOperationException("Unable to calculate PVBP for KnownAmountPaymentPeriod");
+  }
+
   //-------------------------------------------------------------------------
   @Override
   public PointSensitivityBuilder presentValueSensitivity(KnownAmountPaymentPeriod period, RatesProvider provider) {
@@ -84,6 +89,11 @@ public class DiscountingKnownAmountPaymentPeriodPricer
   @Override
   public PointSensitivityBuilder futureValueSensitivity(KnownAmountPaymentPeriod period, RatesProvider provider) {
     return PointSensitivityBuilder.none();
+  }
+
+  @Override
+  public PointSensitivityBuilder pvbpSensitivity(KnownAmountPaymentPeriod period, RatesProvider provider) {
+    throw new UnsupportedOperationException("Unable to calculate PVBP for KnownAmountPaymentPeriod");
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricer.java
@@ -105,6 +105,31 @@ public class DispatchingPaymentPeriodPricer
 
   //-------------------------------------------------------------------------
   @Override
+  public double pvbp(PaymentPeriod paymentPeriod, RatesProvider provider) {
+    // dispatch by runtime type
+    if (paymentPeriod instanceof RatePaymentPeriod) {
+      return ratePaymentPeriodPricer.pvbp((RatePaymentPeriod) paymentPeriod, provider);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      return knownAmountPaymentPeriodPricer.pvbp((KnownAmountPaymentPeriod) paymentPeriod, provider);
+    } else {
+      throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public PointSensitivityBuilder pvbpSensitivity(PaymentPeriod paymentPeriod, RatesProvider provider) {
+    // dispatch by runtime type
+    if (paymentPeriod instanceof RatePaymentPeriod) {
+      return ratePaymentPeriodPricer.pvbpSensitivity((RatePaymentPeriod) paymentPeriod, provider);
+    } else if (paymentPeriod instanceof KnownAmountPaymentPeriod) {
+      return knownAmountPaymentPeriodPricer.pvbpSensitivity((KnownAmountPaymentPeriod) paymentPeriod, provider);
+    } else {
+      throw new IllegalArgumentException("Unknown PaymentPeriod type: " + paymentPeriod.getClass().getSimpleName());
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
   public double accruedInterest(PaymentPeriod paymentPeriod, RatesProvider provider) {
     // dispatch by runtime type
     if (paymentPeriod instanceof RatePaymentPeriod) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapLegPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapLegPricer.java
@@ -14,9 +14,9 @@ import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.finance.rate.swap.ExpandedSwapLeg;
+import com.opengamma.strata.finance.rate.swap.KnownAmountPaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.PaymentEvent;
 import com.opengamma.strata.finance.rate.swap.PaymentPeriod;
-import com.opengamma.strata.finance.rate.swap.RateAccrualPeriod;
 import com.opengamma.strata.finance.rate.swap.RatePaymentPeriod;
 import com.opengamma.strata.finance.rate.swap.SwapLeg;
 import com.opengamma.strata.market.amount.CashFlow;
@@ -24,7 +24,6 @@ import com.opengamma.strata.market.amount.CashFlows;
 import com.opengamma.strata.market.explain.ExplainKey;
 import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
-import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
 /**
@@ -153,30 +152,19 @@ public class DiscountingSwapLegPricer {
    * A better name would be "Present Value of 1".
    * The quantity is also known as "physical annuity" or "level".
    * <p>
-   * All the payments periods must be of type {@link RatePaymentPeriod}.
    * Each period must not have FX reset or compounding.
+   * They must not be of type {@link KnownAmountPaymentPeriod}.
    * 
    * @param leg  the swap leg
    * @param provider  the rates provider
    * @return the Present Value of a Basis Point
    */
   public double pvbp(SwapLeg leg, RatesProvider provider) {
-    double pvbpLeg = 0.0;
+    double pvbpLeg = 0d;
     for (PaymentPeriod period : leg.expand().getPaymentPeriods()) {
-      ArgChecker.isTrue(period instanceof RatePaymentPeriod, "PaymentPeriod must be instance of RatePaymentPeriod");
-      pvbpLeg += pvbpPayment((RatePaymentPeriod) period, provider);
+      pvbpLeg += paymentPeriodPricer.pvbp(period, provider);
     }
     return pvbpLeg;
-  }
-
-  // computes Present Value of a Basis Point for payment with a unique accrual period (no compounding) 
-  // and no FX reset.
-  private double pvbpPayment(RatePaymentPeriod paymentPeriod, RatesProvider provider) {
-    ArgChecker.isTrue(!paymentPeriod.getFxReset().isPresent(), "FX reset is not supported");
-    ArgChecker.isTrue(paymentPeriod.getAccrualPeriods().size() == 1, "Compounding is not supported");
-    RateAccrualPeriod accrualPeriod = paymentPeriod.getAccrualPeriods().get(0);
-    double df = provider.discountFactor(paymentPeriod.getCurrency(), paymentPeriod.getPaymentDate());
-    return df * accrualPeriod.getYearFraction() * paymentPeriod.getNotional();
   }
 
   //-------------------------------------------------------------------------
@@ -266,8 +254,8 @@ public class DiscountingSwapLegPricer {
    * A better name would be "Present Value of 1".
    * The quantity is also known as "physical annuity" or "level".
    * <p>
-   * All the payments periods must be of type {@link RatePaymentPeriod}.
-   * Each period must have a fixed rate, no FX reset and no compounding.
+   * Each period must not have FX reset or compounding.
+   * They must not be of type {@link KnownAmountPaymentPeriod}.
    * 
    * @param fixedLeg  the swap fixed leg
    * @param provider  the rates provider
@@ -276,21 +264,9 @@ public class DiscountingSwapLegPricer {
   public PointSensitivityBuilder pvbpSensitivity(SwapLeg fixedLeg, RatesProvider provider) {
     PointSensitivityBuilder builder = PointSensitivityBuilder.none();
     for (PaymentPeriod period : fixedLeg.expand().getPaymentPeriods()) {
-      ArgChecker.isTrue(period instanceof RatePaymentPeriod, "PaymentPeriod must be instance of RatePaymentPeriod");
-      builder = builder.combinedWith(pvbpSensitivityPayment((RatePaymentPeriod) period, provider));
+      builder = builder.combinedWith(paymentPeriodPricer.pvbpSensitivity(period, provider));
     }
     return builder;
-  }
-
-  // computes Present Value of a Basis Point curve sensitivity for fixed payment with a unique accrual period 
-  // (no compounding) and no FX reset.
-  private PointSensitivityBuilder pvbpSensitivityPayment(RatePaymentPeriod paymentPeriod, RatesProvider provider) {
-    ArgChecker.isTrue(!paymentPeriod.getFxReset().isPresent(), "FX reset is not supported");
-    ArgChecker.isTrue(paymentPeriod.getAccrualPeriods().size() == 1, "Compounding is not supported");
-    RateAccrualPeriod accrualPeriod = paymentPeriod.getAccrualPeriods().get(0);
-    DiscountFactors discountFactors = provider.discountFactors(paymentPeriod.getCurrency());
-    return discountFactors.zeroRatePointSensitivity(paymentPeriod.getPaymentDate())
-        .multipliedBy(accrualPeriod.getYearFraction() * paymentPeriod.getNotional());
   }
 
   //-------------------------------------------------------------------------
@@ -306,7 +282,7 @@ public class DiscountingSwapLegPricer {
    */
   public double annuityCash(SwapLeg fixedLeg, double yield) {
     ExpandedSwapLeg expanded = fixedLeg.expand();
-    int nbFixedPeriod =  expanded.getPaymentPeriods().size();
+    int nbFixedPeriod = expanded.getPaymentPeriods().size();
     PaymentPeriod paymentPeriod = expanded.getPaymentPeriods().get(0);
     ArgChecker.isTrue(paymentPeriod instanceof RatePaymentPeriod, "payment period should be RatePaymentPeriod");
     RatePaymentPeriod ratePaymentPeriod = (RatePaymentPeriod) paymentPeriod;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricer.java
@@ -30,7 +30,6 @@ import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 
-
 /**
  * Pricer for for rate swap products.
  * <p>
@@ -226,7 +225,7 @@ public class DiscountingSwapProductPricer {
    * The par spread is the common spread on all payments of the first leg for which the total swap present value is 0.
    * <p>
    * The par spread will be computed with respect to the first leg. For that leg, all the payments have a unique 
-   * accrual period (no compounding) and no FX reset.
+   * accrual period or multiple accrual periods with Flat compounding and no FX reset.
    * 
    * @param product  the swap product for which the par rate should be computed
    * @param provider  the rates provider
@@ -274,11 +273,11 @@ public class DiscountingSwapProductPricer {
     PointSensitivityBuilder builder = PointSensitivityBuilder.none();
     for (ExpandedSwapLeg leg : product.expand().getLegs()) {
       PointSensitivityBuilder ls = legPricer.presentValueSensitivity(leg, provider);
-      PointSensitivityBuilder lsConverted = 
+      PointSensitivityBuilder lsConverted =
           ls.withCurrency(currency).multipliedBy(provider.fxRate(leg.getCurrency(), currency));
       builder = builder.combinedWith(lsConverted);
     }
-    return builder;    
+    return builder;
   }
 
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/PaymentPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swap/PaymentPeriodPricer.java
@@ -91,6 +91,33 @@ public interface PaymentPeriodPricer<T extends PaymentPeriod> {
 
   //-------------------------------------------------------------------------
   /**
+   * Calculates the present value of a basis point of a period.
+   * <p>
+   * This calculate the amount by which, to the first order, the period present value
+   * changes for a change of the rate defining the payment period. For known amount
+   * payments for which there is rate, the value is 0. In absence of compounding on
+   * the period, this measure is equivalent to the traditional PVBP.
+   * 
+   * @param period  the period to price
+   * @param provider  the rates provider
+   * @return the present value of a basis point
+   */
+  public abstract double pvbp(T period, RatesProvider provider);
+
+  /**
+   * Calculates the present value of a basis point sensitivity of a single payment period.
+   * <p>
+   * This calculate the sensitivity of the present value of a basis point (pvbp) quantity
+   * to the underlying curves.
+   * 
+   * @param period  the period to price
+   * @param provider  the rates provider
+   * @return the present value of a basis point sensitivity
+   */
+  public abstract PointSensitivityBuilder pvbpSensitivity(T period, RatesProvider provider);
+
+  //-------------------------------------------------------------------------
+  /**
    * Calculates the accrued interest since the last payment.
    * <p>
    * This calculates the interest that has accrued between the start of the period

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/DispatchingPaymentPeriodPricerTest.java
@@ -103,6 +103,10 @@ public class DispatchingPaymentPeriodPricerTest {
     ignoreThrows(() -> test.futureValue(kapp, MOCK_PROV));
     ignoreThrows(() -> test.futureValue(mockPaymentPeriod, MOCK_PROV));
 
+    ignoreThrows(() -> test.pvbp(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
+    ignoreThrows(() -> test.pvbp(kapp, MOCK_PROV));
+    ignoreThrows(() -> test.pvbp(mockPaymentPeriod, MOCK_PROV));
+
     ignoreThrows(() -> test.presentValueSensitivity(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
     ignoreThrows(() -> test.presentValueSensitivity(kapp, MOCK_PROV));
     ignoreThrows(() -> test.presentValueSensitivity(mockPaymentPeriod, MOCK_PROV));
@@ -110,6 +114,10 @@ public class DispatchingPaymentPeriodPricerTest {
     ignoreThrows(() -> test.futureValueSensitivity(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
     ignoreThrows(() -> test.futureValueSensitivity(kapp, MOCK_PROV));
     ignoreThrows(() -> test.futureValueSensitivity(mockPaymentPeriod, MOCK_PROV));
+
+    ignoreThrows(() -> test.pvbpSensitivity(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
+    ignoreThrows(() -> test.pvbpSensitivity(kapp, MOCK_PROV));
+    ignoreThrows(() -> test.pvbpSensitivity(mockPaymentPeriod, MOCK_PROV));
 
     ignoreThrows(() -> test.accruedInterest(SwapDummyData.FIXED_RATE_PAYMENT_PERIOD_REC_GBP, MOCK_PROV));
     ignoreThrows(() -> test.accruedInterest(kapp, MOCK_PROV));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/DiscountingSwapProductPricerTest.java
@@ -19,6 +19,7 @@ import static com.opengamma.strata.basics.index.PriceIndices.GB_RPI;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.finance.rate.swap.type.FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M;
+import static com.opengamma.strata.finance.rate.swap.type.IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M;
 import static com.opengamma.strata.pricer.datasets.RatesProviderDataSets.MULTI_USD;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FIXED_EXPANDED_SWAP_LEG_PAY;
 import static com.opengamma.strata.pricer.rate.swap.SwapDummyData.FIXED_EXPANDED_SWAP_LEG_PAY_USD;
@@ -171,9 +172,12 @@ public class DiscountingSwapProductPricerTest {
     double pvCpnIbor = 0.99 * fwdRate * 0.25 * 1_000_000;
     when(mockPeriod.presentValue(IBOR_RATE_PAYMENT_PERIOD_REC_GBP, mockProv))
         .thenReturn(pvCpnIbor);
-    double pvCpnFixed = -0.99 * 0.0123d * 0.25 * 1_000_000;
+    double pvbpCpnFixed = -0.99 * 0.25 * 1_000_000;
+    double pvCpnFixed = 0.0123d * pvbpCpnFixed;
     when(mockPeriod.presentValue(FIXED_RATE_PAYMENT_PERIOD_PAY_GBP, mockProv))
         .thenReturn(pvCpnFixed);
+    when(mockPeriod.pvbp(FIXED_RATE_PAYMENT_PERIOD_PAY_GBP, mockProv))
+        .thenReturn(pvbpCpnFixed);
     PaymentEventPricer<PaymentEvent> mockEvent = mock(PaymentEventPricer.class);
     double pvNotional = 980_000d;
     when(mockEvent.presentValue(NOTIONAL_EXCHANGE_REC_GBP, mockProv))
@@ -705,14 +709,23 @@ public class DiscountingSwapProductPricerTest {
     CurrencyAmount pv0 = SWAP_PRODUCT_PRICER.presentValue(swap0.getProduct(), USD, MULTI_USD);
     assertEquals(pv0.getAmount(),  0, TOLERANCE_PV);
   }
-  
+
   public void par_spread_ibor_ibor() {
     double ps = SWAP_PRODUCT_PRICER.parSpread(SWAP_USD_LIBOR_3M_LIBOR_6M_5Y.getProduct(), MULTI_USD);
     SwapTrade swap0 = IborIborSwapTemplate
         .of(Period.ZERO, TENOR_5Y, CONV_USD_LIBOR3M_LIBOR6M)
         .toTrade(MULTI_USD.getValuationDate(), BUY, NOTIONAL_SWAP, SPREAD + ps);
     CurrencyAmount pv0 = SWAP_PRODUCT_PRICER.presentValue(swap0.getProduct(), USD, MULTI_USD);
-    assertEquals(pv0.getAmount(),  0, TOLERANCE_PV);
+    assertEquals(pv0.getAmount(), 0, TOLERANCE_PV);
+  }
+
+  public void par_spread_ibor_cmp_ibor() {
+    SwapTrade trade = USD_LIBOR_3M_LIBOR_6M.toTrade(MULTI_USD.getValuationDate(), TENOR_5Y, BUY, NOTIONAL_SWAP, SPREAD);
+    double ps = SWAP_PRODUCT_PRICER.parSpread(trade.getProduct(), MULTI_USD);
+    SwapTrade swap0 = USD_LIBOR_3M_LIBOR_6M
+        .toTrade(MULTI_USD.getValuationDate(), TENOR_5Y, BUY, NOTIONAL_SWAP, SPREAD + ps);
+    CurrencyAmount pv0 = SWAP_PRODUCT_PRICER.presentValue(swap0.getProduct(), USD, MULTI_USD);
+    assertEquals(pv0.getAmount(), 0, TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------
@@ -724,7 +737,7 @@ public class DiscountingSwapProductPricerTest {
         MULTI_USD, p -> CurrencyAmount.of(USD, PRICER_SWAP.parSpread(expanded, p)));
     assertTrue(prAd.equalWithTolerance(prFd, TOLERANCE_RATE_DELTA));
   }
-  
+
   public void par_spread_sensitivity_ibor_ibor() {
     ExpandedSwap expanded = SWAP_USD_LIBOR_3M_LIBOR_6M_5Y.getProduct().expand();
     PointSensitivities point = PRICER_SWAP.parSpreadSensitivity(expanded, MULTI_USD).build();

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/SwapDummyData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swap/SwapDummyData.java
@@ -211,12 +211,23 @@ public final class SwapDummyData {
   /**
    * RatePaymentPeriod (fixed - receiver).
    */
-  public static final RatePaymentPeriod FIXED_RATE_PAYMENT_PERIOD_CMP_REC_USD = RatePaymentPeriod.builder()
+  public static final RatePaymentPeriod FIXED_RATE_PAYMENT_PERIOD_CMP_NONE_REC_GBP = RatePaymentPeriod.builder()
       .paymentDate(date(2015, 1, 2))
       .accrualPeriods(FIXED_RATE_ACCRUAL_PERIOD, FIXED_RATE_ACCRUAL_PERIOD_2)
       .dayCount(ACT_365F)
       .currency(Currency.GBP)
       .compoundingMethod(CompoundingMethod.NONE)
+      .notional(NOTIONAL)
+      .build();
+  /**
+   * RatePaymentPeriod (fixed - receiver).
+   */
+  public static final RatePaymentPeriod FIXED_RATE_PAYMENT_PERIOD_CMP_FLAT_REC_GBP = RatePaymentPeriod.builder()
+      .paymentDate(date(2015, 1, 2))
+      .accrualPeriods(FIXED_RATE_ACCRUAL_PERIOD, FIXED_RATE_ACCRUAL_PERIOD_2)
+      .dayCount(ACT_365F)
+      .currency(Currency.GBP)
+      .compoundingMethod(CompoundingMethod.FLAT)
       .notional(NOTIONAL)
       .build();
   /**
@@ -315,12 +326,20 @@ public final class SwapDummyData {
       .paymentEvents(FX_RESET_NOTIONAL_EXCHANGE_REC_USD)
       .build();
   /**
-   * ExpandedSwapLeg  (USD - fixed - receiver - compounding).
+   * ExpandedSwapLeg  (GBP - fixed - receiver - compounding).
    */
-  public static final ExpandedSwapLeg FIXED_CMP_EXPANDED_SWAP_LEG_PAY_USD = ExpandedSwapLeg.builder()
+  public static final ExpandedSwapLeg FIXED_CMP_NONE_EXPANDED_SWAP_LEG_PAY_GBP = ExpandedSwapLeg.builder()
       .type(FIXED)
       .payReceive(PAY)
-      .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD_CMP_REC_USD)
+      .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD_CMP_NONE_REC_GBP)
+      .build();
+  /**
+   * ExpandedSwapLeg  (GBP - fixed - receiver - compounding).
+   */
+  public static final ExpandedSwapLeg FIXED_CMP_FLAT_EXPANDED_SWAP_LEG_PAY_GBP = ExpandedSwapLeg.builder()
+      .type(FIXED)
+      .payReceive(PAY)
+      .paymentPeriods(FIXED_RATE_PAYMENT_PERIOD_CMP_FLAT_REC_GBP)
       .build();
   /**
    * RateCalculationSwapLeg (fixed).


### PR DESCRIPTION
ParSpread and parSpreadSensitivity was supported only for payment period with only one accrual period. The method have been extended to support payments with compounding of accrual periods with compounding method “FLAT”.
Those methods are required for curve calibration with basis swaps. The FLAT compounding is the standard one for the liquid basis swaps.