### PR TITLE
Swaption SABR sensitivities

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivities.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivities.java
@@ -1,0 +1,405 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.market.sensitivity;
+
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanBuilder;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.FxConvertible;
+import com.opengamma.strata.basics.currency.FxRateProvider;
+
+/**
+ * Sensitivities of swaptions to SABR model parameters.
+ * <p>
+ * Contains a list of {@link SwaptionSabrSensitivity} each of which holds sensitivity values
+ * to the grid points of the SABR parameters.
+ */
+@BeanDefinition(builderScope = "private")
+public final class SwaptionSabrSensitivities
+    implements FxConvertible<SwaptionSabrSensitivities>, ImmutableBean, Serializable {
+
+  /**
+   * The swaption SABR sensitivities.
+   * <p>
+   * Each entry includes details of the surface it relates to.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final ImmutableList<SwaptionSabrSensitivity> sensitivities;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains an instance with the specified sensitivities.
+   * 
+   * @param sensitivities  the list of sensitivities
+   * @return the instance with the sensitivities
+   */
+  public static SwaptionSabrSensitivities of(List<SwaptionSabrSensitivity> sensitivities) {
+    List<SwaptionSabrSensitivity> mutableList = new ArrayList<SwaptionSabrSensitivity>(sensitivities);
+    return new SwaptionSabrSensitivities(mutableList);
+  }
+
+  /**
+   * Obtains an instance with the specified sensitivity.
+   * 
+   * @param sensitivity  the sensitivity to add
+   * @return the instance with the sensitivity
+   */
+  public static SwaptionSabrSensitivities of(SwaptionSabrSensitivity sensitivity) {
+    return new SwaptionSabrSensitivities(Arrays.asList(sensitivity));
+  }
+
+  /**
+   * Obtains an empty instance.
+   * <p>
+   * @return the empty instance
+   */
+  public static SwaptionSabrSensitivities empty() {
+    return new SwaptionSabrSensitivities(ImmutableList.of());
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Adds a swaption SABR sensitivity.
+   * <p>
+   * A list will be created with the new sensitivity added.
+   * The created list will be not normalized. Use {@code normalizeSensitivities(List)} if necessary.
+   * 
+   * @param sensitivity  the sensitivity to add
+   * @return the instance with the new sensitivity added.
+   */
+  public SwaptionSabrSensitivities add(SwaptionSabrSensitivity sensitivity) {
+    List<SwaptionSabrSensitivity> mutableList = new ArrayList<SwaptionSabrSensitivity>(sensitivities);
+    mutableList.add(sensitivity);
+    return new SwaptionSabrSensitivities(mutableList);
+  }
+
+  /**
+   * Combines with swaption SABR sensitivities.
+   * <p>
+   * A list will be created with the new sensitivities added.
+   * The created list will be not normalized. Use {@code normalizeSensitivities(List)} if necessary.
+   * 
+   * @param other  the sensitivities to add
+   * @return the instance with the new sensitivities added.
+   */
+  public SwaptionSabrSensitivities combine(SwaptionSabrSensitivities other) {
+    List<SwaptionSabrSensitivity> mutableList =
+        Stream.concat(sensitivities.stream(), other.getSensitivities().stream()).collect(Collectors.toList());
+    return new SwaptionSabrSensitivities(mutableList);
+  }
+
+  /**
+   * Normalizes the sensitivities. 
+   * <p>
+   * Swaption SABR sensitivity objects are combined into a single object if they have the same key. 
+   * 
+   * @return the instance with the sensitivities normalized.
+   */
+  public SwaptionSabrSensitivities normalize() {
+    List<SwaptionSabrSensitivity> mutableList = new ArrayList<SwaptionSabrSensitivity>(sensitivities);
+    normalizeSensitivities(mutableList);
+    return new SwaptionSabrSensitivities(mutableList);
+  }
+
+  // combines entries with the same key
+  private static void normalizeSensitivities(List<SwaptionSabrSensitivity> mutableList) {
+    mutableList.sort(SwaptionSabrSensitivity::compareKey);
+    SwaptionSabrSensitivity previous = mutableList.get(0);
+    for (int i = 1; i < mutableList.size(); i++) {
+      SwaptionSabrSensitivity current = mutableList.get(i);
+      if (current.compareKey(previous) == 0) {
+        mutableList.set(i - 1, previous.withSensitivities(
+            previous.getAlphaSensitivity() + current.getAlphaSensitivity(),
+            previous.getBetaSensitivity() + current.getBetaSensitivity(),
+            previous.getRhoSensitivity() + current.getRhoSensitivity(),
+            previous.getNuSensitivity() + current.getNuSensitivity()));
+        mutableList.remove(i);
+        i--;
+      }
+      previous = current;
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public SwaptionSabrSensitivities convertedTo(Currency resultCurrency, FxRateProvider rateProvider) {
+    List<SwaptionSabrSensitivity> converted = sensitivities
+        .stream()
+        .map(sensitivity -> sensitivity.convertedTo(resultCurrency, rateProvider))
+        .collect(toImmutableList());
+    return SwaptionSabrSensitivities.of(converted);
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code SwaptionSabrSensitivities}.
+   * @return the meta-bean, not null
+   */
+  public static SwaptionSabrSensitivities.Meta meta() {
+    return SwaptionSabrSensitivities.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(SwaptionSabrSensitivities.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  private SwaptionSabrSensitivities(
+      List<SwaptionSabrSensitivity> sensitivities) {
+    JodaBeanUtils.notNull(sensitivities, "sensitivities");
+    this.sensitivities = ImmutableList.copyOf(sensitivities);
+  }
+
+  @Override
+  public SwaptionSabrSensitivities.Meta metaBean() {
+    return SwaptionSabrSensitivities.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the swaption SABR sensitivities.
+   * <p>
+   * Each entry includes details of the surface it relates to.
+   * @return the value of the property, not null
+   */
+  public ImmutableList<SwaptionSabrSensitivity> getSensitivities() {
+    return sensitivities;
+  }
+
+  //-----------------------------------------------------------------------
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      SwaptionSabrSensitivities other = (SwaptionSabrSensitivities) obj;
+      return JodaBeanUtils.equal(sensitivities, other.sensitivities);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(sensitivities);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(64);
+    buf.append("SwaptionSabrSensitivities{");
+    buf.append("sensitivities").append('=').append(JodaBeanUtils.toString(sensitivities));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code SwaptionSabrSensitivities}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code sensitivities} property.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes" })
+    private final MetaProperty<ImmutableList<SwaptionSabrSensitivity>> sensitivities = DirectMetaProperty.ofImmutable(
+        this, "sensitivities", SwaptionSabrSensitivities.class, (Class) ImmutableList.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "sensitivities");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 1226228605:  // sensitivities
+          return sensitivities;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public BeanBuilder<? extends SwaptionSabrSensitivities> builder() {
+      return new SwaptionSabrSensitivities.Builder();
+    }
+
+    @Override
+    public Class<? extends SwaptionSabrSensitivities> beanType() {
+      return SwaptionSabrSensitivities.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code sensitivities} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ImmutableList<SwaptionSabrSensitivity>> sensitivities() {
+      return sensitivities;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 1226228605:  // sensitivities
+          return ((SwaptionSabrSensitivities) bean).getSensitivities();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code SwaptionSabrSensitivities}.
+   */
+  private static final class Builder extends DirectFieldsBeanBuilder<SwaptionSabrSensitivities> {
+
+    private List<SwaptionSabrSensitivity> sensitivities = ImmutableList.of();
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 1226228605:  // sensitivities
+          return sensitivities;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 1226228605:  // sensitivities
+          this.sensitivities = (List<SwaptionSabrSensitivity>) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public SwaptionSabrSensitivities build() {
+      return new SwaptionSabrSensitivities(
+          sensitivities);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(64);
+      buf.append("SwaptionSabrSensitivities.Builder{");
+      buf.append("sensitivities").append('=').append(JodaBeanUtils.toString(sensitivities));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivity.java
@@ -24,6 +24,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ComparisonChain;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxConvertible;
 import com.opengamma.strata.basics.currency.FxRateProvider;
@@ -53,16 +54,6 @@ public final class SwaptionSabrSensitivity
   */
   @PropertyDefinition
   private final double tenor;
-  /**
-  * The swaption strike rate.
-  */
-  @PropertyDefinition
-  private final double strike;
-  /**
-  * The underlying swap forward rate.
-  */
-  @PropertyDefinition
-  private final double forward;
   /**
   * The currency of the sensitivity.
   */
@@ -96,8 +87,6 @@ public final class SwaptionSabrSensitivity
    * @param convention  the convention of the swap for which the data is valid
    * @param expiry  the expiry date/time of the option
    * @param tenor  the underlying swap tenor
-   * @param strike  the swaption strike rate
-   * @param forward  the underlying swap forward rate
    * @param sensitivityCurrency  the currency of the sensitivity
    * @param alphaSensitivity  the value of the alpha sensitivity
    * @param betaSensitivity  the value of the beta sensitivity
@@ -109,16 +98,21 @@ public final class SwaptionSabrSensitivity
       FixedIborSwapConvention convention,
       ZonedDateTime expiry,
       double tenor,
-      double strike,
-      double forward,
       Currency sensitivityCurrency,
       double alphaSensitivity,
       double betaSensitivity,
       double rhoSensitivity,
       double nuSensitivity) {
 
-    return new SwaptionSabrSensitivity(convention, expiry, tenor, strike, forward, sensitivityCurrency,
-        alphaSensitivity, betaSensitivity, rhoSensitivity, nuSensitivity);
+    return new SwaptionSabrSensitivity(
+        convention,
+        expiry,
+        tenor,
+        sensitivityCurrency,
+        alphaSensitivity,
+        betaSensitivity,
+        rhoSensitivity,
+        nuSensitivity);
   }
 
   //-------------------------------------------------------------------------
@@ -132,8 +126,41 @@ public final class SwaptionSabrSensitivity
     if (this.currency.equals(currency)) {
       return this;
     }
-    return new SwaptionSabrSensitivity(convention, expiry, tenor, strike, forward, currency,
-        alphaSensitivity, betaSensitivity, rhoSensitivity, nuSensitivity);
+    return new SwaptionSabrSensitivity(
+        convention,
+        expiry,
+        tenor,
+        currency,
+        alphaSensitivity,
+        betaSensitivity,
+        rhoSensitivity,
+        nuSensitivity);
+  }
+
+  /**
+   * Returns an instance with the specified sensitivity values. 
+   * 
+   * @param alphaSensitivity  the value of the alpha sensitivity
+   * @param betaSensitivity  the value of the beta sensitivity
+   * @param rhoSensitivity  the value of the rho sensitivity
+   * @param nuSensitivity  the value of the nu sensitivity
+   * @return an instance with the specified sensitivity values
+   */
+  public SwaptionSabrSensitivity withSensitivities(
+      double alphaSensitivity,
+      double betaSensitivity,
+      double rhoSensitivity,
+      double nuSensitivity) {
+
+    return new SwaptionSabrSensitivity(
+        convention,
+        expiry,
+        tenor,
+        currency,
+        alphaSensitivity,
+        betaSensitivity,
+        rhoSensitivity,
+        nuSensitivity);
   }
 
   /**
@@ -143,8 +170,15 @@ public final class SwaptionSabrSensitivity
    * @return an instance with the sensitivity values rescaled
    */
   public SwaptionSabrSensitivity multipliedBy(double factor) {
-    return new SwaptionSabrSensitivity(convention, expiry, tenor, strike, forward, currency,
-        alphaSensitivity * factor, betaSensitivity * factor, rhoSensitivity * factor, nuSensitivity * factor);
+    return new SwaptionSabrSensitivity(
+        convention,
+        expiry,
+        tenor,
+        currency,
+        alphaSensitivity * factor,
+        betaSensitivity * factor,
+        rhoSensitivity * factor,
+        nuSensitivity * factor);
   }
 
   @Override
@@ -154,6 +188,23 @@ public final class SwaptionSabrSensitivity
     }
     double fxRate = rateProvider.fxRate(getCurrency(), resultCurrency);
     return withCurrency(resultCurrency).multipliedBy(fxRate);
+  }
+
+  /**
+   * Compares the key of two sensitivities, excluding the sensitivity values.
+   * <p>
+   * The comparison must check the convention, the expiry, the tenor and the currency.
+   * 
+   * @param other  the other sensitivity
+   * @return positive if greater, zero if equal, negative if less
+   */
+  public int compareKey(SwaptionSabrSensitivity other) {
+    return ComparisonChain.start()
+        .compare(convention.toString(), other.convention.toString())
+        .compare(expiry, other.expiry)
+        .compare(tenor, other.tenor)
+        .compare(currency, other.currency)
+        .result();
   }
 
   //------------------------- AUTOGENERATED START -------------------------
@@ -179,8 +230,6 @@ public final class SwaptionSabrSensitivity
       FixedIborSwapConvention convention,
       ZonedDateTime expiry,
       double tenor,
-      double strike,
-      double forward,
       Currency currency,
       double alphaSensitivity,
       double betaSensitivity,
@@ -191,8 +240,6 @@ public final class SwaptionSabrSensitivity
     this.convention = convention;
     this.expiry = expiry;
     this.tenor = tenor;
-    this.strike = strike;
-    this.forward = forward;
     this.currency = currency;
     this.alphaSensitivity = alphaSensitivity;
     this.betaSensitivity = betaSensitivity;
@@ -240,24 +287,6 @@ public final class SwaptionSabrSensitivity
    */
   public double getTenor() {
     return tenor;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets the swaption strike rate.
-   * @return the value of the property
-   */
-  public double getStrike() {
-    return strike;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets the underlying swap forward rate.
-   * @return the value of the property
-   */
-  public double getForward() {
-    return forward;
   }
 
   //-----------------------------------------------------------------------
@@ -316,8 +345,6 @@ public final class SwaptionSabrSensitivity
       return JodaBeanUtils.equal(convention, other.convention) &&
           JodaBeanUtils.equal(expiry, other.expiry) &&
           JodaBeanUtils.equal(tenor, other.tenor) &&
-          JodaBeanUtils.equal(strike, other.strike) &&
-          JodaBeanUtils.equal(forward, other.forward) &&
           JodaBeanUtils.equal(currency, other.currency) &&
           JodaBeanUtils.equal(alphaSensitivity, other.alphaSensitivity) &&
           JodaBeanUtils.equal(betaSensitivity, other.betaSensitivity) &&
@@ -333,8 +360,6 @@ public final class SwaptionSabrSensitivity
     hash = hash * 31 + JodaBeanUtils.hashCode(convention);
     hash = hash * 31 + JodaBeanUtils.hashCode(expiry);
     hash = hash * 31 + JodaBeanUtils.hashCode(tenor);
-    hash = hash * 31 + JodaBeanUtils.hashCode(strike);
-    hash = hash * 31 + JodaBeanUtils.hashCode(forward);
     hash = hash * 31 + JodaBeanUtils.hashCode(currency);
     hash = hash * 31 + JodaBeanUtils.hashCode(alphaSensitivity);
     hash = hash * 31 + JodaBeanUtils.hashCode(betaSensitivity);
@@ -345,13 +370,11 @@ public final class SwaptionSabrSensitivity
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(352);
+    StringBuilder buf = new StringBuilder(288);
     buf.append("SwaptionSabrSensitivity{");
     buf.append("convention").append('=').append(convention).append(',').append(' ');
     buf.append("expiry").append('=').append(expiry).append(',').append(' ');
     buf.append("tenor").append('=').append(tenor).append(',').append(' ');
-    buf.append("strike").append('=').append(strike).append(',').append(' ');
-    buf.append("forward").append('=').append(forward).append(',').append(' ');
     buf.append("currency").append('=').append(currency).append(',').append(' ');
     buf.append("alphaSensitivity").append('=').append(alphaSensitivity).append(',').append(' ');
     buf.append("betaSensitivity").append('=').append(betaSensitivity).append(',').append(' ');
@@ -387,16 +410,6 @@ public final class SwaptionSabrSensitivity
     private final MetaProperty<Double> tenor = DirectMetaProperty.ofImmutable(
         this, "tenor", SwaptionSabrSensitivity.class, Double.TYPE);
     /**
-     * The meta-property for the {@code strike} property.
-     */
-    private final MetaProperty<Double> strike = DirectMetaProperty.ofImmutable(
-        this, "strike", SwaptionSabrSensitivity.class, Double.TYPE);
-    /**
-     * The meta-property for the {@code forward} property.
-     */
-    private final MetaProperty<Double> forward = DirectMetaProperty.ofImmutable(
-        this, "forward", SwaptionSabrSensitivity.class, Double.TYPE);
-    /**
      * The meta-property for the {@code currency} property.
      */
     private final MetaProperty<Currency> currency = DirectMetaProperty.ofImmutable(
@@ -429,8 +442,6 @@ public final class SwaptionSabrSensitivity
         "convention",
         "expiry",
         "tenor",
-        "strike",
-        "forward",
         "currency",
         "alphaSensitivity",
         "betaSensitivity",
@@ -452,10 +463,6 @@ public final class SwaptionSabrSensitivity
           return expiry;
         case 110246592:  // tenor
           return tenor;
-        case -891985998:  // strike
-          return strike;
-        case -677145915:  // forward
-          return forward;
         case 575402001:  // currency
           return currency;
         case -2039075231:  // alphaSensitivity
@@ -511,22 +518,6 @@ public final class SwaptionSabrSensitivity
     }
 
     /**
-     * The meta-property for the {@code strike} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<Double> strike() {
-      return strike;
-    }
-
-    /**
-     * The meta-property for the {@code forward} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<Double> forward() {
-      return forward;
-    }
-
-    /**
      * The meta-property for the {@code currency} property.
      * @return the meta-property, not null
      */
@@ -576,10 +567,6 @@ public final class SwaptionSabrSensitivity
           return ((SwaptionSabrSensitivity) bean).getExpiry();
         case 110246592:  // tenor
           return ((SwaptionSabrSensitivity) bean).getTenor();
-        case -891985998:  // strike
-          return ((SwaptionSabrSensitivity) bean).getStrike();
-        case -677145915:  // forward
-          return ((SwaptionSabrSensitivity) bean).getForward();
         case 575402001:  // currency
           return ((SwaptionSabrSensitivity) bean).getCurrency();
         case -2039075231:  // alphaSensitivity
@@ -614,8 +601,6 @@ public final class SwaptionSabrSensitivity
     private FixedIborSwapConvention convention;
     private ZonedDateTime expiry;
     private double tenor;
-    private double strike;
-    private double forward;
     private Currency currency;
     private double alphaSensitivity;
     private double betaSensitivity;
@@ -638,10 +623,6 @@ public final class SwaptionSabrSensitivity
           return expiry;
         case 110246592:  // tenor
           return tenor;
-        case -891985998:  // strike
-          return strike;
-        case -677145915:  // forward
-          return forward;
         case 575402001:  // currency
           return currency;
         case -2039075231:  // alphaSensitivity
@@ -668,12 +649,6 @@ public final class SwaptionSabrSensitivity
           break;
         case 110246592:  // tenor
           this.tenor = (Double) newValue;
-          break;
-        case -891985998:  // strike
-          this.strike = (Double) newValue;
-          break;
-        case -677145915:  // forward
-          this.forward = (Double) newValue;
           break;
         case 575402001:  // currency
           this.currency = (Currency) newValue;
@@ -726,8 +701,6 @@ public final class SwaptionSabrSensitivity
           convention,
           expiry,
           tenor,
-          strike,
-          forward,
           currency,
           alphaSensitivity,
           betaSensitivity,
@@ -738,13 +711,11 @@ public final class SwaptionSabrSensitivity
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(352);
+      StringBuilder buf = new StringBuilder(288);
       buf.append("SwaptionSabrSensitivity.Builder{");
       buf.append("convention").append('=').append(JodaBeanUtils.toString(convention)).append(',').append(' ');
       buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
       buf.append("tenor").append('=').append(JodaBeanUtils.toString(tenor)).append(',').append(' ');
-      buf.append("strike").append('=').append(JodaBeanUtils.toString(strike)).append(',').append(' ');
-      buf.append("forward").append('=').append(JodaBeanUtils.toString(forward)).append(',').append(' ');
       buf.append("currency").append('=').append(JodaBeanUtils.toString(currency)).append(',').append(' ');
       buf.append("alphaSensitivity").append('=').append(JodaBeanUtils.toString(alphaSensitivity)).append(',').append(' ');
       buf.append("betaSensitivity").append('=').append(JodaBeanUtils.toString(betaSensitivity)).append(',').append(' ');

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivitiesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivitiesTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.market.sensitivity;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.currency.Currency.USD;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.dateUtc;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.currency.CurrencyPair;
+import com.opengamma.strata.basics.currency.FxMatrix;
+import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
+import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
+
+/**
+ * Test {@link SwaptionSabrSensitivities}.
+ */
+@Test
+public class SwaptionSabrSensitivitiesTest {
+
+  private static final FixedIborSwapConvention SWAP_CONV = FixedIborSwapConventions.GBP_FIXED_1Y_LIBOR_3M;
+  private static final ZonedDateTime DATE_TIME_1 = dateUtc(2015, 8, 27);
+  private static final ZonedDateTime DATE_TIME_2 = dateUtc(2016, 8, 28);
+  private static final double SWAP_TENOR = 3d;
+  private static final double ALPHA_SENSI_1 = 2.5d;
+  private static final double BETA_SENSI_1 = 0.75d;
+  private static final double RHO_SENSI_1 = -0.125d;
+  private static final double NU_SENSI_1 = 1.5d;
+  private static final double ALPHA_SENSI_2 = -0.12d;
+  private static final double BETA_SENSI_2 = 1.15d;
+  private static final double RHO_SENSI_2 = 0.15d;
+  private static final double NU_SENSI_2 = 2.5d;
+  private static final SwaptionSabrSensitivity SENSI_1 = SwaptionSabrSensitivity.of(
+      SWAP_CONV, DATE_TIME_1, SWAP_TENOR, GBP, ALPHA_SENSI_1, BETA_SENSI_1, RHO_SENSI_1, NU_SENSI_1);
+  private static final SwaptionSabrSensitivity SENSI_2 = SwaptionSabrSensitivity.of(
+      SWAP_CONV, DATE_TIME_1, SWAP_TENOR, GBP, ALPHA_SENSI_2, BETA_SENSI_2, RHO_SENSI_2, NU_SENSI_2);
+  private static final SwaptionSabrSensitivity SENSI_3 = SwaptionSabrSensitivity.of(
+      SWAP_CONV, DATE_TIME_2, SWAP_TENOR, GBP, ALPHA_SENSI_1, BETA_SENSI_1, RHO_SENSI_1, NU_SENSI_1);
+  private static final SwaptionSabrSensitivity SENSI_12 = SwaptionSabrSensitivity.of(SWAP_CONV, DATE_TIME_1, SWAP_TENOR,
+      GBP, ALPHA_SENSI_1 + ALPHA_SENSI_2, BETA_SENSI_1 + BETA_SENSI_2, RHO_SENSI_1 + RHO_SENSI_2, NU_SENSI_1 + NU_SENSI_2);
+
+  public void test_empty() {
+    SwaptionSabrSensitivities test = SwaptionSabrSensitivities.empty();
+    assertTrue(test.getSensitivities().isEmpty());
+  }
+
+  public void test_of_sensitivity() {
+    SwaptionSabrSensitivities test = SwaptionSabrSensitivities.of(SENSI_1);
+    assertEquals(test.getSensitivities().size(), 1);
+    assertEquals(test.getSensitivities().get(0), SENSI_1);
+  }
+
+  public void test_of_sensitivities() {
+    List<SwaptionSabrSensitivity> list = Arrays.asList(SENSI_1, SENSI_3);
+    SwaptionSabrSensitivities test = SwaptionSabrSensitivities.of(list);
+    assertEquals(test.getSensitivities().size(), 2);
+    assertEquals(test.getSensitivities().get(0), SENSI_1);
+    assertEquals(test.getSensitivities().get(1), SENSI_3);
+  }
+
+  public void test_of_sensitivities_normalize() {
+    List<SwaptionSabrSensitivity> list = Arrays.asList(SENSI_1, SENSI_2);
+    SwaptionSabrSensitivities test = SwaptionSabrSensitivities.of(list).normalize();
+    assertEquals(test.getSensitivities().size(), 1);
+    assertEquals(test.getSensitivities().get(0), SENSI_12);
+  }
+
+  public void test_add() {
+    SwaptionSabrSensitivities base = SwaptionSabrSensitivities.of(SENSI_1);
+    SwaptionSabrSensitivities expected = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_1, SENSI_3));
+    assertEquals(base.add(SENSI_3), expected);
+  }
+
+  public void test_add_normalize() {
+    SwaptionSabrSensitivities base = SwaptionSabrSensitivities.of(SENSI_1);
+    SwaptionSabrSensitivities expected = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_12));
+    assertEquals(base.add(SENSI_2).normalize(), expected);
+  }
+
+  public void test_combine() {
+    SwaptionSabrSensitivities base = SwaptionSabrSensitivities.of(SENSI_1);
+    SwaptionSabrSensitivities other = SwaptionSabrSensitivities.of(SENSI_3);
+    SwaptionSabrSensitivities expected = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_1, SENSI_3));
+    assertEquals(base.combine(other), expected);
+  }
+
+  public void test_combine_normalize() {
+    SwaptionSabrSensitivities base = SwaptionSabrSensitivities.of(SENSI_1);
+    SwaptionSabrSensitivities other = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_2, SENSI_3));
+    SwaptionSabrSensitivities expected = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_12, SENSI_3));
+    assertEquals(base.combine(other).normalize(), expected);
+  }
+
+  public void test_convertedTo() {
+    SwaptionSabrSensitivities base = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_1, SENSI_3));
+    double rate = 1.5d;
+    FxMatrix matrix = FxMatrix.of(CurrencyPair.of(GBP, USD), rate);
+    assertEquals(base.convertedTo(GBP, matrix), base);
+    SwaptionSabrSensitivities expected = SwaptionSabrSensitivities.of(
+        Arrays.asList(SENSI_1.convertedTo(USD, matrix), SENSI_3.convertedTo(USD, matrix)));
+    assertEquals(base.convertedTo(USD, matrix), expected);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    SwaptionSabrSensitivities test1 = SwaptionSabrSensitivities.of(SENSI_1);
+    coverImmutableBean(test1);
+    SwaptionSabrSensitivities test2 = SwaptionSabrSensitivities.of(Arrays.asList(SENSI_2, SENSI_3));
+    coverBeanEquals(test1, test2);
+  }
+
+  public void test_serialization() {
+    SwaptionSabrSensitivities test = SwaptionSabrSensitivities.of(SENSI_1);
+    assertSerialization(test);
+  }
+
+}

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivityTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/SwaptionSabrSensitivityTest.java
@@ -32,8 +32,6 @@ public class SwaptionSabrSensitivityTest {
   private static final FixedIborSwapConvention SWAP_CONV = FixedIborSwapConventions.GBP_FIXED_1Y_LIBOR_3M;
   private static final ZonedDateTime DATE_TIME = dateUtc(2015, 8, 27);
   private static final double SWAP_TENOR = 3d;
-  private static final double FORWARD = 0.015;
-  private static final double STRIKE = -0.005;
   private static final double ALPHA_SENSI = 2.5d;
   private static final double BETA_SENSI = 0.75d;
   private static final double RHO_SENSI = -0.125d;
@@ -42,7 +40,7 @@ public class SwaptionSabrSensitivityTest {
 
   public void test_of() {
     SwaptionSabrSensitivity test = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     assertEquals(test.getAlphaSensitivity(), ALPHA_SENSI);
     assertEquals(test.getBetaSensitivity(), BETA_SENSI);
     assertEquals(test.getRhoSensitivity(), RHO_SENSI);
@@ -50,52 +48,92 @@ public class SwaptionSabrSensitivityTest {
     assertEquals(test.getConvention(), SWAP_CONV);
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getExpiry(), DATE_TIME);
-    assertEquals(test.getStrike(), STRIKE);
     assertEquals(test.getTenor(), SWAP_TENOR);
   }
 
   public void test_withCurrency() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     assertSame(base.withCurrency(GBP), base);
     SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, USD, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, USD, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     assertEquals(base.withCurrency(USD), expected);
+  }
+
+  public void test_withSensitivities() {
+    SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    double alpha = 1d, beta = 2.2d, rho = 1.3d, nu = 0.5d;
+    SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, alpha, beta, rho, nu);
+    assertEquals(base.withSensitivities(alpha, beta, rho, nu), expected);
   }
 
   public void test_multipliedBy() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     double factor = -2.1d;
-    SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD,
+    SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(SWAP_CONV, DATE_TIME, SWAP_TENOR,
         GBP, ALPHA_SENSI * factor, BETA_SENSI * factor, RHO_SENSI * factor, NU_SENSI * factor);
     assertEquals(base.multipliedBy(factor), expected);
   }
 
   public void test_convertedTo() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     double rate = 1.5d;
     FxMatrix matrix = FxMatrix.of(CurrencyPair.of(GBP, USD), rate);
     assertSame(base.convertedTo(GBP, matrix), base);
-    SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD,
+    SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(SWAP_CONV, DATE_TIME, SWAP_TENOR,
         USD, ALPHA_SENSI * rate, BETA_SENSI * rate, RHO_SENSI * rate, NU_SENSI * rate);
     assertEquals(base.convertedTo(USD, matrix), expected);
+  }
+
+  public void test_compareKey() {
+    SwaptionSabrSensitivity test0 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test1 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test2 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, 0.5d, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test3 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, 0.5d, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test4 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, 0.5d, NU_SENSI);
+    SwaptionSabrSensitivity test5 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, 0.5d);
+    SwaptionSabrSensitivity test6 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, USD, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test7 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, DATE_TIME, 2d, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test8 = SwaptionSabrSensitivity.of(
+        SWAP_CONV, dateUtc(2015, 4, 27), SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    SwaptionSabrSensitivity test9 = SwaptionSabrSensitivity.of(FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M,
+        DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+    assertEquals(test0.compareKey(test1), 0);
+    assertEquals(test0.compareKey(test2), 0);
+    assertEquals(test0.compareKey(test3), 0);
+    assertEquals(test0.compareKey(test4), 0);
+    assertEquals(test0.compareKey(test5), 0);
+    assertEquals(test0.compareKey(test6) < 0, true);
+    assertEquals(test0.compareKey(test7) > 0, true);
+    assertEquals(test0.compareKey(test8) > 0, true);
+    assertEquals(test0.compareKey(test9) < 0, true);
   }
 
   //-------------------------------------------------------------------------
   public void coverage() {
     SwaptionSabrSensitivity test1 = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     coverImmutableBean(test1);
     SwaptionSabrSensitivity test2 = SwaptionSabrSensitivity.of(FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M,
-        dateUtc(2015, 4, 27), 10d, 0.015d, 0.005d, USD, 1.2d, -0.24d, 3.01d, 0.98d);
+        dateUtc(2015, 4, 27), 10d, USD, 1.2d, -0.24d, 3.01d, 0.98d);
     coverBeanEquals(test1, test2);
   }
 
   public void test_serialization() {
     SwaptionSabrSensitivity test = SwaptionSabrSensitivity.of(
-        SWAP_CONV, DATE_TIME, SWAP_TENOR, STRIKE, FORWARD, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
+        SWAP_CONV, DATE_TIME, SWAP_TENOR, GBP, ALPHA_SENSI, BETA_SENSI, RHO_SENSI, NU_SENSI);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
@@ -37,6 +38,7 @@ import com.opengamma.strata.basics.value.ValueDerivatives;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.tuple.DoublesPair;
+import com.opengamma.strata.market.sensitivity.SwaptionSabrSensitivities;
 import com.opengamma.strata.market.sensitivity.SwaptionSabrSensitivity;
 import com.opengamma.strata.market.sensitivity.SwaptionSensitivity;
 import com.opengamma.strata.market.surface.NodalSurface;
@@ -151,9 +153,30 @@ public final class SabrParametersSwaptionVolatilities
   }
 
   /**
-   * Calculates the surface parameter sensitivity from the point sensitivity.
+   * Calculates the surface parameter sensitivities from the point sensitivities.
    * <p>
-   * This is used to convert a single point sensitivity to surface parameter sensitivity.
+   * This is used to convert a set of point sensitivities to surface parameter sensitivities.
+   * 
+   * @param pointSensitivities  the point sensitivities to convert
+   * @return the parameter sensitivity
+   * @throws RuntimeException if the result cannot be calculated
+   */
+  public SurfaceCurrencyParameterSensitivities surfaceCurrencyParameterSensitivity(
+      SwaptionSabrSensitivities pointSensitivities) {
+
+    List<SurfaceCurrencyParameterSensitivity> sensitivitiesTotal =
+        pointSensitivities.getSensitivities()
+            .stream()
+            .map(pointSensitivity -> surfaceCurrencyParameterSensitivity(pointSensitivity).getSensitivities())
+            .flatMap(list -> list.stream())
+            .collect(Collectors.toList());
+    return SurfaceCurrencyParameterSensitivities.of(sensitivitiesTotal);
+  }
+
+  /**
+   * Calculates the surface parameter sensitivities from the point sensitivity.
+   * <p>
+   * This is used to convert a single point sensitivity to surface parameter sensitivities.
    * 
    * @param pointSensitivity  the point sensitivity to convert
    * @return the parameter sensitivity

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
@@ -129,7 +129,7 @@ public class SabrSwaptionCashParYieldProductPricer
     double strike = calculateStrike(fixedLeg);
     if (expiry < 0d) { // Option has expired already
       return SwaptionSabrSensitivity.of(
-          swaptionVolatilities.getConvention(), expiryDateTime, tenor, strike, 0d, fixedLeg.getCurrency(), 0d, 0d, 0d, 0d);
+          swaptionVolatilities.getConvention(), expiryDateTime, tenor, fixedLeg.getCurrency(), 0d, 0d, 0d, 0d);
     }
     double forward = getSwapPricer().parRate(underlying, ratesProvider);
     double volatility = swaptionVolatilities.volatility(expiryDateTime, tenor, strike, forward);
@@ -141,8 +141,6 @@ public class SabrSwaptionCashParYieldProductPricer
         swaptionVolatilities.getConvention(),
         expiryDateTime,
         tenor,
-        strike,
-        forward,
         fixedLeg.getCurrency(),
         vega * derivative.get(2),
         vega * derivative.get(3),

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
@@ -125,7 +125,7 @@ public class SabrSwaptionPhysicalProductPricer
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     if (expiry < 0d) { // Option has expired already
       return SwaptionSabrSensitivity.of(
-          swaptionVolatilities.getConvention(), expiryDateTime, tenor, strike, 0d, fixedLeg.getCurrency(), 0d, 0d, 0d, 0d);
+          swaptionVolatilities.getConvention(), expiryDateTime, tenor, fixedLeg.getCurrency(), 0d, 0d, 0d, 0d);
     }
     double forward = getSwapPricer().parRate(underlying, ratesProvider);
     double volatility = swaptionVolatilities.volatility(expiryDateTime, tenor, strike, forward);
@@ -138,8 +138,6 @@ public class SabrSwaptionPhysicalProductPricer
         swaptionVolatilities.getConvention(),
         expiryDateTime,
         tenor,
-        strike,
-        forward,
         fixedLeg.getCurrency(),
         vega * derivative.get(2),
         vega * derivative.get(3),

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -601,8 +601,6 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     assertEquals(sensiRec.getConvention(), SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_EUR);
     assertEquals(sensiRec.getExpiry(), SWAPTION_REC_LONG.getExpiryDateTime());
     assertEquals(sensiRec.getTenor(), (double) TENOR_YEAR);
-    assertEquals(sensiRec.getStrike(), RATE, TOL);
-    assertEquals(sensiRec.getForward(), forward, TOL);
     assertEquals(sensiPay.getCurrency(), EUR);
     assertEquals(sensiPay.getAlphaSensitivity(), vegaPay * volSensi[2], NOTIONAL * TOL);
     assertEquals(sensiPay.getBetaSensitivity(), vegaPay * volSensi[3], NOTIONAL * TOL);
@@ -611,8 +609,6 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     assertEquals(sensiRec.getConvention(), SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_EUR);
     assertEquals(sensiPay.getExpiry(), SWAPTION_REC_LONG.getExpiryDateTime());
     assertEquals(sensiPay.getTenor(), (double) TENOR_YEAR);
-    assertEquals(sensiPay.getStrike(), RATE, TOL);
-    assertEquals(sensiPay.getForward(), forward, TOL);
   }
 
   public void test_presentValueSensitivitySabrParameter_atMaturity() {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -494,8 +494,6 @@ public class SabrSwaptionPhysicalProductPricerTest {
     assertEquals(sensiRec.getConvention(), SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_USD);
     assertEquals(sensiRec.getExpiry(), SWAPTION_REC_LONG.getExpiryDateTime());
     assertEquals(sensiRec.getTenor(), (double) TENOR_YEAR);
-    assertEquals(sensiRec.getStrike(), RATE, TOL);
-    assertEquals(sensiRec.getForward(), forward, TOL);
     assertEquals(sensiPay.getCurrency(), USD);
     assertEquals(sensiPay.getAlphaSensitivity(), vegaPay * volSensi[2], NOTIONAL * TOL);
     assertEquals(sensiPay.getBetaSensitivity(), vegaPay * volSensi[3], NOTIONAL * TOL);
@@ -504,8 +502,6 @@ public class SabrSwaptionPhysicalProductPricerTest {
     assertEquals(sensiRec.getConvention(), SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_USD);
     assertEquals(sensiPay.getExpiry(), SWAPTION_REC_LONG.getExpiryDateTime());
     assertEquals(sensiPay.getTenor(), (double) TENOR_YEAR);
-    assertEquals(sensiPay.getStrike(), RATE, TOL);
-    assertEquals(sensiPay.getForward(), forward, TOL);
   }
 
   public void test_presentValueSensitivitySabrParameter_atMaturity() {


### PR DESCRIPTION
* Created SwaptionSabrSensitivities. 
* Removed forward and strike from SwaptionSabrSensitivity. 
* Added compareKey to SwaptionSabrSensitivity.
* Added surfaceCurrencyParameterSensitivity(SwaptionSabrSensitivities) to SabrParametersSwaptionVolatilities. 
* This work is required by #545 