### PR TITLE
Added forward rate method in IborIndexRates. Changed IborFixingDeposit.

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountIborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountIborIndexRates.java
@@ -145,8 +145,8 @@ public final class DiscountIborIndexRates
     }
   }
 
-  // forward rate
-  private double forwardRate(LocalDate fixingDate) {
+  @Override
+  public double forwardRate(LocalDate fixingDate) {
     LocalDate fixingStartDate = index.calculateEffectiveFromFixing(fixingDate);
     LocalDate fixingEndDate = index.calculateMaturityFromEffective(fixingStartDate);
     double fixingYearFraction = index.getDayCount().yearFraction(fixingStartDate, fixingEndDate);
@@ -169,15 +169,9 @@ public final class DiscountIborIndexRates
     return IborRateSensitivity.of(index, fixingDate, 1d);
   }
 
-  //-------------------------------------------------------------------------
   @Override
-  public CurveUnitParameterSensitivities unitParameterSensitivity(LocalDate fixingDate) {
-    LocalDate valuationDate = getValuationDate();
-    if (fixingDate.isBefore(valuationDate) ||
-        (fixingDate.equals(valuationDate) && timeSeries.get(fixingDate).isPresent())) {
-      return CurveUnitParameterSensitivities.empty();
-    }
-    return discountFactors.unitParameterSensitivity(fixingDate);
+  public PointSensitivityBuilder forwardRatePointSensitivity(LocalDate fixingDate) {
+    return IborRateSensitivity.of(index, fixingDate, 1d);    
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountIborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/DiscountIborIndexRates.java
@@ -126,7 +126,7 @@ public final class DiscountIborIndexRates
     if (!fixingDate.isAfter(getValuationDate())) {
       return historicRate(fixingDate);
     }
-    return forwardRate(fixingDate);
+    return rateIgnoringTimeSeries(fixingDate);
   }
 
   // historic rate
@@ -141,12 +141,12 @@ public final class DiscountIborIndexRates
       }
       throw new IllegalArgumentException(Messages.format("Unable to get fixing for {} on date {}", index, fixingDate));
     } else {
-      return forwardRate(fixingDate);
+      return rateIgnoringTimeSeries(fixingDate);
     }
   }
 
   @Override
-  public double forwardRate(LocalDate fixingDate) {
+  public double rateIgnoringTimeSeries(LocalDate fixingDate) {
     LocalDate fixingStartDate = index.calculateEffectiveFromFixing(fixingDate);
     LocalDate fixingEndDate = index.calculateMaturityFromEffective(fixingStartDate);
     double fixingYearFraction = index.getDayCount().yearFraction(fixingStartDate, fixingEndDate);
@@ -170,7 +170,7 @@ public final class DiscountIborIndexRates
   }
 
   @Override
-  public PointSensitivityBuilder forwardRatePointSensitivity(LocalDate fixingDate) {
+  public PointSensitivityBuilder rateIgnoringTimeSeriesPointSensitivity(LocalDate fixingDate) {
     return IborRateSensitivity.of(index, fixingDate, 1d);    
   }
 

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/IborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/IborIndexRates.java
@@ -14,7 +14,6 @@ import com.opengamma.strata.market.Perturbation;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
 import com.opengamma.strata.market.curve.CurveName;
-import com.opengamma.strata.market.curve.CurveUnitParameterSensitivities;
 import com.opengamma.strata.market.key.IborIndexRatesKey;
 import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -90,6 +89,20 @@ public interface IborIndexRates
    * @throws RuntimeException if the value cannot be obtained
    */
   public abstract double rate(LocalDate fixingDate);
+  
+  /**
+   * Gets the forward rate at the specified fixing date.
+   * <p>
+   * This method bypasses the potential historical time series associated to the index. 
+   * The standard method to access the Ibor rate is {@link IborIndexRates#rate}; this method should be used only 
+   * for specific purposes, when the actual time series are not relevant. 
+   * <p>
+   * In case there is a doubt on using this method, it probably means that it should not be used.
+   * 
+   * @param fixingDate  the fixing date to query the rate for
+   * @return the rate of the index as given by the forward curve
+   */
+  public abstract double forwardRate(LocalDate fixingDate);
 
   /**
    * Calculates the point sensitivity of the historic or forward rate at the specified fixing date.
@@ -104,19 +117,21 @@ public interface IborIndexRates
    */
   public abstract PointSensitivityBuilder ratePointSensitivity(LocalDate fixingDate);
 
-  //-------------------------------------------------------------------------
   /**
-   * Calculates the unit parameter sensitivity of the forward rate at the specified fixing date.
+   * Calculates the point sensitivity of the forward rate at the specified fixing date.
    * <p>
-   * This returns the unit sensitivity to each parameter on the underlying curve at the specified date.
-   * The sensitivity refers to the result of {@link #rate(LocalDate)}.
+   * This method bypasses the potential historical time series associated to the index. 
+   * The standard method to access the Ibor rate sensitivity is {@link IborIndexRates#ratePointSensitivity}; 
+   * this method should be used only for specific purposes, when the actual time series are not relevant. 
+   * <p>
+   * In case there is a doubt on using this method, it probably means that it should not be used.
    * 
-   * @param fixingDate  the fixing date to find the sensitivity for
-   * @return the parameter sensitivity
-   * @throws RuntimeException if the value cannot be obtained
+   * @param fixingDate  the fixing date to query the rate for
+   * @return the point sensitivity of the rate to the forward curve
    */
-  public abstract CurveUnitParameterSensitivities unitParameterSensitivity(LocalDate fixingDate);
+  public abstract PointSensitivityBuilder forwardRatePointSensitivity(LocalDate fixingDate);
 
+  //-------------------------------------------------------------------------
   /**
    * Calculates the curve parameter sensitivity from the point sensitivity.
    * <p>

--- a/modules/market/src/main/java/com/opengamma/strata/market/value/IborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/value/IborIndexRates.java
@@ -91,18 +91,18 @@ public interface IborIndexRates
   public abstract double rate(LocalDate fixingDate);
   
   /**
-   * Gets the forward rate at the specified fixing date.
+   * Ignores the time-series to get the forward rate at the specified fixing date, used in rare and special cases.
+   * In most cases callers should use {@link IborIndexRates#rate(LocalDate) rate(LocalDate)}.
    * <p>
-   * This method bypasses the potential historical time series associated to the index. 
-   * The standard method to access the Ibor rate is {@link IborIndexRates#rate}; this method should be used only 
-   * for specific purposes, when the actual time series are not relevant. 
-   * <p>
-   * In case there is a doubt on using this method, it probably means that it should not be used.
+   * An instance of {@code IborIndexRates} is typically based on a forward curve and a historic time-series.
+   * The {@code rate(LocalDate)} method uses either the curve or time-series, depending on whether the
+   * fixing date is before or after the valuation date. This method only queries the forward curve,
+   * totally ignoring the time-series, which is needed for rare and special cases only.
    * 
    * @param fixingDate  the fixing date to query the rate for
    * @return the rate of the index as given by the forward curve
    */
-  public abstract double forwardRate(LocalDate fixingDate);
+  public abstract double rateIgnoringTimeSeries(LocalDate fixingDate);
 
   /**
    * Calculates the point sensitivity of the historic or forward rate at the specified fixing date.
@@ -118,18 +118,19 @@ public interface IborIndexRates
   public abstract PointSensitivityBuilder ratePointSensitivity(LocalDate fixingDate);
 
   /**
-   * Calculates the point sensitivity of the forward rate at the specified fixing date.
+   * 
+   * This method should only be used in rare and special cases.
+   * In most cases callers should use {@link IborIndexRates#ratePointSensitivity(LocalDate) ratePointSensitivity(LocalDate)}.
    * <p>
-   * This method bypasses the potential historical time series associated to the index. 
-   * The standard method to access the Ibor rate sensitivity is {@link IborIndexRates#ratePointSensitivity}; 
-   * this method should be used only for specific purposes, when the actual time series are not relevant. 
-   * <p>
-   * In case there is a doubt on using this method, it probably means that it should not be used.
+   * An instance of {@code IborIndexRates} is typically based on a forward curve and a historic time-series.
+   * The {@code ratePointSensitivity(LocalDate)} method uses either the curve or time-series, depending on whether the
+   * fixing date is before or after the valuation date. This method only queries the forward curve,
+   * totally ignoring the time-series, which is needed for rare and special cases only.
    * 
    * @param fixingDate  the fixing date to query the rate for
    * @return the point sensitivity of the rate to the forward curve
    */
-  public abstract PointSensitivityBuilder forwardRatePointSensitivity(LocalDate fixingDate);
+  public abstract PointSensitivityBuilder rateIgnoringTimeSeriesPointSensitivity(LocalDate fixingDate);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/market/src/test/java/com/opengamma/strata/market/value/DiscountIborIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/value/DiscountIborIndexRatesTest.java
@@ -139,7 +139,7 @@ public class DiscountIborIndexRatesTest {
     LocalDate endDate = GBP_LIBOR_3M.calculateMaturityFromEffective(startDate);
     double accrualFactor = GBP_LIBOR_3M.getDayCount().yearFraction(startDate, endDate);
     double expected = (DFCURVE.discountFactor(startDate) / DFCURVE.discountFactor(endDate) - 1) / accrualFactor;
-    assertEquals(test.forwardRate(DATE_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringTimeSeries(DATE_VAL), expected, TOLERANCE_RATE);
   }
 
   public void test_rate_onValuation_noFixing() {
@@ -149,7 +149,7 @@ public class DiscountIborIndexRatesTest {
     double accrualFactor = GBP_LIBOR_3M.getDayCount().yearFraction(startDate, endDate);
     double expected = (DFCURVE.discountFactor(startDate) / DFCURVE.discountFactor(endDate) - 1) / accrualFactor;
     assertEquals(test.rate(DATE_VAL), expected, TOLERANCE_RATE);
-    assertEquals(test.forwardRate(DATE_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringTimeSeries(DATE_VAL), expected, TOLERANCE_RATE);
   }
 
   public void test_rate_afterValuation() {
@@ -171,14 +171,14 @@ public class DiscountIborIndexRatesTest {
   public void test_forwardRatePointSensitivity_onValuation() {
     DiscountIborIndexRates test = DiscountIborIndexRates.of(GBP_LIBOR_3M, SERIES, DFCURVE);
     IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M, DATE_VAL, 1d);
-    assertEquals(test.forwardRatePointSensitivity(DATE_VAL), expected);
+    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(DATE_VAL), expected);
   }
 
   public void test_ratePointSensitivity_onValuation_noFixing() {
     DiscountIborIndexRates test = DiscountIborIndexRates.of(GBP_LIBOR_3M, SERIES_EMPTY, DFCURVE);
     IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M, DATE_VAL, 1d);
     assertEquals(test.ratePointSensitivity(DATE_VAL), expected);
-    assertEquals(test.forwardRatePointSensitivity(DATE_VAL), expected);
+    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(DATE_VAL), expected);
   }
 
   public void test_ratePointSensitivity_afterValuation() {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
@@ -7,7 +7,6 @@ package com.opengamma.strata.pricer.deposit;
 
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
-import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.value.DiscountFactors;
@@ -124,16 +123,16 @@ public class DiscountingIborFixingDepositProductPricer {
   //-------------------------------------------------------------------------
   // query the forward rate
   private double forwardRate(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
-    IborIndex index = product.getFloatingRate().getIndex();
-    IborIndexRates rates = provider.iborIndexRates(index);
-    return rates.rate(product.getFloatingRate().getFixingDate());
+    IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
+    // The IborFixingDeposit are fictitious instruments to anchor the beginning of the IborIndex forward curve. 
+    // By using the 'forwardRate' method (instead of 'rate') we ensure that only the forward curve is involved.
+    return rates.forwardRate(product.getFloatingRate().getFixingDate());
   }
 
   // query the forward rate sensitivity
   private PointSensitivityBuilder forwardRateSensitivity(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
-    IborIndex index = product.getFloatingRate().getIndex();
-    IborIndexRates rates = provider.iborIndexRates(index);
-    return rates.ratePointSensitivity(product.getFloatingRate().getFixingDate());
+    IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
+    return rates.forwardRatePointSensitivity(product.getFloatingRate().getFixingDate());
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
@@ -126,13 +126,13 @@ public class DiscountingIborFixingDepositProductPricer {
     IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
     // The IborFixingDeposit are fictitious instruments to anchor the beginning of the IborIndex forward curve. 
     // By using the 'forwardRate' method (instead of 'rate') we ensure that only the forward curve is involved.
-    return rates.forwardRate(product.getFloatingRate().getFixingDate());
+    return rates.rateIgnoringTimeSeries(product.getFloatingRate().getFixingDate());
   }
 
   // query the forward rate sensitivity
   private PointSensitivityBuilder forwardRateSensitivity(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
     IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
-    return rates.forwardRatePointSensitivity(product.getFloatingRate().getFixingDate());
+    return rates.rateIgnoringTimeSeriesPointSensitivity(product.getFloatingRate().getFixingDate());
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationEurStandard.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/CalibrationEurStandard.java
@@ -10,7 +10,6 @@ import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_6M;
 import static com.opengamma.strata.basics.index.OvernightIndices.EUR_EONIA;
-import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_3M;
 import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
 import static com.opengamma.strata.product.swap.type.FixedOvernightSwapConventions.EUR_FIXED_1Y_EONIA_OIS;
@@ -54,7 +53,7 @@ import com.opengamma.strata.product.swap.type.FixedOvernightSwapTemplate;
 
 public class CalibrationEurStandard {
 
-  private static final LocalDate VAL_DATE = date(2015, 6, 30);
+  private static final LocalDate VAL_DATE = LocalDate.of(2015, 6, 30);
   private static final DayCount CURVE_DC = ACT_365F;
   private static final LocalDateDoubleTimeSeries TS_EMTPY = LocalDateDoubleTimeSeries.empty();
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/ImmutableRatesProviderSimpleData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/ImmutableRatesProviderSimpleData.java
@@ -43,7 +43,7 @@ public class ImmutableRatesProviderSimpleData {
         .iborIndexCurve(EUR_EURIBOR_6M, indexCurve)
         .build();
     LocalDateDoubleTimeSeries tsE6 = LocalDateDoubleTimeSeries.builder()
-        .put(EUR_EURIBOR_6M.calculateFixingFromEffective(VAL_DATE), 0.012345).build();
+        .put(VAL_DATE, 0.012345).build();
     IMM_PROV_EUR_FIX = ImmutableRatesProvider.builder(VAL_DATE)
         .discountCurve(EUR, dscCurve)
         .iborIndexCurve(EUR_EURIBOR_6M, indexCurve, tsE6)

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricerTest.java
@@ -109,7 +109,7 @@ public class DiscountingIborFixingDepositProductPricerTest {
   }
 
   //-------------------------------------------------------------------------
-  public void par_spread() {
+  public void par_spread_no_fixing() {
     double parSpread = PRICER.parSpread(DEPOSIT, IMM_PROV_NOFIX);
     IborFixingDeposit deposit0 = DEPOSIT.toBuilder().fixedRate(RATE + parSpread).build();
     CurrencyAmount pv0 = PRICER.presentValue(deposit0, IMM_PROV_NOFIX);
@@ -117,9 +117,15 @@ public class DiscountingIborFixingDepositProductPricerTest {
     double parSpread2 = PRICER.parSpread(DEPOSIT, IMM_PROV_NOFIX);
     assertEquals(parSpread, parSpread2, TOLERANCE_RATE);
   }
+  
+  public void par_spread_fixing() {
+    double parSpread1 = PRICER.parSpread(DEPOSIT, IMM_PROV_FIX);
+    double parSpread2 = PRICER.parSpread(DEPOSIT, IMM_PROV_NOFIX);
+    assertEquals(parSpread1, parSpread2, TOLERANCE_RATE);
+  }
 
   //-------------------------------------------------------------------------
-  public void par_spread_sensitivity() {
+  public void par_spread_sensitivity_no_fixing() {
     PointSensitivities computedNoFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_NOFIX);
     CurveCurrencyParameterSensitivities sensiComputedNoFix = IMM_PROV_NOFIX.curveParameterSensitivity(computedNoFix);
     CurveCurrencyParameterSensitivities sensiExpected =
@@ -128,6 +134,12 @@ public class DiscountingIborFixingDepositProductPricerTest {
     PointSensitivities computedFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_FIX);
     CurveCurrencyParameterSensitivities sensiComputedFix = IMM_PROV_NOFIX.curveParameterSensitivity(computedFix);
     assertTrue(sensiComputedFix.equalWithTolerance(sensiExpected, TOLERANCE_RATE_DELTA));
+  }
+  
+  public void par_spread_sensitivity_fixing() {
+    PointSensitivities computedNoFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_NOFIX);
+    PointSensitivities computedFix = PRICER.parSpreadSensitivity(DEPOSIT, IMM_PROV_FIX);
+    assertTrue(computedNoFix.equalWithTolerance(computedFix, TOLERANCE_PV_DELTA));
   }
 
 }


### PR DESCRIPTION
The IborFixingDeposit pricer has been modified recently, causing problem in curve calibration when the fixing of the day is present in the time series. The test on that feature unfortunately contained an error, passing the wrong date for the fixing.
This PR create a new method in the IborIndexRates to access the forward rates directly.
It also reinstalled the fixing feature in the pricer, correct the test in the pricer, extend the tests to other methods and add a calibration test passing a fixing time series with the fixing of the day.
A new curve calibration test is created to check the curve calibration when the calibration date is an holiday (25-Dec in the test).