### PR TITLE
Swap Conventions: defaults the stub to SHORT_INITIAL.

### DIFF
--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedOvernightSwapConventions.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedOvernightSwapConventions.java
@@ -22,6 +22,7 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.HolidayCalendar;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.StubConvention;
 
 /**
  * Market standard Fixed-Overnight swap conventions.
@@ -125,6 +126,7 @@ public final class FixedOvernightSwapConventions {
             .accrualBusinessDayAdjustment(BusinessDayAdjustment.of(MODIFIED_FOLLOWING, calendar))
             .paymentFrequency(frequency)
             .paymentDateOffset(paymentDateOffset)
+            .stubConvention(StubConvention.SHORT_INITIAL)
             .build(),
         OvernightRateSwapLegConvention.builder()
             .index(index)
@@ -132,6 +134,7 @@ public final class FixedOvernightSwapConventions {
             .accrualFrequency(frequency)
             .paymentFrequency(frequency)
             .paymentDateOffset(paymentDateOffset)
+            .stubConvention(StubConvention.SHORT_INITIAL)
             .build(),
         spotDateOffset);
   }

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedRateSwapLegConvention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedRateSwapLegConvention.java
@@ -163,10 +163,12 @@ public final class FixedRateSwapLegConvention
 
   //-------------------------------------------------------------------------
   /**
-   * Creates a convention based on the specified index.
+   * Creates a convention based on the specified parameters.
    * <p>
    * The standard market convention for a fixed rate leg is based exclusively on these parameters.
    * Use the {@linkplain #builder() builder} for unusual conventions.
+   * <p>
+   * The default stub convention is SHORT_INITIAL.
    * 
    * @param currency  the currency of the leg
    * @param dayCount  the day count
@@ -185,6 +187,7 @@ public final class FixedRateSwapLegConvention
         .dayCount(dayCount)
         .accrualFrequency(accrualFrequency)
         .accrualBusinessDayAdjustment(accrualBusinessDayAdjustment)
+        .stubConvention(StubConvention.SHORT_INITIAL)
         .build();
   }
 

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedRateSwapLegConvention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/FixedRateSwapLegConvention.java
@@ -165,10 +165,9 @@ public final class FixedRateSwapLegConvention
   /**
    * Creates a convention based on the specified parameters.
    * <p>
-   * The standard market convention for a fixed rate leg is based exclusively on these parameters.
+   * The standard market convention for a fixed rate leg is based on these parameters,
+   * with the stub convention set to 'ShortInitial'.
    * Use the {@linkplain #builder() builder} for unusual conventions.
-   * <p>
-   * The default stub convention is SHORT_INITIAL.
    * 
    * @param currency  the currency of the leg
    * @param dayCount  the day count

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventions.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborIborSwapConventions.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.finance.rate.swap.type;
 
 import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.finance.rate.swap.CompoundingMethod;
 
 /**
@@ -27,6 +28,7 @@ public final class IborIborSwapConventions {
               .index(IborIndices.USD_LIBOR_3M)
               .paymentFrequency(Frequency.P6M)
               .compoundingMethod(CompoundingMethod.FLAT)
+              .stubConvention(StubConvention.SHORT_INITIAL)
               .build(),
           IborRateSwapLegConvention.of(IborIndices.USD_LIBOR_6M));
 
@@ -41,6 +43,7 @@ public final class IborIborSwapConventions {
               .index(IborIndices.USD_LIBOR_1M)
               .paymentFrequency(Frequency.P3M)
               .compoundingMethod(CompoundingMethod.FLAT)
+              .stubConvention(StubConvention.SHORT_INITIAL)
               .build(),
           IborRateSwapLegConvention.of(IborIndices.USD_LIBOR_3M));
 

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborRateSwapLegConvention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborRateSwapLegConvention.java
@@ -215,10 +215,9 @@ public final class IborRateSwapLegConvention
   /**
    * Creates a convention based on the specified index.
    * <p>
-   * The standard market convention for an Ibor rate leg is based exclusively on the index.
+   * The standard market convention for an Ibor rate leg is based on the index,
+   * with the stub convention set to 'ShortInitial'.
    * Use the {@linkplain #builder() builder} for unusual conventions.
-   * <p>
-   * The default stub convention is SHORT_INITIAL.
    * 
    * @param index  the index, the market convention values are extracted from the index
    * @return the convention

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborRateSwapLegConvention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/IborRateSwapLegConvention.java
@@ -217,6 +217,8 @@ public final class IborRateSwapLegConvention
    * <p>
    * The standard market convention for an Ibor rate leg is based exclusively on the index.
    * Use the {@linkplain #builder() builder} for unusual conventions.
+   * <p>
+   * The default stub convention is SHORT_INITIAL.
    * 
    * @param index  the index, the market convention values are extracted from the index
    * @return the convention
@@ -224,6 +226,7 @@ public final class IborRateSwapLegConvention
   public static IborRateSwapLegConvention of(IborIndex index) {
     return IborRateSwapLegConvention.builder()
         .index(index)
+        .stubConvention(StubConvention.SHORT_INITIAL)
         .build();
   }
 

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/OvernightRateSwapLegConvention.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swap/type/OvernightRateSwapLegConvention.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.joda.beans.Bean;
 import org.joda.beans.BeanDefinition;
 import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableDefaults;
 import org.joda.beans.ImmutableValidator;
 import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.MetaProperty;
@@ -73,7 +74,7 @@ public final class OvernightRateSwapLegConvention
   @PropertyDefinition(validate = "notNull")
   private final OvernightIndex index;
   /**
-   * The method of accruing overnight interest.
+   * The method of accruing overnight interest, defaulted to 'Compounded'.
    * <p>
    * Two methods of accrual are supported - 'Compounded' and 'Averaged'.
    * Averaging is primarily related to the 'USD-FED-FUND' index.
@@ -225,7 +226,9 @@ public final class OvernightRateSwapLegConvention
   /**
    * Creates a convention based on the specified index, using the 'Compounded' accrual method.
    * <p>
-   * The standard market convention for an Overnight rate leg is based exclusively on the index.
+   * The standard market convention for an Overnight rate leg is based on the index,
+   * frequency and payment offset, with the accrual method set to 'Compounded' and the
+   * stub convention set to 'ShortInitial'.
    * Use the {@linkplain #builder() builder} for unusual conventions.
    * 
    * @param index  the index, the market convention values are extracted from the index
@@ -244,7 +247,8 @@ public final class OvernightRateSwapLegConvention
   /**
    * Creates a convention based on the specified index, specifying the accrual method.
    * <p>
-   * The standard market convention for an Overnight rate leg is based exclusively on the index.
+   * The standard market convention for an Overnight rate leg is based on the index,
+   * frequency, payment offset and accrual type, with the stub convention set to 'ShortInitial'.
    * Use the {@linkplain #builder() builder} for unusual conventions.
    * <p>
    * The accrual method is usually 'Compounded'.
@@ -268,7 +272,13 @@ public final class OvernightRateSwapLegConvention
         .accrualFrequency(frequency)
         .paymentFrequency(frequency)
         .paymentDateOffset(DaysAdjustment.ofBusinessDays(paymentOffsetDays, index.getFixingCalendar()))
+        .stubConvention(StubConvention.SHORT_INITIAL)
         .build();
+  }
+
+  @ImmutableDefaults
+  private static void applyDefaults(Builder builder) {
+    builder.accrualMethod = OvernightAccrualMethod.COMPOUNDED;
   }
 
   @ImmutableValidator
@@ -674,7 +684,7 @@ public final class OvernightRateSwapLegConvention
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the method of accruing overnight interest.
+   * Gets the method of accruing overnight interest, defaulted to 'Compounded'.
    * <p>
    * Two methods of accrual are supported - 'Compounded' and 'Averaged'.
    * Averaging is primarily related to the 'USD-FED-FUND' index.
@@ -1101,6 +1111,7 @@ public final class OvernightRateSwapLegConvention
      * Restricted constructor.
      */
     private Builder() {
+      applyDefaults(this);
     }
 
     /**
@@ -1271,7 +1282,7 @@ public final class OvernightRateSwapLegConvention
     }
 
     /**
-     * Sets the method of accruing overnight interest.
+     * Sets the method of accruing overnight interest, defaulted to 'Compounded'.
      * <p>
      * Two methods of accrual are supported - 'Compounded' and 'Averaged'.
      * Averaging is primarily related to the 'USD-FED-FUND' index.

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/FixedIborSwapConventionsTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/FixedIborSwapConventionsTest.java
@@ -7,17 +7,25 @@ package com.opengamma.strata.finance.rate.swap.type;
 
 import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.basics.BuySell;
+import com.opengamma.strata.basics.PayReceive;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
 import com.opengamma.strata.basics.date.BusinessDayConventions;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.finance.rate.swap.ExpandedSwap;
+import com.opengamma.strata.finance.rate.swap.SwapTrade;
 
 /**
  * Test {@link FixedIborSwapConventions}.
@@ -144,6 +152,31 @@ public class FixedIborSwapConventionsTest {
   @Test(dataProvider = "dayConvention")
   public void test_day_convention(FixedIborSwapConvention convention, BusinessDayConvention dayConvention) {
     assertEquals(convention.getFixedLeg().getAccrualBusinessDayAdjustment().getConvention(), dayConvention);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "stubIbor")
+  static Object[][] data_stub_ibor() {
+    return new Object[][] {
+        {FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_3M, Tenor.TENOR_18M},
+        {FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M, Tenor.TENOR_18M},
+        {FixedIborSwapConventions.GBP_FIXED_1Y_LIBOR_3M, Tenor.TENOR_18M},
+        {FixedIborSwapConventions.GBP_FIXED_6M_LIBOR_6M, Tenor.TENOR_9M},
+        {FixedIborSwapConventions.JPY_FIXED_6M_TIBORJ_3M, Tenor.TENOR_9M},
+        {FixedIborSwapConventions.JPY_FIXED_6M_TIBORJ_3M, Tenor.TENOR_9M},
+        {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, Tenor.TENOR_18M},
+        {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, Tenor.TENOR_9M},
+    };
+  }
+  
+  @Test(dataProvider = "stubIbor")
+  public void test_stub_ibor(FixedIborSwapConvention convention, Tenor tenor) {
+    LocalDate tradeDate = LocalDate.of(2015, 10, 20);
+    SwapTrade swap = convention.toTrade(tradeDate, tenor, BuySell.BUY, 1, 0.01);
+    ExpandedSwap swapExpanded = swap.getProduct().expand();
+    LocalDate endDate = swapExpanded.getLeg(PayReceive.PAY).get().getEndDate();
+    assertTrue(endDate.isAfter(tradeDate.plus(tenor).minusMonths(1)));
+    assertTrue(endDate.isBefore(tradeDate.plus(tenor).plusMonths(1)));
   }
 
   public void coverage() {

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/FixedOvernightSwapConventionsTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/FixedOvernightSwapConventionsTest.java
@@ -7,17 +7,25 @@ package com.opengamma.strata.finance.rate.swap.type;
 
 import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.basics.BuySell;
+import com.opengamma.strata.basics.PayReceive;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
 import com.opengamma.strata.basics.date.BusinessDayConventions;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.index.OvernightIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.finance.rate.swap.ExpandedSwap;
+import com.opengamma.strata.finance.rate.swap.SwapTrade;
 
 /**
  * Test {@link FixedOvernightSwapConventions}.
@@ -134,6 +142,27 @@ public class FixedOvernightSwapConventionsTest {
 
   public void coverage() {
     coverPrivateConstructor(FixedOvernightSwapConventions.class);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "stubOn")
+  static Object[][] data_stub_on() {
+    return new Object[][] {
+        {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, Tenor.TENOR_18M},
+        {FixedOvernightSwapConventions.EUR_FIXED_1Y_EONIA_OIS, Tenor.TENOR_18M},
+        {FixedOvernightSwapConventions.GBP_FIXED_1Y_SONIA_OIS, Tenor.TENOR_18M},
+        {FixedOvernightSwapConventions.JPY_FIXED_1Y_TONAR_OIS, Tenor.TENOR_18M},
+    };
+  }
+  
+  @Test(dataProvider = "stubOn")
+  public void test_stub_overnight(FixedOvernightSwapConvention convention, Tenor tenor) {
+    LocalDate tradeDate = LocalDate.of(2015, 10, 20);
+    SwapTrade swap = convention.toTrade(tradeDate, tenor, BuySell.BUY, 1, 0.01);
+    ExpandedSwap swapExpanded = swap.getProduct().expand();
+    LocalDate endDate = swapExpanded.getLeg(PayReceive.PAY).get().getEndDate();
+    assertTrue(endDate.isAfter(tradeDate.plus(tenor).minusMonths(1)));
+    assertTrue(endDate.isBefore(tradeDate.plus(tenor).plusMonths(1)));
   }
 
 }

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/FixedRateSwapLegConventionTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/FixedRateSwapLegConventionTest.java
@@ -125,6 +125,7 @@ public class FixedRateSwapLegConventionTest {
             .startDate(startDate)
             .endDate(endDate)
             .businessDayAdjustment(BDA_MOD_FOLLOW)
+            .stubConvention(StubConvention.SHORT_INITIAL)
             .build())
         .paymentSchedule(PaymentSchedule.builder()
             .paymentFrequency(P3M)

--- a/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/OvernightRateSwapLegConventionTest.java
+++ b/modules/finance/src/test/java/com/opengamma/strata/finance/rate/swap/type/OvernightRateSwapLegConventionTest.java
@@ -91,6 +91,26 @@ public class OvernightRateSwapLegConventionTest {
     assertEquals(test.getCompoundingMethod(), CompoundingMethod.NONE);
   }
 
+  public void test_builder() {
+    OvernightRateSwapLegConvention test = OvernightRateSwapLegConvention.builder()
+        .index(GBP_SONIA)
+        .build();
+    assertEquals(test.getIndex(), GBP_SONIA);
+    assertEquals(test.getAccrualMethod(), COMPOUNDED);
+    assertEquals(test.getRateCutOffDays(), 0);
+    assertEquals(test.getCurrency(), GBP);
+    assertEquals(test.getDayCount(), ACT_365F);
+    assertEquals(test.getAccrualFrequency(), TERM);
+    assertEquals(test.getAccrualBusinessDayAdjustment(), BDA_MOD_FOLLOW);
+    assertEquals(test.getStartDateBusinessDayAdjustment(), BDA_MOD_FOLLOW);
+    assertEquals(test.getEndDateBusinessDayAdjustment(), BDA_MOD_FOLLOW);
+    assertEquals(test.getStubConvention(), StubConvention.SHORT_INITIAL);
+    assertEquals(test.getRollConvention(), RollConventions.NONE);
+    assertEquals(test.getPaymentFrequency(), TERM);
+    assertEquals(test.getPaymentDateOffset(), DaysAdjustment.NONE);
+    assertEquals(test.getCompoundingMethod(), CompoundingMethod.NONE);
+  }
+
   //-------------------------------------------------------------------------
   public void test_builder_notEnoughData() {
     assertThrowsIllegalArg(() -> OvernightRateSwapLegConvention.builder().build());
@@ -150,10 +170,7 @@ public class OvernightRateSwapLegConventionTest {
 
   //-------------------------------------------------------------------------
   public void test_toLeg() {
-    OvernightRateSwapLegConvention base = OvernightRateSwapLegConvention.builder()
-        .index(GBP_SONIA)
-        .accrualMethod(COMPOUNDED)
-        .build();
+    OvernightRateSwapLegConvention base = OvernightRateSwapLegConvention.of(GBP_SONIA, TERM, 2);
     LocalDate startDate = LocalDate.of(2015, 5, 5);
     LocalDate endDate = LocalDate.of(2020, 5, 5);
     RateCalculationSwapLeg test = base.toLeg(startDate, endDate, PAY, NOTIONAL_2M);
@@ -164,10 +181,11 @@ public class OvernightRateSwapLegConventionTest {
             .startDate(startDate)
             .endDate(endDate)
             .businessDayAdjustment(BDA_MOD_FOLLOW)
+            .stubConvention(StubConvention.SHORT_INITIAL)
             .build())
         .paymentSchedule(PaymentSchedule.builder()
             .paymentFrequency(TERM)
-            .paymentDateOffset(DaysAdjustment.NONE)
+            .paymentDateOffset(DaysAdjustment.ofBusinessDays(2, GBP_SONIA.getFixingCalendar()))
             .build())
         .notionalSchedule(NotionalSchedule.of(GBP, NOTIONAL_2M))
         .calculation(OvernightRateCalculation.of(GBP_SONIA))

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationDiscountingSimpleUsd2Test.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationDiscountingSimpleUsd2Test.java
@@ -107,19 +107,19 @@ public class CalibrationDiscountingSimpleUsd2Test {
   /* Market values */
   private static final double[] DSC_MARKET_QUOTES = new double[] {
       0.00072000, 0.00082000, 0.00093000, 0.00090000, 0.00105000,
-      0.00118500, 0.00318650, 0.00704000, 0.01121500, 0.01515000,
+      0.00118500, 0.00318650, 0.00318650, 0.00704000, 0.01121500, 0.01515000,
       0.01845500, 0.02111000, 0.02332000, 0.02513500, 0.02668500};
   private static final int DSC_NB_NODES = DSC_MARKET_QUOTES.length;
   private static final String[] DSC_ID_VALUE = new String[] {
       "OIS1M", "OIS2M", "OIS3M", "OIS6M", "OIS9M",
-      "OIS1Y", "OIS2Y", "OIS3Y", "OIS4Y", "OIS5Y",
+      "OIS1Y", "OIS18M", "OIS2Y", "OIS3Y", "OIS4Y", "OIS5Y",
       "OIS6Y", "OIS7Y", "OIS8Y", "OIS9Y", "OIS10Y"};
   /* Nodes */
   private static final CurveNode[] DSC_NODES = new CurveNode[DSC_NB_NODES];
   /* Tenors */
   private static final Period[] DSC_OIS_TENORS = new Period[] {
       Period.ofMonths(1), Period.ofMonths(2), Period.ofMonths(3), Period.ofMonths(6), Period.ofMonths(9),
-      Period.ofYears(1), Period.ofYears(2), Period.ofYears(3), Period.ofYears(4), Period.ofYears(5),
+      Period.ofYears(1), Period.ofMonths(18), Period.ofYears(2), Period.ofYears(3), Period.ofYears(4), Period.ofYears(5),
       Period.ofYears(6), Period.ofYears(7), Period.ofYears(8), Period.ofYears(9), Period.ofYears(10)};
   private static final int DSC_NB_OIS_NODES = DSC_OIS_TENORS.length;
   static {


### PR DESCRIPTION
The swap conventions (Fixed Overnight, Fixed Ibor and Ibor Ibor) did not default the stub convention. The market standard is SHORT_INITIAL.
Defaulted the different build-in conventions to that standard.