### PR TITLE
Restore HistoricalScenarioExample

### DIFF
--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurvePointShiftsBuilder.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurvePointShiftsBuilder.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.function.marketdata.curve;
+
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleMatrix;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.market.curve.perturb.ShiftType;
+
+/**
+ * Mutable builder for building instances of {@link CurvePointShifts}.
+ * <p>
+ * This is created via {@link CurvePointShifts#builder(ShiftType)}.
+ */
+public final class CurvePointShiftsBuilder {
+
+  /**
+   * The type of shift to apply to the rates.
+   */
+  private final ShiftType shiftType;
+  /**
+   * The shift amounts, keyed by the identifier of the node to which they should be applied.
+   * <p>
+   * This is a linked map in order to preserve the insertion order. This means the node identifiers
+   * will appear in the same order as the nodes, assuming the shifts are added in node order (which seems
+   * likely).
+   */
+  private final Map<Pair<Integer, Object>, Double> shifts = new LinkedHashMap<>();
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor used by {@link CurvePointShifts#builder}.
+   *
+   * @param shiftType  the type of shift to apply to the rates
+   */
+  CurvePointShiftsBuilder(ShiftType shiftType) {
+    this.shiftType = ArgChecker.notNull(shiftType, "shiftType");
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Adds a shift for a curve node to the builder.
+   *
+   * @param scenarioIndex  the index of the scenario containing the shift
+   * @param nodeIdentifier  the identifier of the node to which the shift should be applied
+   * @param shiftAmount  the size of the shift
+   * @return this builder
+   */
+  public CurvePointShiftsBuilder addShift(int scenarioIndex, Object nodeIdentifier, double shiftAmount) {
+    ArgChecker.notNull(nodeIdentifier, "nodeIdentifier");
+    ArgChecker.notNegative(scenarioIndex, "scenarioIndex");
+    shifts.put(Pair.of(scenarioIndex, nodeIdentifier), shiftAmount);
+    return this;
+  }
+
+  /**
+   * Adds multiple shifts to the builder.
+   *
+   * @param scenarioIndex  the index of the scenario containing the shifts
+   * @param shiftMap  the shift amounts, keyed by the identifier of the node to which they should be applied
+   * @return this builder
+   */
+  public CurvePointShiftsBuilder addShifts(int scenarioIndex, Map<?, Double> shiftMap) {
+    ArgChecker.notNull(shiftMap, "shiftMap");
+    ArgChecker.notNegative(scenarioIndex, "scenarioIndex");
+    shiftMap.entrySet().stream().forEach(e -> shifts.put(Pair.of(scenarioIndex, e.getKey()), e.getValue()));
+    return this;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns an instance of {@link CurvePointShifts} built from the data in this builder.
+   *
+   * @return an instance of {@link CurvePointShifts} built from the data in this builder
+   */
+  public CurvePointShifts build() {
+    // This finds the scenario count by finding the maximum index and adding 1.
+    // If OptionalInt had map() it could be written more sensibly as: ...max().map(i -> i + 1).orElse(0)
+    // but it doesn't, hence using -1 and adding 1 to it for the case of zero scenarios
+    int scenarioCount = shifts.keySet().stream()
+        .mapToInt(Pair::getFirst)
+        .max()
+        .orElse(-1) + 1;
+    List<Object> nodeIdentifiers = shifts.keySet().stream()
+        .map(Pair::getSecond)
+        .distinct() // Use distinct to preserve order. Collecting to a set wouldn't preserve it
+        .collect(toImmutableList());
+    DoubleMatrix shiftMatrix =
+        DoubleMatrix.of(scenarioCount, nodeIdentifiers.size(), (r, c) -> shiftValue(r, nodeIdentifiers.get(c)));
+    return new CurvePointShifts(shiftType, shiftMatrix, nodeIdentifiers);
+  }
+
+  private double shiftValue(int scenarioIndex, Object nodeIdentifier) {
+    Double shift = shifts.get(Pair.of(scenarioIndex, nodeIdentifier));
+    return shift != null ? shift : 0;
+  }
+}

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurvePointShiftsTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurvePointShiftsTest.java
@@ -1,0 +1,265 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.function.marketdata.curve;
+
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.basics.interpolator.CurveInterpolator;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.engine.marketdata.scenario.MarketDataBox;
+import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.DefaultCurveMetadata;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.curve.NodalCurve;
+import com.opengamma.strata.market.curve.SimpleCurveNodeMetadata;
+import com.opengamma.strata.market.curve.perturb.CurvePointShift;
+import com.opengamma.strata.market.curve.perturb.ShiftType;
+import com.opengamma.strata.market.sensitivity.CurveUnitParameterSensitivity;
+import com.opengamma.strata.math.impl.interpolation.LogLinearInterpolator1D;
+
+/**
+ * Test {@link CurvePointShifts}.
+ */
+@Test
+public class CurvePointShiftsTest {
+
+  private static final String TNR_1W = "1W";
+  private static final String TNR_1M = "1M";
+  private static final String TNR_3M = "3M";
+  private static final String TNR_6M = "6M";
+  private static final CurveInterpolator INTERPOLATOR = new LogLinearInterpolator1D();
+
+  public void absolute() {
+    List<SimpleCurveNodeMetadata> nodeMetadata = ImmutableList.of(
+        SimpleCurveNodeMetadata.of(date(2011, 3, 8), TNR_1M),
+        SimpleCurveNodeMetadata.of(date(2011, 5, 8), TNR_3M),
+        SimpleCurveNodeMetadata.of(date(2011, 8, 8), TNR_6M));
+
+    // This should create 4 scenarios. Scenario zero has no shifts and scenario 3 doesn't have shifts on all nodes
+    CurvePointShifts shift = CurvePointShifts.builder(ShiftType.ABSOLUTE)
+        .addShift(1, TNR_1W, 0.1) // Tenor not in the curve, should be ignored
+        .addShift(1, TNR_1M, 0.2)
+        .addShift(1, TNR_3M, 0.3)
+        .addShift(2, TNR_1M, 0.4)
+        .addShift(2, TNR_3M, 0.5)
+        .addShift(2, TNR_6M, 0.6)
+        .addShift(3, TNR_3M, 0.7)
+        .build();
+
+    Curve curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5, 6, 7),
+        INTERPOLATOR);
+
+    MarketDataBox<Curve> shiftedCurveBox = shift.applyTo(MarketDataBox.ofSingleValue(curve));
+
+    Curve scenario1Curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5.2, 6.3, 7),
+        INTERPOLATOR);
+
+    Curve scenario2Curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5.4, 6.5, 7.6),
+        INTERPOLATOR);
+
+    Curve scenario3Curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5, 6.7, 7),
+        INTERPOLATOR);
+
+    // Scenario zero has no perturbations so the expected curve is the same as the input
+    List<Curve> expectedCurves = ImmutableList.of(curve, scenario1Curve, scenario2Curve, scenario3Curve);
+
+    for (int scenarioIndex = 0; scenarioIndex < 4; scenarioIndex++) {
+      // Check every point from 0 to 4 in steps of 0.1 is the same on the bumped curve and the expected curve
+      for (int xIndex = 0; xIndex <= 40; xIndex++) {
+        double xValue = xIndex * 0.1;
+        Curve expectedCurve = expectedCurves.get(scenarioIndex);
+        Curve shiftedCurve = shiftedCurveBox.getValue(scenarioIndex);
+        double shiftedY = shiftedCurve.yValue(xValue);
+        double expectedY = expectedCurve.yValue(xValue);
+        assertThat(shiftedY)
+            .overridingErrorMessage(
+                "Curve differed in scenario %d at x value %f, expected %f, actual %f",
+                scenarioIndex,
+                xValue,
+                expectedY,
+                shiftedY)
+            .isEqualTo(expectedY);
+      }
+    }
+  }
+
+  public void relative() {
+    List<SimpleCurveNodeMetadata> nodeMetadata = ImmutableList.of(
+        SimpleCurveNodeMetadata.of(date(2011, 3, 8), TNR_1M),
+        SimpleCurveNodeMetadata.of(date(2011, 5, 8), TNR_3M),
+        SimpleCurveNodeMetadata.of(date(2011, 8, 8), TNR_6M));
+
+    // This should create 4 scenarios. Scenario zero has no shifts and scenario 3 doesn't have shifts on all nodes
+    CurvePointShifts shift = CurvePointShifts.builder(ShiftType.RELATIVE)
+        .addShift(1, TNR_1W, 0.1) // Tenor not in the curve, should be ignored
+        .addShift(1, TNR_1M, 0.2)
+        .addShift(1, TNR_3M, 0.3)
+        .addShift(2, TNR_1M, 0.4)
+        .addShift(2, TNR_3M, 0.5)
+        .addShift(2, TNR_6M, 0.6)
+        .addShift(3, TNR_3M, 0.7)
+        .build();
+
+    Curve curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5, 6, 7),
+        INTERPOLATOR);
+
+    MarketDataBox<Curve> shiftedCurveBox = shift.applyTo(MarketDataBox.ofSingleValue(curve));
+
+    Curve scenario1Curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(6, 7.8, 7),
+        INTERPOLATOR);
+
+    Curve scenario2Curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(7, 9, 11.2),
+        INTERPOLATOR);
+
+    Curve scenario3Curve = InterpolatedNodalCurve.of(
+        Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, nodeMetadata),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5, 10.2, 7),
+        INTERPOLATOR);
+
+    // Scenario zero has no perturbations so the expected curve is the same as the input
+    List<Curve> expectedCurves = ImmutableList.of(curve, scenario1Curve, scenario2Curve, scenario3Curve);
+
+    for (int scenarioIndex = 0; scenarioIndex < 4; scenarioIndex++) {
+      // Check every point from 0 to 4 in steps of 0.1 is the same on the bumped curve and the expected curve
+      for (int xIndex = 0; xIndex <= 40; xIndex++) {
+        double xValue = xIndex * 0.1;
+        Curve expectedCurve = expectedCurves.get(scenarioIndex);
+        Curve shiftedCurve = shiftedCurveBox.getValue(scenarioIndex);
+        double shiftedY = shiftedCurve.yValue(xValue);
+        double expectedY = expectedCurve.yValue(xValue);
+        assertThat(shiftedY)
+            .overridingErrorMessage(
+                "Curve differed in scenario %d at x value %f, expected %f, actual %f",
+                scenarioIndex,
+                xValue,
+                expectedY,
+                shiftedY)
+            .isEqualTo(expectedY);
+      }
+    }
+  }
+
+  public void noNodeMetadata() {
+    Curve curve = InterpolatedNodalCurve.of(
+        DefaultCurveMetadata.of("curve"),
+        DoubleArray.of(1, 2, 3),
+        DoubleArray.of(5, 6, 7),
+        INTERPOLATOR);
+
+    // use ImmutableMap to test coverage of builder.addShifts()
+    ImmutableMap<Tenor, Double> map = ImmutableMap.of(Tenor.TENOR_1W, 0.1, Tenor.TENOR_1M, 0.2, Tenor.TENOR_3M, 0.3);
+    CurvePointShifts shift = CurvePointShifts.builder(ShiftType.RELATIVE).addShifts(0, map).build();
+    MarketDataBox<Curve> box = MarketDataBox.ofSingleValue(curve);
+
+    assertThrows(() -> shift.applyTo(box), IllegalArgumentException.class, ".* no parameter metadata.*");
+  }
+
+  public void notNodalCurve() {
+    CurveMetadata metadata = Curves.zeroRates(CurveName.of("curve"), DayCounts.ACT_365F, ImmutableList.of());
+    Curve curve = new NonNodalCurve(metadata);
+
+    CurvePointShift shift = CurvePointShift.builder(ShiftType.RELATIVE)
+        .addShift(Tenor.TENOR_1W, 0.1)
+        .addShift(Tenor.TENOR_1M, 0.2)
+        .addShift(Tenor.TENOR_3M, 0.3)
+        .build();
+
+    assertThrows(() -> shift.applyTo(curve), UnsupportedOperationException.class, ".*NodalCurve.*");
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    CurvePointShifts test = CurvePointShifts.builder(ShiftType.RELATIVE)
+        .addShift(0, Tenor.TENOR_1W, 0.1)
+        .addShift(0, Tenor.TENOR_1M, 0.2)
+        .addShift(0, Tenor.TENOR_3M, 0.3)
+        .build();
+    coverImmutableBean(test);
+    CurvePointShifts test2 = CurvePointShifts.builder(ShiftType.ABSOLUTE)
+        .addShift(0, Tenor.TENOR_1M, 0.2)
+        .addShift(0, Tenor.TENOR_3M, 0.3)
+        .build();
+    coverBeanEquals(test, test2);
+  }
+
+  /**
+   * Testing curve implementation.
+   * <p>
+   * Does not implement {@link NodalCurve}.
+   */
+  private static final class NonNodalCurve implements Curve {
+
+    private final CurveMetadata metadata;
+
+    public NonNodalCurve(CurveMetadata metadata) {
+      this.metadata = metadata;
+    }
+
+    //-------------------------------------------------------------------------
+    @Override
+    public CurveMetadata getMetadata() {
+      return metadata;
+    }
+
+    @Override
+    public int getParameterCount() {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public double yValue(double x) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public CurveUnitParameterSensitivity yValueParameterSensitivity(double x) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public double firstDerivative(double x) {
+      throw new IllegalStateException();
+    }
+
+  }
+}

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/perturb/CurvePointShiftBuilder.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/perturb/CurvePointShiftBuilder.java
@@ -56,7 +56,7 @@ public final class CurvePointShiftBuilder {
    * @param shifts  the shift amounts, keyed by the identifier of the node to which they should be applied
    * @return this builder
    */
-  public CurvePointShiftBuilder addShifts(Map<? extends Object, Double> shifts) {
+  public CurvePointShiftBuilder addShifts(Map<?, Double> shifts) {
     ArgChecker.notNull(shifts, "shifts");
     this.shifts.putAll(shifts);
     return this;


### PR DESCRIPTION
This PR restores commented out code in `HistoricalScenarioExample` which was removed to allow the market data API changes to be committed faster.

It adds `CurvePointShifts` and `CurvePointShiftsBuilder` which apply point shifts to curve nodes in multiple scenarios.

Fixes #538 