### PR TITLE
Added implied normal volatility from present value for swaptions.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricer.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.pricer.swaption;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.function.Function;
@@ -14,12 +15,14 @@ import com.opengamma.strata.basics.PayReceive;
 import com.opengamma.strata.basics.PutCall;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
+import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.value.ValueDerivatives;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.sensitivity.SwaptionSensitivity;
 import com.opengamma.strata.pricer.impl.option.EuropeanVanillaOption;
 import com.opengamma.strata.pricer.impl.option.NormalFunctionData;
+import com.opengamma.strata.pricer.impl.option.NormalImpliedVolatilityFormula;
 import com.opengamma.strata.pricer.impl.option.NormalPriceFunction;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
@@ -60,6 +63,8 @@ public class NormalSwaptionPhysicalProductPricer {
    * Normal model pricing function. 
    */
   public static final NormalPriceFunction NORMAL = new NormalPriceFunction();
+  /** The formula to infer the normal implied volatility from a price/present value. */
+  private static final NormalImpliedVolatilityFormula FORMULA_IMPLIED = NormalImpliedVolatilityFormula.DEFAULT;
 
   /**
    * Creates an instance.
@@ -153,6 +158,44 @@ public class NormalSwaptionPhysicalProductPricer {
     double strike = swapPricer.getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     double tenor = volatilityProvider.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
     return volatilityProvider.getVolatility(expiryDateTime, tenor, strike, forward);
+  }
+
+  /**
+   * Computes the implied normal volatility from the present value of a swaption.
+   * <p>
+   * The guess volatility for the start of the root-finding process is 1%.
+   * 
+   * @param swaption  the product to price
+   * @param ratesProvider  the rates provider
+   * @param dayCount  the day-count used to estimate the time between valuation date and swaption expiry
+   * @param presentValue  the present value of the swaption product
+   * @return the implied volatility associated to the present value
+   */
+  public double impliedVolatilityFromPresentValue(
+      SwaptionProduct swaption,
+      RatesProvider ratesProvider,
+      DayCount dayCount,
+      double presentValue) {
+
+    ExpandedSwaption expanded = swaption.expand();
+    double sign = expanded.getLongShort() == LongShort.LONG ? 1.0d : -1.0;
+    ArgChecker.isTrue(presentValue * sign > 0, "present value sign must be in ligne with the option Long/Short flag ");
+    validateSwaption(ratesProvider, expanded);
+    LocalDate valuationDate = ratesProvider.getValuationDate();
+    LocalDate expiryDate = expanded.getExpiryDate();
+    ArgChecker.isTrue(expiryDate.isAfter(valuationDate),
+        "expiry should be after valuation date to compute an implied volatility");
+    double expiry = dayCount.yearFraction(valuationDate, expiryDate);
+    ExpandedSwap underlying = expanded.getUnderlying();
+    ExpandedSwapLeg fixedLeg = fixedLeg(underlying);
+    double forward = swapPricer.parRate(underlying, ratesProvider);
+    double pvbp = swapPricer.getLegPricer().pvbp(fixedLeg, ratesProvider);
+    double strike = swapPricer.getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
+    NormalFunctionData normalData = NormalFunctionData.of(forward, Math.abs(pvbp), 0.01);
+    boolean isCall = (fixedLeg.getPayReceive() == PayReceive.PAY);
+    // Payer at strike is exercise when rate > strike, i.e. call on rate
+    EuropeanVanillaOption option = EuropeanVanillaOption.of(strike, expiry, isCall ? PutCall.CALL : PutCall.PUT);
+    return FORMULA_IMPLIED.impliedVolatility(normalData, option, Math.abs(presentValue));
   }
 
   //-------------------------------------------------------------------------
@@ -380,6 +423,13 @@ public class NormalSwaptionPhysicalProductPricer {
       NormalVolatilitySwaptionProvider volatilityProvider) {
     ArgChecker.isTrue(volatilityProvider.getValuationDateTime().toLocalDate().equals(ratesProvider.getValuationDate()),
         "volatility and rate data should be for the same date");
+    ArgChecker.isFalse(swaption.getUnderlying().isCrossCurrency(), "underlying swap should be single currency");
+    ArgChecker.isTrue(swaption.getSwaptionSettlement().getSettlementType().equals(SettlementType.PHYSICAL),
+        "swaption should be physical settlement");
+  }
+
+  // validate that the rates and volatilities providers are coherent
+  private void validateSwaption(RatesProvider ratesProvider, ExpandedSwaption swaption) {
     ArgChecker.isFalse(swaption.getUnderlying().isCrossCurrency(), "underlying swap should be single currency");
     ArgChecker.isTrue(swaption.getSwaptionSettlement().getSettlementType().equals(SettlementType.PHYSICAL),
         "swaption should be physical settlement");

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
@@ -468,6 +468,36 @@ public class NormalSwaptionCashParYieldProductPricerTest {
     assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER));
     assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER));
   }
+  
+  //-------------------------------------------------------------------------
+  public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
+    CurrencyAmount pvLongRec =
+        PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+    double impliedLongRecComputed = 
+        PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_REC_LONG, RATE_PROVIDER, 
+            VOL_PROVIDER.getDayCount(), pvLongRec.getAmount());
+    double impliedLongRecInterpolated = 
+        PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+    assertEquals(impliedLongRecComputed, impliedLongRecInterpolated, TOL);
+
+    CurrencyAmount pvLongPay =
+        PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
+    double impliedLongPayComputed = 
+        PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, 
+            VOL_PROVIDER.getDayCount(), pvLongPay.getAmount());
+    double impliedLongPayInterpolated = 
+        PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
+    assertEquals(impliedLongPayComputed, impliedLongPayInterpolated, TOL);
+
+    CurrencyAmount pvShortRec =
+        PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    double impliedShortRecComputed = 
+        PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, 
+            VOL_PROVIDER.getDayCount(), pvShortRec.getAmount());
+    double impliedShortRecInterpolated = 
+        PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    assertEquals(impliedShortRecComputed, impliedShortRecInterpolated, TOL);
+  }
 
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivityStickyStrike() {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
@@ -192,6 +192,36 @@ public class NormalSwaptionPhysicalProductPricerTest {
     assertThrowsIllegalArg(() -> PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_PAST, MULTI_USD,
         NORMAL_VOL_SWAPTION_PROVIDER_USD));
   }
+  
+  //-------------------------------------------------------------------------
+  public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
+    CurrencyAmount pvLongRec=
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    double impliedLongRecComputed = 
+        PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_LONG_REC, MULTI_USD, 
+            NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), pvLongRec.getAmount());
+    double impliedLongRecInterpolated = 
+        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    assertEquals(impliedLongRecComputed, impliedLongRecInterpolated, TOLERANCE_RATE);
+
+    CurrencyAmount pvShortRec=
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    double impliedShortRecComputed = 
+        PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_SHORT_REC, MULTI_USD, 
+            NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), pvShortRec.getAmount());
+    double impliedShortRecInterpolated = 
+        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    assertEquals(impliedShortRecComputed, impliedShortRecInterpolated, TOLERANCE_RATE);
+
+    CurrencyAmount pvLongPay=
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    double impliedLongPayComputed = 
+        PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_LONG_PAY, MULTI_USD, 
+            NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), pvLongPay.getAmount());
+    double impliedLongPayInterpolated = 
+        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    assertEquals(impliedLongPayComputed, impliedLongPayInterpolated, TOLERANCE_RATE);
+  }
 
   //-------------------------------------------------------------------------
   public void present_value_formula() {


### PR DESCRIPTION
Created a new method in the swaption pricer by normal volatility.
It allows to compute the implied volatility from a given present value. For swaption this is slightly longer than for a equity case as the pvbp, strike, forward, etc. have to be computed.