### PR TITLE
Improve performance of linear interpolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ cache:
 install:
   - mvn --version
 script:
-  - mvn install -e -B -T 2 -Dstrict
+  - mvn install -e -B -Dstrict
   - rm -rf $HOME/.m2/repository/com/opengamma/strata

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1D.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1D.java
@@ -14,10 +14,8 @@ import org.joda.beans.MetaBean;
 import org.joda.beans.Property;
 import org.joda.beans.impl.light.LightMetaBean;
 
-import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.math.impl.MathException;
 import com.opengamma.strata.math.impl.interpolation.data.ArrayInterpolator1DDataBundle;
-import com.opengamma.strata.math.impl.interpolation.data.InterpolationBoundedValues;
 import com.opengamma.strata.math.impl.interpolation.data.Interpolator1DDataBundle;
 
 /**
@@ -34,56 +32,51 @@ public final class LinearInterpolator1D
 
   @Override
   public double interpolate(Interpolator1DDataBundle data, double value) {
-    JodaBeanUtils.notNull(data, "data");
-    InterpolationBoundedValues boundedValues = data.getBoundedValues(value);
-    double x1 = boundedValues.getLowerBoundKey();
-    double y1 = boundedValues.getLowerBoundValue();
-    if (data.getLowerBoundIndex(value) == data.size() - 1) {
+    int lowerIndex = data.getLowerBoundIndex(value);
+    double y1 = data.getValue(lowerIndex);
+    if (lowerIndex == data.size() - 1) {
       return y1;
     }
-    double x2 = boundedValues.getHigherBoundKey();
-    double y2 = boundedValues.getHigherBoundValue();
+    double x1 = data.getKey(lowerIndex);
+    double x2 = data.getKey(lowerIndex + 1);
+    double y2 = data.getValue(lowerIndex + 1);
     return y1 + (value - x1) / (x2 - x1) * (y2 - y1);
   }
 
   @Override
   public double firstDerivative(Interpolator1DDataBundle data, double value) {
-    JodaBeanUtils.notNull(data, "data");
-    InterpolationBoundedValues boundedValues = data.getBoundedValues(value);
-    double x1 = boundedValues.getLowerBoundKey();
-    double y1 = boundedValues.getLowerBoundValue();
-    if (data.getLowerBoundIndex(value) == data.size() - 1) {
-      if (value > data.lastKey()) {
-        throw new MathException("Value of " + value + " after last key. Use exstrapolator");
+    int lowerIndex = data.getLowerBoundIndex(value);
+    if (lowerIndex == data.size() - 1) {
+      if (data.size() == 1) {
+        return 0d;
       }
-      double[] x = data.getKeys();
-      double[] y = data.getValues();
-      int n = x.length;
-      return n == 1 ? 0.0 : (y[n - 1] - y[n - 2]) / (x[n - 1] - x[n - 2]);
+      if (value > data.lastKey()) {
+        throw new MathException("Value of " + value + " after last key. Use extrapolator");
+      }
+      lowerIndex--;
     }
-    double x2 = boundedValues.getHigherBoundKey();
-    double y2 = boundedValues.getHigherBoundValue();
+    double x1 = data.getKey(lowerIndex);
+    double y1 = data.getValue(lowerIndex);
+    double x2 = data.getKey(lowerIndex + 1);
+    double y2 = data.getValue(lowerIndex + 1);
     return (y2 - y1) / (x2 - x1);
   }
 
   @Override
   public double[] getNodeSensitivitiesForValue(Interpolator1DDataBundle data, double value) {
-    ArgChecker.notNull(data, "data");
-    int n = data.size();
-    double[] result = new double[n];
-    InterpolationBoundedValues boundedValues = data.getBoundedValues(value);
-    if (boundedValues.getHigherBoundKey() == null) {
-      result[n - 1] = 1.0;
+    int size = data.size();
+    double[] result = new double[size];
+    int lowerIndex = data.getLowerBoundIndex(value);
+    if (lowerIndex == size - 1) {
+      result[size - 1] = 1d;
       return result;
     }
-    int index = data.getLowerBoundIndex(value);
-    double x1 = boundedValues.getLowerBoundKey();
-    double x2 = boundedValues.getHigherBoundKey();
+    double x1 = data.getKey(lowerIndex);
+    double x2 = data.getKey(lowerIndex + 1);
     double dx = x2 - x1;
     double a = (x2 - value) / dx;
-    double b = 1 - a;
-    result[index] = a;
-    result[index + 1] = b;
+    result[lowerIndex] = a;
+    result[lowerIndex + 1] = 1 - a;
     return result;
   }
 

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1D.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1D.java
@@ -14,7 +14,6 @@ import org.joda.beans.MetaBean;
 import org.joda.beans.Property;
 import org.joda.beans.impl.light.LightMetaBean;
 
-import com.opengamma.strata.math.impl.MathException;
 import com.opengamma.strata.math.impl.interpolation.data.ArrayInterpolator1DDataBundle;
 import com.opengamma.strata.math.impl.interpolation.data.Interpolator1DDataBundle;
 
@@ -34,7 +33,9 @@ public final class LinearInterpolator1D
   public double interpolate(Interpolator1DDataBundle data, double value) {
     int lowerIndex = data.getLowerBoundIndex(value);
     double y1 = data.getValue(lowerIndex);
+    // check if x-value is at or beyond the last node
     if (lowerIndex == data.size() - 1) {
+      // return the value of the last node (flat extrapolation)
       return y1;
     }
     double x1 = data.getKey(lowerIndex);
@@ -46,13 +47,13 @@ public final class LinearInterpolator1D
   @Override
   public double firstDerivative(Interpolator1DDataBundle data, double value) {
     int lowerIndex = data.getLowerBoundIndex(value);
+    // check if x-value is at or beyond the last node
     if (lowerIndex == data.size() - 1) {
-      if (data.size() == 1) {
+      // return zero to match flat extrapolation in interpolate()
+      if (value > data.lastKey()) {
         return 0d;
       }
-      if (value > data.lastKey()) {
-        throw new MathException("Value of " + value + " after last key. Use extrapolator");
-      }
+      // if value is at last node, calculate the gradient from the previous interval
       lowerIndex--;
     }
     double x1 = data.getKey(lowerIndex);
@@ -67,7 +68,9 @@ public final class LinearInterpolator1D
     int size = data.size();
     double[] result = new double[size];
     int lowerIndex = data.getLowerBoundIndex(value);
+    // check if x-value is at or beyond the last node
     if (lowerIndex == size - 1) {
+      // sensitivity is entirely to the last node
       result[size - 1] = 1d;
       return result;
     }

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/StepUpperInterpolator1D.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/StepUpperInterpolator1D.java
@@ -22,7 +22,7 @@ public class StepUpperInterpolator1D extends Interpolator1D {
     // For x equal to a key
     int index = data.indexOf(x);
     if (index >= 0) {
-      return data.getIndex(index);
+      return data.getValue(index);
     }
     // For intermediary values, return the higher key value.
     return data.higherValue(x);

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/ArrayInterpolator1DDataBundle.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/ArrayInterpolator1DDataBundle.java
@@ -106,7 +106,12 @@ public class ArrayInterpolator1DDataBundle implements Interpolator1DDataBundle {
   }
 
   @Override
-  public double getIndex(int index) {
+  public double getKey(int index) {
+    return _keys[index];
+  }
+
+  @Override
+  public double getValue(int index) {
     return _values[index];
   }
 
@@ -132,7 +137,7 @@ public class ArrayInterpolator1DDataBundle implements Interpolator1DDataBundle {
     }
     if (value > _keys[_n - 1]) {
       throw new IllegalArgumentException("Could not get lower bound index for " + value + ": highest x-value is "
-          + _keys[_keys.length - 1]);
+          + _keys[_n - 1]);
     }
     int index = indexOf(value);
     if (index >= 0) {
@@ -200,7 +205,7 @@ public class ArrayInterpolator1DDataBundle implements Interpolator1DDataBundle {
 
   @Override
   public int size() {
-    return _keys.length;
+    return _n;
   }
 
   @Override

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/ForwardingInterpolator1DDataBundle.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/ForwardingInterpolator1DDataBundle.java
@@ -45,8 +45,13 @@ abstract class ForwardingInterpolator1DDataBundle
   }
 
   @Override
-  public double getIndex(int index) {
-    return underlying.getIndex(index);
+  public double getKey(int index) {
+    return underlying.getKey(index);
+  }
+
+  @Override
+  public double getValue(int index) {
+    return underlying.getValue(index);
   }
 
   @Override

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DDataBundle.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DDataBundle.java
@@ -22,7 +22,9 @@ public interface Interpolator1DDataBundle {
 
   int indexOf(double key);
 
-  double getIndex(int index);
+  double getKey(int index);
+
+  double getValue(int index);
 
   double firstKey();
 

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DLogPiecewisePoynomialDataBundle.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DLogPiecewisePoynomialDataBundle.java
@@ -57,8 +57,8 @@ public class Interpolator1DLogPiecewisePoynomialDataBundle extends Interpolator1
   }
 
   @Override
-  public double getIndex(int index) {
-    return Math.exp(super.getIndex(index));
+  public double getValue(int index) {
+    return Math.exp(super.getValue(index));
   }
 
   @Override

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1DNodeSensitivityCalculatorTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1DNodeSensitivityCalculatorTest.java
@@ -41,11 +41,6 @@ public class LinearInterpolator1DNodeSensitivityCalculatorTest {
     DATA = INTERPOLATOR.getDataBundleFromSortedArrays(x, y);
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testNullData() {
-    INTERPOLATOR.getNodeSensitivitiesForValue(null, 1.);
-  }
-
   @Test
   public void test() {
     double[] result = INTERPOLATOR.getNodeSensitivitiesForValue(DATA, 3.4);

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1DTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator1DTest.java
@@ -31,11 +31,6 @@ public class LinearInterpolator1DTest {
   private static final Interpolator1DDataBundle MODEL = INTERPOLATOR.getDataBundle(new double[] {1, 2, 3 }, new double[] {4, 5, 6 });
 
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testNullDataBundle() {
-    INTERPOLATOR.interpolate(null, 2.3);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
   public void testLowValue() {
     INTERPOLATOR.interpolate(MODEL, -4.);
   }

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DCubicSplineDataBundleTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DCubicSplineDataBundleTest.java
@@ -68,7 +68,7 @@ public class Interpolator1DCubicSplineDataBundleTest {
     assertFalse(DATA.containsKey(3.4));
     assertEquals(DATA.firstKey(), 2., EPS);
     assertEquals(DATA.firstValue(), CUBIC.applyAsDouble(2.), EPS);
-    assertEquals(DATA.getIndex(DATA.indexOf(4.)), CUBIC.applyAsDouble(4.), EPS);
+    assertEquals(DATA.getValue(DATA.indexOf(4.)), CUBIC.applyAsDouble(4.), EPS);
     assertArrayEquals(DATA.getKeys(), X, 0);
     assertEquals(DATA.getLowerBoundIndex(7.), 2);
     assertEquals(DATA.getLowerBoundKey(7.), 6, EPS);

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DDataBundleTestCase.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DDataBundleTestCase.java
@@ -90,10 +90,10 @@ public abstract class Interpolator1DDataBundleTestCase {
 
   @Test
   public void lowerBoundValues() {
-    assertEquals(10, DATA.getIndex(DATA.indexOf(DATA.getLowerBoundKey(1.5))), EPS);
-    assertEquals(10, DATA.getIndex(DATA.indexOf(DATA.getLowerBoundKey(1.))), EPS);
-    assertEquals(40, DATA.getIndex(DATA.indexOf(DATA.getLowerBoundKey(4.))), EPS);
-    assertEquals(50, DATA.getIndex(DATA.indexOf(DATA.getLowerBoundKey(5.))), EPS);
+    assertEquals(10, DATA.getValue(DATA.indexOf(DATA.getLowerBoundKey(1.5))), EPS);
+    assertEquals(10, DATA.getValue(DATA.indexOf(DATA.getLowerBoundKey(1.))), EPS);
+    assertEquals(40, DATA.getValue(DATA.indexOf(DATA.getLowerBoundKey(4.))), EPS);
+    assertEquals(50, DATA.getValue(DATA.indexOf(DATA.getLowerBoundKey(5.))), EPS);
   }
 
   @Test
@@ -122,13 +122,13 @@ public abstract class Interpolator1DDataBundleTestCase {
 
   @Test
   public void pointLookup() {
-    assertEquals(10., DATA.getIndex(DATA.indexOf(1.)), EPS);
-    assertEquals(20., DATA.getIndex(DATA.indexOf(2.)), EPS);
-    assertEquals(30., DATA.getIndex(DATA.indexOf(3.)), EPS);
-    assertEquals(40., DATA.getIndex(DATA.indexOf(4.)), EPS);
-    assertEquals(50., DATA.getIndex(DATA.indexOf(5.)), EPS);
-    assertThrows(() -> DATA.getIndex(-1), IndexOutOfBoundsException.class);
-    assertThrows(() -> DATA.getIndex(6), IndexOutOfBoundsException.class);
+    assertEquals(10., DATA.getValue(DATA.indexOf(1.)), EPS);
+    assertEquals(20., DATA.getValue(DATA.indexOf(2.)), EPS);
+    assertEquals(30., DATA.getValue(DATA.indexOf(3.)), EPS);
+    assertEquals(40., DATA.getValue(DATA.indexOf(4.)), EPS);
+    assertEquals(50., DATA.getValue(DATA.indexOf(5.)), EPS);
+    assertThrows(() -> DATA.getValue(-1), IndexOutOfBoundsException.class);
+    assertThrows(() -> DATA.getValue(6), IndexOutOfBoundsException.class);
   }
 
   @Test

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DDoubleQuadraticDataBundleTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/data/Interpolator1DDoubleQuadraticDataBundleTest.java
@@ -59,7 +59,7 @@ public class Interpolator1DDoubleQuadraticDataBundleTest {
     assertFalse(DATA.containsKey(2.));
     assertEquals(DATA.firstKey(), 0., EPS);
     assertEquals(DATA.firstValue(), QUADRATIC.applyAsDouble(0.), EPS);
-    assertEquals(DATA.getIndex(DATA.indexOf(6.)), QUADRATIC.applyAsDouble(6.), EPS);
+    assertEquals(DATA.getValue(DATA.indexOf(6.)), QUADRATIC.applyAsDouble(6.), EPS);
     assertArrayEquals(DATA.getKeys(), X, 0);
     assertEquals(DATA.getLowerBoundIndex(11.), 3);
     assertEquals(DATA.getLowerBoundKey(7.), 6, EPS);


### PR DESCRIPTION
Rename getIndex() to getValue() and add getKey()
Avoid InterpolationBoundedValues object construction