### PR TITLE
Map factory method for MultiCurrencyValuesArray

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/function/result/MultiCurrencyValuesArray.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/function/result/MultiCurrencyValuesArray.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -31,7 +32,6 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
@@ -276,7 +276,7 @@ public final class MultiCurrencyValuesArray
    * Gets the currency values, keyed by currency.
    * @return the value of the property, not null
    */
-  public ImmutableMap<Currency, DoubleArray> getValues() {
+  public ImmutableSortedMap<Currency, DoubleArray> getValues() {
     return values;
   }
 
@@ -323,8 +323,8 @@ public final class MultiCurrencyValuesArray
      * The meta-property for the {@code values} property.
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
-    private final MetaProperty<ImmutableMap<Currency, DoubleArray>> values = DirectMetaProperty.ofImmutable(
-        this, "values", MultiCurrencyValuesArray.class, (Class) ImmutableMap.class);
+    private final MetaProperty<ImmutableSortedMap<Currency, DoubleArray>> values = DirectMetaProperty.ofImmutable(
+        this, "values", MultiCurrencyValuesArray.class, (Class) ImmutableSortedMap.class);
     /**
      * The meta-properties.
      */
@@ -367,7 +367,7 @@ public final class MultiCurrencyValuesArray
      * The meta-property for the {@code values} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<ImmutableMap<Currency, DoubleArray>> values() {
+    public MetaProperty<ImmutableSortedMap<Currency, DoubleArray>> values() {
       return values;
     }
 
@@ -398,7 +398,7 @@ public final class MultiCurrencyValuesArray
    */
   private static final class Builder extends DirectFieldsBeanBuilder<MultiCurrencyValuesArray> {
 
-    private Map<Currency, DoubleArray> values = ImmutableMap.of();
+    private SortedMap<Currency, DoubleArray> values = ImmutableSortedMap.of();
 
     /**
      * Restricted constructor.
@@ -422,7 +422,7 @@ public final class MultiCurrencyValuesArray
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
         case -823812830:  // values
-          this.values = (Map<Currency, DoubleArray>) newValue;
+          this.values = (SortedMap<Currency, DoubleArray>) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/function/result/MultiCurrencyValuesArray.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/function/result/MultiCurrencyValuesArray.java
@@ -32,6 +32,7 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -64,7 +65,7 @@ public final class MultiCurrencyValuesArray
 
   /** The currency values, keyed by currency. */
   @PropertyDefinition(validate = "notNull")
-  private final ImmutableMap<Currency, DoubleArray> values;
+  private final ImmutableSortedMap<Currency, DoubleArray> values;
 
   /** The number of values for each currency. */
   private final int size;
@@ -103,9 +104,39 @@ public final class MultiCurrencyValuesArray
     return new MultiCurrencyValuesArray(doubleArrayMap);
   }
 
+  /**
+   * Returns an instance containing the values from a map of amounts with the same number of elements in each array.
+   *
+   * @param values  map of currencies to values
+   * @return an instance containing the values from the map
+   */
+  public static MultiCurrencyValuesArray of(Map<Currency, DoubleArray> values) {
+    values.values().stream().reduce((a1, a2) -> checkSize(a1, a2));
+    return new MultiCurrencyValuesArray(values);
+  }
+
+  /**
+   * Checks the size of the arrays are the same and throws an exception if not.
+   *
+   * @param array1  an array
+   * @param array2  an array
+   * @return array1
+   * @throws IllegalArgumentException if the array sizes are not equal
+   */
+  private static DoubleArray checkSize(DoubleArray array1, DoubleArray array2) {
+    if (array1.size() != array2.size()) {
+      throw new IllegalArgumentException(
+          Messages.format(
+              "Arrays must have the same size but found sizes {} and {}",
+              array1.size(),
+              array2.size()));
+    }
+    return array1;
+  }
+
   @ImmutableConstructor
   private MultiCurrencyValuesArray(Map<Currency, DoubleArray> values) {
-    this.values = ImmutableMap.copyOf(values);
+    this.values = ImmutableSortedMap.copyOf(values);
 
     if (values.isEmpty()) {
       size = 0;

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/function/result/MultiCurrencyValuesArrayTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/function/result/MultiCurrencyValuesArrayTest.java
@@ -75,6 +75,23 @@ public class MultiCurrencyValuesArrayTest {
     assertThrowsIllegalArg(() -> raggedArray.getValues(Currency.AUD));
   }
 
+  public void mapFactoryMethod() {
+    MultiCurrencyValuesArray array = MultiCurrencyValuesArray.of(
+        ImmutableMap.of(
+            Currency.GBP, DoubleArray.of(20, 21, 22),
+            Currency.USD, DoubleArray.of(30, 32, 33),
+            Currency.EUR, DoubleArray.of(40, 43, 44)));
+
+    assertThat(array).isEqualTo(VALUES_ARRAY);
+
+    assertThrowsIllegalArg(
+        () -> MultiCurrencyValuesArray.of(
+            ImmutableMap.of(
+                Currency.GBP, DoubleArray.of(20, 21),
+                Currency.EUR, DoubleArray.of(40, 43, 44))),
+        "Arrays must have the same size.*");
+  }
+
   public void getAllValuesUnsafe() {
     Map<Currency, DoubleArray> expected = ImmutableMap.of(
         Currency.GBP, DoubleArray.of(20, 21, 22),


### PR DESCRIPTION
This PR adds a factory method to build a `MultiCurrencyValuesArray` from a map of `Currency` to `DoubleArray`.