### PR TITLE
Create FxRatesArray

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
@@ -120,9 +120,6 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
    * @throws IllegalArgumentException if no FX rate could be found
    */
   public double fxRate(Currency baseCurrency, Currency counterCurrency, int scenarioIndex) {
-    if (baseCurrency.equals(counterCurrency)) {
-      return 1d;
-    }
     if (baseCurrency.equals(pair.getBase()) && counterCurrency.equals(pair.getCounter())) {
       return rates.get(scenarioIndex);
     }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
@@ -1,0 +1,473 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.currency;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableValidator;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.opengamma.strata.basics.market.ScenarioMarketDataValue;
+import com.opengamma.strata.collect.array.DoubleArray;
+
+/**
+ * A set of FX rates between two currencies containing rates for multiple scenarios.
+ * <p>
+ * This represents rates of foreign exchange. The rate 'EUR/USD 1.25' consists of three
+ * elements - the base currency 'EUR', the counter currency 'USD' and the rate '1.25'.
+ * When performing a conversion a rate of '1.25' means that '1 EUR = 1.25 USD'.
+ * <p>
+ * The {@link FxRate} class represents a single rate for a currency pair. This class is
+ * intended as an efficient way of storing multiple rates for the same currency pair
+ * for use in multiple scenarios.
+ *
+ * @see FxRate
+ */
+@BeanDefinition
+public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, ImmutableBean {
+
+  /**
+   * The currency pair.
+   * The pair is formed of two parts, the base and the counter.
+   * In the pair 'AAA/BBB' the base is 'AAA' and the counter is 'BBB'.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final CurrencyPair pair;
+
+  /**
+   * The rates applicable to the currency pair.
+   * One unit of the base currency is exchanged for this amount of the counter currency.
+   */
+  @PropertyDefinition(validate = "notNull", get = "private")
+  private final DoubleArray rates;
+
+  /**
+   * Returns an array of FX rates for a currency pair.
+   * <p>
+   * The rates are the rates from the base currency to the counter currency
+   * as defined by this formula: {@code (1 * baseCurrency = fxRate * counterCurrency)}.
+   *
+   * @param currencyPair  the currency pair
+   * @param rates  the FX rates for the currency pair
+   * @return an array of FX rates for a currency pair
+   */
+  public static FxRatesArray of(CurrencyPair currencyPair, DoubleArray rates) {
+    return new FxRatesArray(currencyPair, rates);
+  }
+
+  /**
+   * Returns an array of FX rates for a currency pair.
+   * <p>
+   * The rates are the rates from the base currency to the counter currency
+   * as defined by this formula: {@code (1 * baseCurrency = fxRate * counterCurrency)}.
+   *
+   * @param base  the base currency of the pair
+   * @param counter  the counter currency of the pair
+   * @param rates  the FX rates for the currency pair
+   * @return an array of FX rates for a currency pair
+   */
+  public static FxRatesArray of(Currency base, Currency counter, DoubleArray rates) {
+    return new FxRatesArray(CurrencyPair.of(base, counter), rates);
+  }
+
+  /**
+   * Returns the FX rate for a scenario.
+   *
+   * @param scenarioIndex  the index of the scenario
+   * @return the FX rate for the specified scenario
+   */
+  @Override
+  public FxRate getValue(int scenarioIndex) {
+    return FxRate.of(pair, rates.get(scenarioIndex));
+  }
+
+  @Override
+  public int getScenarioCount() {
+    return rates.size();
+  }
+
+  /**
+   * Returns the FX rate for the specified currency pair and scenario index.
+   * <p>
+   * The rate returned is the rate from the base currency to the counter currency
+   * as defined by this formula: {@code (1 * baseCurrency = fxRate * counterCurrency)}.
+   * <p>
+   * This will return the rate or inverse rate, or 1 if the two input currencies are the same.
+   * <p>
+   * This method is more efficient than {@link #getValue(int)} as it doesn't create an instance
+   * of {@link FxRate} for every invocation.
+   *
+   * @param baseCurrency  the base currency, to convert from
+   * @param counterCurrency  the counter currency, to convert to
+   * @param scenarioIndex  the index of the scenario for which rates are required
+   * @return the FX rate for the currency pair
+   * @throws IllegalArgumentException if no FX rate could be found
+   */
+  public double fxRate(Currency baseCurrency, Currency counterCurrency, int scenarioIndex) {
+    if (baseCurrency.equals(counterCurrency)) {
+      return 1d;
+    }
+    if (baseCurrency.equals(pair.getBase()) && counterCurrency.equals(pair.getCounter())) {
+      return rates.get(scenarioIndex);
+    }
+    if (counterCurrency.equals(pair.getBase()) && baseCurrency.equals(pair.getCounter())) {
+      return 1d / rates.get(scenarioIndex);
+    }
+    throw new IllegalArgumentException("Unknown rate: " + baseCurrency + "/" + counterCurrency);
+  }
+
+  @ImmutableValidator
+  private void validate() {
+    if (pair.getBase().equals(pair.getCounter()) && !rates.stream().allMatch(v -> v == 1d)) {
+      throw new IllegalArgumentException("Conversion rate between identical currencies must be one");
+    }
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code FxRatesArray}.
+   * @return the meta-bean, not null
+   */
+  public static FxRatesArray.Meta meta() {
+    return FxRatesArray.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(FxRatesArray.Meta.INSTANCE);
+  }
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static FxRatesArray.Builder builder() {
+    return new FxRatesArray.Builder();
+  }
+
+  private FxRatesArray(
+      CurrencyPair pair,
+      DoubleArray rates) {
+    JodaBeanUtils.notNull(pair, "pair");
+    JodaBeanUtils.notNull(rates, "rates");
+    this.pair = pair;
+    this.rates = rates;
+    validate();
+  }
+
+  @Override
+  public FxRatesArray.Meta metaBean() {
+    return FxRatesArray.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the currency pair.
+   * The pair is formed of two parts, the base and the counter.
+   * In the pair 'AAA/BBB' the base is 'AAA' and the counter is 'BBB'.
+   * @return the value of the property, not null
+   */
+  public CurrencyPair getPair() {
+    return pair;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the rate applicable to the currency pair.
+   * One unit of the base currency is exchanged for this amount of the counter currency.
+   * @return the value of the property, not null
+   */
+  private DoubleArray getRates() {
+    return rates;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      FxRatesArray other = (FxRatesArray) obj;
+      return JodaBeanUtils.equal(pair, other.pair) &&
+          JodaBeanUtils.equal(rates, other.rates);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(pair);
+    hash = hash * 31 + JodaBeanUtils.hashCode(rates);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(96);
+    buf.append("FxRatesArray{");
+    buf.append("pair").append('=').append(pair).append(',').append(' ');
+    buf.append("rates").append('=').append(JodaBeanUtils.toString(rates));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code FxRatesArray}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code pair} property.
+     */
+    private final MetaProperty<CurrencyPair> pair = DirectMetaProperty.ofImmutable(
+        this, "pair", FxRatesArray.class, CurrencyPair.class);
+    /**
+     * The meta-property for the {@code rates} property.
+     */
+    private final MetaProperty<DoubleArray> rates = DirectMetaProperty.ofImmutable(
+        this, "rates", FxRatesArray.class, DoubleArray.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "pair",
+        "rates");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 3433178:  // pair
+          return pair;
+        case 108285843:  // rates
+          return rates;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public FxRatesArray.Builder builder() {
+      return new FxRatesArray.Builder();
+    }
+
+    @Override
+    public Class<? extends FxRatesArray> beanType() {
+      return FxRatesArray.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code pair} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<CurrencyPair> pair() {
+      return pair;
+    }
+
+    /**
+     * The meta-property for the {@code rates} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<DoubleArray> rates() {
+      return rates;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 3433178:  // pair
+          return ((FxRatesArray) bean).getPair();
+        case 108285843:  // rates
+          return ((FxRatesArray) bean).getRates();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code FxRatesArray}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<FxRatesArray> {
+
+    private CurrencyPair pair;
+    private DoubleArray rates;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(FxRatesArray beanToCopy) {
+      this.pair = beanToCopy.getPair();
+      this.rates = beanToCopy.getRates();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 3433178:  // pair
+          return pair;
+        case 108285843:  // rates
+          return rates;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 3433178:  // pair
+          this.pair = (CurrencyPair) newValue;
+          break;
+        case 108285843:  // rates
+          this.rates = (DoubleArray) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public FxRatesArray build() {
+      return new FxRatesArray(
+          pair,
+          rates);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the currency pair.
+     * The pair is formed of two parts, the base and the counter.
+     * In the pair 'AAA/BBB' the base is 'AAA' and the counter is 'BBB'.
+     * @param pair  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder pair(CurrencyPair pair) {
+      JodaBeanUtils.notNull(pair, "pair");
+      this.pair = pair;
+      return this;
+    }
+
+    /**
+     * Sets the rate applicable to the currency pair.
+     * One unit of the base currency is exchanged for this amount of the counter currency.
+     * @param rates  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder rates(DoubleArray rates) {
+      JodaBeanUtils.notNull(rates, "rates");
+      this.rates = rates;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(96);
+      buf.append("FxRatesArray.Builder{");
+      buf.append("pair").append('=').append(JodaBeanUtils.toString(pair)).append(',').append(' ');
+      buf.append("rates").append('=').append(JodaBeanUtils.toString(rates));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
@@ -10,6 +10,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.joda.beans.Bean;
+import org.joda.beans.BeanBuilder;
 import org.joda.beans.BeanDefinition;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.ImmutableValidator;
@@ -38,7 +39,7 @@ import com.opengamma.strata.collect.array.DoubleArray;
  *
  * @see FxRate
  */
-@BeanDefinition
+@BeanDefinition(builderScope = "private")
 public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, ImmutableBean {
 
   /**
@@ -152,14 +153,6 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
     JodaBeanUtils.registerMetaBean(FxRatesArray.Meta.INSTANCE);
   }
 
-  /**
-   * Returns a builder used to create an instance of the bean.
-   * @return the builder, not null
-   */
-  public static FxRatesArray.Builder builder() {
-    return new FxRatesArray.Builder();
-  }
-
   private FxRatesArray(
       CurrencyPair pair,
       DoubleArray rates) {
@@ -207,14 +200,6 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
   }
 
   //-----------------------------------------------------------------------
-  /**
-   * Returns a builder that allows this bean to be mutated.
-   * @return the mutable builder, not null
-   */
-  public Builder toBuilder() {
-    return new Builder(this);
-  }
-
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
@@ -292,7 +277,7 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
     }
 
     @Override
-    public FxRatesArray.Builder builder() {
+    public BeanBuilder<? extends FxRatesArray> builder() {
       return new FxRatesArray.Builder();
     }
 
@@ -350,7 +335,7 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
   /**
    * The bean-builder for {@code FxRatesArray}.
    */
-  public static final class Builder extends DirectFieldsBeanBuilder<FxRatesArray> {
+  private static final class Builder extends DirectFieldsBeanBuilder<FxRatesArray> {
 
     private CurrencyPair pair;
     private DoubleArray rates;
@@ -359,15 +344,6 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
      * Restricted constructor.
      */
     private Builder() {
-    }
-
-    /**
-     * Restricted copy constructor.
-     * @param beanToCopy  the bean to copy from, not null
-     */
-    private Builder(FxRatesArray beanToCopy) {
-      this.pair = beanToCopy.getPair();
-      this.rates = beanToCopy.getRates();
     }
 
     //-----------------------------------------------------------------------
@@ -427,32 +403,6 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
       return new FxRatesArray(
           pair,
           rates);
-    }
-
-    //-----------------------------------------------------------------------
-    /**
-     * Sets the currency pair.
-     * The pair is formed of two parts, the base and the counter.
-     * In the pair 'AAA/BBB' the base is 'AAA' and the counter is 'BBB'.
-     * @param pair  the new value, not null
-     * @return this, for chaining, not null
-     */
-    public Builder pair(CurrencyPair pair) {
-      JodaBeanUtils.notNull(pair, "pair");
-      this.pair = pair;
-      return this;
-    }
-
-    /**
-     * Sets the rates applicable to the currency pair.
-     * One unit of the base currency is exchanged for this amount of the counter currency.
-     * @param rates  the new value, not null
-     * @return this, for chaining, not null
-     */
-    public Builder rates(DoubleArray rates) {
-      JodaBeanUtils.notNull(rates, "rates");
-      this.rates = rates;
-      return this;
     }
 
     //-----------------------------------------------------------------------

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRatesArray.java
@@ -198,7 +198,7 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the rate applicable to the currency pair.
+   * Gets the rates applicable to the currency pair.
    * One unit of the base currency is exchanged for this amount of the counter currency.
    * @return the value of the property, not null
    */
@@ -444,7 +444,7 @@ public final class FxRatesArray implements ScenarioMarketDataValue<FxRate>, Immu
     }
 
     /**
-     * Sets the rate applicable to the currency pair.
+     * Sets the rates applicable to the currency pair.
      * One unit of the base currency is exchanged for this amount of the counter currency.
      * @param rates  the new value, not null
      * @return this, for chaining, not null

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRatesArrayTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRatesArrayTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.currency;
+
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertThrows;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.collect.array.DoubleArray;
+
+@Test
+public class FxRatesArrayTest {
+
+  public void getValues() {
+    FxRatesArray rates = FxRatesArray.of(Currency.EUR, Currency.USD, DoubleArray.of(1.07, 1.08, 1.09));
+    assertThat(rates.getPair()).isEqualTo(CurrencyPair.of(Currency.EUR, Currency.USD));
+    assertThat(rates.getScenarioCount()).isEqualTo(3);
+    assertThat(rates.getValue(0)).isEqualTo(FxRate.of(Currency.EUR, Currency.USD, 1.07));
+    assertThat(rates.getValue(1)).isEqualTo(FxRate.of(Currency.EUR, Currency.USD, 1.08));
+    assertThat(rates.getValue(2)).isEqualTo(FxRate.of(Currency.EUR, Currency.USD, 1.09));
+    assertThrows(ArrayIndexOutOfBoundsException.class, () -> rates.getValue(3));
+  }
+
+  public void fxRate() {
+    FxRatesArray rates = FxRatesArray.of(Currency.EUR, Currency.USD, DoubleArray.of(1.07, 1.08, 1.09));
+    assertThat(rates.fxRate(Currency.EUR, Currency.USD, 0)).isEqualTo(1.07);
+    assertThat(rates.fxRate(Currency.EUR, Currency.USD, 1)).isEqualTo(1.08);
+    assertThat(rates.fxRate(Currency.EUR, Currency.USD, 2)).isEqualTo(1.09);
+
+    assertThat(rates.fxRate(Currency.USD, Currency.EUR, 0)).isEqualTo(1 / 1.07);
+    assertThat(rates.fxRate(Currency.USD, Currency.EUR, 1)).isEqualTo(1 / 1.08);
+    assertThat(rates.fxRate(Currency.USD, Currency.EUR, 2)).isEqualTo(1 / 1.09);
+  }
+
+  public void identicalCurrenciesHaveRateOfOne() {
+    assertThrowsIllegalArg(
+        () -> FxRatesArray.of(Currency.EUR, Currency.EUR, DoubleArray.of(1.07, 1.08, 1.09)),
+        "Conversion rate between identical currencies must be one");
+  }
+}

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRatesArrayTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRatesArrayTest.java
@@ -29,7 +29,7 @@ public class FxRatesArrayTest {
   }
 
   public void fxRate() {
-    FxRatesArray rates = FxRatesArray.of(Currency.EUR, Currency.USD, DoubleArray.of(1.07, 1.08, 1.09));
+    FxRatesArray rates = FxRatesArray.of(CurrencyPair.of(Currency.EUR, Currency.USD), DoubleArray.of(1.07, 1.08, 1.09));
     assertThat(rates.fxRate(Currency.EUR, Currency.USD, 0)).isEqualTo(1.07);
     assertThat(rates.fxRate(Currency.EUR, Currency.USD, 1)).isEqualTo(1.08);
     assertThat(rates.fxRate(Currency.EUR, Currency.USD, 2)).isEqualTo(1.09);
@@ -43,6 +43,11 @@ public class FxRatesArrayTest {
     assertThrowsIllegalArg(
         () -> FxRatesArray.of(Currency.EUR, Currency.EUR, DoubleArray.of(1.07, 1.08, 1.09)),
         "Conversion rate between identical currencies must be one");
+  }
+
+  public void unknownCurrencyPair() {
+    FxRatesArray rates = FxRatesArray.of(Currency.EUR, Currency.USD, DoubleArray.of(1.07, 1.08, 1.09));
+    assertThrowsIllegalArg(() -> rates.fxRate(Currency.AED, Currency.ARS, 0));
   }
 
   public void coverage() {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRatesArrayTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRatesArrayTest.java
@@ -6,6 +6,8 @@
 package com.opengamma.strata.basics.currency;
 
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertThrows;
 
@@ -41,5 +43,12 @@ public class FxRatesArrayTest {
     assertThrowsIllegalArg(
         () -> FxRatesArray.of(Currency.EUR, Currency.EUR, DoubleArray.of(1.07, 1.08, 1.09)),
         "Conversion rate between identical currencies must be one");
+  }
+
+  public void coverage() {
+    FxRatesArray rates1 = FxRatesArray.of(Currency.EUR, Currency.USD, DoubleArray.of(1.07, 1.08, 1.09));
+    FxRatesArray rates2 = FxRatesArray.of(Currency.GBP, Currency.USD, DoubleArray.of(1.46, 1.47, 1.48));
+    coverImmutableBean(rates1);
+    coverBeanEquals(rates1, rates2);
   }
 }


### PR DESCRIPTION
This PR adds the `FxRatesArray` class which is an efficient container for multiple FX rates for the same currency pair for use in multiple scenarios.

Currently an `FxRate` instance containing a currency pair and rate must be created for each scenario. `FxRatesArray` has a single reference to the currency pair and stores the rates without boxing.

Fixes #582 