### PR TITLE
Added a method to compute Normal implied volatility from Black implied volatility.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
@@ -38,6 +38,9 @@ public final class NormalFormulaRepository {
    * The solution precision.
    */
   private static final double EPS = 1e-15;
+  
+  /** Limit defining "close to ATM forward" to avoid the formula singularity in the impliedVolatilityFromBlackVolatility. **/
+  private static final double ATM_LIMIT = 1.0E-3;
 
   // restricted constructor
   private NormalFormulaRepository() {
@@ -305,6 +308,36 @@ public final class NormalFormulaRepository {
       }
     }
     return sigma;
+  }
+  
+  /**
+   * Compute the implied volatility using an approximate explicit transformation formula.
+   * <p>
+   * Reference: Hagan, P. S. Volatility conversion calculator. Technical report, Bloomberg.
+   * 
+   * @param forward  the forward rate/price
+   * @param strike  the option strike
+   * @param timeToExpiry  the option time to maturity
+   * @param blackVolatility  the Black implied volatility
+   * @return the implied volatility
+   */
+  public static double impliedVolatilityFromBlackVolatility(
+      double forward,
+      double strike,
+      double timeToExpiry,
+      double blackVolatility) {
+    ArgChecker.isTrue(strike > 0, "strike must be strctly positive");
+    ArgChecker.isTrue(forward > 0, "strike must be strctly positive");
+    double lnFK = Math.log(forward / strike);
+    double s2t = blackVolatility * blackVolatility * timeToExpiry;
+    if (Math.abs((forward - strike) / strike) < ATM_LIMIT) {
+      double factor1 = Math.sqrt(forward * strike);
+      double factor2 = (1.0d + lnFK * lnFK / 24.0d) / (1.0d + s2t / 24.0d + s2t * s2t / 5670.0d);
+      return blackVolatility * factor1 * factor2;
+    }
+    double factor1 = (forward - strike) / lnFK;
+    double factor2 = 1.0d / (1.0d + (1.0d - lnFK * lnFK / 120.0d) / 24.0d * s2t + s2t * s2t / 5670.0d);
+    return blackVolatility * factor1 * factor2;
   }
 
 }


### PR DESCRIPTION
Create a method to convert Black implied volatility to Normal implied volatility using the Hagan explicit approximate formula. Reference: Hagan, P. S. Volatility conversion calculator. Technical report, Bloomberg.