### PR TITLE
Refactor CurveGroupDefinition to make curve definitions optional

### DIFF
--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurveGroupMarketDataFunction.java
@@ -25,7 +25,6 @@ import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.curve.CurveGroup;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
-import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.curve.CurveInputs;
 import com.opengamma.strata.market.curve.NodalCurveDefinition;
@@ -78,9 +77,9 @@ public class CurveGroupMarketDataFunction implements MarketDataFunction<CurveGro
 
     // request input data for any curves that need market data
     // no input data is requested if the curve definition contains all the market data needed to build the curve
-    List<CurveInputsId> curveInputsIds = groupDefn.getEntries().stream()
-        .filter(entry -> requiresMarketData(entry.getCurveDefinition()))
-        .map(entry -> entry.getCurveDefinition().getName())
+    List<CurveInputsId> curveInputsIds = groupDefn.getCurveDefinitions().stream()
+        .filter(defn -> requiresMarketData(defn))
+        .map(defn -> defn.getName())
         .map(curveName -> CurveInputsId.of(groupDefn.getName(), curveName, id.getMarketDataFeed()))
         .collect(toImmutableList());
 
@@ -120,8 +119,7 @@ public class CurveGroupMarketDataFunction implements MarketDataFunction<CurveGro
     // find and combine all the input data
     CurveGroupName groupName = groupDefn.getName();
 
-    List<MarketDataBox<CurveInputs>> inputBoxes = groupDefn.getEntries().stream()
-        .map(CurveGroupEntry::getCurveDefinition)
+    List<MarketDataBox<CurveInputs>> inputBoxes = groupDefn.getCurveDefinitions().stream()
         .map(curveDefn -> curveInputs(curveDefn, marketData, groupName, feed))
         .collect(toImmutableList());
     // If any of the inputs have values for multiple scenarios then we need to build a curve group for each scenario.

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurveInputsMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurveInputsMarketDataFunction.java
@@ -44,7 +44,7 @@ public final class CurveInputsMarketDataFunction implements MarketDataFunction<C
   @Override
   public MarketDataRequirements requirements(CurveInputsId id, MarketDataConfig marketDataConfig) {
     CurveGroupDefinition groupConfig = marketDataConfig.get(CurveGroupDefinition.class, id.getCurveGroupName());
-    Optional<NodalCurveDefinition> optionalDefinition = groupConfig.findDefinition(id.getCurveName());
+    Optional<NodalCurveDefinition> optionalDefinition = groupConfig.findCurveDefinition(id.getCurveName());
 
     if (!optionalDefinition.isPresent()) {
       return MarketDataRequirements.empty();
@@ -72,7 +72,7 @@ public final class CurveInputsMarketDataFunction implements MarketDataFunction<C
     CurveGroupName groupName = id.getCurveGroupName();
     CurveName curveName = id.getCurveName();
     CurveGroupDefinition groupDefn = marketDataConfig.get(CurveGroupDefinition.class, groupName);
-    Optional<NodalCurveDefinition> optionalDefinition = groupDefn.findDefinition(id.getCurveName());
+    Optional<NodalCurveDefinition> optionalDefinition = groupDefn.findCurveDefinition(id.getCurveName());
 
     if (!optionalDefinition.isPresent()) {
       throw new IllegalArgumentException(Messages.format("No curve named '{}' found in group '{}'", curveName, groupName));

--- a/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurveInputsMarketDataFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/marketdata/curve/CurveInputsMarketDataFunction.java
@@ -28,7 +28,6 @@ import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
 import com.opengamma.strata.calc.marketdata.function.MarketDataFunction;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
-import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.curve.CurveInputs;
 import com.opengamma.strata.market.curve.CurveMetadata;
@@ -45,17 +44,17 @@ public final class CurveInputsMarketDataFunction implements MarketDataFunction<C
   @Override
   public MarketDataRequirements requirements(CurveInputsId id, MarketDataConfig marketDataConfig) {
     CurveGroupDefinition groupConfig = marketDataConfig.get(CurveGroupDefinition.class, id.getCurveGroupName());
-    Optional<CurveGroupEntry> optionalEntry = groupConfig.findEntry(id.getCurveName());
+    Optional<NodalCurveDefinition> optionalDefinition = groupConfig.findDefinition(id.getCurveName());
 
-    if (!optionalEntry.isPresent()) {
+    if (!optionalDefinition.isPresent()) {
       return MarketDataRequirements.empty();
     }
-    CurveGroupEntry entry = optionalEntry.get();
+    NodalCurveDefinition definition = optionalDefinition.get();
 
-    if (!(entry.getCurveDefinition() instanceof InterpolatedNodalCurveDefinition)) {
+    if (!(definition instanceof InterpolatedNodalCurveDefinition)) {
       return MarketDataRequirements.empty();
     }
-    InterpolatedNodalCurveDefinition curveDefn = (InterpolatedNodalCurveDefinition) entry.getCurveDefinition();
+    InterpolatedNodalCurveDefinition curveDefn = (InterpolatedNodalCurveDefinition) definition;
     MarketDataFeed marketDataFeed = id.getMarketDataFeed();
     Set<? extends SimpleMarketDataKey<?>> requirementKeys = nodeRequirements(curveDefn);
     Set<MarketDataId<?>> requirements = requirementKeys.stream()
@@ -73,13 +72,12 @@ public final class CurveInputsMarketDataFunction implements MarketDataFunction<C
     CurveGroupName groupName = id.getCurveGroupName();
     CurveName curveName = id.getCurveName();
     CurveGroupDefinition groupDefn = marketDataConfig.get(CurveGroupDefinition.class, groupName);
-    Optional<CurveGroupEntry> optionalEntry = groupDefn.findEntry(curveName);
+    Optional<NodalCurveDefinition> optionalDefinition = groupDefn.findDefinition(id.getCurveName());
 
-    if (!optionalEntry.isPresent()) {
+    if (!optionalDefinition.isPresent()) {
       throw new IllegalArgumentException(Messages.format("No curve named '{}' found in group '{}'", curveName, groupName));
     }
-    CurveGroupEntry entry = optionalEntry.get();
-    NodalCurveDefinition curveDefn = entry.getCurveDefinition();
+    NodalCurveDefinition curveDefn = optionalDefinition.get();
     MarketDataFeed marketDataFeed = id.getMarketDataFeed();
     Set<? extends SimpleMarketDataKey<?>> requirements = nodeRequirements(curveDefn);
     Map<? extends MarketDataKey<?>, MarketDataBox<?>> marketDataValues =

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoaderTest.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.market.curve.CurveGroupDefinition;
 import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.NodalCurveDefinition;
 
 /**
  * Test {@link RatesCalibrationCsvLoader}.
@@ -83,25 +84,27 @@ public class RatesCalibrationCsvLoaderTest {
 
     CurveGroupEntry entry0 = defn.getEntries().get(0);
     CurveGroupEntry entry1 = defn.getEntries().get(1);
-    if (entry0.getCurveDefinition().getName().equals(CurveName.of("USD-3ML"))) {
+    if (entry0.getCurveName().equals(CurveName.of("USD-3ML"))) {
       CurveGroupEntry temp = entry0;
       entry0 = entry1;
       entry1 = temp;
     }
+    NodalCurveDefinition defn0 = defn.findDefinition(entry0.getCurveName()).get();
+    NodalCurveDefinition defn1 = defn.findDefinition(entry1.getCurveName()).get();
 
     assertEquals(entry0.getDiscountCurrencies(), ImmutableSet.of(Currency.USD));
     assertEquals(entry0.getIborIndices(), ImmutableSet.of());
     assertEquals(entry0.getOvernightIndices(), ImmutableSet.of());
-    assertEquals(entry0.getCurveDefinition().getName(), CurveName.of("USD-Disc"));
-    assertEquals(entry0.getCurveDefinition().getYValueType(), ValueType.ZERO_RATE);
-    assertEquals(entry0.getCurveDefinition().getParameterCount(), 15);
+    assertEquals(defn0.getName(), CurveName.of("USD-Disc"));
+    assertEquals(defn0.getYValueType(), ValueType.ZERO_RATE);
+    assertEquals(defn0.getParameterCount(), 15);
 
     assertEquals(entry1.getDiscountCurrencies(), ImmutableSet.of());
     assertEquals(entry1.getIborIndices(), ImmutableSet.of(IborIndices.USD_LIBOR_3M));
     assertEquals(entry1.getOvernightIndices(), ImmutableSet.of());
-    assertEquals(entry1.getCurveDefinition().getName(), CurveName.of("USD-3ML"));
-    assertEquals(entry1.getCurveDefinition().getYValueType(), ValueType.ZERO_RATE);
-    assertEquals(entry1.getCurveDefinition().getParameterCount(), 25);
+    assertEquals(defn1.getName(), CurveName.of("USD-3ML"));
+    assertEquals(defn1.getYValueType(), ValueType.ZERO_RATE);
+    assertEquals(defn1.getParameterCount(), 25);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoaderTest.java
@@ -89,8 +89,8 @@ public class RatesCalibrationCsvLoaderTest {
       entry0 = entry1;
       entry1 = temp;
     }
-    NodalCurveDefinition defn0 = defn.findDefinition(entry0.getCurveName()).get();
-    NodalCurveDefinition defn1 = defn.findDefinition(entry1.getCurveName()).get();
+    NodalCurveDefinition defn0 = defn.findCurveDefinition(entry0.getCurveName()).get();
+    NodalCurveDefinition defn1 = defn.findCurveDefinition(entry1.getCurveName()).get();
 
     assertEquals(entry0.getDiscountCurrencies(), ImmutableSet.of(Currency.USD));
     assertEquals(entry0.getIborIndices(), ImmutableSet.of());

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
@@ -84,7 +84,7 @@ public final class CurveGroup
    * @param curveGroupDefinition  the definition of a curve group
    * @param curves  some curves
    * @return a curve group built from the definition and the list of curves
-   * @throws IllegalArgumentException if there are any curves named in the definition which are not present in the list
+   * @throws IllegalArgumentException if there are any curves named in the definition but not included in the curves
    */
   public static CurveGroup ofCurves(CurveGroupDefinition curveGroupDefinition, Curve... curves) {
     return ofCurves(curveGroupDefinition, Arrays.asList(curves));

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
@@ -5,7 +5,12 @@
  */
 package com.opengamma.strata.market.curve;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -25,13 +30,18 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.collect.Messages;
 
 /**
  * A group of curves.
  * <p>
  * This is used to hold a group of related curves, typically forming a logical set.
  * It is often used to hold the results of a curve calibration.
+ * <p>
+ * Curve groups can also be created from a set of existing curves.
  */
 @BeanDefinition
 public final class CurveGroup
@@ -64,6 +74,60 @@ public final class CurveGroup
    */
   public static CurveGroup of(CurveGroupName name, Map<Currency, Curve> discountCurves, Map<Index, Curve> forwardCurves) {
     return new CurveGroup(name, discountCurves, forwardCurves);
+  }
+
+  /**
+   * Creates a curve group using a curve group definition and some existing curves.
+   * <p>
+   * The curves must include all curves named in the curve group definition.
+   *
+   * @param curveGroupDefinition  the definition of a curve group
+   * @param curves  some curves
+   * @return a curve group built from the definition and the list of curves
+   * @throws IllegalArgumentException if there are any curves named in the definition which are not present in the list
+   */
+  public static CurveGroup ofCurves(CurveGroupDefinition curveGroupDefinition, Curve... curves) {
+    return ofCurves(curveGroupDefinition, Arrays.asList(curves));
+  }
+
+  /**
+   * Creates a curve group using a curve group definition and a list of existing curves.
+   * <p>
+   * The list of curves must contain all curves named in the curve group definition.
+   *
+   * @param curveGroupDefinition  the definition of a curve group
+   * @param curves  some curves
+   * @return a curve group built from the definition and the list of curves
+   * @throws IllegalArgumentException if there are any curves named in the definition which are not present in the list
+   */
+  public static CurveGroup ofCurves(CurveGroupDefinition curveGroupDefinition, List<Curve> curves) {
+    Map<Currency, Curve> discountCurves = new HashMap<>();
+    Map<Index, Curve> forwardCurves = new HashMap<>();
+    Map<CurveName, Curve> curveMap =
+        curves.stream().collect(toMap(curve -> curve.getMetadata().getCurveName(), curve -> curve));
+
+    for (CurveGroupEntry entry : curveGroupDefinition.getEntries()) {
+      CurveName curveName = entry.getCurveName();
+      Curve curve = curveMap.get(curveName);
+
+      if (curve == null) {
+        throw new IllegalArgumentException(
+            Messages.format(
+                "No curve found named '{}' when building curve group '{}'",
+                curveName,
+                curveGroupDefinition.getName()));
+      }
+      for (Currency currency : entry.getDiscountCurrencies()) {
+        discountCurves.put(currency, curve);
+      }
+      for (IborIndex index : entry.getIborIndices()) {
+        forwardCurves.put(index, curve);
+      }
+      for (OvernightIndex index : entry.getOvernightIndices()) {
+        forwardCurves.put(index, curve);
+      }
+    }
+    return CurveGroup.of(curveGroupDefinition.getName(), discountCurves, forwardCurves);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
@@ -166,7 +166,7 @@ public final class CurveGroupDefinition
    * @param curveName  the name of the curve
    * @return the definition for the curve with the specified name
    */
-  public Optional<NodalCurveDefinition> findDefinition(CurveName curveName) {
+  public Optional<NodalCurveDefinition> findCurveDefinition(CurveName curveName) {
     return Optional.ofNullable(curveDefinitionsByName.get(curveName));
   }
 

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
@@ -22,6 +22,7 @@ import org.joda.beans.BeanBuilder;
 import org.joda.beans.BeanDefinition;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.ImmutableConstructor;
+import org.joda.beans.ImmutableValidator;
 import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.MetaProperty;
 import org.joda.beans.Property;
@@ -33,6 +34,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.opengamma.strata.basics.Trade;
 import com.opengamma.strata.basics.market.MarketData;
 import com.opengamma.strata.collect.ArgChecker;
@@ -70,9 +72,21 @@ public final class CurveGroupDefinition
   @PropertyDefinition(validate = "notNull")
   private final ImmutableList<CurveGroupEntry> entries;
   /**
+   * Definitions which specify how the curves are calibrated.
+   * <p>
+   * Curve definitions are required for curves that need to be calibrated. A definition is not necessary if
+   * the curve is not built by the Strata curve calibrator.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final ImmutableList<NodalCurveDefinition> curveDefinitions;
+  /**
    * Entries for the curves, keyed by the curve name.
    */
   private final ImmutableMap<CurveName, CurveGroupEntry> entriesByName;
+  /**
+   * Definitions for the curves, keyed by the curve name.
+   */
+  private final ImmutableMap<CurveName, NodalCurveDefinition> curveDefinitionsByName;
 
   //-------------------------------------------------------------------------
   /**
@@ -89,10 +103,15 @@ public final class CurveGroupDefinition
    *
    * @param name  the name of the curve group
    * @param entries  entries describing the curves in the group
+   * @param curveDefinitions  definitions which specify how the curves are calibrated
    * @return a curve group definition with the specified name and containing the specified entries
    */
-  public static CurveGroupDefinition of(CurveGroupName name, Collection<CurveGroupEntry> entries) {
-    return new CurveGroupDefinition(name, entries);
+  public static CurveGroupDefinition of(
+      CurveGroupName name,
+      Collection<CurveGroupEntry> entries,
+      Collection<NodalCurveDefinition> curveDefinitions) {
+
+    return new CurveGroupDefinition(name, entries, curveDefinitions);
   }
 
   /**
@@ -100,25 +119,55 @@ public final class CurveGroupDefinition
    *
    * @param name  the name of the curve group
    * @param entries  details of the curves in the group
+   * @param curveDefinitions  definitions which specify how the curves are calibrated
    */
   @ImmutableConstructor
-  CurveGroupDefinition(CurveGroupName name, Collection<CurveGroupEntry> entries) {
+  CurveGroupDefinition(
+      CurveGroupName name,
+      Collection<CurveGroupEntry> entries,
+      Collection<NodalCurveDefinition> curveDefinitions) {
+
     this.name = ArgChecker.notNull(name, "name");
     this.entries = ImmutableList.copyOf(entries);
-    entriesByName = entries.stream().collect(toImmutableMap(entry -> entry.getCurveDefinition().getName(), entry -> entry));
+    this.curveDefinitions = ImmutableList.copyOf(curveDefinitions);
+    entriesByName = entries.stream().collect(toImmutableMap(entry -> entry.getCurveName(), entry -> entry));
+    curveDefinitionsByName = curveDefinitions.stream().collect(toImmutableMap(def -> def.getName(), def -> def));
+    validate();
+  }
+
+  @ImmutableValidator
+  private void validate() {
+    Set<CurveName> missingEntries = Sets.difference(curveDefinitionsByName.keySet(), entriesByName.keySet());
+
+    if (!missingEntries.isEmpty()) {
+      throw new IllegalArgumentException("An entry must be provided for every curve definition but the following " +
+          "curves have a definition but no entry: " + missingEntries);
+    }
   }
 
   //-------------------------------------------------------------------------
   /**
-   * Finds the entry for the curve group with the specified name.
+   * Finds the entry for the curve with the specified name.
    * <p>
-   * If the group is not found, optional empty is returned.
+   * If the curve is not found, optional empty is returned.
    *
    * @param curveName  the name of the curve
    * @return the entry for the curve group with the specified name
    */
   public Optional<CurveGroupEntry> findEntry(CurveName curveName) {
     return Optional.ofNullable(entriesByName.get(curveName));
+  }
+
+  /**
+   * Finds the definition for the curve with the specified name.
+   * <p>
+   * If the curve is not found, optional empty is returned.
+   *
+   * @param curveName  the name of the curve
+   * @return the entry for the curve group with the specified name
+   */
+  public Optional<NodalCurveDefinition> findDefinition(CurveName curveName) {
+    return Optional.ofNullable(curveDefinitionsByName.get(curveName));
   }
 
   //-------------------------------------------------------------------------
@@ -132,9 +181,7 @@ public final class CurveGroupDefinition
    * @return the number of parameters
    */
   public int getTotalParameterCount() {
-    return entries.stream()
-        .mapToInt(entry -> entry.getCurveDefinition().getParameterCount())
-        .sum();
+    return curveDefinitionsByName.entrySet().stream().mapToInt(entry -> entry.getValue().getParameterCount()).sum();
   }
 
   /**
@@ -148,8 +195,8 @@ public final class CurveGroupDefinition
    * @return the list of all trades
    */
   public ImmutableList<Trade> trades(LocalDate valuationDate, MarketData marketData) {
-    return entries.stream()
-        .map(CurveGroupEntry::getCurveDefinition)
+    return curveDefinitionsByName.entrySet().stream()
+        .map(entry -> entry.getValue())
         .flatMap(curveDef -> curveDef.getNodes().stream())
         .map(node -> node.trade(valuationDate, marketData))
         .collect(toImmutableList());
@@ -166,8 +213,8 @@ public final class CurveGroupDefinition
    */
   public ImmutableList<Double> initialGuesses(LocalDate valuationDate, MarketData marketData) {
     ImmutableList.Builder<Double> result = ImmutableList.builder();
-    for (CurveGroupEntry entry : entries) {
-      NodalCurveDefinition defn = entry.getCurveDefinition();
+
+    for (NodalCurveDefinition defn : curveDefinitions) {
       ValueType valueType = defn.getYValueType();
       for (CurveNode node : defn.getNodes()) {
         result.add(node.initialGuess(valuationDate, marketData, valueType));
@@ -229,6 +276,18 @@ public final class CurveGroupDefinition
   }
 
   //-----------------------------------------------------------------------
+  /**
+   * Gets definitions which specify how the curves are calibrated.
+   * <p>
+   * Curve definitions are required for curves that need to be calibrated. A definition is not necessary if
+   * the curve is not built by the Strata curve calibrator.
+   * @return the value of the property, not null
+   */
+  public ImmutableList<NodalCurveDefinition> getCurveDefinitions() {
+    return curveDefinitions;
+  }
+
+  //-----------------------------------------------------------------------
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
@@ -237,7 +296,8 @@ public final class CurveGroupDefinition
     if (obj != null && obj.getClass() == this.getClass()) {
       CurveGroupDefinition other = (CurveGroupDefinition) obj;
       return JodaBeanUtils.equal(name, other.name) &&
-          JodaBeanUtils.equal(entries, other.entries);
+          JodaBeanUtils.equal(entries, other.entries) &&
+          JodaBeanUtils.equal(curveDefinitions, other.curveDefinitions);
     }
     return false;
   }
@@ -247,15 +307,17 @@ public final class CurveGroupDefinition
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(name);
     hash = hash * 31 + JodaBeanUtils.hashCode(entries);
+    hash = hash * 31 + JodaBeanUtils.hashCode(curveDefinitions);
     return hash;
   }
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(96);
+    StringBuilder buf = new StringBuilder(128);
     buf.append("CurveGroupDefinition{");
     buf.append("name").append('=').append(name).append(',').append(' ');
-    buf.append("entries").append('=').append(JodaBeanUtils.toString(entries));
+    buf.append("entries").append('=').append(entries).append(',').append(' ');
+    buf.append("curveDefinitions").append('=').append(JodaBeanUtils.toString(curveDefinitions));
     buf.append('}');
     return buf.toString();
   }
@@ -282,12 +344,19 @@ public final class CurveGroupDefinition
     private final MetaProperty<ImmutableList<CurveGroupEntry>> entries = DirectMetaProperty.ofImmutable(
         this, "entries", CurveGroupDefinition.class, (Class) ImmutableList.class);
     /**
+     * The meta-property for the {@code curveDefinitions} property.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    private final MetaProperty<ImmutableList<NodalCurveDefinition>> curveDefinitions = DirectMetaProperty.ofImmutable(
+        this, "curveDefinitions", CurveGroupDefinition.class, (Class) ImmutableList.class);
+    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "name",
-        "entries");
+        "entries",
+        "curveDefinitions");
 
     /**
      * Restricted constructor.
@@ -302,6 +371,8 @@ public final class CurveGroupDefinition
           return name;
         case -1591573360:  // entries
           return entries;
+        case -336166639:  // curveDefinitions
+          return curveDefinitions;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -338,6 +409,14 @@ public final class CurveGroupDefinition
       return entries;
     }
 
+    /**
+     * The meta-property for the {@code curveDefinitions} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ImmutableList<NodalCurveDefinition>> curveDefinitions() {
+      return curveDefinitions;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
@@ -346,6 +425,8 @@ public final class CurveGroupDefinition
           return ((CurveGroupDefinition) bean).getName();
         case -1591573360:  // entries
           return ((CurveGroupDefinition) bean).getEntries();
+        case -336166639:  // curveDefinitions
+          return ((CurveGroupDefinition) bean).getCurveDefinitions();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -369,6 +450,7 @@ public final class CurveGroupDefinition
 
     private CurveGroupName name;
     private List<CurveGroupEntry> entries = ImmutableList.of();
+    private List<NodalCurveDefinition> curveDefinitions = ImmutableList.of();
 
     /**
      * Restricted constructor.
@@ -384,6 +466,8 @@ public final class CurveGroupDefinition
           return name;
         case -1591573360:  // entries
           return entries;
+        case -336166639:  // curveDefinitions
+          return curveDefinitions;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -398,6 +482,9 @@ public final class CurveGroupDefinition
           break;
         case -1591573360:  // entries
           this.entries = (List<CurveGroupEntry>) newValue;
+          break;
+        case -336166639:  // curveDefinitions
+          this.curveDefinitions = (List<NodalCurveDefinition>) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -433,16 +520,18 @@ public final class CurveGroupDefinition
     public CurveGroupDefinition build() {
       return new CurveGroupDefinition(
           name,
-          entries);
+          entries,
+          curveDefinitions);
     }
 
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(96);
+      StringBuilder buf = new StringBuilder(128);
       buf.append("CurveGroupDefinition.Builder{");
       buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
-      buf.append("entries").append('=').append(JodaBeanUtils.toString(entries));
+      buf.append("entries").append('=').append(JodaBeanUtils.toString(entries)).append(',').append(' ');
+      buf.append("curveDefinitions").append('=').append(JodaBeanUtils.toString(curveDefinitions));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
@@ -152,7 +152,7 @@ public final class CurveGroupDefinition
    * If the curve is not found, optional empty is returned.
    *
    * @param curveName  the name of the curve
-   * @return the entry for the curve group with the specified name
+   * @return the entry for the curve with the specified name
    */
   public Optional<CurveGroupEntry> findEntry(CurveName curveName) {
     return Optional.ofNullable(entriesByName.get(curveName));
@@ -164,7 +164,7 @@ public final class CurveGroupDefinition
    * If the curve is not found, optional empty is returned.
    *
    * @param curveName  the name of the curve
-   * @return the entry for the curve group with the specified name
+   * @return the definition for the curve with the specified name
    */
   public Optional<NodalCurveDefinition> findDefinition(CurveName curveName) {
     return Optional.ofNullable(curveDefinitionsByName.get(curveName));

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinitionBuilder.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinitionBuilder.java
@@ -7,9 +7,8 @@ package com.opengamma.strata.market.curve;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableSet;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ListIterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
@@ -34,7 +33,11 @@ public final class CurveGroupDefinitionBuilder {
   /**
    * The entries in the curve group.
    */
-  private final List<CurveGroupEntry> entries = new ArrayList<>();
+  private final Map<CurveName, CurveGroupEntry> entries = new LinkedHashMap<>();
+  /**
+   * The definitions specifying how the curves are calibrated.
+   */
+  private final Map<CurveName, NodalCurveDefinition> curveDefinitions = new LinkedHashMap<>();
 
   //-------------------------------------------------------------------------
   /**
@@ -65,7 +68,32 @@ public final class CurveGroupDefinitionBuilder {
     ArgChecker.notNull(curveDefinition, "curveDefinition");
     ArgChecker.notNull(currency, "currency");
     CurveGroupEntry entry = CurveGroupEntry.builder()
-        .curveDefinition(curveDefinition)
+        .curveName(curveDefinition.getName())
+        .discountCurrencies(ImmutableSet.copyOf(Lists.asList(currency, otherCurrencies)))
+        .build();
+    return merge(entry, curveDefinition);
+  }
+
+  /**
+   * Adds the definition of a discount curve to the curve group definition.
+   * <p>
+   * A curve added with this method cannot be calibrated by the market data system as it does not include
+   * a curve definition. It is intended to be used with curves which are supplied by the user.
+   *
+   * @param curveName  the name of the curve
+   * @param otherCurrencies  additional currencies for which the curve can provide discount factors
+   * @param currency  the currency for which the curve provides discount rates
+   * @return this builder
+   */
+  public CurveGroupDefinitionBuilder addDiscountCurve(
+      CurveName curveName,
+      Currency currency,
+      Currency... otherCurrencies) {
+
+    ArgChecker.notNull(curveName, "curveName");
+    ArgChecker.notNull(currency, "currency");
+    CurveGroupEntry entry = CurveGroupEntry.builder()
+        .curveName(curveName)
         .discountCurrencies(ImmutableSet.copyOf(Lists.asList(currency, otherCurrencies)))
         .build();
     return mergeEntry(entry);
@@ -87,7 +115,30 @@ public final class CurveGroupDefinitionBuilder {
     ArgChecker.notNull(curveDefinition, "curveDefinition");
     ArgChecker.notNull(index, "index");
     CurveGroupEntry entry = CurveGroupEntry.builder()
-        .curveDefinition(curveDefinition)
+        .curveName(curveDefinition.getName())
+        .iborIndices(iborIndices(index, otherIndices))
+        .overnightIndices(overnightIndices(index, otherIndices))
+        .build();
+    return merge(entry, curveDefinition);
+  }
+
+  /**
+   * Adds the definition of a forward curve to the curve group definition.
+   * <p>
+   * A curve added with this method cannot be calibrated by the market data system as it does not include
+   * a curve definition. It is intended to be used with curves which are supplied by the user.
+   *
+   * @param curveName  the name of the curve
+   * @param index  the index for which the curve provides forward rates
+   * @param otherIndices  the additional indices for which the curve provides forward rates
+   * @return this builder
+   */
+  public CurveGroupDefinitionBuilder addForwardCurve(CurveName curveName, RateIndex index, RateIndex... otherIndices) {
+    ArgChecker.notNull(curveName, "curveName");
+    ArgChecker.notNull(index, "index");
+
+    CurveGroupEntry entry = CurveGroupEntry.builder()
+        .curveName(curveName)
         .iborIndices(iborIndices(index, otherIndices))
         .overnightIndices(overnightIndices(index, otherIndices))
         .build();
@@ -95,7 +146,8 @@ public final class CurveGroupDefinitionBuilder {
   }
 
   /**
-   * Adds the definition of a curve to the curve group definition used to provide discount rates and forward rates.
+   * Adds the definition of a curve to the curve group definition which is used to provide
+   * discount rates and forward rates.
    *
    * @param curveDefinition  the definition of the forward curve
    * @param currency  the currency for which the curve provides discount rates
@@ -109,8 +161,39 @@ public final class CurveGroupDefinitionBuilder {
       RateIndex index,
       RateIndex... otherIndices) {
 
+    ArgChecker.notNull(curveDefinition, "curveDefinition");
+    ArgChecker.notNull(currency, "currency");
+    ArgChecker.notNull(index, "index");
+
     CurveGroupEntry entry = CurveGroupEntry.builder()
-        .curveDefinition(curveDefinition)
+        .curveName(curveDefinition.getName())
+        .discountCurrencies(ImmutableSet.of(currency))
+        .iborIndices(iborIndices(index, otherIndices))
+        .overnightIndices(overnightIndices(index, otherIndices))
+        .build();
+    return merge(entry, curveDefinition);
+  }
+
+  /**
+   * Adds a curve to the curve group definition which is used to provide discount rates and forward rates.
+   * <p>
+   * A curve added with this method cannot be calibrated by the market data system as it does not include
+   * a curve definition. It is intended to be used with curves which are supplied by the user.
+   *
+   * @param curveName  the name of the curve
+   * @param currency  the currency for which the curve provides discount rates
+   * @param index  the index for which the curve provides forward rates
+   * @param otherIndices  the additional indices for which the curve provides forward rates
+   * @return this builder
+   */
+  public CurveGroupDefinitionBuilder addCurve(
+      CurveName curveName,
+      Currency currency,
+      RateIndex index,
+      RateIndex... otherIndices) {
+
+    CurveGroupEntry entry = CurveGroupEntry.builder()
+        .curveName(curveName)
         .discountCurrencies(ImmutableSet.of(currency))
         .iborIndices(iborIndices(index, otherIndices))
         .overnightIndices(overnightIndices(index, otherIndices))
@@ -118,16 +201,17 @@ public final class CurveGroupDefinitionBuilder {
     return mergeEntry(entry);
   }
 
+  private CurveGroupDefinitionBuilder merge(CurveGroupEntry newEntry, NodalCurveDefinition curveDefinition) {
+    curveDefinitions.put(curveDefinition.getName(), curveDefinition);
+    return mergeEntry(newEntry);
+  }
+
   // merges the specified entry with those already stored
   private CurveGroupDefinitionBuilder mergeEntry(CurveGroupEntry newEntry) {
-    for (ListIterator<CurveGroupEntry> it = entries.listIterator(); it.hasNext();) {
-      CurveGroupEntry entry = (CurveGroupEntry) it.next();
-      if (entry.getCurveDefinition().equals(newEntry.getCurveDefinition())) {
-        it.set(entry.merge(newEntry));
-        return this;
-      }
-    }
-    entries.add(newEntry);
+    CurveName curveName = newEntry.getCurveName();
+    CurveGroupEntry existingEntry = entries.get(curveName);
+    CurveGroupEntry entry = existingEntry == null ? newEntry : existingEntry.merge(newEntry);
+    entries.put(curveName, entry);
     return this;
   }
 
@@ -135,7 +219,7 @@ public final class CurveGroupDefinitionBuilder {
    * Returns a set containing any Ibor indices in the arguments.
    */
   private static Set<IborIndex> iborIndices(RateIndex index, RateIndex... otherIndices) {
-    return ImmutableList.<RateIndex>builder().add(index).add(otherIndices).build().stream()
+    return ImmutableList.builder().add(index).add(otherIndices).build().stream()
         .filter(IborIndex.class::isInstance)
         .map(IborIndex.class::cast)
         .collect(toImmutableSet());
@@ -145,7 +229,7 @@ public final class CurveGroupDefinitionBuilder {
    * Returns a set containing any overnight indices in the arguments.
    */
   private static Set<OvernightIndex> overnightIndices(RateIndex index, RateIndex... otherIndices) {
-    return ImmutableList.<RateIndex>builder().add(index).add(otherIndices).build().stream()
+    return ImmutableList.builder().add(index).add(otherIndices).build().stream()
         .filter(OvernightIndex.class::isInstance)
         .map(OvernightIndex.class::cast)
         .collect(toImmutableSet());
@@ -158,7 +242,7 @@ public final class CurveGroupDefinitionBuilder {
    * @return the definition of the curve group built from the data in this object
    */
   public CurveGroupDefinition build() {
-    return new CurveGroupDefinition(name, entries);
+    return new CurveGroupDefinition(name, entries.values(), curveDefinitions.values());
   }
 
 }

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupEntry.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupEntry.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.collect.Messages;
 
 /**
  * A single entry in the curve group definition.
@@ -47,10 +48,10 @@ public final class CurveGroupEntry
     implements ImmutableBean, Serializable {
 
   /**
-   * The curve definition.
+   * The curve name.
    */
   @PropertyDefinition(validate = "notNull")
-  private final NodalCurveDefinition curveDefinition;
+  private final CurveName curveName;
   /**
    * The currencies for which the curve provides discount rates.
    * This is empty if the curve is not used for Ibor rates.
@@ -74,14 +75,21 @@ public final class CurveGroupEntry
   /**
    * Merges the specified entry with this entry, returning a new entry.
    * <p>
-   * The two entries must have the same curve definition.
+   * The two entries must have the same curve name.
    * 
    * @param newEntry  the new entry
    * @return the merged entry
    */
   CurveGroupEntry merge(CurveGroupEntry newEntry) {
+    if (!curveName.equals(newEntry.curveName)) {
+      throw new IllegalArgumentException(
+          Messages.format(
+              "A CurveGroupEntry can only be merged with an entry with the same curve name. name: {}, other name: {}",
+              curveName,
+              newEntry.curveName));
+    }
     return CurveGroupEntry.builder()
-        .curveDefinition(curveDefinition)
+        .curveName(curveName)
         .discountCurrencies(Sets.union(discountCurrencies, newEntry.discountCurrencies))
         .iborIndices(Sets.union(iborIndices, newEntry.iborIndices))
         .overnightIndices(Sets.union(overnightIndices, newEntry.overnightIndices))
@@ -116,15 +124,15 @@ public final class CurveGroupEntry
   }
 
   private CurveGroupEntry(
-      NodalCurveDefinition curveDefinition,
+      CurveName curveName,
       Set<Currency> discountCurrencies,
       Set<IborIndex> iborIndices,
       Set<OvernightIndex> overnightIndices) {
-    JodaBeanUtils.notNull(curveDefinition, "curveDefinition");
+    JodaBeanUtils.notNull(curveName, "curveName");
     JodaBeanUtils.notNull(discountCurrencies, "discountCurrencies");
     JodaBeanUtils.notNull(iborIndices, "iborIndices");
     JodaBeanUtils.notNull(overnightIndices, "overnightIndices");
-    this.curveDefinition = curveDefinition;
+    this.curveName = curveName;
     this.discountCurrencies = ImmutableSet.copyOf(discountCurrencies);
     this.iborIndices = ImmutableSet.copyOf(iborIndices);
     this.overnightIndices = ImmutableSet.copyOf(overnightIndices);
@@ -147,11 +155,11 @@ public final class CurveGroupEntry
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the curve definition.
+   * Gets the curve name.
    * @return the value of the property, not null
    */
-  public NodalCurveDefinition getCurveDefinition() {
-    return curveDefinition;
+  public CurveName getCurveName() {
+    return curveName;
   }
 
   //-----------------------------------------------------------------------
@@ -200,7 +208,7 @@ public final class CurveGroupEntry
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       CurveGroupEntry other = (CurveGroupEntry) obj;
-      return JodaBeanUtils.equal(curveDefinition, other.curveDefinition) &&
+      return JodaBeanUtils.equal(curveName, other.curveName) &&
           JodaBeanUtils.equal(discountCurrencies, other.discountCurrencies) &&
           JodaBeanUtils.equal(iborIndices, other.iborIndices) &&
           JodaBeanUtils.equal(overnightIndices, other.overnightIndices);
@@ -211,7 +219,7 @@ public final class CurveGroupEntry
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
-    hash = hash * 31 + JodaBeanUtils.hashCode(curveDefinition);
+    hash = hash * 31 + JodaBeanUtils.hashCode(curveName);
     hash = hash * 31 + JodaBeanUtils.hashCode(discountCurrencies);
     hash = hash * 31 + JodaBeanUtils.hashCode(iborIndices);
     hash = hash * 31 + JodaBeanUtils.hashCode(overnightIndices);
@@ -222,7 +230,7 @@ public final class CurveGroupEntry
   public String toString() {
     StringBuilder buf = new StringBuilder(160);
     buf.append("CurveGroupEntry{");
-    buf.append("curveDefinition").append('=').append(curveDefinition).append(',').append(' ');
+    buf.append("curveName").append('=').append(curveName).append(',').append(' ');
     buf.append("discountCurrencies").append('=').append(discountCurrencies).append(',').append(' ');
     buf.append("iborIndices").append('=').append(iborIndices).append(',').append(' ');
     buf.append("overnightIndices").append('=').append(JodaBeanUtils.toString(overnightIndices));
@@ -241,10 +249,10 @@ public final class CurveGroupEntry
     static final Meta INSTANCE = new Meta();
 
     /**
-     * The meta-property for the {@code curveDefinition} property.
+     * The meta-property for the {@code curveName} property.
      */
-    private final MetaProperty<NodalCurveDefinition> curveDefinition = DirectMetaProperty.ofImmutable(
-        this, "curveDefinition", CurveGroupEntry.class, NodalCurveDefinition.class);
+    private final MetaProperty<CurveName> curveName = DirectMetaProperty.ofImmutable(
+        this, "curveName", CurveGroupEntry.class, CurveName.class);
     /**
      * The meta-property for the {@code discountCurrencies} property.
      */
@@ -268,7 +276,7 @@ public final class CurveGroupEntry
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "curveDefinition",
+        "curveName",
         "discountCurrencies",
         "iborIndices",
         "overnightIndices");
@@ -282,8 +290,8 @@ public final class CurveGroupEntry
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
-        case -1257770078:  // curveDefinition
-          return curveDefinition;
+        case 771153946:  // curveName
+          return curveName;
         case -538086256:  // discountCurrencies
           return discountCurrencies;
         case -118808757:  // iborIndices
@@ -311,11 +319,11 @@ public final class CurveGroupEntry
 
     //-----------------------------------------------------------------------
     /**
-     * The meta-property for the {@code curveDefinition} property.
+     * The meta-property for the {@code curveName} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<NodalCurveDefinition> curveDefinition() {
-      return curveDefinition;
+    public MetaProperty<CurveName> curveName() {
+      return curveName;
     }
 
     /**
@@ -346,8 +354,8 @@ public final class CurveGroupEntry
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
-        case -1257770078:  // curveDefinition
-          return ((CurveGroupEntry) bean).getCurveDefinition();
+        case 771153946:  // curveName
+          return ((CurveGroupEntry) bean).getCurveName();
         case -538086256:  // discountCurrencies
           return ((CurveGroupEntry) bean).getDiscountCurrencies();
         case -118808757:  // iborIndices
@@ -375,7 +383,7 @@ public final class CurveGroupEntry
    */
   public static final class Builder extends DirectFieldsBeanBuilder<CurveGroupEntry> {
 
-    private NodalCurveDefinition curveDefinition;
+    private CurveName curveName;
     private Set<Currency> discountCurrencies = ImmutableSet.of();
     private Set<IborIndex> iborIndices = ImmutableSet.of();
     private Set<OvernightIndex> overnightIndices = ImmutableSet.of();
@@ -391,7 +399,7 @@ public final class CurveGroupEntry
      * @param beanToCopy  the bean to copy from, not null
      */
     private Builder(CurveGroupEntry beanToCopy) {
-      this.curveDefinition = beanToCopy.getCurveDefinition();
+      this.curveName = beanToCopy.getCurveName();
       this.discountCurrencies = beanToCopy.getDiscountCurrencies();
       this.iborIndices = beanToCopy.getIborIndices();
       this.overnightIndices = beanToCopy.getOvernightIndices();
@@ -401,8 +409,8 @@ public final class CurveGroupEntry
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
-        case -1257770078:  // curveDefinition
-          return curveDefinition;
+        case 771153946:  // curveName
+          return curveName;
         case -538086256:  // discountCurrencies
           return discountCurrencies;
         case -118808757:  // iborIndices
@@ -418,8 +426,8 @@ public final class CurveGroupEntry
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
-        case -1257770078:  // curveDefinition
-          this.curveDefinition = (NodalCurveDefinition) newValue;
+        case 771153946:  // curveName
+          this.curveName = (CurveName) newValue;
           break;
         case -538086256:  // discountCurrencies
           this.discountCurrencies = (Set<Currency>) newValue;
@@ -463,7 +471,7 @@ public final class CurveGroupEntry
     @Override
     public CurveGroupEntry build() {
       return new CurveGroupEntry(
-          curveDefinition,
+          curveName,
           discountCurrencies,
           iborIndices,
           overnightIndices);
@@ -471,13 +479,13 @@ public final class CurveGroupEntry
 
     //-----------------------------------------------------------------------
     /**
-     * Sets the curve definition.
-     * @param curveDefinition  the new value, not null
+     * Sets the curve name.
+     * @param curveName  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder curveDefinition(NodalCurveDefinition curveDefinition) {
-      JodaBeanUtils.notNull(curveDefinition, "curveDefinition");
-      this.curveDefinition = curveDefinition;
+    public Builder curveName(CurveName curveName) {
+      JodaBeanUtils.notNull(curveName, "curveName");
+      this.curveName = curveName;
       return this;
     }
 
@@ -552,7 +560,7 @@ public final class CurveGroupEntry
     public String toString() {
       StringBuilder buf = new StringBuilder(160);
       buf.append("CurveGroupEntry.Builder{");
-      buf.append("curveDefinition").append('=').append(JodaBeanUtils.toString(curveDefinition)).append(',').append(' ');
+      buf.append("curveName").append('=').append(JodaBeanUtils.toString(curveName)).append(',').append(' ');
       buf.append("discountCurrencies").append('=').append(JodaBeanUtils.toString(discountCurrencies)).append(',').append(' ');
       buf.append("iborIndices").append('=').append(JodaBeanUtils.toString(iborIndices)).append(',').append(' ');
       buf.append("overnightIndices").append('=').append(JodaBeanUtils.toString(overnightIndices));

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupDefinitionTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupDefinitionTest.java
@@ -12,6 +12,7 @@ import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_1W;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -44,8 +45,10 @@ public class CurveGroupDefinitionTest {
   private static final ObservableKey GBP_LIBOR_3M_ID = QuoteKey.of(StandardId.of("OG", "Ticker3"));
   private static final DummyFraCurveNode NODE1 = DummyFraCurveNode.of(Period.ofMonths(1), GBP_LIBOR_1M, GBP_LIBOR_1M_ID);
   private static final DummyFraCurveNode NODE2 = DummyFraCurveNode.of(Period.ofMonths(3), GBP_LIBOR_3M, GBP_LIBOR_3M_ID);
-  private static final InterpolatedNodalCurveDefinition CURVE_DEFN = InterpolatedNodalCurveDefinition.builder()
-      .name(CurveName.of("Test"))
+  private static final CurveName CURVE_NAME1 = CurveName.of("Test");
+  private static final CurveName CURVE_NAME2 = CurveName.of("Test2");
+  private static final InterpolatedNodalCurveDefinition CURVE_DEFN1 = InterpolatedNodalCurveDefinition.builder()
+      .name(CURVE_NAME1)
       .xValueType(ValueType.YEAR_FRACTION)
       .yValueType(ValueType.ZERO_RATE)
       .dayCount(ACT_365F)
@@ -54,21 +57,21 @@ public class CurveGroupDefinitionTest {
       .extrapolatorLeft(CurveExtrapolators.FLAT)
       .extrapolatorRight(CurveExtrapolators.FLAT)
       .build();
-  private static final InterpolatedNodalCurveDefinition CURVE_CONFIG2 = CURVE_DEFN.toBuilder()
-      .name(CurveName.of("Test2"))
+  private static final InterpolatedNodalCurveDefinition CURVE_DEFN2 = CURVE_DEFN1.toBuilder()
+      .name(CURVE_NAME2)
       .build();
   private static final CurveGroupEntry ENTRY1 = CurveGroupEntry.builder()
-      .curveDefinition(CURVE_DEFN)
+      .curveName(CURVE_NAME1)
       .discountCurrencies(GBP)
       .iborIndices(GBP_LIBOR_1W)
       .overnightIndices(GBP_SONIA)
       .build();
   private static final CurveGroupEntry ENTRY2 = CurveGroupEntry.builder()
-      .curveDefinition(CURVE_CONFIG2)
+      .curveName(CURVE_NAME2)
       .iborIndices(GBP_LIBOR_1M, GBP_LIBOR_3M)
       .build();
   private static final CurveGroupEntry ENTRY3 = CurveGroupEntry.builder()
-      .curveDefinition(CURVE_DEFN)
+      .curveName(CURVE_NAME1)
       .discountCurrencies(GBP)
       .iborIndices(GBP_LIBOR_1M, GBP_LIBOR_3M)
       .build();
@@ -76,10 +79,43 @@ public class CurveGroupDefinitionTest {
   public void test_builder1() {
     CurveGroupDefinition test = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test"))
-        .addDiscountCurve(CURVE_DEFN, GBP)
-        .addForwardCurve(CURVE_DEFN, GBP_SONIA)
-        .addForwardCurve(CURVE_DEFN, GBP_LIBOR_1W)
-        .addForwardCurve(CURVE_CONFIG2, GBP_LIBOR_1M, GBP_LIBOR_3M)
+        .addDiscountCurve(CURVE_DEFN1, GBP)
+        .addForwardCurve(CURVE_DEFN1, GBP_SONIA)
+        .addForwardCurve(CURVE_DEFN1, GBP_LIBOR_1W)
+        .addForwardCurve(CURVE_DEFN2, GBP_LIBOR_1M, GBP_LIBOR_3M)
+        .build();
+    assertEquals(test.getName(), CurveGroupName.of("Test"));
+    assertEquals(test.getEntries(), ImmutableList.of(ENTRY1, ENTRY2));
+    assertEquals(test.findEntry(CurveName.of("Test")), Optional.of(ENTRY1));
+    assertEquals(test.findEntry(CurveName.of("Test2")), Optional.of(ENTRY2));
+    assertEquals(test.findEntry(CurveName.of("Rubbish")), Optional.empty());
+    assertEquals(test.findDefinition(CurveName.of("Test")), Optional.of(CURVE_DEFN1));
+    assertEquals(test.findDefinition(CurveName.of("Test2")), Optional.of(CURVE_DEFN2));
+    assertEquals(test.findDefinition(CurveName.of("Rubbish")), Optional.empty());
+  }
+
+  public void test_builder2() {
+    CurveGroupDefinition test = CurveGroupDefinition.builder()
+        .name(CurveGroupName.of("Test"))
+        .addCurve(CURVE_DEFN1, GBP, GBP_LIBOR_1M, GBP_LIBOR_3M)
+        .build();
+    assertEquals(test.getName(), CurveGroupName.of("Test"));
+    assertEquals(test.getEntries(), ImmutableList.of(ENTRY3));
+    assertEquals(test.findEntry(CurveName.of("Test")), Optional.of(ENTRY3));
+    assertEquals(test.findEntry(CurveName.of("Test2")), Optional.empty());
+    assertEquals(test.findEntry(CurveName.of("Rubbish")), Optional.empty());
+    assertEquals(test.findDefinition(CurveName.of("Test")), Optional.of(CURVE_DEFN1));
+    assertEquals(test.findDefinition(CurveName.of("Test2")), Optional.empty());
+    assertEquals(test.findDefinition(CurveName.of("Rubbish")), Optional.empty());
+  }
+
+  public void test_builder3() {
+    CurveGroupDefinition test = CurveGroupDefinition.builder()
+        .name(CurveGroupName.of("Test"))
+        .addDiscountCurve(CURVE_NAME1, GBP)
+        .addForwardCurve(CURVE_NAME1, GBP_SONIA)
+        .addForwardCurve(CURVE_NAME1, GBP_LIBOR_1W)
+        .addForwardCurve(CURVE_NAME2, GBP_LIBOR_1M, GBP_LIBOR_3M)
         .build();
     assertEquals(test.getName(), CurveGroupName.of("Test"));
     assertEquals(test.getEntries(), ImmutableList.of(ENTRY1, ENTRY2));
@@ -88,10 +124,10 @@ public class CurveGroupDefinitionTest {
     assertEquals(test.findEntry(CurveName.of("Rubbish")), Optional.empty());
   }
 
-  public void test_builder2() {
+  public void test_builder4() {
     CurveGroupDefinition test = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test"))
-        .addCurve(CURVE_DEFN, GBP, GBP_LIBOR_1M, GBP_LIBOR_3M)
+        .addCurve(CURVE_NAME1, GBP, GBP_LIBOR_1M, GBP_LIBOR_3M)
         .build();
     assertEquals(test.getName(), CurveGroupName.of("Test"));
     assertEquals(test.getEntries(), ImmutableList.of(ENTRY3));
@@ -100,11 +136,19 @@ public class CurveGroupDefinitionTest {
     assertEquals(test.findEntry(CurveName.of("Rubbish")), Optional.empty());
   }
 
+  public void test_missingEntries() {
+    assertThrowsIllegalArg(() -> CurveGroupDefinition.of(
+        CurveGroupName.of("group"),
+        ImmutableList.of(ENTRY1),
+        ImmutableList.of(CURVE_DEFN1, CURVE_DEFN2)),
+        "An entry must be provided .* \\[Test2\\]");
+  }
+
   //-------------------------------------------------------------------------
   public void test_tradesInitialGuesses() {
     CurveGroupDefinition test = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test"))
-        .addCurve(CURVE_DEFN, GBP, GBP_LIBOR_1M, GBP_LIBOR_3M)
+        .addCurve(CURVE_DEFN1, GBP, GBP_LIBOR_1M, GBP_LIBOR_3M)
         .build();
 
     MarketData marketData = MarketData.builder()
@@ -121,12 +165,12 @@ public class CurveGroupDefinitionTest {
   public void coverage() {
     CurveGroupDefinition test = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test"))
-        .addDiscountCurve(CURVE_DEFN, GBP)
+        .addDiscountCurve(CURVE_DEFN1, GBP)
         .build();
     coverImmutableBean(test);
     CurveGroupDefinition test2 = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test2"))
-        .addForwardCurve(CURVE_CONFIG2, GBP_LIBOR_1M)
+        .addForwardCurve(CURVE_DEFN2, GBP_LIBOR_1M)
         .build();
     coverBeanEquals(test, test2);
   }
@@ -134,7 +178,7 @@ public class CurveGroupDefinitionTest {
   public void test_serialization() {
     CurveGroupDefinition test = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test"))
-        .addDiscountCurve(CURVE_DEFN, GBP)
+        .addDiscountCurve(CURVE_DEFN1, GBP)
         .build();
     assertSerialization(test);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupDefinitionTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupDefinitionTest.java
@@ -89,9 +89,9 @@ public class CurveGroupDefinitionTest {
     assertEquals(test.findEntry(CurveName.of("Test")), Optional.of(ENTRY1));
     assertEquals(test.findEntry(CurveName.of("Test2")), Optional.of(ENTRY2));
     assertEquals(test.findEntry(CurveName.of("Rubbish")), Optional.empty());
-    assertEquals(test.findDefinition(CurveName.of("Test")), Optional.of(CURVE_DEFN1));
-    assertEquals(test.findDefinition(CurveName.of("Test2")), Optional.of(CURVE_DEFN2));
-    assertEquals(test.findDefinition(CurveName.of("Rubbish")), Optional.empty());
+    assertEquals(test.findCurveDefinition(CurveName.of("Test")), Optional.of(CURVE_DEFN1));
+    assertEquals(test.findCurveDefinition(CurveName.of("Test2")), Optional.of(CURVE_DEFN2));
+    assertEquals(test.findCurveDefinition(CurveName.of("Rubbish")), Optional.empty());
   }
 
   public void test_builder2() {
@@ -104,9 +104,9 @@ public class CurveGroupDefinitionTest {
     assertEquals(test.findEntry(CurveName.of("Test")), Optional.of(ENTRY3));
     assertEquals(test.findEntry(CurveName.of("Test2")), Optional.empty());
     assertEquals(test.findEntry(CurveName.of("Rubbish")), Optional.empty());
-    assertEquals(test.findDefinition(CurveName.of("Test")), Optional.of(CURVE_DEFN1));
-    assertEquals(test.findDefinition(CurveName.of("Test2")), Optional.empty());
-    assertEquals(test.findDefinition(CurveName.of("Rubbish")), Optional.empty());
+    assertEquals(test.findCurveDefinition(CurveName.of("Test")), Optional.of(CURVE_DEFN1));
+    assertEquals(test.findCurveDefinition(CurveName.of("Test2")), Optional.empty());
+    assertEquals(test.findCurveDefinition(CurveName.of("Rubbish")), Optional.empty());
   }
 
   public void test_builder3() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupEntryTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupEntryTest.java
@@ -6,7 +6,6 @@
 package com.opengamma.strata.market.curve;
 
 import static com.opengamma.strata.basics.currency.Currency.GBP;
-import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_1M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
@@ -15,18 +14,9 @@ import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.testng.Assert.assertEquals;
 
-import java.time.Period;
-
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.opengamma.strata.collect.id.StandardId;
-import com.opengamma.strata.market.ValueType;
-import com.opengamma.strata.market.curve.node.DummyFraCurveNode;
-import com.opengamma.strata.market.interpolator.CurveExtrapolators;
-import com.opengamma.strata.market.interpolator.CurveInterpolators;
-import com.opengamma.strata.market.key.QuoteKey;
 
 /**
  * Test {@link CurveGroupEntry}.
@@ -34,30 +24,17 @@ import com.opengamma.strata.market.key.QuoteKey;
 @Test
 public class CurveGroupEntryTest {
 
-  private static final InterpolatedNodalCurveDefinition CURVE_DEFN =
-      InterpolatedNodalCurveDefinition.builder()
-          .name(CurveName.of("Test"))
-          .xValueType(ValueType.YEAR_FRACTION)
-          .yValueType(ValueType.ZERO_RATE)
-          .dayCount(ACT_365F)
-          .nodes(ImmutableList.of(
-              DummyFraCurveNode.of(Period.ofMonths(1), GBP_LIBOR_1M, QuoteKey.of(StandardId.of("OG", "Ticker")))))
-          .interpolator(CurveInterpolators.LINEAR)
-          .extrapolatorLeft(CurveExtrapolators.FLAT)
-          .extrapolatorRight(CurveExtrapolators.FLAT)
-          .build();
-  private static final InterpolatedNodalCurveDefinition CURVE_DEFN2 = CURVE_DEFN.toBuilder()
-      .name(CurveName.of("Test2"))
-      .build();
+  private static final CurveName CURVE_NAME1 = CurveName.of("Test");
+  private static final CurveName CURVE_NAME2 = CurveName.of("Test2");
 
   public void test_builder() {
     CurveGroupEntry test = CurveGroupEntry.builder()
-        .curveDefinition(CURVE_DEFN)
+        .curveName(CURVE_NAME1)
         .discountCurrencies(GBP)
         .iborIndices(GBP_LIBOR_1M, GBP_LIBOR_3M)
         .overnightIndices(GBP_SONIA)
         .build();
-    assertEquals(test.getCurveDefinition(), CURVE_DEFN);
+    assertEquals(test.getCurveName(), CURVE_NAME1);
     assertEquals(test.getDiscountCurrencies(), ImmutableSet.of(GBP));
     assertEquals(test.getIborIndices(), ImmutableSet.of(GBP_LIBOR_1M, GBP_LIBOR_3M));
     assertEquals(test.getOvernightIndices(), ImmutableSet.of(GBP_SONIA));
@@ -66,12 +43,12 @@ public class CurveGroupEntryTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     CurveGroupEntry test = CurveGroupEntry.builder()
-        .curveDefinition(CURVE_DEFN)
+        .curveName(CURVE_NAME1)
         .discountCurrencies(GBP)
         .build();
     coverImmutableBean(test);
     CurveGroupEntry test2 = CurveGroupEntry.builder()
-        .curveDefinition(CURVE_DEFN2)
+        .curveName(CURVE_NAME2)
         .iborIndices(GBP_LIBOR_1M)
         .overnightIndices(GBP_SONIA)
         .build();
@@ -80,7 +57,7 @@ public class CurveGroupEntryTest {
 
   public void test_serialization() {
     CurveGroupEntry test = CurveGroupEntry.builder()
-        .curveDefinition(CURVE_DEFN)
+        .curveName(CURVE_NAME1)
         .discountCurrencies(GBP)
         .build();
     assertSerialization(test);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupTest.java
@@ -8,11 +8,16 @@ package com.opengamma.strata.market.curve;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.index.IborIndices.CHF_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_1M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_1M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_2M;
+import static com.opengamma.strata.basics.index.OvernightIndices.EUR_EONIA;
+import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
@@ -21,7 +26,6 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.Index;
-import com.opengamma.strata.collect.CollectProjectAssertions;
 
 /**
  * Test {@link CurveGroup}.
@@ -29,50 +33,80 @@ import com.opengamma.strata.collect.CollectProjectAssertions;
 @Test
 public class CurveGroupTest {
 
-  private static final CurveGroupName NAME = CurveGroupName.of("Test");
-  private static final CurveGroupName NAME2 = CurveGroupName.of("Test2");
+  private static final CurveGroupName NAME = CurveGroupName.of("TestGroup");
+  private static final CurveGroupName NAME2 = CurveGroupName.of("TestGroup2");
+  private static final CurveName DISCOUNT_NAME = CurveName.of("Discount");
+  private static final CurveName IBOR_NAME = CurveName.of("Ibor");
+  private static final CurveName OVERNIGHT_NAME = CurveName.of("Overnight");
   private static final Curve DISCOUNT_CURVE = ConstantNodalCurve.of("Discount", 0.99);
   private static final Map<Currency, Curve> DISCOUNT_CURVES = ImmutableMap.of(GBP, DISCOUNT_CURVE);
-  private static final Curve FORWARD_CURVE = ConstantNodalCurve.of("Forward", 0.5);
-  private static final Map<Index, Curve> FORWARD_CURVES = ImmutableMap.of(GBP_LIBOR_3M, FORWARD_CURVE);
+  private static final Curve IBOR_CURVE = ConstantNodalCurve.of("Ibor", 0.5);
+  private static final Curve OVERNIGHT_CURVE = ConstantNodalCurve.of("Overnight", 0.6);
+  private static final Map<Index, Curve> IBOR_CURVES = ImmutableMap.of(GBP_LIBOR_3M, IBOR_CURVE);
 
   //-------------------------------------------------------------------------
   public void test_of() {
-    CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, FORWARD_CURVES);
+    CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, IBOR_CURVES);
     assertThat(test.getName()).isEqualTo(NAME);
     assertThat(test.getDiscountCurves()).isEqualTo(DISCOUNT_CURVES);
-    assertThat(test.getForwardCurves()).isEqualTo(FORWARD_CURVES);
-    CollectProjectAssertions.assertThat(test.findDiscountCurve(GBP)).hasValue(DISCOUNT_CURVE);
-    CollectProjectAssertions.assertThat(test.findDiscountCurve(USD)).isEmpty();
-    CollectProjectAssertions.assertThat(test.findForwardCurve(GBP_LIBOR_3M)).hasValue(FORWARD_CURVE);
-    CollectProjectAssertions.assertThat(test.findForwardCurve(CHF_LIBOR_3M)).isEmpty();
+    assertThat(test.getForwardCurves()).isEqualTo(IBOR_CURVES);
+    assertThat(test.findDiscountCurve(GBP)).hasValue(DISCOUNT_CURVE);
+    assertThat(test.findDiscountCurve(USD)).isEmpty();
+    assertThat(test.findForwardCurve(GBP_LIBOR_3M)).hasValue(IBOR_CURVE);
+    assertThat(test.findForwardCurve(CHF_LIBOR_3M)).isEmpty();
   }
 
   public void test_builder() {
     CurveGroup test = CurveGroup.builder()
         .name(NAME)
         .discountCurves(DISCOUNT_CURVES)
-        .forwardCurves(FORWARD_CURVES)
+        .forwardCurves(IBOR_CURVES)
         .build();
     assertThat(test.getName()).isEqualTo(NAME);
     assertThat(test.getDiscountCurves()).isEqualTo(DISCOUNT_CURVES);
-    assertThat(test.getForwardCurves()).isEqualTo(FORWARD_CURVES);
-    CollectProjectAssertions.assertThat(test.findDiscountCurve(GBP)).hasValue(DISCOUNT_CURVE);
-    CollectProjectAssertions.assertThat(test.findDiscountCurve(USD)).isEmpty();
-    CollectProjectAssertions.assertThat(test.findForwardCurve(GBP_LIBOR_3M)).hasValue(FORWARD_CURVE);
-    CollectProjectAssertions.assertThat(test.findForwardCurve(CHF_LIBOR_3M)).isEmpty();
+    assertThat(test.getForwardCurves()).isEqualTo(IBOR_CURVES);
+    assertThat(test.findDiscountCurve(GBP)).hasValue(DISCOUNT_CURVE);
+    assertThat(test.findDiscountCurve(USD)).isEmpty();
+    assertThat(test.findForwardCurve(GBP_LIBOR_3M)).hasValue(IBOR_CURVE);
+    assertThat(test.findForwardCurve(CHF_LIBOR_3M)).isEmpty();
+  }
+
+  public void test_ofCurves() {
+    CurveGroupDefinition definition = CurveGroupDefinition.builder()
+        .name(CurveGroupName.of("group"))
+        .addCurve(DISCOUNT_NAME, GBP, GBP_LIBOR_1M)
+        .addForwardCurve(IBOR_NAME, USD_LIBOR_1M, USD_LIBOR_2M)
+        .addForwardCurve(OVERNIGHT_NAME, EUR_EONIA)
+        .build();
+    CurveGroup group = CurveGroup.ofCurves(definition, DISCOUNT_CURVE, OVERNIGHT_CURVE, IBOR_CURVE);
+    assertThat(group.findDiscountCurve(GBP)).hasValue(DISCOUNT_CURVE);
+    assertThat(group.findForwardCurve(USD_LIBOR_1M)).hasValue(IBOR_CURVE);
+    assertThat(group.findForwardCurve(USD_LIBOR_2M)).hasValue(IBOR_CURVE);
+    assertThat(group.findForwardCurve(EUR_EONIA)).hasValue(OVERNIGHT_CURVE);
+  }
+
+  public void test_ofCurves_missingCurve() {
+    CurveGroupDefinition definition = CurveGroupDefinition.builder()
+        .name(CurveGroupName.of("group"))
+        .addCurve(DISCOUNT_NAME, GBP, GBP_LIBOR_1M)
+        .addForwardCurve(IBOR_NAME, USD_LIBOR_1M, USD_LIBOR_2M)
+        .addForwardCurve(OVERNIGHT_NAME, EUR_EONIA)
+        .build();
+    assertThrowsIllegalArg(
+        () -> CurveGroup.ofCurves(definition, DISCOUNT_CURVE, IBOR_CURVE),
+        "No curve found named 'Overnight' when building curve group 'group'");
   }
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, FORWARD_CURVES);
+    CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, IBOR_CURVES);
     coverImmutableBean(test);
     CurveGroup test2 = CurveGroup.of(NAME2, ImmutableMap.of(), ImmutableMap.of());
     coverBeanEquals(test, test2);
   }
 
   public void test_serialization() {
-    CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, FORWARD_CURVES);
+    CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, IBOR_CURVES);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/ImmutableRatesProviderGenerator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/ImmutableRatesProviderGenerator.java
@@ -74,13 +74,16 @@ public class ImmutableRatesProviderGenerator
     List<NodalCurveDefinition> curveDefns = new ArrayList<>();
     SetMultimap<CurveName, Currency> discountNames = HashMultimap.create();
     SetMultimap<CurveName, Index> indexNames = HashMultimap.create();
-    for (CurveGroupEntry entry : groupDefn.getEntries()) {
-      NodalCurveDefinition curveDefn = entry.getCurveDefinition();
+
+    for (NodalCurveDefinition curveDefn : groupDefn.getCurveDefinitions()) {
       curveDefns.add(curveDefn);
+      CurveName curveName = curveDefn.getName();
+      // A curve group is guaranteed to include an entry for every definition
+      CurveGroupEntry entry = groupDefn.findEntry(curveName).get();
       Set<Currency> ccy = entry.getDiscountCurrencies();
-      discountNames.putAll(curveDefn.getName(), ccy);
-      indexNames.putAll(curveDefn.getName(), entry.getIborIndices());
-      indexNames.putAll(curveDefn.getName(), entry.getOvernightIndices());
+      discountNames.putAll(curveName, ccy);
+      indexNames.putAll(curveName, entry.getIborIndices());
+      indexNames.putAll(curveName, entry.getOvernightIndices());
     }
     return new ImmutableRatesProviderGenerator(knownProvider, curveDefns, discountNames, indexNames);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/StandardCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/StandardCurveCalibrator.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.pricer.calibration;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -19,7 +21,6 @@ import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
-import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.CurveNode;
 import com.opengamma.strata.market.curve.CurveParameterSize;
@@ -159,11 +160,7 @@ final class StandardCurveCalibrator implements CurveCalibrator {
 
   // converts a definition to the curve order list
   private static ImmutableList<CurveParameterSize> toOrder(CurveGroupDefinition groupDefn) {
-    ImmutableList.Builder<CurveParameterSize> builder = ImmutableList.builder();
-    for (CurveGroupEntry entry : groupDefn.getEntries()) {
-      builder.add(entry.getCurveDefinition().toCurveParameterSize());
-    }
-    return builder.build();
+    return groupDefn.getCurveDefinitions().stream().map(def -> def.toCurveParameterSize()).collect(toImmutableList());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationDiscountingSimpleEur3Test.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationDiscountingSimpleEur3Test.java
@@ -25,8 +25,8 @@ import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
 import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivity;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
-import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveNode;
+import com.opengamma.strata.market.curve.NodalCurveDefinition;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.deposit.DiscountingIborFixingDepositProductPricer;
 import com.opengamma.strata.pricer.fra.DiscountingFraProductPricer;
@@ -115,9 +115,9 @@ public class CalibrationDiscountingSimpleEur3Test {
     CurveGroupDefinition config = CalibrationEurStandard.config(DSC_OIS_TENORS, dscIdValues,
         FWD3_FRA_TENORS, FWD3_IRS_TENORS, fwd3IdValue, FWD6_FRA_TENORS, FWD6_IRS_TENORS, fwd6IdValue);
 
-    ImmutableList<CurveGroupEntry> entries = config.getEntries();
+    ImmutableList<NodalCurveDefinition> definitions = config.getCurveDefinitions();
     // Test PV Dsc
-    ImmutableList<CurveNode> dscNodes = entries.get(0).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> dscNodes = definitions.get(0).getNodes();
     List<Trade> dscTrades = new ArrayList<>();
     for (int i = 0; i < dscNodes.size(); i++) {
       dscTrades.add(dscNodes.get(i).trade(VAL_DATE, allQuotes));
@@ -129,7 +129,7 @@ public class CalibrationDiscountingSimpleEur3Test {
       assertEquals(pvIrs.getAmount(EUR).getAmount(), 0.0, TOLERANCE_PV);
     }
     // Test PV Fwd3
-    ImmutableList<CurveNode> fwd3Nodes = entries.get(1).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> fwd3Nodes = definitions.get(1).getNodes();
     List<Trade> fwd3Trades = new ArrayList<>();
     for (int i = 0; i < fwd3Nodes.size(); i++) {
       fwd3Trades.add(fwd3Nodes.get(i).trade(VAL_DATE, allQuotes));
@@ -147,7 +147,7 @@ public class CalibrationDiscountingSimpleEur3Test {
       assertEquals(pvIrs.getAmount(EUR).getAmount(), 0.0, TOLERANCE_PV);
     }
     // Test PV Fwd6
-    ImmutableList<CurveNode> fwd6Nodes = entries.get(2).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> fwd6Nodes = definitions.get(2).getNodes();
     List<Trade> fwd6Trades = new ArrayList<>();
     for (int i = 0; i < fwd6Nodes.size(); i++) {
       fwd6Trades.add(fwd6Nodes.get(i).trade(VAL_DATE, allQuotes));
@@ -191,9 +191,9 @@ public class CalibrationDiscountingSimpleEur3Test {
     CurveGroupDefinition config = CalibrationEurStandard.config(DSC_OIS_TENORS, dscIdValues,
         FWD3_FRA_TENORS, FWD3_IRS_TENORS, fwd3IdValue, FWD6_FRA_TENORS, FWD6_IRS_TENORS, fwd6IdValue);
 
-    ImmutableList<CurveGroupEntry> entries = config.getEntries();
-    // Test PV Dsc
-    ImmutableList<CurveNode> dscNodes = entries.get(0).getCurveDefinition().getNodes();
+    ImmutableList<NodalCurveDefinition> definitions = config.getCurveDefinitions();
+// Test PV Dsc
+    ImmutableList<CurveNode> dscNodes = definitions.get(0).getNodes();
     List<Trade> dscTrades = new ArrayList<>();
     for (int i = 0; i < dscNodes.size(); i++) {
       dscTrades.add(dscNodes.get(i).trade(VAL_DATE, allQuotes));
@@ -215,7 +215,7 @@ public class CalibrationDiscountingSimpleEur3Test {
       }
     }
     // Test PV Fwd3
-    ImmutableList<CurveNode> fwd3Nodes = entries.get(1).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> fwd3Nodes = definitions.get(1).getNodes();
     List<Trade> fwd3Trades = new ArrayList<>();
     for (int i = 0; i < fwd3Nodes.size(); i++) {
       fwd3Trades.add(fwd3Nodes.get(i).trade(VAL_DATE, allQuotes));
@@ -251,7 +251,7 @@ public class CalibrationDiscountingSimpleEur3Test {
       }
     }
     // Test PV Fwd6
-    ImmutableList<CurveNode> fwd6Nodes = entries.get(2).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> fwd6Nodes = definitions.get(2).getNodes();
     List<Trade> fwd6Trades = new ArrayList<>();
     for (int i = 0; i < fwd6Nodes.size(); i++) {
       fwd6Trades.add(fwd6Nodes.get(i).trade(VAL_DATE, allQuotes));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationDiscountingSimpleEurStdTenorsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationDiscountingSimpleEurStdTenorsTest.java
@@ -36,11 +36,11 @@ import com.opengamma.strata.collect.id.StandardId;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
-import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.CurveNode;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurveDefinition;
+import com.opengamma.strata.market.curve.NodalCurveDefinition;
 import com.opengamma.strata.market.curve.node.FixedIborSwapCurveNode;
 import com.opengamma.strata.market.curve.node.FixedOvernightSwapCurveNode;
 import com.opengamma.strata.market.interpolator.CurveExtrapolator;
@@ -217,9 +217,9 @@ public class CalibrationDiscountingSimpleEurStdTenorsTest {
     ImmutableRatesProvider result =
         CALIBRATOR.calibrate(CURVE_GROUP_CONFIG, VAL_DATE, ALL_QUOTES, TS);
 
-    ImmutableList<CurveGroupEntry> entries = CURVE_GROUP_CONFIG.getEntries();
+    ImmutableList<NodalCurveDefinition> definitions = CURVE_GROUP_CONFIG.getCurveDefinitions();
     // Test PV Dsc
-    ImmutableList<CurveNode> dscNodes = entries.get(0).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> dscNodes = definitions.get(0).getNodes();
     List<Trade> dscTrades = new ArrayList<>();
     for (int i = 0; i < dscNodes.size(); i++) {
       dscTrades.add(dscNodes.get(i).trade(VAL_DATE, ALL_QUOTES));
@@ -231,7 +231,7 @@ public class CalibrationDiscountingSimpleEurStdTenorsTest {
       assertEquals(pvIrs.getAmount(EUR).getAmount(), 0.0, TOLERANCE_PV);
     }
     // Test PV Fwd3
-    ImmutableList<CurveNode> fwd3Nodes = entries.get(1).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> fwd3Nodes = definitions.get(1).getNodes();
     List<Trade> fwd3Trades = new ArrayList<>();
     for (int i = 0; i < fwd3Nodes.size(); i++) {
       fwd3Trades.add(fwd3Nodes.get(i).trade(VAL_DATE, ALL_QUOTES));
@@ -243,7 +243,7 @@ public class CalibrationDiscountingSimpleEurStdTenorsTest {
       assertEquals(pvIrs.getAmount(EUR).getAmount(), 0.0, TOLERANCE_PV);
     }
     // Test PV Fwd6
-    ImmutableList<CurveNode> fwd6Nodes = entries.get(2).getCurveDefinition().getNodes();
+    ImmutableList<CurveNode> fwd6Nodes = definitions.get(2).getNodes();
     List<Trade> fwd6Trades = new ArrayList<>();
     for (int i = 0; i < fwd6Nodes.size(); i++) {
       fwd6Trades.add(fwd6Nodes.get(i).trade(VAL_DATE, ALL_QUOTES));


### PR DESCRIPTION
Remove `NodalCurveDefinition` from `CurveGroupEntry` and add a map of curve definitions to `CurveGroupDefinition`. This has the effect of making curve definitions optional and allows curve group definitions to be used with curves that are created outside Strata.