### PR TITLE
Enhance end of February roll convention support

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/DayRollConventions.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/DayRollConventions.java
@@ -96,7 +96,8 @@ final class DayRollConventions implements NamedLookup<RollConvention> {
     @Override
     public boolean matches(LocalDate date) {
       ArgChecker.notNull(date, "date");
-      return date.getDayOfMonth() == day;
+      return date.getDayOfMonth() == day ||
+          (date.getMonthValue() == 2 && day >= date.lengthOfMonth() && date.getDayOfMonth() == date.lengthOfMonth());
     }
 
     @Override

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -362,6 +362,17 @@ public class PeriodicScheduleTest {
         {date(2014, 9, 17), date(2014, 10, 1), Frequency.ofDays(2), STUB_NONE, IMM, null, null,
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 1)),
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 1))},
+
+        // Day30 rolling with February
+        {date(2015, 1, 30), date(2015, 4, 30), P1M, STUB_NONE, RollConvention.ofDayOfMonth(30), null, null,
+            ImmutableList.of(date(2015, 1, 30), date(2015, 2, 28), date(2015, 3, 30), date(2015, 4, 30)),
+            ImmutableList.of(date(2015, 1, 30), date(2015, 2, 27), date(2015, 3, 30), date(2015, 4, 30))},
+        {date(2015, 2, 28), date(2015, 4, 30), P1M, STUB_NONE, RollConvention.ofDayOfMonth(30), null, null,
+            ImmutableList.of(date(2015, 2, 28), date(2015, 3, 30), date(2015, 4, 30)),
+            ImmutableList.of(date(2015, 2, 27), date(2015, 3, 30), date(2015, 4, 30))},
+        {date(2015, 2, 28), date(2015, 4, 30), P1M, SHORT_INITIAL, RollConvention.ofDayOfMonth(30), null, null,
+            ImmutableList.of(date(2015, 2, 28), date(2015, 3, 30), date(2015, 4, 30)),
+            ImmutableList.of(date(2015, 2, 27), date(2015, 3, 30), date(2015, 4, 30))},
     };
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/RollConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/RollConventionTest.java
@@ -370,17 +370,38 @@ public class RollConventionTest {
     assertThrowsIllegalArg(() -> RollConvention.ofDayOfMonth(32));
   }
 
-  public void test_ofDayOfMonth_adjust() {
-    assertEquals(RollConvention.ofDayOfMonth(30).adjust(date(2014, FEBRUARY, 2)), date(2014, FEBRUARY, 28));
-    assertEquals(RollConvention.ofDayOfMonth(30).adjust(date(2016, FEBRUARY, 2)), date(2016, FEBRUARY, 29));
+  public void test_ofDayOfMonth_adjust_Day29() {
     assertEquals(RollConvention.ofDayOfMonth(29).adjust(date(2014, FEBRUARY, 2)), date(2014, FEBRUARY, 28));
     assertEquals(RollConvention.ofDayOfMonth(29).adjust(date(2016, FEBRUARY, 2)), date(2016, FEBRUARY, 29));
   }
 
-  public void test_ofDayOfMonth_matches() {
+  public void test_ofDayOfMonth_adjust_Day30() {
+    assertEquals(RollConvention.ofDayOfMonth(30).adjust(date(2014, FEBRUARY, 2)), date(2014, FEBRUARY, 28));
+    assertEquals(RollConvention.ofDayOfMonth(30).adjust(date(2016, FEBRUARY, 2)), date(2016, FEBRUARY, 29));
+  }
+
+  public void test_ofDayOfMonth_matches_Day29() {
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2016, JANUARY, 30)), false);
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2016, JANUARY, 29)), true);
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2016, JANUARY, 30)), false);
+
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2016, FEBRUARY, 28)), false);
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2016, FEBRUARY, 29)), true);
+
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2015, FEBRUARY, 27)), false);
+    assertEquals(RollConvention.ofDayOfMonth(29).matches(date(2015, FEBRUARY, 28)), true);
+  }
+
+  public void test_ofDayOfMonth_matches_Day30() {
     assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2016, JANUARY, 29)), false);
     assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2016, JANUARY, 30)), true);
     assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2016, JANUARY, 31)), false);
+
+    assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2016, FEBRUARY, 28)), false);
+    assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2016, FEBRUARY, 29)), true);
+
+    assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2015, FEBRUARY, 27)), false);
+    assertEquals(RollConvention.ofDayOfMonth(30).matches(date(2015, FEBRUARY, 28)), true);
   }
 
   public void test_ofDayOfMonth_next_oneMonth() {


### PR DESCRIPTION
Last day of February should return true from matches(LocalDate)
when using Day29 or Day30
This allows swap schedule without stubs starting/ending in February