### PR TITLE
Modified IborFixingDeposit pricer to work when the day fixing is present in the provider.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
@@ -8,9 +8,12 @@ package com.opengamma.strata.pricer.deposit;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.index.IborIndex;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.value.DiscountFactors;
+import com.opengamma.strata.market.value.DiscountIborIndexRates;
 import com.opengamma.strata.market.value.IborIndexRates;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.product.deposit.ExpandedIborFixingDeposit;
@@ -125,14 +128,18 @@ public class DiscountingIborFixingDepositProductPricer {
   // query the forward rate
   private double forwardRate(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
     IborIndex index = product.getFloatingRate().getIndex();
-    IborIndexRates rates = provider.iborIndexRates(index);
+    Curve curve = provider.getIndexCurves().get(index);
+    IborIndexRates rates = DiscountIborIndexRates.of(index, LocalDateDoubleTimeSeries.empty(),
+        DiscountFactors.of(index.getCurrency(), provider.getValuationDate(), curve));
     return rates.rate(product.getFloatingRate().getFixingDate());
   }
 
   // query the forward rate sensitivity
   private PointSensitivityBuilder forwardRateSensitivity(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
     IborIndex index = product.getFloatingRate().getIndex();
-    IborIndexRates rates = provider.iborIndexRates(index);
+    Curve curve = provider.getIndexCurves().get(index);
+    IborIndexRates rates = DiscountIborIndexRates.of(index, LocalDateDoubleTimeSeries.empty(),
+        DiscountFactors.of(index.getCurrency(), provider.getValuationDate(), curve));
     return rates.ratePointSensitivity(product.getFloatingRate().getFixingDate());
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationEurStandard.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationEurStandard.java
@@ -10,7 +10,6 @@ import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_6M;
 import static com.opengamma.strata.basics.index.OvernightIndices.EUR_EONIA;
-import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_3M;
 import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
 import static com.opengamma.strata.product.swap.type.FixedOvernightSwapConventions.EUR_FIXED_1Y_EONIA_OIS;
@@ -54,7 +53,7 @@ import com.opengamma.strata.product.swap.type.FixedOvernightSwapTemplate;
 
 public class CalibrationEurStandard {
 
-  private static final LocalDate VAL_DATE = date(2015, 6, 30);
+  private static final LocalDate VAL_DATE = LocalDate.of(2015, 6, 30);
   private static final DayCount CURVE_DC = ACT_365F;
   private static final LocalDateDoubleTimeSeries TS_EMTPY = LocalDateDoubleTimeSeries.empty();
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/ImmutableRatesProviderSimpleData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/ImmutableRatesProviderSimpleData.java
@@ -43,7 +43,7 @@ public class ImmutableRatesProviderSimpleData {
         .iborIndexCurve(EUR_EURIBOR_6M, indexCurve)
         .build();
     LocalDateDoubleTimeSeries tsE6 = LocalDateDoubleTimeSeries.builder()
-        .put(EUR_EURIBOR_6M.calculateFixingFromEffective(VAL_DATE), 0.012345).build();
+        .put(VAL_DATE, 0.012345).build();
     IMM_PROV_EUR_FIX = ImmutableRatesProvider.builder(VAL_DATE)
         .discountCurve(EUR, dscCurve)
         .iborIndexCurve(EUR_EURIBOR_6M, indexCurve, tsE6)

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricerTest.java
@@ -109,7 +109,7 @@ public class DiscountingIborFixingDepositProductPricerTest {
   }
 
   //-------------------------------------------------------------------------
-  public void par_spread() {
+  public void par_spread_no_fixing() {
     double parSpread = PRICER.parSpread(DEPOSIT, IMM_PROV_NOFIX);
     IborFixingDeposit deposit0 = DEPOSIT.toBuilder().fixedRate(RATE + parSpread).build();
     CurrencyAmount pv0 = PRICER.presentValue(deposit0, IMM_PROV_NOFIX);
@@ -117,9 +117,15 @@ public class DiscountingIborFixingDepositProductPricerTest {
     double parSpread2 = PRICER.parSpread(DEPOSIT, IMM_PROV_NOFIX);
     assertEquals(parSpread, parSpread2, TOLERANCE_RATE);
   }
+  
+  public void par_spread_fixing() {
+    double parSpread1 = PRICER.parSpread(DEPOSIT, IMM_PROV_FIX);
+    double parSpread2 = PRICER.parSpread(DEPOSIT, IMM_PROV_NOFIX);
+    assertEquals(parSpread1, parSpread2, TOLERANCE_RATE);
+  }
 
   //-------------------------------------------------------------------------
-  public void par_spread_sensitivity() {
+  public void par_spread_sensitivity_no_fixing() {
     PointSensitivities computedNoFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_NOFIX);
     CurveCurrencyParameterSensitivities sensiComputedNoFix = IMM_PROV_NOFIX.curveParameterSensitivity(computedNoFix);
     CurveCurrencyParameterSensitivities sensiExpected =
@@ -128,6 +134,12 @@ public class DiscountingIborFixingDepositProductPricerTest {
     PointSensitivities computedFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_FIX);
     CurveCurrencyParameterSensitivities sensiComputedFix = IMM_PROV_NOFIX.curveParameterSensitivity(computedFix);
     assertTrue(sensiComputedFix.equalWithTolerance(sensiExpected, TOLERANCE_RATE_DELTA));
+  }
+  
+  public void par_spread_sensitivity_fixing() {
+    PointSensitivities computedNoFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_NOFIX);
+    PointSensitivities computedFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_FIX);
+    assertTrue(computedNoFix.equalWithTolerance(computedFix, TOLERANCE_PV_DELTA));
   }
 
 }


### PR DESCRIPTION
The IborFixingDeposit pricer has been modified recently, causing problem in curve calibration when the fixing of the day is present in the time series. The test on that feature unfortunately contained an error, passing the wrong date for the fixing.
This PR should reinstalled the initial feature, correct the test in the pricer, extend the tests to other methods and add a calibration test passing a fixing time series with the fixing of the day.