### PR TITLE
Allow duplicate curve names in CurveGroup.ofCurves

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
@@ -126,10 +126,9 @@ public final class RatesCurvesCsvLoader {
 
     // Ensure curve names are unique
     for (Curve curve : curves) {
-      if (curveNames.contains(curve.getName())) {
+      if (!curveNames.add(curve.getName())) {
         throw new IllegalArgumentException("Multiple curves with the same name: " + curve.getName());
       }
-      curveNames.add(curve.getName());
     }
     return curveGroups.stream().map(groupDef -> CurveGroup.ofCurves(groupDef, curves)).collect(toImmutableList());
   }

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
@@ -12,9 +12,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -120,6 +122,15 @@ public final class RatesCurvesCsvLoader {
     List<CurveGroupDefinition> curveGroups = CurveGroupDefinitionCsvLoader.loadCurveGroups(groupsResource);
     Multimap<LocalDate, Curve> allCurves = loadCurves(settingsResource, curvesResources, marketDataDate);
     Collection<Curve> curves = allCurves.get(marketDataDate);
+    Set<CurveName> curveNames = new HashSet<>();
+
+    // Ensure curve names are unique
+    for (Curve curve : curves) {
+      if (curveNames.contains(curve.getName())) {
+        throw new IllegalArgumentException("Multiple curves with the same name: " + curve.getName());
+      }
+      curveNames.add(curve.getName());
+    }
     return curveGroups.stream().map(groupDef -> CurveGroup.ofCurves(groupDef, curves)).collect(toImmutableList());
   }
 

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoaderTest.java
@@ -171,7 +171,7 @@ public class RatesCurvesCsvLoaderTest {
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class,
-      expectedExceptionsMessageRegExp = "Multiple entries with same key: .*")
+      expectedExceptionsMessageRegExp = "Multiple curves with the same name: .*")
   public void test_single_curve_multiple_Files() {
     RatesCurvesCsvLoader.load(
         CURVE_DATE,

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
@@ -83,7 +83,10 @@ public final class CurveGroup
    * If there are curves named in the definition which are not present in the curves the group is built using
    * whatever curves are available.
    * <p>
-   * If there are multiple curves with the same name in the curves it is undefined which one is used.
+   * If there are multiple curves with the same name in the curves one of them is arbitrarily chosen.
+   * <p>
+   * Multiple curves with the same name are allowed to support the use case where the list contains the same
+   * curve multiple times. This means the caller doesn't have to filter the input curves to remove duplicates.
    *
    * @param curveGroupDefinition  the definition of a curve group
    * @param curves  some curves
@@ -99,7 +102,10 @@ public final class CurveGroup
    * If there are curves named in the definition which are not present in the curves the group is built using
    * whatever curves are available.
    * <p>
-   * If there are multiple curves with the same name in the curves it is undefined which one is used.
+   * If there are multiple curves with the same name in the curves one of them is arbitrarily chosen.
+   * <p>
+   * Multiple curves with the same name are allowed to support the use case where the list contains the same
+   * curve multiple times. This means the caller doesn't have to filter the input curves to remove duplicates.
    *
    * @param curveGroupDefinition  the definition of a curve group
    * @param curves  some curves

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroup.java
@@ -5,7 +5,7 @@
  */
 package com.opengamma.strata.market.curve;
 
-import static com.opengamma.strata.collect.Guavate.toImmutableMap;
+import static java.util.stream.Collectors.toMap;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -80,7 +80,10 @@ public final class CurveGroup
   /**
    * Creates a curve group using a curve group definition and some existing curves.
    * <p>
-   * The curves must include all curves named in the curve group definition.
+   * If there are curves named in the definition which are not present in the curves the group is built using
+   * whatever curves are available.
+   * <p>
+   * If there are multiple curves with the same name in the curves it is undefined which one is used.
    *
    * @param curveGroupDefinition  the definition of a curve group
    * @param curves  some curves
@@ -95,6 +98,8 @@ public final class CurveGroup
    * <p>
    * If there are curves named in the definition which are not present in the curves the group is built using
    * whatever curves are available.
+   * <p>
+   * If there are multiple curves with the same name in the curves it is undefined which one is used.
    *
    * @param curveGroupDefinition  the definition of a curve group
    * @param curves  some curves
@@ -103,9 +108,8 @@ public final class CurveGroup
   public static CurveGroup ofCurves(CurveGroupDefinition curveGroupDefinition, Collection<? extends Curve> curves) {
     Map<Currency, Curve> discountCurves = new HashMap<>();
     Map<Index, Curve> forwardCurves = new HashMap<>();
-    // The immutable curve builder in toImmutableMap ensures the same curve doesn't appear twice
-    Map<CurveName, Curve> curveMap =
-        curves.stream().collect(toImmutableMap(curve -> curve.getMetadata().getCurveName(), curve -> curve));
+    Map<CurveName, Curve> curveMap = curves.stream()
+        .collect(toMap(curve -> curve.getMetadata().getCurveName(), curve -> curve, (curve1, curve2) -> curve1));
 
     for (CurveGroupEntry entry : curveGroupDefinition.getEntries()) {
       CurveName curveName = entry.getCurveName();

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupTest.java
@@ -84,6 +84,16 @@ public class CurveGroupTest {
     assertThat(group.findForwardCurve(EUR_EONIA)).hasValue(OVERNIGHT_CURVE);
   }
 
+  public void test_ofCurves_duplicateCurveName() {
+    CurveGroupDefinition definition = CurveGroupDefinition.builder()
+        .name(CurveGroupName.of("group"))
+        .addForwardCurve(IBOR_NAME, USD_LIBOR_1M, USD_LIBOR_2M)
+        .build();
+    CurveGroup group = CurveGroup.ofCurves(definition, IBOR_CURVE, IBOR_CURVE);
+    assertThat(group.findForwardCurve(USD_LIBOR_1M)).hasValue(IBOR_CURVE);
+    assertThat(group.findForwardCurve(USD_LIBOR_2M)).hasValue(IBOR_CURVE);
+  }
+
   //-------------------------------------------------------------------------
   public void coverage() {
     CurveGroup test = CurveGroup.of(NAME, DISCOUNT_CURVES, IBOR_CURVES);


### PR DESCRIPTION
This change allows `CurveGroup.ofCurves` to accept a list of curves which contains duplicates. Previously an exception was thrown if there were multiple curves in the list with the same name.

It turns out a common use case for this method is passing in a list created from the curves in another curve group. If the same curve is used for discounting and a rates index it can appear twice in the list.