### PR TITLE
Change "expiration" to "expiry"

### DIFF
--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swaption/ExpandedSwaption.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swaption/ExpandedSwaption.java
@@ -57,7 +57,7 @@ public final class ExpandedSwaption
   /**
    * The expiry date of the option.  
    * <p>
-   * The option is European, and can only be exercised on the expiration date. 
+   * The option is European, and can only be exercised on the expiry date.
    * <p>
    * This is an adjusted date, which should be a valid business day.
    */
@@ -66,14 +66,14 @@ public final class ExpandedSwaption
   /**
    * The expiry time of the option.  
    * <p>
-   * The expiry time is related to the expiration date and time-zone.
+   * The expiry time is related to the expiry date and time-zone.
    */
   @PropertyDefinition(validate = "notNull")
   private final LocalTime expiryTime;
   /**
    * The time-zone of the expiry time.  
    * <p>
-   * The expiry time-zone is related to the expiration date and time.
+   * The expiry time-zone is related to the expiry date and time.
    */
   @PropertyDefinition(validate = "notNull")
   private final ZoneId expiryZone;
@@ -94,7 +94,7 @@ public final class ExpandedSwaption
    * <p>
    * The result is returned by combining the expiry date, time and time-zone.
    * 
-   * @return the expiration date and time
+   * @return the expiry date and time
    */
   public ZonedDateTime getExpiryDateTime() {
     return expiryDate.atTime(expiryTime).atZone(expiryZone);
@@ -201,7 +201,7 @@ public final class ExpandedSwaption
   /**
    * Gets the expiry date of the option.
    * <p>
-   * The option is European, and can only be exercised on the expiration date.
+   * The option is European, and can only be exercised on the expiry date.
    * <p>
    * This is an adjusted date, which should be a valid business day.
    * @return the value of the property, not null
@@ -214,7 +214,7 @@ public final class ExpandedSwaption
   /**
    * Gets the expiry time of the option.
    * <p>
-   * The expiry time is related to the expiration date and time-zone.
+   * The expiry time is related to the expiry date and time-zone.
    * @return the value of the property, not null
    */
   public LocalTime getExpiryTime() {
@@ -225,7 +225,7 @@ public final class ExpandedSwaption
   /**
    * Gets the time-zone of the expiry time.
    * <p>
-   * The expiry time-zone is related to the expiration date and time.
+   * The expiry time-zone is related to the expiry date and time.
    * @return the value of the property, not null
    */
   public ZoneId getExpiryZone() {
@@ -614,7 +614,7 @@ public final class ExpandedSwaption
     /**
      * Sets the expiry date of the option.
      * <p>
-     * The option is European, and can only be exercised on the expiration date.
+     * The option is European, and can only be exercised on the expiry date.
      * <p>
      * This is an adjusted date, which should be a valid business day.
      * @param expiryDate  the new value, not null
@@ -629,7 +629,7 @@ public final class ExpandedSwaption
     /**
      * Sets the expiry time of the option.
      * <p>
-     * The expiry time is related to the expiration date and time-zone.
+     * The expiry time is related to the expiry date and time-zone.
      * @param expiryTime  the new value, not null
      * @return this, for chaining, not null
      */
@@ -642,7 +642,7 @@ public final class ExpandedSwaption
     /**
      * Sets the time-zone of the expiry time.
      * <p>
-     * The expiry time-zone is related to the expiration date and time.
+     * The expiry time-zone is related to the expiry date and time.
      * @param expiryZone  the new value, not null
      * @return this, for chaining, not null
      */

--- a/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swaption/Swaption.java
+++ b/modules/finance/src/main/java/com/opengamma/strata/finance/rate/swaption/Swaption.java
@@ -59,7 +59,7 @@ public final class Swaption
   /**
    * The expiry date of the option.  
    * <p>
-   * The option is European, and can only be exercised on the expiration date. 
+   * The option is European, and can only be exercised on the expiry date.
    * <p>
    * This date is typically set to be a valid business day.
    * However, the {@code businessDayAdjustment} property may be set to provide a rule for adjustment.
@@ -69,14 +69,14 @@ public final class Swaption
   /**
    * The expiry time of the option.  
    * <p>
-   * The expiry time is related to the expiration date and time-zone.
+   * The expiry time is related to the expiry date and time-zone.
    */
   @PropertyDefinition(validate = "notNull")
   private final LocalTime expiryTime;
   /**
    * The time-zone of the expiry time.  
    * <p>
-   * The expiry time-zone is related to the expiration date and time.
+   * The expiry time-zone is related to the expiry date and time.
    */
   @PropertyDefinition(validate = "notNull")
   private final ZoneId expiryZone;
@@ -103,7 +103,7 @@ public final class Swaption
    * <p>
    * The result is returned by combining the expiry date, time and time-zone.
    * 
-   * @return the expiration date and time
+   * @return the expiry date and time
    */
   public ZonedDateTime getExpiryDateTime() {
     return expiryDate.getUnadjusted().atTime(expiryTime).atZone(expiryZone);
@@ -220,7 +220,7 @@ public final class Swaption
   /**
    * Gets the expiry date of the option.
    * <p>
-   * The option is European, and can only be exercised on the expiration date.
+   * The option is European, and can only be exercised on the expiry date.
    * <p>
    * This date is typically set to be a valid business day.
    * However, the {@code businessDayAdjustment} property may be set to provide a rule for adjustment.
@@ -234,7 +234,7 @@ public final class Swaption
   /**
    * Gets the expiry time of the option.
    * <p>
-   * The expiry time is related to the expiration date and time-zone.
+   * The expiry time is related to the expiry date and time-zone.
    * @return the value of the property, not null
    */
   public LocalTime getExpiryTime() {
@@ -245,7 +245,7 @@ public final class Swaption
   /**
    * Gets the time-zone of the expiry time.
    * <p>
-   * The expiry time-zone is related to the expiration date and time.
+   * The expiry time-zone is related to the expiry date and time.
    * @return the value of the property, not null
    */
   public ZoneId getExpiryZone() {
@@ -634,7 +634,7 @@ public final class Swaption
     /**
      * Sets the expiry date of the option.
      * <p>
-     * The option is European, and can only be exercised on the expiration date.
+     * The option is European, and can only be exercised on the expiry date.
      * <p>
      * This date is typically set to be a valid business day.
      * However, the {@code businessDayAdjustment} property may be set to provide a rule for adjustment.
@@ -650,7 +650,7 @@ public final class Swaption
     /**
      * Sets the expiry time of the option.
      * <p>
-     * The expiry time is related to the expiration date and time-zone.
+     * The expiry time is related to the expiry date and time-zone.
      * @param expiryTime  the new value, not null
      * @return this, for chaining, not null
      */
@@ -663,7 +663,7 @@ public final class Swaption
     /**
      * Sets the time-zone of the expiry time.
      * <p>
-     * The expiry time-zone is related to the expiration date and time.
+     * The expiry time-zone is related to the expiry date and time.
      * @param expiryZone  the new value, not null
      * @return this, for chaining, not null
      */

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/FxOptionSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/FxOptionSensitivity.java
@@ -44,7 +44,7 @@ public final class FxOptionSensitivity
   @PropertyDefinition(validate = "notNull")
   private final CurrencyPair currencyPair;
   /**
-   * The expiration zoned date time of the option.
+   * The expiry zoned date time of the option.
    */
   @PropertyDefinition(validate = "notNull")
   private final ZonedDateTime expiryDateTime;
@@ -213,7 +213,7 @@ public final class FxOptionSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the expiration zoned date time of the option.
+   * Gets the expiry zoned date time of the option.
    * @return the value of the property, not null
    */
   public ZonedDateTime getExpiryDateTime() {

--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/FxVolatilitySurfaceYearFractionNodeMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/FxVolatilitySurfaceYearFractionNodeMetadata.java
@@ -29,7 +29,7 @@ import com.opengamma.strata.collect.tuple.Pair;
 import com.opengamma.strata.market.option.Strike;
 
 /**
- * Surface node metadata for a surface node with a specific time to expiration and strike.
+ * Surface node metadata for a surface node with a specific time to expiry and strike.
  */
 @BeanDefinition(builderScope = "private")
 public final class FxVolatilitySurfaceYearFractionNodeMetadata
@@ -38,7 +38,7 @@ public final class FxVolatilitySurfaceYearFractionNodeMetadata
   /**
    * The year fraction of the surface node.
    * <p>
-   * This is the time to expiration that the node on the surface is defined as.
+   * This is the time to expiry that the node on the surface is defined as.
    * There is not necessarily a direct relationship with a date from an underlying instrument.
    */
   @PropertyDefinition
@@ -161,7 +161,7 @@ public final class FxVolatilitySurfaceYearFractionNodeMetadata
   /**
    * Gets the year fraction of the surface node.
    * <p>
-   * This is the time to expiration that the node on the surface is defined as.
+   * This is the time to expiry that the node on the surface is defined as.
    * There is not necessarily a direct relationship with a date from an underlying instrument.
    * @return the value of the property
    */

--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/SwaptionSurfaceExpiryTenorNodeMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/SwaptionSurfaceExpiryTenorNodeMetadata.java
@@ -27,7 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import com.opengamma.strata.collect.tuple.Pair;
 
 /**
- * Surface node metadata for a surface node for swaptions with a specific time to expiration and underlying swap tenor.
+ * Surface node metadata for a surface node for swaptions with a specific time to expiry and underlying swap tenor.
  * <p>
  * This typically represents a node of swaption volatility surface parameterized by expiry and tenor. 
  * Alternative applications include a representation of a node on model parameter surface, e.g., SABR model parameters.
@@ -39,7 +39,7 @@ public final class SwaptionSurfaceExpiryTenorNodeMetadata
   /**
   * The year fraction of the surface node.
   * <p>
-  * This is the time to expiration that the node on the surface is defined as.
+  * This is the time to expiry that the node on the surface is defined as.
   * There is not necessarily a direct relationship with a date from an underlying instrument.
   */
   @PropertyDefinition
@@ -149,7 +149,7 @@ public final class SwaptionSurfaceExpiryTenorNodeMetadata
   /**
    * Gets the year fraction of the surface node.
    * <p>
-   * This is the time to expiration that the node on the surface is defined as.
+   * This is the time to expiry that the node on the surface is defined as.
    * There is not necessarily a direct relationship with a date from an underlying instrument.
    * @return the value of the property
    */

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackVolatilityFlatFxProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackVolatilityFlatFxProvider.java
@@ -43,7 +43,7 @@ import com.opengamma.strata.market.value.ValueType;
 /**
  * Data provider of volatility for FX options in the lognormal or Black-Scholes model.
  * <p>
- * The volatility is represented by a curve on the expiration and the volatility
+ * The volatility is represented by a curve on the expiry and the volatility
  * is flat along the strike direction.
  */
 @BeanDefinition

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackVolatilitySmileFxProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackVolatilitySmileFxProvider.java
@@ -43,7 +43,7 @@ import com.opengamma.strata.market.value.ValueType;
  * Data provider of volatility for FX options in the lognormal or Black-Scholes model. 
  * <p>
  * The volatility is represented by a term structure of interpolated smile, 
- * {@link SmileDeltaTermStructureParametersStrikeInterpolation}, which represents expiration dependent smile formed of
+ * {@link SmileDeltaTermStructureParametersStrikeInterpolation}, which represents expiry dependent smile formed of
  * ATM, risk reversal and strangle as used in FX market.
  */
 @BeanDefinition
@@ -54,7 +54,7 @@ final class BlackVolatilitySmileFxProvider
   /**
    * The volatility model. 
    * <p>
-   * This represents expiration dependent smile which consists of ATM, risk reversal
+   * This represents expiry dependent smile which consists of ATM, risk reversal
    * and strangle as used in FX market.
    */
   @PropertyDefinition(validate = "notNull")
@@ -120,7 +120,7 @@ final class BlackVolatilitySmileFxProvider
     double forward = currencyPair.isInverse(point.getCurrencyPair()) ? 1d / point.getForward() : point.getForward();
     double pointValue = point.getSensitivity();
     DoubleMatrix bucketedSensi = smile.getVolatilityAndSensitivities(expiryTime, strike, forward).getSensitivities();
-    double[] times = smile.getTimeToExpiration();
+    double[] times = smile.getTimeToExpiry();
     int nTimes = times.length;
     List<Double> sensiList = new ArrayList<Double>();
     List<SurfaceParameterMetadata> paramList = new ArrayList<SurfaceParameterMetadata>();
@@ -208,7 +208,7 @@ final class BlackVolatilitySmileFxProvider
   /**
    * Gets the volatility model.
    * <p>
-   * This represents expiration dependent smile which consists of ATM, risk reversal
+   * This represents expiry dependent smile which consists of ATM, risk reversal
    * and strangle as used in FX market.
    * @return the value of the property, not null
    */
@@ -531,7 +531,7 @@ final class BlackVolatilitySmileFxProvider
     /**
      * Sets the volatility model.
      * <p>
-     * This represents expiration dependent smile which consists of ATM, risk reversal
+     * This represents expiry dependent smile which consists of ATM, risk reversal
      * and strangle as used in FX market.
      * @param smile  the new value, not null
      * @return this, for chaining, not null

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackVolatilitySurfaceFxProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackVolatilitySurfaceFxProvider.java
@@ -42,7 +42,7 @@ import com.opengamma.strata.market.value.ValueType;
 /**
  * Data provider of volatility for FX options in the lognormal or Black-Scholes model. 
  * <p>
- * The volatility is represented by a surface on the expiration and strike value.
+ * The volatility is represented by a surface on the expiry and strike value.
  */
 @BeanDefinition
 public final class BlackVolatilitySurfaceFxProvider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/SmileDeltaTermStructureParameters.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/SmileDeltaTermStructureParameters.java
@@ -36,11 +36,11 @@ class SmileDeltaTermStructureParameters {
    */
   private final String _name;
   /**
-   * The time to expiration in the term structure.
+   * The time to expiry in the term structure.
    */
-  private final double[] _timeToExpiration;
+  private final double[] _timeToExpiry;
   /**
-   * The smile description at the different time to expiration. All item should have the same deltas.
+   * The smile description at the different time to expiry. All item should have the same deltas.
    */
   private final SmileDeltaParameters[] _volatilityTerm;
   /**
@@ -59,7 +59,7 @@ class SmileDeltaTermStructureParameters {
   /**
    * Constructor from volatility term structure.
    * 
-   * @param volatilityTerm The volatility description at the different expiration.
+   * @param volatilityTerm The volatility description at the different expiry.
    */
   public SmileDeltaTermStructureParameters(SmileDeltaParameters[] volatilityTerm) {
     this(Long.toString(ATOMIC.getAndIncrement()), volatilityTerm, DEFAULT_INTERPOLATOR_EXPIRY);
@@ -71,7 +71,7 @@ class SmileDeltaTermStructureParameters {
    * The default interpolator is used to interpolate in the time dimension. 
    * 
    * @param name  the name of the smile parameter term structure
-   * @param volatilityTerm The volatility description at the different expiration.
+   * @param volatilityTerm The volatility description at the different expiry.
    */
   public SmileDeltaTermStructureParameters(String name, SmileDeltaParameters[] volatilityTerm) {
     this(name, volatilityTerm, DEFAULT_INTERPOLATOR_EXPIRY);
@@ -82,7 +82,7 @@ class SmileDeltaTermStructureParameters {
    * <p>
    * The default interpolator is used to interpolate in the time dimension. 
    * 
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    * @param interpolator  the time interpolator
    */
   public SmileDeltaTermStructureParameters(SmileDeltaParameters[] volatilityTerm, Interpolator1D interpolator) {
@@ -93,7 +93,7 @@ class SmileDeltaTermStructureParameters {
    * Constructor from name, volatility term structure and time interpolator.
    * 
    * @param name  the name of the smile parameter term structure
-   * @param volatilityTerm  the volatility description at the different expiration
+   * @param volatilityTerm  the volatility description at the different expiry
    * @param interpolator  the time interpolator
    */
   public SmileDeltaTermStructureParameters(
@@ -104,54 +104,54 @@ class SmileDeltaTermStructureParameters {
     _volatilityTerm = ArgChecker.notNull(volatilityTerm, "volatilityTerm");
     _name = ArgChecker.notNull(name, "name");
     int nbExp = volatilityTerm.length;
-    _timeToExpiration = new double[nbExp];
+    _timeToExpiry = new double[nbExp];
     for (int loopexp = 0; loopexp < nbExp; loopexp++) {
-      _timeToExpiration[loopexp] = _volatilityTerm[loopexp].getTimeToExpiry();
+      _timeToExpiry[loopexp] = _volatilityTerm[loopexp].getTimeToExpiry();
     }
   }
 
   /**
    * Constructor from market data.
    * <p>
-   * The market date consists of time to expiration, delta and volatility.  
+   * The market date consists of time to expiry, delta and volatility.
    * <p>
-   * The range of delta is common to all time to expiration. 
-   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiration} 
+   * The range of delta is common to all time to expiry.
+   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiry}
    * and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the time dimension. 
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
    * @param volatility  the volatilities at each delta 
    */
-  public SmileDeltaTermStructureParameters(double[] timeToExpiration, double[] delta, double[][] volatility) {
-    this(Long.toString(ATOMIC.getAndIncrement()), timeToExpiration, delta, volatility);
+  public SmileDeltaTermStructureParameters(double[] timeToExpiry, double[] delta, double[][] volatility) {
+    this(Long.toString(ATOMIC.getAndIncrement()), timeToExpiry, delta, volatility);
   }
 
   /**
    * Constructor from name and market data.
    * <p>
-   * The market date consists of time to expiration, delta and volatility.  
+   * The market date consists of time to expiry, delta and volatility.
    * <p>
-   * The range of delta is common to all time to expiration. 
-   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiration} 
+   * The range of delta is common to all time to expiry.
+   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiry}
    * and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the time dimension. 
    * 
    * @param name  the name of smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given
    * @param volatility  the volatilities at each delta 
    */
-  public SmileDeltaTermStructureParameters(String name, double[] timeToExpiration, double[] delta, double[][] volatility) {
-    ArgChecker.notNull(timeToExpiration, "time to expiry");
+  public SmileDeltaTermStructureParameters(String name, double[] timeToExpiry, double[] delta, double[][] volatility) {
+    ArgChecker.notNull(timeToExpiry, "time to expiry");
     ArgChecker.notNull(delta, "delta");
     ArgChecker.notNull(volatility, "volatility");
     _name = ArgChecker.notNull(name, "name");
-    _timeToExpiration = ArgChecker.notNull(timeToExpiration, "timeToExpiration");
-    int nbExp = timeToExpiration.length;
+    _timeToExpiry = ArgChecker.notNull(timeToExpiry, "timeToExpiry");
+    int nbExp = timeToExpiry.length;
     ArgChecker.isTrue(volatility.length == nbExp,
         "Volatility array length {} should be equal to the number of expiries {}", volatility.length, nbExp);
     ArgChecker.isTrue(volatility[0].length == 2 * delta.length + 1,
@@ -160,7 +160,7 @@ class SmileDeltaTermStructureParameters {
     _volatilityTerm = new SmileDeltaParameters[nbExp];
     for (int loopexp = 0; loopexp < nbExp; loopexp++) {
       _volatilityTerm[loopexp] = SmileDeltaParameters.of(
-          timeToExpiration[loopexp], DoubleArray.copyOf(delta), DoubleArray.copyOf(volatility[loopexp]));
+          timeToExpiry[loopexp], DoubleArray.copyOf(delta), DoubleArray.copyOf(volatility[loopexp]));
     }
     _timeInterpolator = DEFAULT_INTERPOLATOR_EXPIRY;
     ArgChecker.isTrue(_volatilityTerm[0].getVolatility().size() > 1,
@@ -170,84 +170,84 @@ class SmileDeltaTermStructureParameters {
   /**
    * Constructor from market data.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the time dimension. 
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    */
   public SmileDeltaTermStructureParameters(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle) {
-    this(Long.toString(ATOMIC.getAndIncrement()), timeToExpiration, delta, atm, riskReversal, strangle);
+    this(Long.toString(ATOMIC.getAndIncrement()), timeToExpiry, delta, atm, riskReversal, strangle);
   }
 
   /**
    * Constructor from name and market data.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the time dimension. 
    * 
    * @param name  the name of smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    */
   public SmileDeltaTermStructureParameters(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle) {
-    this(name, timeToExpiration, delta, atm, riskReversal, strangle, DEFAULT_INTERPOLATOR_EXPIRY);
+    this(name, timeToExpiry, delta, atm, riskReversal, strangle, DEFAULT_INTERPOLATOR_EXPIRY);
   }
 
   /**
    * Constructor from market data and time interpolator.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    * @param timeInterpolator  the interpolator to be used in the time dimension
    */
   public SmileDeltaTermStructureParameters(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle,
       Interpolator1D timeInterpolator) {
-    this(Long.toString(ATOMIC.getAndIncrement()), timeToExpiration, delta, atm, riskReversal, strangle,
+    this(Long.toString(ATOMIC.getAndIncrement()), timeToExpiry, delta, atm, riskReversal, strangle,
         timeInterpolator);
   }
 
@@ -257,21 +257,21 @@ class SmileDeltaTermStructureParameters {
    * The market data consists of time to expoiration, delta, ATM volatilities, risk reversal figures and 
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * 
    * @param name  the name of the smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    * @param timeInterpolator  the interpolator to be used in the time dimension
    */
   public SmileDeltaTermStructureParameters(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
@@ -283,19 +283,19 @@ class SmileDeltaTermStructureParameters {
     ArgChecker.notNull(strangle, "strangle");
     _timeInterpolator = ArgChecker.notNull(timeInterpolator, "timeInterpolator");
     _name = ArgChecker.notNull(name, "name");
-    _timeToExpiration = ArgChecker.notNull(timeToExpiration, "timeToExpiration");
-    int nbExp = timeToExpiration.length;
-    ArgChecker.isTrue(atm.length == nbExp, "ATM length should be coherent with time to expiration length");
+    _timeToExpiry = ArgChecker.notNull(timeToExpiry, "timeToExpiry");
+    int nbExp = timeToExpiry.length;
+    ArgChecker.isTrue(atm.length == nbExp, "ATM length should be coherent with time to expiry length");
     ArgChecker.isTrue(riskReversal.length == nbExp,
-        "Risk reversal length should be coherent with time to expiration length");
-    ArgChecker.isTrue(strangle.length == nbExp, "Strangle length should be coherent with time to expiration length");
+        "Risk reversal length should be coherent with time to expiry length");
+    ArgChecker.isTrue(strangle.length == nbExp, "Strangle length should be coherent with time to expiry length");
     ArgChecker.isTrue(riskReversal[0].length == delta.length,
         "Risk reversal size should be coherent with time to delta length");
     ArgChecker.isTrue(strangle[0].length == delta.length, "Strangle size should be coherent with time to delta length");
     _volatilityTerm = new SmileDeltaParameters[nbExp];
     for (int loopexp = 0; loopexp < nbExp; loopexp++) {
       _volatilityTerm[loopexp] = SmileDeltaParameters.of(
-          timeToExpiration[loopexp],
+          timeToExpiry[loopexp],
           atm[loopexp],
           DoubleArray.copyOf(delta),
           DoubleArray.copyOf(riskReversal[loopexp]),
@@ -316,12 +316,12 @@ class SmileDeltaTermStructureParameters {
 
   /**
    * Get smile at a given time. The smile is described by the volatilities at a given delta. The smile is obtained from the data by the given interpolator.
-   * @param time The time to expiration.
+   * @param time The time to expiry.
    * @return The smile.
    */
   public SmileDeltaParameters getSmileForTime(double time) {
     int nbVol = _volatilityTerm[0].getVolatility().size();
-    int nbTime = _timeToExpiration.length;
+    int nbTime = _timeToExpiry.length;
     ArgChecker.isTrue(nbTime > 1, "Need more than one time value to perform interpolation");
     double[] volatilityT = new double[nbVol];
     for (int loopvol = 0; loopvol < nbVol; loopvol++) {
@@ -330,7 +330,7 @@ class SmileDeltaTermStructureParameters {
         volDelta[looptime] = _volatilityTerm[looptime].getVolatility().get(loopvol);
       }
       Interpolator1DDataBundle interpData =
-          _timeInterpolator.getDataBundleFromSortedArrays(_timeToExpiration, volDelta);
+          _timeInterpolator.getDataBundleFromSortedArrays(_timeToExpiry, volDelta);
       volatilityT[loopvol] = _timeInterpolator.interpolate(interpData, time);
     }
     SmileDeltaParameters smile = SmileDeltaParameters.of(
@@ -340,7 +340,7 @@ class SmileDeltaTermStructureParameters {
 
   /**
    * Get the smile at a given time and the sensitivities with respect to the volatilities.
-   * @param time The time to expiration.
+   * @param time The time to expiry.
    * @param volatilityAtTimeSensitivity The sensitivity to the volatilities of the smile at the given time.
    * After the methods, it contains the volatility sensitivity to the data points.
    * @return The smile
@@ -349,7 +349,7 @@ class SmileDeltaTermStructureParameters {
     int nbVol = _volatilityTerm[0].getVolatility().size();
     ArgChecker.isTrue(volatilityAtTimeSensitivity.length == nbVol, "Sensitivity with incorrect size");
     ArgChecker.isTrue(nbVol > 1, "Need more than one volatility value to perform interpolation");
-    int nbTime = _timeToExpiration.length;
+    int nbTime = _timeToExpiry.length;
     ArgChecker.isTrue(nbTime > 1, "Need more than one time value to perform interpolation");
     double[] volatilityT = new double[nbVol];
     double[][] volatilitySensitivity = new double[nbTime][nbVol];
@@ -359,7 +359,7 @@ class SmileDeltaTermStructureParameters {
         volDelta[looptime] = _volatilityTerm[looptime].getVolatility().get(loopvol);
       }
       Interpolator1DDataBundle interpData =
-          _timeInterpolator.getDataBundleFromSortedArrays(_timeToExpiration, volDelta);
+          _timeInterpolator.getDataBundleFromSortedArrays(_timeToExpiry, volDelta);
       double[] volatilitySensitivityVol = _timeInterpolator.getNodeSensitivitiesForValue(interpData, time);
       for (int looptime = 0; looptime < nbTime; looptime++) {
         volatilitySensitivity[looptime][loopvol] = volatilitySensitivityVol[looptime] * volatilityAtTimeSensitivity[loopvol];
@@ -380,19 +380,19 @@ class SmileDeltaTermStructureParameters {
   }
 
   /**
-   * Gets the times to expiration.
+   * Gets the times to expiry.
    * @return The times.
    */
-  public double[] getTimeToExpiration() {
-    return _timeToExpiration;
+  public double[] getTimeToExpiry() {
+    return _timeToExpiry;
   }
 
   /**
-   * Gets the number of expirations.
-   * @return The number of expirations.
+   * Gets the number of expirys.
+   * @return The number of expirys.
    */
-  public int getNumberExpiration() {
-    return _timeToExpiration.length;
+  public int getNumberExpiry() {
+    return _timeToExpiry.length;
   }
 
   /**
@@ -420,7 +420,7 @@ class SmileDeltaTermStructureParameters {
   }
 
   /**
-   * Gets delta (common to all time to expiration).
+   * Gets delta (common to all time to expiry).
    * @return The delta.
    */
   public double[] getDelta() {
@@ -447,7 +447,7 @@ class SmileDeltaTermStructureParameters {
     int prime = 31;
     int result = 1;
     result = prime * result + _name.hashCode();
-    result = prime * result + Arrays.hashCode(_timeToExpiration);
+    result = prime * result + Arrays.hashCode(_timeToExpiry);
     result = prime * result + Arrays.hashCode(_volatilityTerm);
     result = prime * result + _timeInterpolator.hashCode();
     return result;
@@ -468,7 +468,7 @@ class SmileDeltaTermStructureParameters {
     if (!Objects.equals(_name, other._name)) {
       return false;
     }
-    if (!Arrays.equals(_timeToExpiration, other._timeToExpiration)) {
+    if (!Arrays.equals(_timeToExpiry, other._timeToExpiry)) {
       return false;
     }
     if (!Arrays.equals(_volatilityTerm, other._volatilityTerm)) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/SmileDeltaTermStructureParametersStrikeInterpolation.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/SmileDeltaTermStructureParametersStrikeInterpolation.java
@@ -45,7 +45,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
    * The default interpolator is used to interpolate in the strike dimension. 
    * The default interpolator is linear with flat extrapolation.
    * 
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(SmileDeltaParameters[] volatilityTerm) {
     this(volatilityTerm, DEFAULT_INTERPOLATOR_STRIKE);
@@ -58,7 +58,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
    * The default interpolator is linear with flat extrapolation.
    * 
    * @param name  the name of the smile parameter term structure
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(String name, SmileDeltaParameters[] volatilityTerm) {
     this(name, volatilityTerm, DEFAULT_INTERPOLATOR_STRIKE);
@@ -67,7 +67,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
   /**
    * Constructor from volatility term structure and strike interpolator. 
    * 
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    * @param strikeInterpolator  the interpolator used in the strike dimension.
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
@@ -81,7 +81,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
    * Constructor from name, volatility term structure, strike interpolator. 
    * 
    * @param name  the name of the smile parameter term structure
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    * @param strikeInterpolator  the interpolator used in the strike dimension.
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
@@ -95,7 +95,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
   /**
    * Constructor from volatility term structure, strike interpolator and time interpolator.
    * 
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    * @param strikeInterpolator  the interpolator used in the strike dimension.
    * @param timeInterpolator  the interpolator used in the time dimension.
    */
@@ -111,7 +111,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
    * Constructor from volatility term structure, strike interpolator and time interpolator.
    * 
    * @param name  the name of the smile parameter term structure
-   * @param volatilityTerm  the volatility description at the different expiration.
+   * @param volatilityTerm  the volatility description at the different expiry.
    * @param strikeInterpolator  the interpolator used in the strike dimension.
    * @param timeInterpolator  the interpolator used in the time dimension.
    */
@@ -127,71 +127,71 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
   /**
    * Constructor from market data. 
    * <p>
-   * The market date consists of time to expiration, delta and volatility.  
+   * The market date consists of time to expiry, delta and volatility.
    * The delta must be positive and sorted in ascending order.
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * <p>
    * The default interpolator is used to interpolate in the strike dimension. 
    * The default interpolator is linear with flat extrapolation.
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile.
+   * @param timeToExpiry  the time to expiry of each volatility smile.
    * @param delta  the delta at which the volatilities are given. 
    * @param volatility  the volatilities at each delta.
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[][] volatility) {
-    this(timeToExpiration, delta, volatility, DEFAULT_INTERPOLATOR_STRIKE);
+    this(timeToExpiry, delta, volatility, DEFAULT_INTERPOLATOR_STRIKE);
   }
 
   /**
    * Constructor from name and market data. 
    * <p>
-   * The market date consists of time to expiration, delta and volatility.  
+   * The market date consists of time to expiry, delta and volatility.
    * The delta must be positive and sorted in ascending order.
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * <p>
-   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiration} 
+   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiry}
    * and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the strike dimension. 
    * The default interpolator is linear with flat extrapolation.
    * 
    * @param name  the name of the smile parameter term structure
-   * @param timeToExpiration  the time to expiration of each volatility smile.
+   * @param timeToExpiry  the time to expiry of each volatility smile.
    * @param delta  the delta at which the volatilities are given. 
    * @param volatility  the volatilities at each delta.
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[][] volatility) {
-    this(name, timeToExpiration, delta, volatility, DEFAULT_INTERPOLATOR_STRIKE);
+    this(name, timeToExpiry, delta, volatility, DEFAULT_INTERPOLATOR_STRIKE);
   }
 
   /**
    * Constructor from market data and strike interpolator. 
    * <p>
-   * The market date consists of time to expiration, delta and volatility.  
+   * The market date consists of time to expiry, delta and volatility.
    * The delta must be positive and sorted in ascending order.
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * <p>
-   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiration} 
+   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiry}
    * and {@code m} is the length of {@code delta}.
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
    * @param volatility  the volatilities at each delta 
    * @param strikeInterpolator  the interpolator used in the strike dimension 
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[][] volatility,
       Interpolator1D strikeInterpolator) {
-    super(timeToExpiration, delta, volatility);
+    super(timeToExpiry, delta, volatility);
     ArgChecker.notNull(strikeInterpolator, "strike interpolator");
     _strikeInterpolator = ArgChecker.notNull(strikeInterpolator, "strikeInterpolator");
   }
@@ -199,171 +199,171 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
   /**
    * Constructor from name, market data and strike interpolator. 
    * <p>
-   * The market date consists of time to expiration, delta and volatility.  
+   * The market date consists of time to expiry, delta and volatility.
    * The delta must be positive and sorted in ascending order.
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * <p>
-   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiration} 
+   * {@code volatility} should be {@code n * (2 * m + 1)}, where {@code n} is the length of {@code timeToExpiry}
    * and {@code m} is the length of {@code delta}.
    * 
    * @param name  the name of smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
    * @param volatility  the volatilities at each delta 
    * @param strikeInterpolator  the interpolator used in the strike dimension 
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[][] volatility,
       Interpolator1D strikeInterpolator) {
-    super(name, timeToExpiration, delta, volatility);
+    super(name, timeToExpiry, delta, volatility);
     _strikeInterpolator = ArgChecker.notNull(strikeInterpolator, "strikeInterpolator");
   }
 
   /**
    * Constructor from market data.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the strike dimension. 
    * The default interpolator is linear with flat extrapolation.
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta, double[] atm,
       double[][] riskReversal,
       double[][] strangle) {
-    this(timeToExpiration, delta, atm, riskReversal, strangle, DEFAULT_INTERPOLATOR_STRIKE);
+    this(timeToExpiry, delta, atm, riskReversal, strangle, DEFAULT_INTERPOLATOR_STRIKE);
   }
 
   /**
    * Constructor from name and market data.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * <p>
    * The default interpolator is used to interpolate in the strike dimension. 
    * The default interpolator is linear with flat extrapolation.
    * 
    * @param name  the name of smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle) {
-    this(name, timeToExpiration, delta, atm, riskReversal, strangle, DEFAULT_INTERPOLATOR_STRIKE);
+    this(name, timeToExpiry, delta, atm, riskReversal, strangle, DEFAULT_INTERPOLATOR_STRIKE);
   }
 
   /**
    * Constructor from market data and strike interpolator.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    * @param strikeInterpolator  the interpolator to be used in the strike dimension
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle,
       Interpolator1D strikeInterpolator) {
-    super(timeToExpiration, delta, atm, riskReversal, strangle);
+    super(timeToExpiry, delta, atm, riskReversal, strangle);
     _strikeInterpolator = ArgChecker.notNull(strikeInterpolator, "strikeInterpolator");
   }
 
   /**
    * Constructor from name, market data and strike interpolator.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * 
    * @param name  the name of smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    * @param strikeInterpolator  the interpolator to be used in the strike dimension
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle,
       Interpolator1D strikeInterpolator) {
-    super(name, timeToExpiration, delta, atm, riskReversal, strangle);
+    super(name, timeToExpiry, delta, atm, riskReversal, strangle);
     _strikeInterpolator = ArgChecker.notNull(strikeInterpolator, "strikeInterpolator");
   }
 
   /**
    * Constructor from market data, strike interpolator and time interpolator.
    * <p>
-   * The market data consists of time to expiration, delta, ATM volatilities, risk reversal figures and 
+   * The market data consists of time to expiry, delta, ATM volatilities, risk reversal figures and
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    * @param strikeInterpolator  the interpolator to be used in the strike dimension
    * @param timeInterpolator  the interpolator to be used in the time dimension
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle,
       Interpolator1D strikeInterpolator,
       Interpolator1D timeInterpolator) {
-    super(timeToExpiration, delta, atm, riskReversal, strangle, timeInterpolator);
+    super(timeToExpiry, delta, atm, riskReversal, strangle, timeInterpolator);
     _strikeInterpolator = ArgChecker.notNull(strikeInterpolator, "strikeInterpolator");
   }
 
@@ -373,14 +373,14 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
    * The market data consists of time to expoiration, delta, ATM volatilities, risk reversal figures and 
    * strangle figures.
    * <p>
-   * The range of delta is common to all time to expiration. 
+   * The range of delta is common to all time to expiry.
    * {@code riskReversal} and {@code strangle} should be {@code n * m}, and the length of {@code atm} should {@code n}, 
-   * where {@code n} is the length of {@code timeToExpiration} and {@code m} is the length of {@code delta}. 
+   * where {@code n} is the length of {@code timeToExpiry} and {@code m} is the length of {@code delta}.
    * 
    * @param name  the name of the smile parameter term structure 
-   * @param timeToExpiration  the time to expiration of each volatility smile 
+   * @param timeToExpiry  the time to expiry of each volatility smile
    * @param delta  the delta at which the volatilities are given 
-   * @param atm  the ATM volatilities for each time to expiration
+   * @param atm  the ATM volatilities for each time to expiry
    * @param riskReversal  the risk reversal figures
    * @param strangle  the strangle figure
    * @param strikeInterpolator  the interpolator to be used in the strike dimension
@@ -388,14 +388,14 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
    */
   public SmileDeltaTermStructureParametersStrikeInterpolation(
       String name,
-      double[] timeToExpiration,
+      double[] timeToExpiry,
       double[] delta,
       double[] atm,
       double[][] riskReversal,
       double[][] strangle,
       Interpolator1D strikeInterpolator,
       Interpolator1D timeInterpolator) {
-    super(name, timeToExpiration, delta, atm, riskReversal, strangle, timeInterpolator);
+    super(name, timeToExpiry, delta, atm, riskReversal, strangle, timeInterpolator);
     _strikeInterpolator = ArgChecker.notNull(strikeInterpolator, "strikeInterpolator");
   }
 
@@ -430,7 +430,7 @@ class SmileDeltaTermStructureParametersStrikeInterpolation
 
   /**
    * Computes the volatility and the volatility sensitivity with respect to the volatility data points.
-   * @param time The time to expiration.
+   * @param time The time to expiry.
    * @param strike The strike.
    * @param forward The forward.
    * After the methods, it contains the volatility sensitivity to the data points.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepository.java
@@ -1111,7 +1111,7 @@ public final class BlackFormulaRepository {
    * @param delta The option delta
    * @param isCall  true for call, false for put
    * @param forward The forward.
-   * @param time The time to expiration.
+   * @param time The time to expiry.
    * @param volatility The volatility.
    * @return the strike.
    */

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/EuropeanVanillaOption.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/EuropeanVanillaOption.java
@@ -47,12 +47,12 @@ public final class EuropeanVanillaOption
    * Obtains an instance.
    * 
    * @param strike  the strike
-   * @param timeToExpiration  the time to expiration, year fraction
+   * @param timeToExpiry  the time to expiry, year fraction
    * @param putCall  whether the option is put or call.
    * @return the option definition
    */
-  public static EuropeanVanillaOption of(double strike, double timeToExpiration, PutCall putCall) {
-    return new EuropeanVanillaOption(strike, timeToExpiration, putCall);
+  public static EuropeanVanillaOption of(double strike, double timeToExpiry, PutCall putCall) {
+    return new EuropeanVanillaOption(strike, timeToExpiry, putCall);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/SabrInterestRateParameters.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/SabrInterestRateParameters.java
@@ -36,10 +36,10 @@ import com.opengamma.strata.pricer.impl.volatility.smile.function.VolatilityFunc
  * The volatility surface description under SABR model.  
  * <p>
  * This is used in interest rate modeling. 
- * Each SABR parameter is {@link NodalSurface} spanned by expiration and tenor. 
+ * Each SABR parameter is {@link NodalSurface} spanned by expiry and tenor.
  * <p>
  * The implementation allows for shifted SABR model. 
- * The shift parameter is also {@link NodalSurface} spanned by expiration and tenor.
+ * The shift parameter is also {@link NodalSurface} spanned by expiry and tenor.
  */
 @BeanDefinition(builderScope = "private")
 public final class SabrInterestRateParameters
@@ -48,28 +48,28 @@ public final class SabrInterestRateParameters
   /**
    * The alpha (volatility level) surface. 
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    */
   @PropertyDefinition(validate = "notNull")
   private final NodalSurface alphaSurface;
   /**
    * The beta (elasticity) surface. 
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    */
   @PropertyDefinition(validate = "notNull")
   private final NodalSurface betaSurface;
   /**
    * The rho (correlation) surface. 
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    */
   @PropertyDefinition(validate = "notNull")
   private final NodalSurface rhoSurface;
   /**
    * The nu (volatility of volatility) surface. 
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    */
   @PropertyDefinition(validate = "notNull")
   private final NodalSurface nuSurface;
@@ -83,7 +83,7 @@ public final class SabrInterestRateParameters
   /**
    * The shift parameter of shifted SABR model.
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    * The shift is set to be 0 unless specified.
    */
   @PropertyDefinition(validate = "notNull")
@@ -284,7 +284,7 @@ public final class SabrInterestRateParameters
   /**
    * Gets the alpha (volatility level) surface.
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    * @return the value of the property, not null
    */
   public NodalSurface getAlphaSurface() {
@@ -295,7 +295,7 @@ public final class SabrInterestRateParameters
   /**
    * Gets the beta (elasticity) surface.
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    * @return the value of the property, not null
    */
   public NodalSurface getBetaSurface() {
@@ -306,7 +306,7 @@ public final class SabrInterestRateParameters
   /**
    * Gets the rho (correlation) surface.
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    * @return the value of the property, not null
    */
   public NodalSurface getRhoSurface() {
@@ -317,7 +317,7 @@ public final class SabrInterestRateParameters
   /**
    * Gets the nu (volatility of volatility) surface.
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    * @return the value of the property, not null
    */
   public NodalSurface getNuSurface() {
@@ -339,7 +339,7 @@ public final class SabrInterestRateParameters
   /**
    * Gets the shift parameter of shifted SABR model.
    * <p>
-   * The first dimension is the expiration and the second the tenor.
+   * The first dimension is the expiry and the second the tenor.
    * The shift is set to be 0 unless specified.
    * @return the value of the property, not null
    */

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swaption/BlackVolatilityExpiryTenorSwaptionProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swaption/BlackVolatilityExpiryTenorSwaptionProvider.java
@@ -46,7 +46,7 @@ import com.opengamma.strata.market.surface.SwaptionSurfaceExpiryTenorNodeMetadat
 
 /**
  * Volatility environment for swaptions in the log-normal or Black model. 
- * The volatility is represented by a surface on the expiration and swap tenor dimensions.
+ * The volatility is represented by a surface on the expiry and swap tenor dimensions.
  */
 @BeanDefinition(builderScope = "private")
 public final class BlackVolatilityExpiryTenorSwaptionProvider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swaption/NormalVolatilityExpiryTenorSwaptionProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/swaption/NormalVolatilityExpiryTenorSwaptionProvider.java
@@ -46,7 +46,7 @@ import com.opengamma.strata.market.surface.SwaptionSurfaceExpiryTenorNodeMetadat
 
 /**
  * Volatility environment for swaptions in the normal or Bachelier model. 
- * The volatility is represented by a surface on the expiration and swap tenor dimensions.
+ * The volatility is represented by a surface on the expiry and swap tenor dimensions.
  */
 @BeanDefinition(builderScope = "private")
 public final class NormalVolatilityExpiryTenorSwaptionProvider
@@ -263,7 +263,7 @@ public final class NormalVolatilityExpiryTenorSwaptionProvider
   //-----------------------------------------------------------------------
   /**
    * Gets volatility environment for swaptions in the normal or Bachelier model.
-   * The volatility is represented by a surface on the expiration and swap tenor dimensions.
+   * The volatility is represented by a surface on the expiry and swap tenor dimensions.
    * /
    * @BeanDefinition(builderScope = "private")
    * public final class NormalVolatilityExpiryTenorSwaptionProvider

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/BlackVolatilitySmileFxProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/BlackVolatilitySmileFxProviderTest.java
@@ -181,7 +181,7 @@ public class BlackVolatilitySmileFxProviderTest {
     double forwardMod = provider.getCurrencyPair().equals(pair) ? forward : 1.0 / forward;
 
     SmileDeltaTermStructureParametersStrikeInterpolation smileTerm = provider.getSmile();
-    double[] times = smileTerm.getTimeToExpiration();
+    double[] times = smileTerm.getTimeToExpiry();
     int nTimes = times.length;
     SmileDeltaParameters[] volTermUp = new SmileDeltaParameters[nTimes];
     SmileDeltaParameters[] volTermDw = new SmileDeltaParameters[nTimes];

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/SmileDeltaTermStructureParametersStrikeInterpolationTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/SmileDeltaTermStructureParametersStrikeInterpolationTest.java
@@ -96,9 +96,9 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
    */
   public void volatilityAtPoint() {
     double forward = 1.40;
-    double timeToExpiration = 0.50;
+    double timeToExpiry = 0.50;
     double[] strikes = SMILE_TERM.getVolatilityTerm()[2].getStrike(forward);
-    double volComputed = SMILE_TERM.getVolatility(timeToExpiration, strikes[1], forward);
+    double volComputed = SMILE_TERM.getVolatility(timeToExpiry, strikes[1], forward);
     double volExpected = SMILE_TERM.getVolatilityTerm()[2].getVolatility().get(1);
     assertEquals("Smile by delta term structure: volatility at a point", volExpected, volComputed, TOLERANCE_VOL);
   }
@@ -108,26 +108,26 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
    */
   public void volatilityStrikeInterpolation() {
     double forward = 1.40;
-    double timeToExpiration = 0.50;
+    double timeToExpiry = 0.50;
     double strike = 1.50;
     double[] strikes = SMILE_TERM.getVolatilityTerm()[2].getStrike(forward);
     double[] vol = SMILE_TERM.getVolatilityTerm()[2].getVolatility().toArray();
     ArrayInterpolator1DDataBundle volatilityInterpolation = new ArrayInterpolator1DDataBundle(strikes, vol);
     LinearInterpolator1D interpolator = new LinearInterpolator1D();
     double volExpected = interpolator.interpolate(volatilityInterpolation, strike);
-    double volComputed = SMILE_TERM.getVolatility(timeToExpiration, strike, forward);
+    double volComputed = SMILE_TERM.getVolatility(timeToExpiry, strike, forward);
     assertEquals("Smile by delta term structure: volatility interpolation on strike", volExpected, volComputed, TOLERANCE_VOL);
   }
 
   /**
-   * Tests the extrapolation below the first expiration.
+   * Tests the extrapolation below the first expiry.
    */
   public void volatilityBelowFirstExpiry() {
     double forward = 1.40;
-    double timeToExpiration = 0.05;
+    double timeToExpiry = 0.05;
     double strike = 1.45;
     SmileDeltaParameters smile = SmileDeltaParameters.of(
-        timeToExpiration,
+        timeToExpiry,
         ATM[0],
         DELTA,
         DoubleArray.copyOf(RISK_REVERSAL[0]),
@@ -136,19 +136,19 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
     double[] vol = smile.getVolatility().toArray();
     ArrayInterpolator1DDataBundle volatilityInterpolation = new ArrayInterpolator1DDataBundle(strikes, vol);
     double volExpected = INTERPOLATOR_STRIKE.interpolate(volatilityInterpolation, strike);
-    double volComputed = SMILE_TERM.getVolatility(timeToExpiration, strike, forward);
+    double volComputed = SMILE_TERM.getVolatility(timeToExpiry, strike, forward);
     assertEquals("Smile by delta term structure: volatility interpolation on strike", volExpected, volComputed, TOLERANCE_VOL);
   }
 
   /**
-   * Tests the extrapolation above the last expiration.
+   * Tests the extrapolation above the last expiry.
    */
   public void volatilityAboveLastExpiry() {
     double forward = 1.40;
-    double timeToExpiration = 5.00;
+    double timeToExpiry = 5.00;
     double strike = 1.45;
     SmileDeltaParameters smile = SmileDeltaParameters.of(
-        timeToExpiration,
+        timeToExpiry,
         ATM[NB_EXP - 1],
         DELTA,
         DoubleArray.copyOf(RISK_REVERSAL[NB_EXP - 1]),
@@ -157,7 +157,7 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
     double[] vol = smile.getVolatility().toArray();
     ArrayInterpolator1DDataBundle volatilityInterpolation = new ArrayInterpolator1DDataBundle(strikes, vol);
     double volExpected = INTERPOLATOR_STRIKE.interpolate(volatilityInterpolation, strike);
-    double volComputed = SMILE_TERM.getVolatility(timeToExpiration, strike, forward);
+    double volComputed = SMILE_TERM.getVolatility(timeToExpiry, strike, forward);
     assertEquals("Smile by delta term structure: volatility interpolation on strike", volExpected, volComputed, TOLERANCE_VOL);
   }
 
@@ -166,27 +166,27 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
    */
   public void volatilityTimeInterpolation() {
     double forward = 1.40;
-    double timeToExpiration = 0.75;
+    double timeToExpiry = 0.75;
     double strike = 1.50;
     double[] vol050 = SMILE_TERM.getVolatilityTerm()[2].getVolatility().toArray();
     double[] vol100 = SMILE_TERM.getVolatilityTerm()[3].getVolatility().toArray();
     double[] vol = new double[vol050.length];
     for (int loopvol = 0; loopvol < vol050.length; loopvol++) {
-      vol[loopvol] = Math.sqrt(((vol050[loopvol] * vol050[loopvol] * TIME_TO_EXPIRY[2] + vol100[loopvol] * vol100[loopvol] * TIME_TO_EXPIRY[3]) / 2.0) / timeToExpiration);
+      vol[loopvol] = Math.sqrt(((vol050[loopvol] * vol050[loopvol] * TIME_TO_EXPIRY[2] + vol100[loopvol] * vol100[loopvol] * TIME_TO_EXPIRY[3]) / 2.0) / timeToExpiry);
     }
-    SmileDeltaParameters smile = SmileDeltaParameters.of(timeToExpiration, DELTA, DoubleArray.copyOf(vol));
+    SmileDeltaParameters smile = SmileDeltaParameters.of(timeToExpiry, DELTA, DoubleArray.copyOf(vol));
     double[] strikes = smile.getStrike(forward);
     ArrayInterpolator1DDataBundle volatilityInterpolation = new ArrayInterpolator1DDataBundle(strikes, vol);
     LinearInterpolator1D interpolator = new LinearInterpolator1D();
     double volExpected = interpolator.interpolate(volatilityInterpolation, strike);
-    double volComputed = SMILE_TERM.getVolatility(timeToExpiration, strike, forward);
+    double volComputed = SMILE_TERM.getVolatility(timeToExpiry, strike, forward);
     assertEquals("Smile by delta term structure: volatility interpolation on strike", volExpected, volComputed, TOLERANCE_VOL);
-    double volTriple = SMILE_TERM.getVolatility(Triple.of(timeToExpiration, strike, forward));
+    double volTriple = SMILE_TERM.getVolatility(Triple.of(timeToExpiry, strike, forward));
     assertEquals("Smile by delta term structure: volatility interpolation on strike", volComputed, volTriple, TOLERANCE_VOL);
     SmileDeltaTermStructureParametersStrikeInterpolation smileTerm2 =
         new SmileDeltaTermStructureParametersStrikeInterpolation(
             TIME_TO_EXPIRY, DELTA.toArray(), ATM, RISK_REVERSAL, STRANGLE, INTERPOLATOR_STRIKE, INTERPOLATOR_TIME);
-    double volComputed2 = smileTerm2.getVolatility(timeToExpiration, strike, forward);
+    double volComputed2 = smileTerm2.getVolatility(timeToExpiry, strike, forward);
     assertEquals("Smile by delta term structure: volatility interpolation on strike", volComputed, volComputed2, TOLERANCE_VOL);
   }
 
@@ -195,16 +195,16 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
    */
   public void volatilityAjoint() {
     double forward = 1.40;
-    double[] timeToExpiration = new double[] {0.75, 1.00, 2.50};
+    double[] timeToExpiry = new double[] {0.75, 1.00, 2.50};
     double[] strike = new double[] {1.50, 1.70, 2.20};
     double[] tolerance = new double[] {3e-2, 1e-1, 1e-5};
     int nbTest = strike.length;
     double shift = 0.00001;
     for (int looptest = 0; looptest < nbTest; looptest++) {
-      double vol = SMILE_TERM.getVolatility(timeToExpiration[looptest], strike[looptest], forward);
+      double vol = SMILE_TERM.getVolatility(timeToExpiry[looptest], strike[looptest], forward);
       double[][] bucketTest = new double[TIME_TO_EXPIRY.length][2 * DELTA.size() + 1];
       VolatilityAndBucketedSensitivities volComputed =
-          SMILE_TERM.getVolatilityAndSensitivities(timeToExpiration[looptest], strike[looptest], forward);
+          SMILE_TERM.getVolatilityAndSensitivities(timeToExpiry[looptest], strike[looptest], forward);
       DoubleMatrix bucketSensi = volComputed.getSensitivities();
       assertEquals("Smile by delta term structure: volatility adjoint", vol, volComputed.getVolatility(), 1.0E-10);
       SmileDeltaParameters[] volData = new SmileDeltaParameters[TIME_TO_EXPIRY.length];
@@ -218,7 +218,7 @@ public class SmileDeltaTermStructureParametersStrikeInterpolationTest {
           volData[loopexp] = SmileDeltaParameters.of(TIME_TO_EXPIRY[loopexp], DELTA, DoubleArray.copyOf(volBumped));
           SmileDeltaTermStructureParametersStrikeInterpolation smileTermBumped =
               new SmileDeltaTermStructureParametersStrikeInterpolation(volData, INTERPOLATOR_STRIKE);
-          bucketTest[loopexp][loopsmile] = (smileTermBumped.getVolatility(timeToExpiration[looptest], strike[looptest], forward) - volComputed.getVolatility()) / shift;
+          bucketTest[loopexp][loopsmile] = (smileTermBumped.getVolatility(timeToExpiry[looptest], strike[looptest], forward) - volComputed.getVolatility()) / shift;
           // FIXME: the strike sensitivity to volatility is missing. To be corrected when [PLAT-1396] is fixed.
           assertEquals("Smile by delta term structure: (test: " + looptest + ") volatility bucket sensitivity " + loopexp + " - " + loopsmile, bucketTest[loopexp][loopsmile],
               bucketSensi.get(loopexp, loopsmile), tolerance[looptest]);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swaption/BlackVolatilityExpiryTenorSwaptionProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swaption/BlackVolatilityExpiryTenorSwaptionProviderTest.java
@@ -139,8 +139,8 @@ public class BlackVolatilityExpiryTenorSwaptionProviderTest {
 
   public void test_volatility() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expirationTime = PROVIDER_WITH_PARAM.relativeTime(TEST_OPTION_EXPIRY[i]);
-      double volExpected = SURFACE_WITH_PARAM.zValue(expirationTime, TEST_TENOR[i]);
+      double expiryTime = PROVIDER_WITH_PARAM.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double volExpected = SURFACE_WITH_PARAM.zValue(expiryTime, TEST_TENOR[i]);
       double volComputed = PROVIDER_WITH_PARAM.getVolatility(
           TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swaption/NormalVolatilityExpiryTenorSwaptionProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swaption/NormalVolatilityExpiryTenorSwaptionProviderTest.java
@@ -139,8 +139,8 @@ public class NormalVolatilityExpiryTenorSwaptionProviderTest {
 
   public void test_volatility() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expirationTime = PROVIDER_WITH_PARAM.relativeTime(TEST_OPTION_EXPIRY[i]);
-      double volExpected = SURFACE_WITH_PARAM.zValue(expirationTime, TEST_TENOR[i]);
+      double expiryTime = PROVIDER_WITH_PARAM.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double volExpected = SURFACE_WITH_PARAM.zValue(expiryTime, TEST_TENOR[i]);
       double volComputed = PROVIDER_WITH_PARAM.getVolatility(
           TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swaption/SabrVolatilitySwaptionProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/swaption/SabrVolatilitySwaptionProviderTest.java
@@ -98,8 +98,8 @@ public class SabrVolatilitySwaptionProviderTest {
     SabrVolatilitySwaptionProvider prov = SabrVolatilitySwaptionProvider.of(PARAM, CONV, ACT_ACT_ISDA, DATE);
     for (int i = 0; i < NB_TEST; i++) {
       for (int j=0;j<NB_STRIKE;++j) {
-        double expirationTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
-        double volExpected = PARAM.getVolatility(expirationTime, TEST_TENOR[i], TEST_STRIKE[j], TEST_FORWARD);
+        double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
+        double volExpected = PARAM.getVolatility(expiryTime, TEST_TENOR[i], TEST_STRIKE[j], TEST_FORWARD);
         double volComputed = prov.getVolatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE[j], TEST_FORWARD);
         assertEquals(volComputed, volExpected, TOLERANCE_VOL);
       }
@@ -111,18 +111,18 @@ public class SabrVolatilitySwaptionProviderTest {
     SabrVolatilitySwaptionProvider prov = SabrVolatilitySwaptionProvider.of(PARAM, CONV, ACT_ACT_ISDA, DATE);
     for (int i = 0; i < NB_TEST; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
-        double expirationTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
+        double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
         SwaptionSabrSensitivity point = SwaptionSabrSensitivity.of(CONV, TEST_OPTION_EXPIRY[i], TEST_TENOR[i],
             TEST_STRIKE[j], TEST_FORWARD, USD, alphaSensi, betaSensi, rhoSensi, nuSensi);
         SurfaceCurrencyParameterSensitivities sensiComputed = prov.surfaceCurrencyParameterSensitivity(point);
         Map<DoublesPair, Double> alphaMap = prov.getParameters().getAlphaSurface()
-            .zValueParameterSensitivity(expirationTime, TEST_TENOR[i]);
+            .zValueParameterSensitivity(expiryTime, TEST_TENOR[i]);
         Map<DoublesPair, Double> betaMap = prov.getParameters().getBetaSurface()
-            .zValueParameterSensitivity(expirationTime, TEST_TENOR[i]);
+            .zValueParameterSensitivity(expiryTime, TEST_TENOR[i]);
         Map<DoublesPair, Double> rhoMap = prov.getParameters().getRhoSurface()
-            .zValueParameterSensitivity(expirationTime, TEST_TENOR[i]);
+            .zValueParameterSensitivity(expiryTime, TEST_TENOR[i]);
         Map<DoublesPair, Double> nuMap = prov.getParameters().getNuSurface()
-            .zValueParameterSensitivity(expirationTime, TEST_TENOR[i]);
+            .zValueParameterSensitivity(expiryTime, TEST_TENOR[i]);
         SurfaceCurrencyParameterSensitivity alphaSensiObj = sensiComputed.getSensitivity(
             SwaptionSabrRateVolatilityDataSet.META_ALPHA.getSurfaceName(), USD);
         SurfaceCurrencyParameterSensitivity betaSensiObj = sensiComputed.getSensitivity(


### PR DESCRIPTION
This PR changes use of the word "expiration" to "expiry".