### PR TITLE
Tidy the cross-currency calibration example

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationCheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationCheckExample.java
@@ -203,7 +203,7 @@ public class CalibrationCheckExample {
       for (CurveNode node : nodes) {
         if (!(node instanceof IborFixingDepositCurveNode)) {
           // IborFixingDeposit is not a real trade, so there is no appropriate comparison
-          trades.add(node.trade(VALUATION_DATE, MarketData.builder().addObservableValuesById(quotes).build()));
+          trades.add(node.trade(VALUATION_DATE, MarketData.builder().addValuesById(quotes).build()));
         }
       }
     }

--- a/examples/src/main/resources/example-calibration/quotes/fx-rates-xccy.csv
+++ b/examples/src/main/resources/example-calibration/quotes/fx-rates-xccy.csv
@@ -1,0 +1,3 @@
+Valuation Date,Currency Pair,Value
+,,
+2015-11-02,EUR/USD,1.1

--- a/examples/src/main/resources/example-calibration/quotes/quotes-xccy.csv
+++ b/examples/src/main/resources/example-calibration/quotes/quotes-xccy.csv
@@ -1,7 +1,5 @@
 Valuation Date,Symbology,Ticker,Field Name,Value
 ,,,,
-2015-11-02,OG-Ticker,EUR-USD,MarketValue,1.1
-,,,,
 2015-11-02,OG-Ticker,USD-OIS-1M,MarketValue,0.0013
 2015-11-02,OG-Ticker,USD-OIS-2M,MarketValue,0.0016
 2015-11-02,OG-Ticker,USD-OIS-3M,MarketValue,0.002

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketDataBuilder.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketDataBuilder.java
@@ -59,10 +59,10 @@ public class MarketDataBuilder {
    * @param values  the values
    * @return this builder
    */
-  public MarketDataBuilder addObservableValuesById(Map<? extends ObservableId, ?> values) {
+  public MarketDataBuilder addValuesById(Map<? extends MarketDataId<?>, ?> values) {
     ArgChecker.notNull(values, "values");
     values.entrySet().forEach(e -> {
-      ObservableKey key = e.getKey().toMarketDataKey();
+      MarketDataKey<?> key = e.getKey().toMarketDataKey();
       checkType(key, e.getValue());
       this.values.put(key, e.getValue());
     });

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveEndToEndTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveEndToEndTest.java
@@ -137,7 +137,7 @@ public class CurveEndToEndTest {
     LocalDate valuationDate = date(2011, 3, 8);
 
     // Build the trades from the node instruments
-    MarketData quotes = MarketData.builder().addObservableValuesById(parRateData).build();
+    MarketData quotes = MarketData.builder().addValuesById(parRateData).build();
     Trade fra3x6Trade = fra3x6Node.trade(valuationDate, quotes);
     Trade fra6x9Trade = fra6x9Node.trade(valuationDate, quotes);
     Trade swap1yTrade = swap1yNode.trade(valuationDate, quotes);


### PR DESCRIPTION
This PR tidies up the cross-currency calibration example by using recently added methods on `MarketDataBuilder` to add FX rates. Also the empty time series is no longer required as the market data containers always return an empty series if the ID is unknown.