### PR TITLE
Added method to compute Black implied volatility from normal implied volatility

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
@@ -321,13 +321,13 @@ public final class NormalFormulaRepository {
    * @param blackVolatility  the Black implied volatility
    * @return the implied volatility
    */
-  public static double impliedVolatilityFromBlackVolatility(
+  public static double impliedVolatilityFromBlackApproximated(
       double forward,
       double strike,
       double timeToExpiry,
       double blackVolatility) {
-    ArgChecker.isTrue(strike > 0, "strike must be strctly positive");
-    ArgChecker.isTrue(forward > 0, "strike must be strctly positive");
+    ArgChecker.isTrue(strike > 0, "strike must be strictly positive");
+    ArgChecker.isTrue(forward > 0, "strike must be strictly positive");
     double lnFK = Math.log(forward / strike);
     double s2t = blackVolatility * blackVolatility * timeToExpiry;
     if (Math.abs((forward - strike) / strike) < ATM_LIMIT) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepositoryImpliedVolatilityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepositoryImpliedVolatilityTest.java
@@ -80,12 +80,12 @@ public class NormalFormulaRepositoryImpliedVolatilityTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void wrong_strike() {
-    NormalFormulaRepository.impliedVolatilityFromBlackVolatility(FORWARD, -1.0d, T, 0.20d);
+    NormalFormulaRepository.impliedVolatilityFromBlackApproximated(FORWARD, -1.0d, T, 0.20d);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void wrong_forward() {
-    NormalFormulaRepository.impliedVolatilityFromBlackVolatility(-1.0d, FORWARD, T, 0.20d);
+    NormalFormulaRepository.impliedVolatilityFromBlackApproximated(-1.0d, FORWARD, T, 0.20d);
   }
 
   @Test
@@ -97,7 +97,7 @@ public class NormalFormulaRepositoryImpliedVolatilityTest {
   private void priceCheck(double[] strikes) {
     for (int i = 0; i < N; i++) {
       double ivNormalComputed = NormalFormulaRepository
-          .impliedVolatilityFromBlackVolatility(FORWARD, strikes[i], T, SIGMA_BLACK[i]);
+          .impliedVolatilityFromBlackApproximated(FORWARD, strikes[i], T, SIGMA_BLACK[i]);
       double priceNormalComputed = 
           NormalFormulaRepository.price(FORWARD, strikes[i], T, ivNormalComputed, PutCall.CALL) * DF;
       double priceBlack = BlackFormulaRepository.price(FORWARD, strikes[i], T, SIGMA_BLACK[i], true) * DF;


### PR DESCRIPTION
Two method added
- One explicit approximation. Good for an initial guess but not precise enough to be use on its own.
- Root-finding with the Back to Normal formula.