### PR TITLE
Changed the pricer of IborFixingDeposit to accept any RatesProvider.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationMeasure.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CalibrationMeasure.java
@@ -7,7 +7,7 @@ package com.opengamma.strata.pricer.calibration;
 
 import com.opengamma.strata.basics.Trade;
 import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
-import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
+import com.opengamma.strata.pricer.rate.RatesProvider;
 
 /**
  * Provides access to the measures needed to perform curve calibration for a single type of trade.
@@ -37,7 +37,7 @@ public interface CalibrationMeasure<T extends Trade> {
    * @return the sensitivity
    * @throws IllegalArgumentException if the trade cannot be valued
    */
-  public abstract double value(T trade, ImmutableRatesProvider provider);
+  public abstract double value(T trade, RatesProvider provider);
 
   /**
    * Calculates the parameter sensitivities that relate to the value.
@@ -49,6 +49,6 @@ public interface CalibrationMeasure<T extends Trade> {
    * @return the sensitivity
    * @throws IllegalArgumentException if the trade cannot be valued
    */
-  public abstract CurveCurrencyParameterSensitivities sensitivities(T trade, ImmutableRatesProvider provider);
+  public abstract CurveCurrencyParameterSensitivities sensitivities(T trade, RatesProvider provider);
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/TradeCalibrationMeasure.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/TradeCalibrationMeasure.java
@@ -17,7 +17,7 @@ import com.opengamma.strata.pricer.deposit.DiscountingTermDepositProductPricer;
 import com.opengamma.strata.pricer.fra.DiscountingFraProductPricer;
 import com.opengamma.strata.pricer.fx.DiscountingFxSwapProductPricer;
 import com.opengamma.strata.pricer.index.DiscountingIborFutureTradePricer;
-import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
+import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.product.deposit.IborFixingDepositTrade;
 import com.opengamma.strata.product.deposit.TermDepositTrade;
@@ -108,11 +108,11 @@ public class TradeCalibrationMeasure<T extends Trade>
   /**
    * The value measure.
    */
-  private final ToDoubleBiFunction<T, ImmutableRatesProvider> valueFn;
+  private final ToDoubleBiFunction<T, RatesProvider> valueFn;
   /**
    * The sensitivity measure.
    */
-  private final BiFunction<T, ImmutableRatesProvider, PointSensitivities> sensitivityFn;
+  private final BiFunction<T, RatesProvider, PointSensitivities> sensitivityFn;
 
   //-------------------------------------------------------------------------
   /**
@@ -130,8 +130,8 @@ public class TradeCalibrationMeasure<T extends Trade>
   public static <R extends Trade> TradeCalibrationMeasure<R> of(
       String name,
       Class<R> tradeType,
-      ToDoubleBiFunction<R, ImmutableRatesProvider> valueFn,
-      BiFunction<R, ImmutableRatesProvider, PointSensitivities> sensitivityFn) {
+      ToDoubleBiFunction<R, RatesProvider> valueFn,
+      BiFunction<R, RatesProvider, PointSensitivities> sensitivityFn) {
 
     return new TradeCalibrationMeasure<R>(name, tradeType, valueFn, sensitivityFn);
   }
@@ -140,8 +140,8 @@ public class TradeCalibrationMeasure<T extends Trade>
   private TradeCalibrationMeasure(
       String name,
       Class<T> tradeType,
-      ToDoubleBiFunction<T, ImmutableRatesProvider> valueFn,
-      BiFunction<T, ImmutableRatesProvider, PointSensitivities> sensitivityFn) {
+      ToDoubleBiFunction<T, RatesProvider> valueFn,
+      BiFunction<T, RatesProvider, PointSensitivities> sensitivityFn) {
 
     this.name = name;
     this.tradeType = tradeType;
@@ -157,12 +157,12 @@ public class TradeCalibrationMeasure<T extends Trade>
 
   //-------------------------------------------------------------------------
   @Override
-  public double value(T trade, ImmutableRatesProvider provider) {
+  public double value(T trade, RatesProvider provider) {
     return valueFn.applyAsDouble(trade, provider);
   }
 
   @Override
-  public CurveCurrencyParameterSensitivities sensitivities(T trade, ImmutableRatesProvider provider) {
+  public CurveCurrencyParameterSensitivities sensitivities(T trade, RatesProvider provider) {
     PointSensitivities pts = sensitivityFn.apply(trade, provider);
     return provider.curveParameterSensitivity(pts);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
@@ -11,7 +11,7 @@ import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.market.view.DiscountFactors;
 import com.opengamma.strata.market.view.IborIndexRates;
-import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
+import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.product.deposit.ExpandedIborFixingDeposit;
 import com.opengamma.strata.product.deposit.IborFixingDeposit;
 import com.opengamma.strata.product.deposit.IborFixingDepositProduct;
@@ -46,7 +46,7 @@ public class DiscountingIborFixingDepositProductPricer {
    * @param provider  the rates provider
    * @return the present value of the product
    */
-  public CurrencyAmount presentValue(IborFixingDepositProduct product, ImmutableRatesProvider provider) {
+  public CurrencyAmount presentValue(IborFixingDepositProduct product, RatesProvider provider) {
     ExpandedIborFixingDeposit deposit = product.expand();
     Currency currency = deposit.getCurrency();
     if (provider.getValuationDate().isAfter(deposit.getEndDate())) {
@@ -69,7 +69,7 @@ public class DiscountingIborFixingDepositProductPricer {
    * @param provider  the rates provider
    * @return the point sensitivity of the present value
    */
-  public PointSensitivities presentValueSensitivity(IborFixingDepositProduct product, ImmutableRatesProvider provider) {
+  public PointSensitivities presentValueSensitivity(IborFixingDepositProduct product, RatesProvider provider) {
     ExpandedIborFixingDeposit deposit = product.expand();
     double forwardRate = forwardRate(deposit, provider);
     DiscountFactors discountFactors = provider.discountFactors(deposit.getCurrency());
@@ -90,7 +90,7 @@ public class DiscountingIborFixingDepositProductPricer {
    * @param provider  the rates provider
    * @return the par rate
    */
-  public double parRate(IborFixingDepositProduct product, ImmutableRatesProvider provider) {
+  public double parRate(IborFixingDepositProduct product, RatesProvider provider) {
     ExpandedIborFixingDeposit deposit = product.expand();
     return forwardRate(deposit, provider);
   }
@@ -103,7 +103,7 @@ public class DiscountingIborFixingDepositProductPricer {
    * @param provider  the rates provider
    * @return the par spread
    */
-  public double parSpread(IborFixingDepositProduct product, ImmutableRatesProvider provider) {
+  public double parSpread(IborFixingDepositProduct product, RatesProvider provider) {
     ExpandedIborFixingDeposit deposit = product.expand();
     return forwardRate(deposit, provider) - deposit.getFixedRate();
   }
@@ -115,22 +115,22 @@ public class DiscountingIborFixingDepositProductPricer {
    * @param provider  the rates provider
    * @return the par spread curve sensitivity
    */
-  public PointSensitivities parSpreadSensitivity(IborFixingDepositProduct product, ImmutableRatesProvider provider) {
+  public PointSensitivities parSpreadSensitivity(IborFixingDepositProduct product, RatesProvider provider) {
     ExpandedIborFixingDeposit deposit = product.expand();
     return forwardRateSensitivity(deposit, provider).build();
   }
 
   //-------------------------------------------------------------------------
   // query the forward rate
-  private double forwardRate(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
+  private double forwardRate(ExpandedIborFixingDeposit product, RatesProvider provider) {
     IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
     // The IborFixingDeposit are fictitious instruments to anchor the beginning of the IborIndex forward curve. 
-    // By using the 'forwardRate' method (instead of 'rate') we ensure that only the forward curve is involved.
+    // By using the 'rateIgnoringTimeSeries' method (instead of 'rate') we ensure that only the forward curve is involved.
     return rates.rateIgnoringTimeSeries(product.getFloatingRate().getFixingDate());
   }
 
   // query the forward rate sensitivity
-  private PointSensitivityBuilder forwardRateSensitivity(ExpandedIborFixingDeposit product, ImmutableRatesProvider provider) {
+  private PointSensitivityBuilder forwardRateSensitivity(ExpandedIborFixingDeposit product, RatesProvider provider) {
     IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
     return rates.rateIgnoringTimeSeriesPointSensitivity(product.getFloatingRate().getFixingDate());
   }


### PR DESCRIPTION
Previously, the pricer for IborFixingDeposit worked only on ImmutableRatesProvider and not on a generic RatesProvider. In the mean time the structure of IborIndexRates/RatesProvider has been changed. This PR simply recognize the fact that the limitation has disappeared and the pricer and related methods can be adapted.