### PR TITLE
Handle duplicate curve input keys when building a curve group

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
@@ -54,7 +54,13 @@ import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 public final class MarketEnvironment implements ImmutableBean, CalculationEnvironment {
 
   /** An instance containing no market data. */
-  static final MarketEnvironment EMPTY = builder().build();
+  static final MarketEnvironment EMPTY = new MarketEnvironment(
+      MarketDataBox.empty(),
+      0,
+      ImmutableMap.of(),
+      ImmutableMap.of(),
+      ImmutableMap.of(),
+      ImmutableMap.of());
 
   /** The valuation date associated with the data. */
   @PropertyDefinition(validate = "notNull", overrideGet = true)

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentBuilder.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentBuilder.java
@@ -330,6 +330,10 @@ public final class MarketEnvironmentBuilder {
    * @return a set of market data from the data in this builder
    */
   public MarketEnvironment build() {
+    if (valuationDate.getScenarioCount() == 0) {
+      // This isn't checked in MarketEnvironment otherwise it would be impossible to have an empty environment
+      throw new IllegalArgumentException("Valuation date must be specified");
+    }
     return new MarketEnvironment(valuationDate, scenarioCount, values, timeSeries, valueFailures, timeSeriesFailures);
   }
 

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentTest.java
@@ -6,9 +6,11 @@
 package com.opengamma.strata.calc.marketdata;
 
 import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.util.Objects;
 
 import org.testng.annotations.Test;
@@ -87,6 +89,7 @@ public class MarketEnvironmentTest {
         .build();
 
     MarketEnvironment marketData = MarketEnvironment.builder()
+        .valuationDate(LocalDate.of(2011, 3, 8))
         .addTimeSeries(TEST_ID1, timeSeries1)
         .addTimeSeries(TEST_ID2, timeSeries2)
         .addValue(TEST_ID1, 1d)
@@ -100,6 +103,10 @@ public class MarketEnvironmentTest {
     assertThat(marketData.containsTimeSeries(TEST_ID1)).isFalse();
     assertThat(marketData.containsTimeSeries(TEST_ID2)).isTrue();
     assertThat(marketData.getTimeSeries(TEST_ID2)).isEqualTo(timeSeries2);
+  }
+
+  public void valuationDateRequired() {
+    assertThrowsIllegalArg(() -> MarketEnvironment.builder().build(), "Valuation date must be specified");
   }
 
   private static final class TestId implements ObservableId {

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
@@ -375,7 +375,7 @@ public class CurveGroupMarketDataFunctionTest {
         .addValue(CurveInputsId.of(curveGroupName, curveName1, MarketDataFeed.NONE), curveInputs1)
         .addValue(CurveInputsId.of(curveGroupName, curveName2, MarketDataFeed.NONE), badCurveInputs)
         .build();
-    String msg = "Values with the same key must be equal but found unequal values.*";
+    String msg = "Multiple unequal values found for key .*\\. Values: .* and .*";
     assertThrowsIllegalArg(() -> fn.buildCurveGroup(groupDefinition, badMarketData, MarketDataFeed.NONE), msg);
   }
 

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunctionTest.java
@@ -6,11 +6,13 @@
 package com.opengamma.strata.function.marketdata.curve;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 import java.util.Map;
 
@@ -21,17 +23,23 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.Trade;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.market.FxRateKey;
 import com.opengamma.strata.basics.market.MarketData;
 import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.basics.market.MarketDataKey;
+import com.opengamma.strata.calc.marketdata.CalculationEnvironment;
 import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.scenario.MarketDataBox;
 import com.opengamma.strata.calc.runner.DefaultSingleCalculationMarketData;
+import com.opengamma.strata.collect.id.StandardId;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.function.marketdata.MarketDataRatesProvider;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroup;
@@ -45,21 +53,27 @@ import com.opengamma.strata.market.curve.DefaultCurveMetadata;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurveDefinition;
 import com.opengamma.strata.market.curve.node.FixedIborSwapCurveNode;
 import com.opengamma.strata.market.curve.node.FraCurveNode;
+import com.opengamma.strata.market.curve.node.FxSwapCurveNode;
 import com.opengamma.strata.market.id.CurveGroupId;
 import com.opengamma.strata.market.id.CurveInputsId;
 import com.opengamma.strata.market.interpolator.CurveExtrapolators;
 import com.opengamma.strata.market.interpolator.CurveInterpolators;
 import com.opengamma.strata.market.key.DiscountFactorsKey;
 import com.opengamma.strata.market.key.IborIndexRatesKey;
+import com.opengamma.strata.market.key.QuoteKey;
 import com.opengamma.strata.market.value.DiscountFactors;
 import com.opengamma.strata.market.value.DiscountIborIndexRates;
 import com.opengamma.strata.market.value.IborIndexRates;
 import com.opengamma.strata.market.value.ZeroRateDiscountFactors;
 import com.opengamma.strata.pricer.calibration.CalibrationMeasures;
+import com.opengamma.strata.pricer.calibration.CurveCalibrator;
 import com.opengamma.strata.pricer.fra.DiscountingFraTradePricer;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.swap.DiscountingSwapTradePricer;
 import com.opengamma.strata.product.fra.FraTrade;
+import com.opengamma.strata.product.fx.type.FxSwapConventions;
+import com.opengamma.strata.product.fx.type.FxSwapTemplate;
 import com.opengamma.strata.product.swap.SwapTrade;
 
 /**
@@ -281,6 +295,88 @@ public class CurveGroupMarketDataFunctionTest {
         .collect(toImmutableList());
 
     assertThat(forwardMetadata).isEqualTo(expectedForwardMetadata);
+  }
+
+  /**
+   * Tests
+   */
+  public void duplicateInputDataKeys() {
+    FxSwapTemplate template = FxSwapTemplate.of(Period.ZERO, FxSwapConventions.EUR_USD);
+    QuoteKey pointsKey1 = QuoteKey.of(StandardId.of("test", "1"));
+    QuoteKey pointsKey2 = QuoteKey.of(StandardId.of("test", "2"));
+    FxSwapCurveNode node1 = FxSwapCurveNode.of(template, pointsKey1);
+    FxSwapCurveNode node2 = FxSwapCurveNode.of(template, pointsKey2);
+    CurveName curveName1 = CurveName.of("curve1");
+    InterpolatedNodalCurveDefinition curve1 = InterpolatedNodalCurveDefinition.builder()
+        .name(curveName1)
+        .interpolator(CurveInterpolators.LINEAR)
+        .extrapolatorLeft(CurveExtrapolators.LINEAR)
+        .extrapolatorRight(CurveExtrapolators.LINEAR)
+        .nodes(node1)
+        .build();
+    CurveName curveName2 = CurveName.of("curve2");
+    InterpolatedNodalCurveDefinition curve2 = InterpolatedNodalCurveDefinition.builder()
+        .name(curveName2)
+        .interpolator(CurveInterpolators.LINEAR)
+        .extrapolatorLeft(CurveExtrapolators.LINEAR)
+        .extrapolatorRight(CurveExtrapolators.LINEAR)
+        .nodes(node2)
+        .build();
+    CurveGroupName curveGroupName = CurveGroupName.of("group");
+    CurveGroupDefinition groupDefinition = CurveGroupDefinition.builder()
+        .name(curveGroupName)
+        .addDiscountCurve(curve1, Currency.EUR)
+        .addDiscountCurve(curve2, Currency.USD)
+        .build();
+
+    CurveCalibrator curveCalibrator = new CurveCalibrator() {
+      @Override
+      public ImmutableRatesProvider calibrate(
+          CurveGroupDefinition curveGroupDefn,
+          LocalDate valuationDate,
+          MarketData marketData,
+          Map<Index, LocalDateDoubleTimeSeries> timeSeries) {
+
+        return ImmutableRatesProvider.builder().valuationDate(LocalDate.of(2011, 3, 8)).build();
+      }
+
+      @Override
+      public ImmutableRatesProvider calibrate(
+          List<CurveGroupDefinition> allGroupsDefn,
+          ImmutableRatesProvider knownData,
+          MarketData marketData) {
+
+        return ImmutableRatesProvider.builder().valuationDate(LocalDate.of(2011, 3, 8)).build();
+      }
+    };
+    CurveGroupMarketDataFunction fn = new CurveGroupMarketDataFunction(curveCalibrator);
+    Map<MarketDataKey<?>, Object> marketDataMap1 = ImmutableMap.of(
+        FxRateKey.of(Currency.EUR, Currency.USD), FxRate.of(Currency.EUR, Currency.USD, 1.01),
+        pointsKey1, 0.1d);
+    Map<MarketDataKey<?>, Object> marketDataMap2 = ImmutableMap.of(
+        FxRateKey.of(Currency.EUR, Currency.USD), FxRate.of(Currency.EUR, Currency.USD, 1.01),
+        pointsKey2, 0.2d);
+    CurveInputs curveInputs1 = CurveInputs.of(marketDataMap1, DefaultCurveMetadata.of("curve1"));
+    CurveInputs curveInputs2 = CurveInputs.of(marketDataMap2, DefaultCurveMetadata.of("curve2"));
+    MarketEnvironment marketData = CalculationEnvironment.builder()
+        .valuationDate(LocalDate.of(2011, 3, 8))
+        .addValue(CurveInputsId.of(curveGroupName, curveName1, MarketDataFeed.NONE), curveInputs1)
+        .addValue(CurveInputsId.of(curveGroupName, curveName2, MarketDataFeed.NONE), curveInputs2)
+        .build();
+    fn.buildCurveGroup(groupDefinition, marketData, MarketDataFeed.NONE);
+
+    // This has a duplicate key with a different value which should fail
+    Map<MarketDataKey<?>, Object> badMarketDataMap = ImmutableMap.of(
+        FxRateKey.of(Currency.EUR, Currency.USD), FxRate.of(Currency.EUR, Currency.USD, 1.02),
+        pointsKey2, 0.2d);
+    CurveInputs badCurveInputs = CurveInputs.of(badMarketDataMap, DefaultCurveMetadata.of("curve2"));
+    MarketEnvironment badMarketData = CalculationEnvironment.builder()
+        .valuationDate(LocalDate.of(2011, 3, 8))
+        .addValue(CurveInputsId.of(curveGroupName, curveName1, MarketDataFeed.NONE), curveInputs1)
+        .addValue(CurveInputsId.of(curveGroupName, curveName2, MarketDataFeed.NONE), badCurveInputs)
+        .build();
+    String msg = "Values with the same key must be equal but found unequal values.*";
+    assertThrowsIllegalArg(() -> fn.buildCurveGroup(groupDefinition, badMarketData, MarketDataFeed.NONE), msg);
   }
 
   //-----------------------------------------------------------------------------------------------------------

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/fx/FxRateMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/fx/FxRateMarketDataFunctionTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.function.marketdata.fx;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 import org.testng.annotations.Test;
@@ -61,7 +62,10 @@ public class FxRateMarketDataFunctionTest {
   public void build() {
     FxRateMarketDataFunction function = new FxRateMarketDataFunction();
     MarketDataBox<Double> quoteBox = MarketDataBox.ofSingleValue(1.1d);
-    CalculationEnvironment marketData = CalculationEnvironment.builder().addValue(QUOTE_ID, quoteBox).build();
+    CalculationEnvironment marketData = CalculationEnvironment.builder()
+        .valuationDate(LocalDate.of(2011, 3, 8))
+        .addValue(QUOTE_ID, quoteBox)
+        .build();
     MarketDataBox<FxRate> rateBox = function.build(RATE_ID, marketData, config());
     assertThat(rateBox.isSingleValue()).isTrue();
     assertThat(rateBox.getSingleValue()).isEqualTo(FxRate.of(CURRENCY_PAIR, 1.1d));
@@ -70,7 +74,10 @@ public class FxRateMarketDataFunctionTest {
   public void buildInverse() {
     FxRateMarketDataFunction function = new FxRateMarketDataFunction();
     MarketDataBox<Double> quoteBox = MarketDataBox.ofSingleValue(1.1d);
-    CalculationEnvironment marketData = CalculationEnvironment.builder().addValue(QUOTE_ID, quoteBox).build();
+    CalculationEnvironment marketData = CalculationEnvironment.builder()
+        .valuationDate(LocalDate.of(2011, 3, 8))
+        .addValue(QUOTE_ID, quoteBox)
+        .build();
     MarketDataBox<FxRate> rateBox = function.build(FxRateId.of(CURRENCY_PAIR.inverse()), marketData, config());
     assertThat(rateBox.isSingleValue()).isTrue();
     assertThat(rateBox.getSingleValue()).isEqualTo(FxRate.of(CURRENCY_PAIR, 1.1d));
@@ -79,7 +86,10 @@ public class FxRateMarketDataFunctionTest {
   public void buildScenario() {
     FxRateMarketDataFunction function = new FxRateMarketDataFunction();
     MarketDataBox<Double> quoteBox = MarketDataBox.ofScenarioValues(1.1d, 1.2d, 1.3d);
-    CalculationEnvironment marketData = CalculationEnvironment.builder().addValue(QUOTE_ID, quoteBox).build();
+    CalculationEnvironment marketData = CalculationEnvironment.builder()
+        .valuationDate(LocalDate.of(2011, 3, 8))
+        .addValue(QUOTE_ID, quoteBox)
+        .build();
     MarketDataBox<FxRate> rateBox = function.build(RATE_ID, marketData, config());
     assertThat(rateBox.isSingleValue()).isFalse();
     assertThat(rateBox.getScenarioCount()).isEqualTo(3);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CurveCalibrator.java
@@ -9,25 +9,11 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.opengamma.strata.basics.Trade;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.market.MarketData;
-import com.opengamma.strata.collect.array.DoubleArray;
-import com.opengamma.strata.collect.array.DoubleMatrix;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
-import com.opengamma.strata.market.curve.CurveGroupEntry;
-import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.CurveNode;
-import com.opengamma.strata.market.curve.CurveParameterSize;
-import com.opengamma.strata.market.curve.JacobianCalibrationMatrix;
-import com.opengamma.strata.math.impl.function.Function1D;
-import com.opengamma.strata.math.impl.linearalgebra.DecompositionFactory;
-import com.opengamma.strata.math.impl.matrix.CommonsMatrixAlgebra;
-import com.opengamma.strata.math.impl.matrix.MatrixAlgebra;
-import com.opengamma.strata.math.impl.rootfinding.newton.BroydenVectorRootFinder;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
@@ -46,38 +32,15 @@ import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
  * Once calibrated, the curves are then available for use.
  * Each node in the curve definition becomes a parameter in the matching output curve.
  */
-public final class CurveCalibrator {
+public interface CurveCalibrator {
 
   /**
-   * The default curve calibrator.
-   * <p>
-   * This uses the default tolerance of 1e-9, a maximum of 1000 steps and the
-   * default {@link CalibrationMeasures} instance.
-   */
-  public static final CurveCalibrator DEFAULT = CurveCalibrator.of(1e-9, 1e-9, 1000, CalibrationMeasures.DEFAULT);
-
-  /**
-   * The matrix algebra used for matrix inversion.
-   */
-  private static final MatrixAlgebra MATRIX_ALGEBRA = new CommonsMatrixAlgebra();
-  /**
-   * The root finder used for curve calibration.
-   */
-  private final BroydenVectorRootFinder rootFinder;
-  /**
-   * The calibration measures.
-   * This is used to compute the function for which the root is found.
-   */
-  private final CalibrationMeasures measures;
-
-  //-------------------------------------------------------------------------
-  /**
-   * Obtains an instance, specifying tolerances and measures to use.
-   * 
-   * @param toleranceAbs  the absolute tolerance
-   * @param toleranceRel  the relative tolerance
-   * @param stepMaximum  the maximum steps
-   * @param measures  the calibration measures, used to compute the function for which the root is found
+   * Obtains a curve calibrator, specifying tolerances and measures to use.
+   *
+   * @param toleranceAbs the absolute tolerance
+   * @param toleranceRel the relative tolerance
+   * @param stepMaximum the maximum steps
+   * @param measures the calibration measures, used to compute the function for which the root is found
    * @return the curve calibrator
    */
   public static CurveCalibrator of(
@@ -86,53 +49,43 @@ public final class CurveCalibrator {
       int stepMaximum,
       CalibrationMeasures measures) {
 
-    return new CurveCalibrator(toleranceAbs, toleranceRel, stepMaximum, measures);
+    return StandardCurveCalibrator.of(toleranceAbs, toleranceRel, stepMaximum, measures);
+  }
+
+  /**
+   * The default curve calibrator.
+   * <p>
+   * This uses the default tolerance of 1e-9, a maximum of 1000 steps and the
+   * default {@link CalibrationMeasures} instance.
+   *
+   * @return the default curve calibrator
+   */
+  public static CurveCalibrator defaultCurveCalibrator() {
+    return StandardCurveCalibrator.DEFAULT;
   }
 
   //-------------------------------------------------------------------------
-  // restricted constructor
-  private CurveCalibrator(
-      double toleranceAbs,
-      double toleranceRel,
-      int stepMaximum,
-      CalibrationMeasures measures) {
 
-    this.rootFinder = new BroydenVectorRootFinder(
-        toleranceAbs,
-        toleranceRel,
-        stepMaximum,
-        DecompositionFactory.getDecomposition(DecompositionFactory.SV_COMMONS_NAME));
-    this.measures = measures;
-  }
-
-  //-------------------------------------------------------------------------
   /**
    * Calibrates a single curve group, containing one or more curves.
    * <p>
    * The calibration is defined using {@link CurveGroupDefinition}.
    * Observable market data, time-series and FX are also needed to complete the calibration.
-   * 
-   * @param curveGroupDefn  the curve group definition
-   * @param valuationDate  the validation date
-   * @param marketData  the market data required to build a trade for the instrument
-   * @param timeSeries  the time-series
+   *
+   * @param curveGroupDefn the curve group definition
+   * @param valuationDate the validation date
+   * @param marketData the market data required to build a trade for the instrument
+   * @param timeSeries the time-series
    * @return the rates provider resulting from the calibration
    */
-  public ImmutableRatesProvider calibrate(
+  public abstract ImmutableRatesProvider calibrate(
       CurveGroupDefinition curveGroupDefn,
       LocalDate valuationDate,
       MarketData marketData,
-      Map<Index, LocalDateDoubleTimeSeries> timeSeries) {
-
-    ImmutableRatesProvider knownData = ImmutableRatesProvider.builder()
-        .valuationDate(valuationDate)
-        .fxRateProvider(new MarketDataFxRateProvider(marketData))
-        .timeSeries(timeSeries)
-        .build();
-    return calibrate(ImmutableList.of(curveGroupDefn), knownData, marketData);
-  }
+      Map<Index, LocalDateDoubleTimeSeries> timeSeries);
 
   //-------------------------------------------------------------------------
+
   /**
    * Calibrates a list of curve groups, each containing one or more curves.
    * <p>
@@ -140,201 +93,15 @@ public final class CurveCalibrator {
    * Observable market data and existing known data are also needed to complete the calibration.
    * <p>
    * A curve must only exist in one group.
-   * 
-   * @param allGroupsDefn  the curve group definitions
-   * @param knownData  the starting data for the calibration
-   * @param marketData  the market data required to build a trade for the instrument
+   *
+   * @param allGroupsDefn the curve group definitions
+   * @param knownData the starting data for the calibration
+   * @param marketData the market data required to build a trade for the instrument
    * @return the rates provider resulting from the calibration
    */
-  public ImmutableRatesProvider calibrate(
+  public abstract ImmutableRatesProvider calibrate(
       List<CurveGroupDefinition> allGroupsDefn,
       ImmutableRatesProvider knownData,
-      MarketData marketData) {
-
-    // perform calibration one group at a time, building up the result by mutating these variables
-    ImmutableRatesProvider providerCombined = knownData;
-    ImmutableList<CurveParameterSize> orderPrev = ImmutableList.of();
-    ImmutableMap<CurveName, JacobianCalibrationMatrix> jacobians = ImmutableMap.of();
-    for (CurveGroupDefinition groupDefn : allGroupsDefn) {
-      // combine all data in the group into flat lists
-      ImmutableList<Trade> trades = groupDefn.trades(knownData.getValuationDate(), marketData);
-      ImmutableList<Double> initialGuesses = groupDefn.initialGuesses(knownData.getValuationDate(), marketData);
-      ImmutableList<CurveParameterSize> orderGroup = toOrder(groupDefn);
-      ImmutableList<CurveParameterSize> orderPrevAndGroup = ImmutableList.<CurveParameterSize>builder()
-          .addAll(orderPrev)
-          .addAll(orderGroup)
-          .build();
-
-      // calibrate
-      RatesProviderGenerator providerGenerator = ImmutableRatesProviderGenerator.of(providerCombined, groupDefn);
-      DoubleArray calibratedGroupParams = calibrateGroup(providerGenerator, trades, initialGuesses, orderGroup);
-      ImmutableRatesProvider calibratedProvider = providerGenerator.generate(calibratedGroupParams);
-
-      // use calibration to build Jacobian matrices
-      jacobians = updateJacobiansForGroup(
-          calibratedProvider, trades, orderGroup, orderPrev, orderPrevAndGroup, jacobians);
-      orderPrev = orderPrevAndGroup;
-
-      // use Jacobians to build output curves
-      providerCombined = providerGenerator.generate(calibratedGroupParams, jacobians);
-    }
-    // return the calibrated provider
-    return providerCombined;
-  }
-
-  // converts a definition to the curve order list
-  private static ImmutableList<CurveParameterSize> toOrder(CurveGroupDefinition groupDefn) {
-    ImmutableList.Builder<CurveParameterSize> builder = ImmutableList.builder();
-    for (CurveGroupEntry entry : groupDefn.getEntries()) {
-      builder.add(entry.getCurveDefinition().toCurveParameterSize());
-    }
-    return builder.build();
-  }
-
-  //-------------------------------------------------------------------------
-  // calibrates a single group
-  private DoubleArray calibrateGroup(
-      RatesProviderGenerator providerGenerator,
-      ImmutableList<Trade> trades,
-      ImmutableList<Double> initialGuesses,
-      ImmutableList<CurveParameterSize> curveOrder) {
-
-    // setup for calibration
-    Function1D<DoubleArray, DoubleArray> valueCalculator =
-        new CalibrationValue(trades, measures, providerGenerator);
-    Function1D<DoubleArray, DoubleMatrix> derivativeCalculator =
-        new CalibrationDerivative(trades, measures, providerGenerator, curveOrder);
-
-    // calibrate
-    DoubleArray initGuessMatrix = DoubleArray.copyOf(initialGuesses);
-    return rootFinder.getRoot(valueCalculator, derivativeCalculator, initGuessMatrix);
-  }
-
-  //-------------------------------------------------------------------------
-  // calculates the Jacobian and builds the result, called once per group
-  // this uses, but does not alter, data from previous groups
-  private ImmutableMap<CurveName, JacobianCalibrationMatrix> updateJacobiansForGroup(
-      ImmutableRatesProvider provider,
-      ImmutableList<Trade> trades,
-      ImmutableList<CurveParameterSize> orderGroup,
-      ImmutableList<CurveParameterSize> orderPrev,
-      ImmutableList<CurveParameterSize> orderAll,
-      ImmutableMap<CurveName, JacobianCalibrationMatrix> jacobians) {
-
-    // sensitivity to all parameters in the stated order
-    int totalParamsAll = orderAll.stream().mapToInt(e -> e.getParameterCount()).sum();
-    DoubleMatrix res = derivatives(trades, provider, orderAll, totalParamsAll);
-
-    // jacobian direct
-    int nbTrades = trades.size();
-    int totalParamsGroup = orderGroup.stream().mapToInt(e -> e.getParameterCount()).sum();
-    int totalParamsPrevious = totalParamsAll - totalParamsGroup;
-    DoubleMatrix pDmCurrentMatrix = jacobianDirect(res, nbTrades, totalParamsGroup, totalParamsPrevious);
-
-    // jacobian indirect: when totalParamsPrevious > 0
-    DoubleMatrix pDmPrevious = jacobianIndirect(
-        res, pDmCurrentMatrix, nbTrades, totalParamsGroup, totalParamsPrevious, orderPrev, jacobians);
-
-    // add to the map of jacobians, one entry for each curve in this group
-    ImmutableMap.Builder<CurveName, JacobianCalibrationMatrix> jacobianBuilder = ImmutableMap.builder();
-    jacobianBuilder.putAll(jacobians);
-    int startIndex = 0;
-    for (CurveParameterSize order : orderGroup) {
-      int paramCount = order.getParameterCount();
-      double[][] pDmCurveArray = new double[paramCount][totalParamsAll];
-      // copy data for previous groups
-      if (totalParamsPrevious > 0) {
-        for (int p = 0; p < paramCount; p++) {
-          System.arraycopy(pDmPrevious.rowArray(startIndex + p), 0, pDmCurveArray[p], 0, totalParamsPrevious);
-        }
-      }
-      // copy data for this group
-      for (int p = 0; p < paramCount; p++) {
-        System.arraycopy(pDmCurrentMatrix.rowArray(startIndex + p), 0, pDmCurveArray[p], totalParamsPrevious, totalParamsGroup);
-      }
-      // build final Jacobian matrix
-      DoubleMatrix pDmCurveMatrix = DoubleMatrix.ofUnsafe(pDmCurveArray);
-      jacobianBuilder.put(order.getName(), JacobianCalibrationMatrix.of(orderAll, pDmCurveMatrix));
-      startIndex += paramCount;
-    }
-    return jacobianBuilder.build();
-  }
-
-  // calculate the derivatives
-  private DoubleMatrix derivatives(
-      ImmutableList<Trade> trades,
-      ImmutableRatesProvider provider,
-      ImmutableList<CurveParameterSize> orderAll,
-      int totalParamsAll) {
-
-    return DoubleMatrix.ofArrayObjects(
-        trades.size(),
-        totalParamsAll,
-        i -> measures.derivative(trades.get(i), provider, orderAll));
-  }
-
-  // jacobian direct, for the current group
-  private static DoubleMatrix jacobianDirect(
-      DoubleMatrix res,
-      int nbTrades,
-      int totalParamsGroup,
-      int totalParamsPrevious) {
-
-    double[][] direct = new double[totalParamsGroup][totalParamsGroup];
-    for (int i = 0; i < nbTrades; i++) {
-      System.arraycopy(res.rowArray(i), totalParamsPrevious, direct[i], 0, totalParamsGroup);
-    }
-    return MATRIX_ALGEBRA.getInverse(DoubleMatrix.copyOf(direct));
-  }
-
-  // jacobian indirect, merging groups
-  private static DoubleMatrix jacobianIndirect(
-      DoubleMatrix res,
-      DoubleMatrix pDmCurrentMatrix,
-      int nbTrades,
-      int totalParamsGroup,
-      int totalParamsPrevious,
-      ImmutableList<CurveParameterSize> orderPrevious,
-      ImmutableMap<CurveName, JacobianCalibrationMatrix> jacobiansPrevious) {
-
-    if (totalParamsPrevious == 0) {
-      return DoubleMatrix.EMPTY;
-    }
-    double[][] nonDirect = new double[totalParamsGroup][totalParamsPrevious];
-    for (int i = 0; i < nbTrades; i++) {
-      System.arraycopy(res.rowArray(i), 0, nonDirect[i], 0, totalParamsPrevious);
-    }
-    DoubleMatrix pDpPreviousMatrix = (DoubleMatrix) MATRIX_ALGEBRA.scale(
-        MATRIX_ALGEBRA.multiply(pDmCurrentMatrix, DoubleMatrix.copyOf(nonDirect)), -1d);
-    // all curves: order and size
-    int[] startIndexBefore = new int[orderPrevious.size()];
-    for (int i = 1; i < orderPrevious.size(); i++) {
-      startIndexBefore[i] = startIndexBefore[i - 1] + orderPrevious.get(i - 1).getParameterCount();
-    }
-    // transition Matrix: all curves from previous groups
-    double[][] transition = new double[totalParamsPrevious][totalParamsPrevious];
-    for (int i = 0; i < orderPrevious.size(); i++) {
-      int paramCountOuter = orderPrevious.get(i).getParameterCount();
-      JacobianCalibrationMatrix thisInfo = jacobiansPrevious.get(orderPrevious.get(i).getName());
-      DoubleMatrix thisMatrix = thisInfo.getJacobianMatrix();
-      int startIndexInner = 0;
-      for (int j = 0; j < orderPrevious.size(); j++) {
-        int paramCountInner = orderPrevious.get(j).getParameterCount();
-        if (thisInfo.containsCurve(orderPrevious.get(j).getName())) { // If not, the matrix stay with 0
-          for (int k = 0; k < paramCountOuter; k++) {
-            System.arraycopy(
-                thisMatrix.rowArray(k),
-                startIndexInner,
-                transition[startIndexBefore[i] + k],
-                startIndexBefore[j],
-                paramCountInner);
-          }
-        }
-        startIndexInner += paramCountInner;
-      }
-    }
-    DoubleMatrix transitionMatrix = DoubleMatrix.copyOf(transition);
-    return (DoubleMatrix) MATRIX_ALGEBRA.multiply(pDpPreviousMatrix, transitionMatrix);
-  }
+      MarketData marketData);
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/StandardCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/StandardCurveCalibrator.java
@@ -1,0 +1,315 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.calibration;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.Trade;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.array.DoubleMatrix;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.curve.CurveGroupDefinition;
+import com.opengamma.strata.market.curve.CurveGroupEntry;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.CurveNode;
+import com.opengamma.strata.market.curve.CurveParameterSize;
+import com.opengamma.strata.market.curve.JacobianCalibrationMatrix;
+import com.opengamma.strata.math.impl.function.Function1D;
+import com.opengamma.strata.math.impl.linearalgebra.DecompositionFactory;
+import com.opengamma.strata.math.impl.matrix.CommonsMatrixAlgebra;
+import com.opengamma.strata.math.impl.matrix.MatrixAlgebra;
+import com.opengamma.strata.math.impl.rootfinding.newton.BroydenVectorRootFinder;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
+
+/**
+ * The standard curve calibrator.
+ * <p>
+ * This calibrator takes an abstract curve definition and produces real curves.
+ * <p>
+ * Curves are calibrated in groups or one or more curves.
+ * In addition, more than one group may be calibrated together.
+ * <p>
+ * Each curve is defined using two or more {@linkplain CurveNode nodes}.
+ * Each node primarily defines enough information to produce a reference trade.
+ * Calibration involves pricing, and re-pricing, these trades to find the best fit
+ * using a root finder.
+ * <p>
+ * Once calibrated, the curves are then available for use.
+ * Each node in the curve definition becomes a parameter in the matching output curve.
+ */
+final class StandardCurveCalibrator implements CurveCalibrator {
+
+  /**
+   * The default curve calibrator.
+   * <p>
+   * This uses the default tolerance of 1e-9, a maximum of 1000 steps and the
+   * default {@link CalibrationMeasures} instance.
+   */
+  static final StandardCurveCalibrator DEFAULT = StandardCurveCalibrator.of(1e-9, 1e-9, 1000, CalibrationMeasures.DEFAULT);
+
+  /**
+   * The matrix algebra used for matrix inversion.
+   */
+  private static final MatrixAlgebra MATRIX_ALGEBRA = new CommonsMatrixAlgebra();
+  /**
+   * The root finder used for curve calibration.
+   */
+  private final BroydenVectorRootFinder rootFinder;
+  /**
+   * The calibration measures.
+   * This is used to compute the function for which the root is found.
+   */
+  private final CalibrationMeasures measures;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains an instance, specifying tolerances and measures to use.
+   *
+   * @param toleranceAbs  the absolute tolerance
+   * @param toleranceRel  the relative tolerance
+   * @param stepMaximum  the maximum steps
+   * @param measures  the calibration measures, used to compute the function for which the root is found
+   * @return the curve calibrator
+   */
+  static StandardCurveCalibrator of(
+      double toleranceAbs,
+      double toleranceRel,
+      int stepMaximum,
+      CalibrationMeasures measures) {
+
+    return new StandardCurveCalibrator(toleranceAbs, toleranceRel, stepMaximum, measures);
+  }
+
+  //-------------------------------------------------------------------------
+  // restricted constructor
+  private StandardCurveCalibrator(
+      double toleranceAbs,
+      double toleranceRel,
+      int stepMaximum,
+      CalibrationMeasures measures) {
+
+    this.rootFinder = new BroydenVectorRootFinder(
+        toleranceAbs,
+        toleranceRel,
+        stepMaximum,
+        DecompositionFactory.getDecomposition(DecompositionFactory.SV_COMMONS_NAME));
+    this.measures = measures;
+  }
+
+  @Override
+  public ImmutableRatesProvider calibrate(
+      CurveGroupDefinition curveGroupDefn,
+      LocalDate valuationDate,
+      MarketData marketData,
+      Map<Index, LocalDateDoubleTimeSeries> timeSeries) {
+
+    ImmutableRatesProvider knownData = ImmutableRatesProvider.builder()
+        .valuationDate(valuationDate)
+        .fxRateProvider(new MarketDataFxRateProvider(marketData))
+        .timeSeries(timeSeries)
+        .build();
+    return calibrate(ImmutableList.of(curveGroupDefn), knownData, marketData);
+  }
+
+  @Override
+  public ImmutableRatesProvider calibrate(
+      List<CurveGroupDefinition> allGroupsDefn,
+      ImmutableRatesProvider knownData,
+      MarketData marketData) {
+
+    // perform calibration one group at a time, building up the result by mutating these variables
+    ImmutableRatesProvider providerCombined = knownData;
+    ImmutableList<CurveParameterSize> orderPrev = ImmutableList.of();
+    ImmutableMap<CurveName, JacobianCalibrationMatrix> jacobians = ImmutableMap.of();
+    for (CurveGroupDefinition groupDefn : allGroupsDefn) {
+      // combine all data in the group into flat lists
+      ImmutableList<Trade> trades = groupDefn.trades(knownData.getValuationDate(), marketData);
+      ImmutableList<Double> initialGuesses = groupDefn.initialGuesses(knownData.getValuationDate(), marketData);
+      ImmutableList<CurveParameterSize> orderGroup = toOrder(groupDefn);
+      ImmutableList<CurveParameterSize> orderPrevAndGroup = ImmutableList.<CurveParameterSize>builder()
+          .addAll(orderPrev)
+          .addAll(orderGroup)
+          .build();
+
+      // calibrate
+      RatesProviderGenerator providerGenerator = ImmutableRatesProviderGenerator.of(providerCombined, groupDefn);
+      DoubleArray calibratedGroupParams = calibrateGroup(providerGenerator, trades, initialGuesses, orderGroup);
+      ImmutableRatesProvider calibratedProvider = providerGenerator.generate(calibratedGroupParams);
+
+      // use calibration to build Jacobian matrices
+      jacobians = updateJacobiansForGroup(
+          calibratedProvider, trades, orderGroup, orderPrev, orderPrevAndGroup, jacobians);
+      orderPrev = orderPrevAndGroup;
+
+      // use Jacobians to build output curves
+      providerCombined = providerGenerator.generate(calibratedGroupParams, jacobians);
+    }
+    // return the calibrated provider
+    return providerCombined;
+  }
+
+  // converts a definition to the curve order list
+  private static ImmutableList<CurveParameterSize> toOrder(CurveGroupDefinition groupDefn) {
+    ImmutableList.Builder<CurveParameterSize> builder = ImmutableList.builder();
+    for (CurveGroupEntry entry : groupDefn.getEntries()) {
+      builder.add(entry.getCurveDefinition().toCurveParameterSize());
+    }
+    return builder.build();
+  }
+
+  //-------------------------------------------------------------------------
+  // calibrates a single group
+  private DoubleArray calibrateGroup(
+      RatesProviderGenerator providerGenerator,
+      ImmutableList<Trade> trades,
+      ImmutableList<Double> initialGuesses,
+      ImmutableList<CurveParameterSize> curveOrder) {
+
+    // setup for calibration
+    Function1D<DoubleArray, DoubleArray> valueCalculator =
+        new CalibrationValue(trades, measures, providerGenerator);
+    Function1D<DoubleArray, DoubleMatrix> derivativeCalculator =
+        new CalibrationDerivative(trades, measures, providerGenerator, curveOrder);
+
+    // calibrate
+    DoubleArray initGuessMatrix = DoubleArray.copyOf(initialGuesses);
+    return rootFinder.getRoot(valueCalculator, derivativeCalculator, initGuessMatrix);
+  }
+
+  //-------------------------------------------------------------------------
+  // calculates the Jacobian and builds the result, called once per group
+  // this uses, but does not alter, data from previous groups
+  private ImmutableMap<CurveName, JacobianCalibrationMatrix> updateJacobiansForGroup(
+      ImmutableRatesProvider provider,
+      ImmutableList<Trade> trades,
+      ImmutableList<CurveParameterSize> orderGroup,
+      ImmutableList<CurveParameterSize> orderPrev,
+      ImmutableList<CurveParameterSize> orderAll,
+      ImmutableMap<CurveName, JacobianCalibrationMatrix> jacobians) {
+
+    // sensitivity to all parameters in the stated order
+    int totalParamsAll = orderAll.stream().mapToInt(e -> e.getParameterCount()).sum();
+    DoubleMatrix res = derivatives(trades, provider, orderAll, totalParamsAll);
+
+    // jacobian direct
+    int nbTrades = trades.size();
+    int totalParamsGroup = orderGroup.stream().mapToInt(e -> e.getParameterCount()).sum();
+    int totalParamsPrevious = totalParamsAll - totalParamsGroup;
+    DoubleMatrix pDmCurrentMatrix = jacobianDirect(res, nbTrades, totalParamsGroup, totalParamsPrevious);
+
+    // jacobian indirect: when totalParamsPrevious > 0
+    DoubleMatrix pDmPrevious = jacobianIndirect(
+        res, pDmCurrentMatrix, nbTrades, totalParamsGroup, totalParamsPrevious, orderPrev, jacobians);
+
+    // add to the map of jacobians, one entry for each curve in this group
+    ImmutableMap.Builder<CurveName, JacobianCalibrationMatrix> jacobianBuilder = ImmutableMap.builder();
+    jacobianBuilder.putAll(jacobians);
+    int startIndex = 0;
+    for (CurveParameterSize order : orderGroup) {
+      int paramCount = order.getParameterCount();
+      double[][] pDmCurveArray = new double[paramCount][totalParamsAll];
+      // copy data for previous groups
+      if (totalParamsPrevious > 0) {
+        for (int p = 0; p < paramCount; p++) {
+          System.arraycopy(pDmPrevious.rowArray(startIndex + p), 0, pDmCurveArray[p], 0, totalParamsPrevious);
+        }
+      }
+      // copy data for this group
+      for (int p = 0; p < paramCount; p++) {
+        System.arraycopy(pDmCurrentMatrix.rowArray(startIndex + p), 0, pDmCurveArray[p], totalParamsPrevious, totalParamsGroup);
+      }
+      // build final Jacobian matrix
+      DoubleMatrix pDmCurveMatrix = DoubleMatrix.ofUnsafe(pDmCurveArray);
+      jacobianBuilder.put(order.getName(), JacobianCalibrationMatrix.of(orderAll, pDmCurveMatrix));
+      startIndex += paramCount;
+    }
+    return jacobianBuilder.build();
+  }
+
+  // calculate the derivatives
+  private DoubleMatrix derivatives(
+      ImmutableList<Trade> trades,
+      ImmutableRatesProvider provider,
+      ImmutableList<CurveParameterSize> orderAll,
+      int totalParamsAll) {
+
+    return DoubleMatrix.ofArrayObjects(
+        trades.size(),
+        totalParamsAll,
+        i -> measures.derivative(trades.get(i), provider, orderAll));
+  }
+
+  // jacobian direct, for the current group
+  private static DoubleMatrix jacobianDirect(
+      DoubleMatrix res,
+      int nbTrades,
+      int totalParamsGroup,
+      int totalParamsPrevious) {
+
+    double[][] direct = new double[totalParamsGroup][totalParamsGroup];
+    for (int i = 0; i < nbTrades; i++) {
+      System.arraycopy(res.rowArray(i), totalParamsPrevious, direct[i], 0, totalParamsGroup);
+    }
+    return MATRIX_ALGEBRA.getInverse(DoubleMatrix.copyOf(direct));
+  }
+
+  // jacobian indirect, merging groups
+  private static DoubleMatrix jacobianIndirect(
+      DoubleMatrix res,
+      DoubleMatrix pDmCurrentMatrix,
+      int nbTrades,
+      int totalParamsGroup,
+      int totalParamsPrevious,
+      ImmutableList<CurveParameterSize> orderPrevious,
+      ImmutableMap<CurveName, JacobianCalibrationMatrix> jacobiansPrevious) {
+
+    if (totalParamsPrevious == 0) {
+      return DoubleMatrix.EMPTY;
+    }
+    double[][] nonDirect = new double[totalParamsGroup][totalParamsPrevious];
+    for (int i = 0; i < nbTrades; i++) {
+      System.arraycopy(res.rowArray(i), 0, nonDirect[i], 0, totalParamsPrevious);
+    }
+    DoubleMatrix pDpPreviousMatrix = (DoubleMatrix) MATRIX_ALGEBRA.scale(
+        MATRIX_ALGEBRA.multiply(pDmCurrentMatrix, DoubleMatrix.copyOf(nonDirect)), -1d);
+    // all curves: order and size
+    int[] startIndexBefore = new int[orderPrevious.size()];
+    for (int i = 1; i < orderPrevious.size(); i++) {
+      startIndexBefore[i] = startIndexBefore[i - 1] + orderPrevious.get(i - 1).getParameterCount();
+    }
+    // transition Matrix: all curves from previous groups
+    double[][] transition = new double[totalParamsPrevious][totalParamsPrevious];
+    for (int i = 0; i < orderPrevious.size(); i++) {
+      int paramCountOuter = orderPrevious.get(i).getParameterCount();
+      JacobianCalibrationMatrix thisInfo = jacobiansPrevious.get(orderPrevious.get(i).getName());
+      DoubleMatrix thisMatrix = thisInfo.getJacobianMatrix();
+      int startIndexInner = 0;
+      for (int j = 0; j < orderPrevious.size(); j++) {
+        int paramCountInner = orderPrevious.get(j).getParameterCount();
+        if (thisInfo.containsCurve(orderPrevious.get(j).getName())) { // If not, the matrix stay with 0
+          for (int k = 0; k < paramCountOuter; k++) {
+            System.arraycopy(
+                thisMatrix.rowArray(k),
+                startIndexInner,
+                transition[startIndexBefore[i] + k],
+                startIndexBefore[j],
+                paramCountInner);
+          }
+        }
+        startIndexInner += paramCountInner;
+      }
+    }
+    DoubleMatrix transitionMatrix = DoubleMatrix.copyOf(transition);
+    return (DoubleMatrix) MATRIX_ALGEBRA.multiply(pDpPreviousMatrix, transitionMatrix);
+  }
+
+}


### PR DESCRIPTION
This fixes a bug where an exception was thrown when two curves in the same group used the same market data.

It also tightens up construction of `MarketEnvironment` and requires the valuation date to be specified.

`CurveCalibrator` has been converted to an interface to allow the curve group function to be tested without providing data to allow a real curve to be calibrated.