### PR TITLE
Remove Result from MarketDataFunction.build

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/NoMatchingRulesMarketDataFunction.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/NoMatchingRulesMarketDataFunction.java
@@ -8,9 +8,8 @@ package com.opengamma.strata.calc.marketdata;
 import com.opengamma.strata.basics.market.MarketDataId;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
+import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
 import com.opengamma.strata.calc.runner.NoMatchingRuleId;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 
 /**
  * Market data function that creates failures with helpful error messages when the market
@@ -36,11 +35,9 @@ public final class NoMatchingRulesMarketDataFunction implements MarketDataFuncti
 
   @SuppressWarnings("unchecked")
   @Override
-  public Result build(MarketDataId id, MarketDataLookup marketData, MarketDataConfig marketDataConfig) {
-    return Result.failure(
-        FailureReason.MISSING_DATA,
-        "No market data rules were available to build the market data for key {}",
-        ((NoMatchingRuleId) id).getKey());
+  public MarketDataBox build(MarketDataId id, MarketDataLookup marketData, MarketDataConfig marketDataConfig) {
+    throw new IllegalArgumentException(
+        "No market data rules were available to build the market data for key " + ((NoMatchingRuleId) id).getKey());
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/function/MarketDataFunction.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/function/MarketDataFunction.java
@@ -10,7 +10,6 @@ import com.opengamma.strata.calc.marketdata.MarketDataLookup;
 import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.Result;
 
 /**
  * A market data function creates items of market data for a set of market data IDs.
@@ -41,7 +40,7 @@ public interface MarketDataFunction<T, I extends MarketDataId<? extends T>> {
    * @param marketDataConfig  configuration specifying how the market data should be built
    * @return built market data, or details of the problems that prevented building
    */
-  public abstract Result<MarketDataBox<T>> build(I id, MarketDataLookup marketData, MarketDataConfig marketDataConfig);
+  public abstract MarketDataBox<T> build(I id, MarketDataLookup marketData, MarketDataConfig marketDataConfig);
 
   /**
    * Returns the type of market data ID this function can handle.

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/function/MissingMappingMarketDataFunction.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/function/MissingMappingMarketDataFunction.java
@@ -10,8 +10,6 @@ import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
 import com.opengamma.strata.calc.runner.MissingMappingId;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 
 /**
  * Market data function that creates failures with helpful error messages when there is no
@@ -32,15 +30,12 @@ public final class MissingMappingMarketDataFunction implements MarketDataFunctio
   }
 
   @Override
-  public Result<MarketDataBox<Void>> build(
+  public MarketDataBox<Void> build(
       MissingMappingId id,
       MarketDataLookup marketData,
       MarketDataConfig marketDataConfig) {
 
-    return Result.failure(
-        FailureReason.MISSING_DATA,
-        "No market data mapping found for market data key {}",
-        id.getKey());
+    throw new IllegalArgumentException("No market data mapping found for market data key " + id.getKey());
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/scenario/EmptyMarketDataBox.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/scenario/EmptyMarketDataBox.java
@@ -10,7 +10,6 @@ import java.util.function.Function;
 
 import com.opengamma.strata.basics.market.ScenarioMarketDataValue;
 import com.opengamma.strata.collect.function.ObjIntFunction;
-import com.opengamma.strata.collect.result.Result;
 
 /**
  * A market data box that contains no data.
@@ -52,13 +51,13 @@ class EmptyMarketDataBox implements MarketDataBox<Void> {
   }
 
   @Override
-  public <R> Result<MarketDataBox<R>> apply(Function<Void, Result<R>> fn) {
-    return Result.success(empty());
+  public <R> MarketDataBox<R> apply(Function<Void, R> fn) {
+    return empty();
   }
 
   @Override
-  public <U, R> Result<MarketDataBox<R>> combineWith(MarketDataBox<U> other, BiFunction<Void, U, Result<R>> fn) {
-    return Result.success(empty());
+  public <U, R> MarketDataBox<R> combineWith(MarketDataBox<U> other, BiFunction<Void, U, R> fn) {
+    return empty();
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/scenario/MarketDataBox.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/scenario/MarketDataBox.java
@@ -157,11 +157,11 @@ public interface MarketDataBox<T> {
    * This is primarily intended for use by market data factories which might receive single values or
    * scenario values from upstream market data factories.
    *
-   * @param fn  a function to apply to the market data in the box
    * @param <R>  the return type of the function
+   * @param fn  a function to apply to the market data in the box
    * @return a result wrapping a box containing the return value of the function
    */
-  public abstract <R> Result<MarketDataBox<R>> apply(Function<T, Result<R>> fn);
+  public abstract <R> MarketDataBox<R> apply(Function<T, R> fn);
 
   /**
    * Applies a function to the contents of the box once for each scenario and returns a box containing
@@ -179,7 +179,7 @@ public interface MarketDataBox<T> {
    * @param <R>  the type of the returned market data
    * @return a box containing market data created by applying the function to the contents of this box
    */
-  public abstract  <R> MarketDataBox<R> apply(int scenarioCount, ObjIntFunction<T, R> fn);
+  public abstract <R> MarketDataBox<R> apply(int scenarioCount, ObjIntFunction<T, R> fn);
 
   /**
    * Applies a function to the market data in this box and another box and returns a box containing the result.
@@ -190,14 +190,14 @@ public interface MarketDataBox<T> {
    * This is primarily intended for use by market data factories which might receive single values or
    * scenario values from upstream market data factories.
    *
+   * @param <U>  the type of market data in the other box
+   * @param <R>  the type of the market data returned in the result of the function
    * @param other  another market data box
    * @param fn  a function invoked with the market data from each box. The return value is used to build the data
    *   in the returned box
-   * @param <U>  the type of market data in the other box
-   * @param <R>  the type of the market data returned in the result of the function
    * @return a box containing market data created by applying the function to the data in this box and another box
    */
-  public abstract <U, R> Result<MarketDataBox<R>> combineWith(MarketDataBox<U> other, BiFunction<T, U, Result<R>> fn);
+  public abstract <U, R> MarketDataBox<R> combineWith(MarketDataBox<U> other, BiFunction<T, U, R> fn);
 
   /**
    * Returns the number of scenarios for which this box contains data.

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketDataNodeTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketDataNodeTest.java
@@ -24,7 +24,6 @@ import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
 import com.opengamma.strata.collect.id.StandardId;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.collect.tuple.Pair;
 
 @Test
@@ -413,7 +412,7 @@ public class MarketDataNodeTest {
     }
 
     @Override
-    public Result<MarketDataBox<Double>> build(TestIdA id, MarketDataLookup marketData, MarketDataConfig marketDataConfig) {
+    public MarketDataBox<Double> build(TestIdA id, MarketDataLookup marketData, MarketDataConfig marketDataConfig) {
       throw new UnsupportedOperationException("build not implemented");
     }
 
@@ -439,7 +438,7 @@ public class MarketDataNodeTest {
     }
 
     @Override
-    public Result<MarketDataBox<TestMarketDataB>> build(
+    public MarketDataBox<TestMarketDataB> build(
         TestIdB id,
         MarketDataLookup marketData,
         MarketDataConfig marketDataConfig) {

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/scenario/ScenarioMarketDataBoxTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/scenario/ScenarioMarketDataBoxTest.java
@@ -11,7 +11,6 @@ import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import org.testng.annotations.Test;
 
 import com.opengamma.strata.basics.market.ScenarioMarketDataValue;
-import com.opengamma.strata.collect.result.Result;
 
 @Test
 public class ScenarioMarketDataBoxTest {
@@ -52,8 +51,8 @@ public class ScenarioMarketDataBoxTest {
 
   public void apply() {
     MarketDataBox<Integer> box = MarketDataBox.ofScenarioValues(27, 28, 29);
-    Result<MarketDataBox<Integer>> result = box.apply(v -> Result.success(v * 2));
-    assertThat(result).hasValue(MarketDataBox.ofScenarioValues(54, 56, 58));
+    MarketDataBox<Integer> result = box.apply(v -> v * 2);
+    assertThat(result).isEqualTo(MarketDataBox.ofScenarioValues(54, 56, 58));
   }
 
   /**
@@ -81,9 +80,7 @@ public class ScenarioMarketDataBoxTest {
   public void combineWithSingleBox() {
     MarketDataBox<Integer> box = MarketDataBox.ofScenarioValues(27, 28, 29);
     MarketDataBox<Integer> otherBox = MarketDataBox.ofSingleValue(15);
-    Result<MarketDataBox<Integer>> result = box.combineWith(otherBox, (v1, v2) -> Result.success(v1 + v2));
-    assertThat(result).isSuccess();
-    MarketDataBox<Integer> resultBox = result.getValue();
+    MarketDataBox<Integer> resultBox = box.combineWith(otherBox, (v1, v2) -> v1 + v2);
     assertThat(resultBox.isScenarioValue()).isTrue();
     assertThat(resultBox.getScenarioCount()).isEqualTo(3);
     assertThat(resultBox.getValue(0)).isEqualTo(42);
@@ -94,9 +91,7 @@ public class ScenarioMarketDataBoxTest {
   public void combineWithScenarioBox() {
     MarketDataBox<Integer> box = MarketDataBox.ofScenarioValues(27, 28, 29);
     MarketDataBox<Integer> otherBox = MarketDataBox.ofScenarioValues(15, 16, 17);
-    Result<MarketDataBox<Integer>> result = box.combineWith(otherBox, (v1, v2) -> Result.success(v1 + v2));
-    assertThat(result).isSuccess();
-    MarketDataBox<Integer> resultBox = result.getValue();
+    MarketDataBox<Integer> resultBox = box.combineWith(otherBox, (v1, v2) -> v1 + v2);
     assertThat(resultBox.isScenarioValue()).isTrue();
     assertThat(resultBox.getScenarioCount()).isEqualTo(3);
     assertThat(resultBox.getValue(0)).isEqualTo(42);
@@ -107,8 +102,10 @@ public class ScenarioMarketDataBoxTest {
   public void combineWithScenarioBoxWithWrongNumberOfScenarios() {
     MarketDataBox<Integer> box = MarketDataBox.ofScenarioValues(27, 28, 29);
     MarketDataBox<Integer> otherBox = MarketDataBox.ofScenarioValues(15, 16, 17, 18);
-    Result<MarketDataBox<Integer>> result = box.combineWith(otherBox, (v1, v2) -> Result.success(v1 + v2));
-    assertThat(result).hasFailureMessageMatching("Scenario values must have the same number of scenarios.*");
+    assertThrows(
+        () -> box.combineWith(otherBox, (v1, v2) -> v1 + v2),
+        IllegalArgumentException.class,
+        "Scenario values must have the same number of scenarios.*");
   }
 
   public void getMarketDataType() {

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/scenario/SingleMarketDataBoxTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/scenario/SingleMarketDataBoxTest.java
@@ -10,8 +10,6 @@ import static com.opengamma.strata.collect.TestHelper.assertThrows;
 
 import org.testng.annotations.Test;
 
-import com.opengamma.strata.collect.result.Result;
-
 @Test
 public class SingleMarketDataBoxTest {
 
@@ -48,8 +46,8 @@ public class SingleMarketDataBoxTest {
 
   public void apply() {
     MarketDataBox<Integer> box = MarketDataBox.ofSingleValue(27);
-    Result<MarketDataBox<Integer>> result = box.apply(v -> Result.success(v * 2));
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(54));
+    MarketDataBox<Integer> result = box.apply(v -> v * 2);
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(54));
   }
 
   /**
@@ -68,9 +66,7 @@ public class SingleMarketDataBoxTest {
   public void combineWithSingleBox() {
     MarketDataBox<Integer> box = MarketDataBox.ofSingleValue(27);
     MarketDataBox<Integer> otherBox = MarketDataBox.ofSingleValue(15);
-    Result<MarketDataBox<Integer>> result = box.combineWith(otherBox, (v1, v2) -> Result.success(v1 + v2));
-    assertThat(result).isSuccess();
-    MarketDataBox<Integer> resultBox = result.getValue();
+    MarketDataBox<Integer> resultBox = box.combineWith(otherBox, (v1, v2) -> v1 + v2);
     assertThat(resultBox.isSingleValue()).isTrue();
     assertThat(resultBox.getValue(0)).isEqualTo(42);
   }
@@ -78,9 +74,7 @@ public class SingleMarketDataBoxTest {
   public void combineWithScenarioBox() {
     MarketDataBox<Integer> box = MarketDataBox.ofSingleValue(27);
     MarketDataBox<Integer> otherBox = MarketDataBox.ofScenarioValues(15, 16, 17);
-    Result<MarketDataBox<Integer>> result = box.combineWith(otherBox, (v1, v2) -> Result.success(v1 + v2));
-    assertThat(result).isSuccess();
-    MarketDataBox<Integer> resultBox = result.getValue();
+    MarketDataBox<Integer> resultBox = box.combineWith(otherBox, (v1, v2) -> v1 + v2);
     assertThat(resultBox.isScenarioValue()).isTrue();
     assertThat(resultBox.getScenarioCount()).isEqualTo(3);
     assertThat(resultBox.getValue(0)).isEqualTo(42);

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/DiscountCurveMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/DiscountCurveMarketDataFunction.java
@@ -12,8 +12,7 @@ import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
 import com.opengamma.strata.market.id.CurveGroupId;
@@ -40,32 +39,25 @@ public class DiscountCurveMarketDataFunction
   }
 
   @Override
-  public Result<MarketDataBox<Curve>> build(DiscountCurveId id, MarketDataLookup marketData, MarketDataConfig config) {
+  public MarketDataBox<Curve> build(DiscountCurveId id, MarketDataLookup marketData, MarketDataConfig config) {
 
     // find curve
     CurveGroupId curveGroupId = CurveGroupId.of(id.getCurveGroupName(), id.getMarketDataFeed());
-    if (!marketData.containsValue(curveGroupId)) {
-      return Result.failure(
-          FailureReason.MISSING_DATA,
-          "No curve group found: Group: {}, Feed: {}",
-          id.getCurveGroupName(),
-          id.getMarketDataFeed());
-    }
     MarketDataBox<CurveGroup> curveGroupBox = marketData.getValue(curveGroupId);
     return curveGroupBox.apply(curveGroup -> buildCurve(id, curveGroup));
   }
 
-  private Result<Curve> buildCurve(DiscountCurveId id, CurveGroup curveGroup) {
+  private Curve buildCurve(DiscountCurveId id, CurveGroup curveGroup) {
     Optional<Curve> optionalDiscountCurve = curveGroup.findDiscountCurve(id.getCurrency());
     if (optionalDiscountCurve.isPresent()) {
-      return Result.success(optionalDiscountCurve.get());
+      return optionalDiscountCurve.get();
     } else {
-      return Result.failure(
-          FailureReason.MISSING_DATA,
-          "No discount curve found: Currency: {}, Group: {}, Feed: {}",
-          id.getCurrency(),
-          id.getCurveGroupName(),
-          id.getMarketDataFeed());
+      throw new IllegalArgumentException(
+          Messages.format(
+              "No discount curve found: Currency: {}, Group: {}, Feed: {}",
+              id.getCurrency(),
+              id.getCurveGroupName(),
+              id.getMarketDataFeed()));
     }
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/DiscountFactorsMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/DiscountFactorsMarketDataFunction.java
@@ -13,8 +13,6 @@ import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
 import com.opengamma.strata.market.curve.CurveMetadata;
@@ -47,21 +45,13 @@ public class DiscountFactorsMarketDataFunction
   }
 
   @Override
-  public Result<MarketDataBox<DiscountFactors>> build(
+  public MarketDataBox<DiscountFactors> build(
       DiscountFactorsId id,
       MarketDataLookup marketData,
       MarketDataConfig config) {
 
     // find curve
     DiscountCurveId curveId = DiscountCurveId.of(id.getCurrency(), id.getCurveGroupName(), id.getMarketDataFeed());
-    if (!marketData.containsValue(curveId)) {
-      return Result.failure(
-          FailureReason.MISSING_DATA,
-          "No discount curve found: Currency: {}, Group: {}, Feed: {}",
-          id.getCurrency(),
-          id.getCurveGroupName(),
-          id.getMarketDataFeed());
-    }
     MarketDataBox<Curve> curveBox = marketData.getValue(curveId);
     MarketDataBox<LocalDate> valDateBox = marketData.getValuationDate();
     return curveBox.combineWith(valDateBox, (curve, valDate) -> createDiscountFactors(id.getCurrency(), valDate, curve));
@@ -73,23 +63,21 @@ public class DiscountFactorsMarketDataFunction
   }
 
   // create the instance of DiscountFactors
-  private Result<DiscountFactors> createDiscountFactors(
+  private DiscountFactors createDiscountFactors(
       Currency currency, 
       LocalDate valuationDate, 
       Curve curve) {
     
     ValueType yValueType = curve.getMetadata().getYValueType();
     if (ValueType.ZERO_RATE.equals(yValueType)) {
-      return Result.success(ZeroRateDiscountFactors.of(currency, valuationDate, curve));
+      return ZeroRateDiscountFactors.of(currency, valuationDate, curve);
 
     } else if (ValueType.DISCOUNT_FACTOR.equals(yValueType)) {
-      return Result.success(SimpleDiscountFactors.of(currency, valuationDate, curve));
+      return SimpleDiscountFactors.of(currency, valuationDate, curve);
 
     } else {
-      return Result.failure(
-          FailureReason.MISSING_DATA,
-          "Invalid curve, must have ValueType of 'ZeroRate' or 'DiscountFactor', but was: {}",
-          yValueType);
+      throw new IllegalArgumentException(
+          "Invalid curve, must have ValueType of 'ZeroRate' or 'DiscountFactor', but was " + yValueType);
     }
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/ParRatesMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/ParRatesMarketDataFunction.java
@@ -5,7 +5,6 @@
  */
 package com.opengamma.strata.function.marketdata.curve;
 
-import static com.opengamma.strata.collect.Guavate.not;
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
 import static com.opengamma.strata.collect.Guavate.toImmutableMap;
 import static com.opengamma.strata.collect.Guavate.toImmutableSet;
@@ -25,8 +24,7 @@ import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.curve.CurveMetadata;
 import com.opengamma.strata.market.curve.CurveName;
@@ -66,7 +64,7 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
   }
 
   @Override
-  public Result<MarketDataBox<ParRates>> build(
+  public MarketDataBox<ParRates> build(
       ParRatesId id,
       MarketDataLookup marketData,
       MarketDataConfig marketDataConfig) {
@@ -76,24 +74,17 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
     Optional<CurveGroupDefinition> optionalGroup = marketDataConfig.get(CurveGroupDefinition.class, groupName);
 
     if (!optionalGroup.isPresent()) {
-      return Result.failure(FailureReason.MISSING_DATA, "No configuration found for curve group '{}'", groupName);
+      throw new IllegalArgumentException(Messages.format("No configuration found for curve group '{}'", groupName));
     }
     CurveGroupDefinition groupDefn = optionalGroup.get();
     Optional<CurveGroupEntry> optionalEntry = groupDefn.findEntry(curveName);
 
     if (!optionalEntry.isPresent()) {
-      return Result.failure(FailureReason.MISSING_DATA, "No curve named '{}' found in group '{}'", curveName, groupName);
+      throw new IllegalArgumentException(Messages.format("No curve named '{}' found in group '{}'", curveName, groupName));
     }
     CurveGroupEntry entry = optionalEntry.get();
     NodalCurveDefinition curveDefn = entry.getCurveDefinition();
     Set<ObservableId> requirements = nodeRequirements(id.getMarketDataFeed(), curveDefn);
-
-    if (!marketData.containsValues(requirements)) {
-      Set<ObservableId> missingRequirements = requirements.stream()
-          .filter(not(marketData::containsValue))
-          .collect(toImmutableSet());
-      return Result.failure(FailureReason.MISSING_DATA, "No market data available for '{}'", missingRequirements);
-    }
     Map<ObservableId, MarketDataBox<Double>> rates = marketData.getObservableValues(requirements);
     MarketDataBox<LocalDate> valuationDate = marketData.getValuationDate();
     // Do any of the rates contain values for multiple scenarios, or do they contain 1 rate each?
@@ -105,7 +96,7 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
         buildSingleParRates(curveDefn, rates, valuationDate);
   }
 
-  private Result<MarketDataBox<ParRates>> buildSingleParRates(
+  private MarketDataBox<ParRates> buildSingleParRates(
       NodalCurveDefinition curveDefn,
       Map<ObservableId, MarketDataBox<Double>> rates, MarketDataBox<LocalDate> valuationDate) {
     // There is only a single map of rates and single valuation date - create a single ParRates instance
@@ -114,20 +105,15 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
         .collect(toImmutableMap(e -> e.getKey(), e -> e.getValue().getSingleValue()));
 
     ParRates parRates = ParRates.of(singleRates, curveMetadata);
-    return Result.success(MarketDataBox.ofSingleValue(parRates));
+    return MarketDataBox.ofSingleValue(parRates);
   }
 
-  private Result<MarketDataBox<ParRates>> buildMultipleParRates(
+  private MarketDataBox<ParRates> buildMultipleParRates(
       NodalCurveDefinition curveDefn,
       Map<ObservableId, MarketDataBox<Double>> rates, MarketDataBox<LocalDate> valuationDate) {
     // If there are multiple values for any of the rates or for the valuation dates then we need to create
     // multiple sets of ParRates
-    Result<Integer> scenarioCountResult = scenarioCount(valuationDate, rates);
-
-    if (scenarioCountResult.isFailure()) {
-      return Result.failure(scenarioCountResult);
-    }
-    int scenarioCount = scenarioCountResult.getValue();
+    int scenarioCount = scenarioCount(valuationDate, rates);
 
     List<CurveMetadata> curveMetadata = IntStream.range(0, scenarioCount)
         .mapToObj(valuationDate::getValue)
@@ -142,7 +128,7 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
         .map(pair -> ParRates.of(pair.getFirst(), pair.getSecond()))
         .collect(toImmutableList());
 
-    return Result.success(MarketDataBox.ofScenarioValues(parRates));
+    return MarketDataBox.ofScenarioValues(parRates);
   }
 
   private static Map<ObservableId, Double> buildSingleRates(
@@ -152,11 +138,11 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
     return rates.entrySet().stream().collect(toImmutableMap(e -> e.getKey(), e -> e.getValue().getValue(scenarioIndex)));
   }
 
-  private static Result<Integer> scenarioCount(
+  private static int scenarioCount(
       MarketDataBox<LocalDate> valuationDate,
       Map<ObservableId, MarketDataBox<Double>> rates) {
 
-    Integer scenarioCount = null;
+    int scenarioCount = 0;
 
     if (valuationDate.isScenarioValue()) {
       scenarioCount = valuationDate.getScenarioCount();
@@ -168,26 +154,26 @@ public final class ParRatesMarketDataFunction implements MarketDataFunction<ParR
       if (box.isScenarioValue()) {
         int boxScenarioCount = box.getScenarioCount();
 
-        if (scenarioCount == null) {
+        if (scenarioCount == 0) {
           scenarioCount = boxScenarioCount;
         } else {
           if (scenarioCount != boxScenarioCount) {
-            return Result.failure(
-                FailureReason.INVALID_INPUT,
-                "There are {} scenarios for ID {} which does not match the previous scenario count {}",
-                boxScenarioCount,
-                id,
-                scenarioCount);
+            throw new IllegalArgumentException(
+                Messages.format(
+                    "There are {} scenarios for ID {} which does not match the previous scenario count {}",
+                    boxScenarioCount,
+                    id,
+                    scenarioCount));
           }
         }
       }
     }
-    if (scenarioCount != null) {
-      return Result.success(scenarioCount);
+    if (scenarioCount != 0) {
+      return scenarioCount;
     }
     // This shouldn't happen, this method is only called after checking at least one of the values contains data
     // for multiple scenarios.
-    return Result.failure(FailureReason.INVALID_INPUT, "Cannot count the scenarios, all data contained single values");
+    throw new IllegalArgumentException("Cannot count the scenarios, all data contained single values");
   }
 
   @Override

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/RateIndexCurveMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/RateIndexCurveMarketDataFunction.java
@@ -12,8 +12,7 @@ import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
 import com.opengamma.strata.market.id.CurveGroupId;
@@ -37,31 +36,27 @@ public final class RateIndexCurveMarketDataFunction implements MarketDataFunctio
   }
 
   @Override
-  public Result<MarketDataBox<Curve>> build(
+  public MarketDataBox<Curve> build(
       RateIndexCurveId id,
       MarketDataLookup marketData,
       MarketDataConfig marketDataConfig) {
 
     CurveGroupId curveGroupId = CurveGroupId.of(id.getCurveGroupName(), id.getMarketDataFeed());
-
-    if (!marketData.containsValue(curveGroupId)) {
-      return Result.failure(FailureReason.MISSING_DATA, "No curve group found with name {}", id.getCurveGroupName());
-    }
     MarketDataBox<CurveGroup> curveGroupBox = marketData.getValue(curveGroupId);
     return curveGroupBox.apply(curveGroup -> buildCurve(id, curveGroup));
   }
 
-  private Result<Curve> buildCurve(RateIndexCurveId id, CurveGroup curveGroup) {
+  private Curve buildCurve(RateIndexCurveId id, CurveGroup curveGroup) {
     Optional<Curve> optionalForwardCurve = curveGroup.findForwardCurve(id.getIndex());
 
     if (optionalForwardCurve.isPresent()) {
-      return Result.success(optionalForwardCurve.get());
+      return optionalForwardCurve.get();
     } else {
-      return Result.failure(
-          FailureReason.MISSING_DATA,
-          "No forward curve available for index {} in curve group {}",
-          id.getIndex().getName(),
-          id.getCurveGroupName());
+      throw new IllegalArgumentException(
+          Messages.format(
+              "No forward curve available for index {} in curve group {}",
+              id.getIndex().getName(),
+              id.getCurveGroupName()));
     }
   }
 

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
@@ -35,7 +35,6 @@ import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
 import com.opengamma.strata.calc.runner.DefaultSingleCalculationMarketData;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.function.marketdata.MarketDataRatesProvider;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
@@ -112,10 +111,8 @@ public class CurveGroupMarketDataFunctionTest {
         .valuationDate(valuationDate)
         .addValue(ParRatesId.of(groupName, curveName, MarketDataFeed.NONE), parRates)
         .build();
-    Result<MarketDataBox<CurveGroup>> result = function.buildCurveGroup(groupDefn, marketData, MarketDataFeed.NONE);
+    MarketDataBox<CurveGroup> curveGroup = function.buildCurveGroup(groupDefn, marketData, MarketDataFeed.NONE);
 
-    assertThat(result).isSuccess();
-    MarketDataBox<CurveGroup> curveGroup = result.getValue();
     Curve curve = curveGroup.getSingleValue().findDiscountCurve(Currency.USD).get();
     DiscountFactors discountFactors = ZeroRateDiscountFactors.of(Currency.USD, valuationDate, curve);
     IborIndexRates iborIndexRates = DiscountIborIndexRates.of(IborIndices.USD_LIBOR_3M, discountFactors);
@@ -166,9 +163,7 @@ public class CurveGroupMarketDataFunctionTest {
         .addValue(ParRatesId.of(groupName, curveName, MarketDataFeed.NONE), parRates)
         .build();
 
-    Result<MarketDataBox<CurveGroup>> result = function.buildCurveGroup(groupDefn, marketData, MarketDataFeed.NONE);
-    assertThat(result).isSuccess();
-    MarketDataBox<CurveGroup> curveGroup = result.getValue();
+    MarketDataBox<CurveGroup> curveGroup = function.buildCurveGroup(groupDefn, marketData, MarketDataFeed.NONE);
     Curve curve = curveGroup.getSingleValue().findDiscountCurve(Currency.USD).get();
     DiscountFactors discountFactors = ZeroRateDiscountFactors.of(Currency.USD, valuationDate, curve);
     IborIndexRates iborIndexRates = DiscountIborIndexRates.of(IborIndices.USD_LIBOR_3M, discountFactors);
@@ -263,10 +258,7 @@ public class CurveGroupMarketDataFunctionTest {
 
     CurveGroupMarketDataFunction function =
         new CurveGroupMarketDataFunction(RootFinderConfig.defaults(), CalibrationMeasures.DEFAULT);
-    Result<MarketDataBox<CurveGroup>> result = function.build(curveGroupId, marketData, marketDataConfig);
-
-    assertThat(result).isSuccess();
-    MarketDataBox<CurveGroup> curveGroup = result.getValue();
+    MarketDataBox<CurveGroup> curveGroup = function.build(curveGroupId, marketData, marketDataConfig);
 
     // Check the FRA curve identifiers are the expected tenors
     Curve forwardCurve = curveGroup.getSingleValue().findForwardCurve(IborIndices.USD_LIBOR_3M).get();

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/DiscountCurveMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/DiscountCurveMarketDataFunctionTest.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.function.marketdata.curve;
 
 import static com.opengamma.strata.basics.currency.Currency.AUD;
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.date;
 
 import java.time.LocalDate;
@@ -19,8 +20,6 @@ import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.curve.ConstantNodalCurve;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
@@ -51,8 +50,8 @@ public class DiscountCurveMarketDataFunctionTest {
     MarketEnvironment marketData = MarketEnvironment.builder().valuationDate(VAL_DATE).addValue(groupId, curveGroup).build();
     DiscountCurveMarketDataFunction builder = new DiscountCurveMarketDataFunction();
 
-    Result<MarketDataBox<Curve>> result = builder.build(curveId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(curve));
+    MarketDataBox<Curve> result = builder.build(curveId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(curve));
   }
 
   // tests building multiple curves from the same curve group
@@ -69,11 +68,11 @@ public class DiscountCurveMarketDataFunctionTest {
     MarketEnvironment marketData = MarketEnvironment.builder().valuationDate(VAL_DATE).addValue(groupId, curveGroup).build();
     DiscountCurveMarketDataFunction builder = new DiscountCurveMarketDataFunction();
 
-    Result<MarketDataBox<Curve>> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
-    assertThat(result1).hasValue(MarketDataBox.ofSingleValue(curve1));
+    MarketDataBox<Curve> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
+    assertThat(result1).isEqualTo(MarketDataBox.ofSingleValue(curve1));
 
-    Result<MarketDataBox<Curve>> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
-    assertThat(result2).hasValue(MarketDataBox.ofSingleValue(curve2));
+    MarketDataBox<Curve> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
+    assertThat(result2).isEqualTo(MarketDataBox.ofSingleValue(curve2));
   }
 
   // tests building curves from multiple curve groups
@@ -108,17 +107,17 @@ public class DiscountCurveMarketDataFunctionTest {
 
     DiscountCurveMarketDataFunction builder = new DiscountCurveMarketDataFunction();
 
-    Result<MarketDataBox<Curve>> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
-    assertThat(result1).hasValue(MarketDataBox.ofSingleValue(curve1));
+    MarketDataBox<Curve> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
+    assertThat(result1).isEqualTo(MarketDataBox.ofSingleValue(curve1));
 
-    Result<MarketDataBox<Curve>> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
-    assertThat(result2).hasValue(MarketDataBox.ofSingleValue(curve2));
+    MarketDataBox<Curve> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
+    assertThat(result2).isEqualTo(MarketDataBox.ofSingleValue(curve2));
 
-    Result<MarketDataBox<Curve>> result3 = builder.build(curveId3, marketData, MarketDataConfig.empty());
-    assertThat(result3).hasValue(MarketDataBox.ofSingleValue(curve3));
+    MarketDataBox<Curve> result3 = builder.build(curveId3, marketData, MarketDataConfig.empty());
+    assertThat(result3).isEqualTo(MarketDataBox.ofSingleValue(curve3));
 
-    Result<MarketDataBox<Curve>> result4 = builder.build(curveId4, marketData, MarketDataConfig.empty());
-    assertThat(result4).hasValue(MarketDataBox.ofSingleValue(curve4));
+    MarketDataBox<Curve> result4 = builder.build(curveId4, marketData, MarketDataConfig.empty());
+    assertThat(result4).isEqualTo(MarketDataBox.ofSingleValue(curve4));
   }
 
   public void test_noCurveGroup() {
@@ -126,8 +125,7 @@ public class DiscountCurveMarketDataFunctionTest {
     DiscountCurveMarketDataFunction test = new DiscountCurveMarketDataFunction();
 
     DiscountCurveId id = DiscountCurveId.of(AUD, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<Curve>> result = test.build(id, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(id, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
   public void test_noCurveOfDesiredCurrencyInGroup() {
@@ -144,8 +142,7 @@ public class DiscountCurveMarketDataFunctionTest {
     DiscountCurveMarketDataFunction test = new DiscountCurveMarketDataFunction();
 
     DiscountCurveId id = DiscountCurveId.of(AUD, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<Curve>> result = test.build(id, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(id, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
 }

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/DiscountFactorsMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/DiscountFactorsMarketDataFunctionTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.function.marketdata.curve;
 import static com.opengamma.strata.basics.currency.Currency.AUD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_ACT_ISDA;
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.date;
 
 import java.time.LocalDate;
@@ -18,8 +19,6 @@ import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.curve.ConstantNodalCurve;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroupName;
@@ -53,8 +52,8 @@ public class DiscountFactorsMarketDataFunctionTest {
     DiscountFactors expected1 = ZeroRateDiscountFactors.of(AUD, VAL_DATE, curve);
 
     DiscountFactorsId dfId = DiscountFactorsId.of(AUD, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<DiscountFactors>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(expected1));
+    MarketDataBox<DiscountFactors> result = test.build(dfId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(expected1));
   }
 
   public void test_buildDiscountFactors() {
@@ -69,8 +68,8 @@ public class DiscountFactorsMarketDataFunctionTest {
     DiscountFactors expected1 = SimpleDiscountFactors.of(AUD, VAL_DATE, curve);
 
     DiscountFactorsId dfId = DiscountFactorsId.of(AUD, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<DiscountFactors>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(expected1));
+    MarketDataBox<DiscountFactors> result = test.build(dfId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(expected1));
   }
 
   public void test_noCurve() {
@@ -78,8 +77,7 @@ public class DiscountFactorsMarketDataFunctionTest {
     DiscountFactorsMarketDataFunction test = new DiscountFactorsMarketDataFunction();
 
     DiscountFactorsId dfId = DiscountFactorsId.of(AUD, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<DiscountFactors>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
   public void test_unknownCurve() {
@@ -92,8 +90,7 @@ public class DiscountFactorsMarketDataFunctionTest {
     DiscountFactorsMarketDataFunction test = new DiscountFactorsMarketDataFunction();
 
     DiscountFactorsId dfId = DiscountFactorsId.of(AUD, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<DiscountFactors>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
 }

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/IborIndexRatesMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/IborIndexRatesMarketDataFunctionTest.java
@@ -9,6 +9,7 @@ import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_ACT_ISDA;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.date;
 
 import java.time.LocalDate;
@@ -19,8 +20,6 @@ import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.ConstantNodalCurve;
 import com.opengamma.strata.market.curve.Curve;
@@ -61,8 +60,8 @@ public class IborIndexRatesMarketDataFunctionTest {
         USD_LIBOR_3M, timeSeries, ZeroRateDiscountFactors.of(USD, VAL_DATE, curve));
 
     IborIndexRatesId dfId = IborIndexRatesId.of(USD_LIBOR_3M, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<IborIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(expected1));
+    MarketDataBox<IborIndexRates> result = test.build(dfId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(expected1));
   }
 
   public void test_buildIborIndexRates() {
@@ -81,8 +80,8 @@ public class IborIndexRatesMarketDataFunctionTest {
         USD_LIBOR_3M, timeSeries, SimpleDiscountFactors.of(USD, VAL_DATE, curve));
 
     IborIndexRatesId dfId = IborIndexRatesId.of(USD_LIBOR_3M, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<IborIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(expected1));
+    MarketDataBox<IborIndexRates> result = test.build(dfId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(expected1));
   }
 
   public void test_noCurve() {
@@ -95,8 +94,7 @@ public class IborIndexRatesMarketDataFunctionTest {
     IborIndexRatesMarketDataFunction test = new IborIndexRatesMarketDataFunction();
 
     IborIndexRatesId dfId = IborIndexRatesId.of(USD_LIBOR_3M, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<IborIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
   public void test_noTimeSeries() {
@@ -109,8 +107,7 @@ public class IborIndexRatesMarketDataFunctionTest {
     IborIndexRatesMarketDataFunction test = new IborIndexRatesMarketDataFunction();
 
     IborIndexRatesId dfId = IborIndexRatesId.of(USD_LIBOR_3M, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<IborIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
   public void test_unknownCurve() {
@@ -126,8 +123,7 @@ public class IborIndexRatesMarketDataFunctionTest {
     IborIndexRatesMarketDataFunction test = new IborIndexRatesMarketDataFunction();
 
     IborIndexRatesId dfId = IborIndexRatesId.of(USD_LIBOR_3M, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<IborIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
 }

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/OvernightIndexRatesMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/OvernightIndexRatesMarketDataFunctionTest.java
@@ -9,6 +9,7 @@ import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_ACT_ISDA;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.date;
 
 import java.time.LocalDate;
@@ -19,8 +20,6 @@ import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.FailureReason;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.ConstantNodalCurve;
 import com.opengamma.strata.market.curve.Curve;
@@ -61,8 +60,8 @@ public class OvernightIndexRatesMarketDataFunctionTest {
         USD_FED_FUND, timeSeries, ZeroRateDiscountFactors.of(USD, VAL_DATE, curve));
 
     OvernightIndexRatesId dfId = OvernightIndexRatesId.of(USD_FED_FUND, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<OvernightIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(expected1));
+    MarketDataBox<OvernightIndexRates> result = test.build(dfId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(expected1));
   }
 
   public void test_buildOvernightIndexRates() {
@@ -81,8 +80,8 @@ public class OvernightIndexRatesMarketDataFunctionTest {
         USD_FED_FUND, timeSeries, SimpleDiscountFactors.of(USD, VAL_DATE, curve));
 
     OvernightIndexRatesId dfId = OvernightIndexRatesId.of(USD_FED_FUND, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<OvernightIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(expected1));
+    MarketDataBox<OvernightIndexRates> result = test.build(dfId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(expected1));
   }
 
   public void test_noCurve() {
@@ -95,8 +94,7 @@ public class OvernightIndexRatesMarketDataFunctionTest {
     OvernightIndexRatesMarketDataFunction test = new OvernightIndexRatesMarketDataFunction();
 
     OvernightIndexRatesId dfId = OvernightIndexRatesId.of(USD_FED_FUND, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<OvernightIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
   public void test_noTimeSeries() {
@@ -109,8 +107,7 @@ public class OvernightIndexRatesMarketDataFunctionTest {
     OvernightIndexRatesMarketDataFunction test = new OvernightIndexRatesMarketDataFunction();
 
     OvernightIndexRatesId dfId = OvernightIndexRatesId.of(USD_FED_FUND, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<OvernightIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
   public void test_unknownCurve() {
@@ -126,8 +123,7 @@ public class OvernightIndexRatesMarketDataFunctionTest {
     OvernightIndexRatesMarketDataFunction test = new OvernightIndexRatesMarketDataFunction();
 
     OvernightIndexRatesId dfId = OvernightIndexRatesId.of(USD_FED_FUND, CURVE_GROUP_NAME, FEED);
-    Result<MarketDataBox<OvernightIndexRates>> result = test.build(dfId, marketData, MarketDataConfig.empty());
-    assertThat(result).isFailure(FailureReason.MISSING_DATA);
+    assertThrows(() -> test.build(dfId, marketData, MarketDataConfig.empty()), IllegalArgumentException.class);
   }
 
 }

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/ParRatesMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/ParRatesMarketDataFunctionTest.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.function.marketdata.curve;
 
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,7 +27,6 @@ import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
 import com.opengamma.strata.collect.id.StandardId;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.CurveParameterMetadata;
@@ -166,10 +166,9 @@ public class ParRatesMarketDataFunctionTest {
 
     ParRatesMarketDataFunction marketDataFunction = new ParRatesMarketDataFunction();
     ParRatesId parRatesId = ParRatesId.of(groupDefn.getName(), curveDefn.getName(), MarketDataFeed.NONE);
-    Result<MarketDataBox<ParRates>> result = marketDataFunction.build(parRatesId, marketData, marketDataConfig);
+    MarketDataBox<ParRates> result = marketDataFunction.build(parRatesId, marketData, marketDataConfig);
 
-    assertThat(result).isSuccess();
-    ParRates parRates = result.getValue().getSingleValue();
+    ParRates parRates = result.getSingleValue();
     assertThat(parRates.getRates().get(idA)).isEqualTo(1d);
     assertThat(parRates.getRates().get(idB)).isEqualTo(2d);
     assertThat(parRates.getRates().get(idC)).isEqualTo(3d);
@@ -188,8 +187,10 @@ public class ParRatesMarketDataFunctionTest {
     ParRatesMarketDataFunction marketDataFunction = new ParRatesMarketDataFunction();
     ParRatesId parRatesId = ParRatesId.of(CurveGroupName.of("curve group"), CurveName.of("curve"), MarketDataFeed.NONE);
     MarketEnvironment emptyData = MarketEnvironment.empty();
-    Result<MarketDataBox<ParRates>> result = marketDataFunction.build(parRatesId, emptyData, MarketDataConfig.empty());
-    assertThat(result).hasFailureMessageMatching("No configuration found for curve group .*");
+    assertThrows(
+        () -> marketDataFunction.build(parRatesId, emptyData, MarketDataConfig.empty()),
+        IllegalArgumentException.class,
+        "No configuration found for curve group .*");
   }
 
   /**
@@ -201,9 +202,11 @@ public class ParRatesMarketDataFunctionTest {
     CurveGroupDefinition groupDefn = CurveGroupDefinition.builder().name(CurveGroupName.of("curve group")).build();
     MarketDataConfig marketDataConfig = MarketDataConfig.builder().add(groupDefn.getName(), groupDefn).build();
     MarketEnvironment emptyData = MarketEnvironment.empty();
-    Result<MarketDataBox<ParRates>> result = marketDataFunction.build(parRatesId, emptyData, marketDataConfig);
-    assertThat(result).hasFailureMessageMatching("No curve named .*");
-  }
+
+    assertThrows(
+        () -> marketDataFunction.build(parRatesId, emptyData, marketDataConfig),
+        IllegalArgumentException.class,
+        "No curve named .*");}
 
   /**
    * Test that a failure is returned if the observable data isn't available.
@@ -234,8 +237,11 @@ public class ParRatesMarketDataFunctionTest {
 
     ParRatesMarketDataFunction marketDataFunction = new ParRatesMarketDataFunction();
     ParRatesId parRatesId = ParRatesId.of(groupDefn.getName(), curve.getName(), MarketDataFeed.NONE);
-    Result<MarketDataBox<ParRates>> result = marketDataFunction.build(parRatesId, emptyData, marketDataConfig);
-    assertThat(result).hasFailureMessageMatching("No market data available for .*");
+
+    assertThrows(
+        () -> marketDataFunction.build(parRatesId, emptyData, marketDataConfig),
+        IllegalArgumentException.class,
+        "No market data value available for .*");
   }
 
   //-------------------------------------------------------------------------

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/RateIndexCurveMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/RateIndexCurveMarketDataFunctionTest.java
@@ -19,7 +19,6 @@ import com.opengamma.strata.basics.index.OvernightIndices;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
-import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.market.curve.ConstantNodalCurve;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
@@ -53,8 +52,8 @@ public class RateIndexCurveMarketDataFunctionTest {
         .build();
     RateIndexCurveMarketDataFunction builder = new RateIndexCurveMarketDataFunction();
 
-    Result<MarketDataBox<Curve>> result = builder.build(curveId, marketData, MarketDataConfig.empty());
-    assertThat(result).hasValue(MarketDataBox.ofSingleValue(curve));
+    MarketDataBox<Curve> result = builder.build(curveId, marketData, MarketDataConfig.empty());
+    assertThat(result).isEqualTo(MarketDataBox.ofSingleValue(curve));
   }
 
   /**
@@ -79,11 +78,11 @@ public class RateIndexCurveMarketDataFunctionTest {
         .build();
     RateIndexCurveMarketDataFunction builder = new RateIndexCurveMarketDataFunction();
 
-    Result<MarketDataBox<Curve>> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
-    assertThat(result1).hasValue(MarketDataBox.ofSingleValue(curve1));
+    MarketDataBox<Curve> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
+    assertThat(result1).isEqualTo(MarketDataBox.ofSingleValue(curve1));
 
-    Result<MarketDataBox<Curve>> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
-    assertThat(result2).hasValue(MarketDataBox.ofSingleValue(curve2));
+    MarketDataBox<Curve> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
+    assertThat(result2).isEqualTo(MarketDataBox.ofSingleValue(curve2));
   }
 
   /**
@@ -126,17 +125,17 @@ public class RateIndexCurveMarketDataFunctionTest {
 
     RateIndexCurveMarketDataFunction builder = new RateIndexCurveMarketDataFunction();
 
-    Result<MarketDataBox<Curve>> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
-    assertThat(result1).hasValue(MarketDataBox.ofSingleValue(curve1));
+    MarketDataBox<Curve> result1 = builder.build(curveId1, marketData, MarketDataConfig.empty());
+    assertThat(result1).isEqualTo(MarketDataBox.ofSingleValue(curve1));
 
-    Result<MarketDataBox<Curve>> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
-    assertThat(result2).hasValue(MarketDataBox.ofSingleValue(curve2));
+    MarketDataBox<Curve> result2 = builder.build(curveId2, marketData, MarketDataConfig.empty());
+    assertThat(result2).isEqualTo(MarketDataBox.ofSingleValue(curve2));
 
-    Result<MarketDataBox<Curve>> result3 = builder.build(curveId3, marketData, MarketDataConfig.empty());
-    assertThat(result3).hasValue(MarketDataBox.ofSingleValue(curve3));
+    MarketDataBox<Curve> result3 = builder.build(curveId3, marketData, MarketDataConfig.empty());
+    assertThat(result3).isEqualTo(MarketDataBox.ofSingleValue(curve3));
 
-    Result<MarketDataBox<Curve>> result4 = builder.build(curveId4, marketData, MarketDataConfig.empty());
-    assertThat(result4).hasValue(MarketDataBox.ofSingleValue(curve4));
+    MarketDataBox<Curve> result4 = builder.build(curveId4, marketData, MarketDataConfig.empty());
+    assertThat(result4).isEqualTo(MarketDataBox.ofSingleValue(curve4));
   }
 
 }


### PR DESCRIPTION
This PR removes the `Result` from the return type of `MarketDataFunction.build`. This has three benefits:

* More consistent API
* Less surprising API; it now returns objects and throws exceptions like most Java APIs
* Removes boilerplate associated with `Result`

After this change user code should not be expected to create a `Result` and can indicate failures by throwing an exception.

This also fixes #486 so market data building fails with an exception if no market data function is available for an ID type. This is a system configuration error and should terminate the attempt to build data.