### PR TITLE
Added new IborindexRates based on direct representation of forward rates

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationSimpleForwardCheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationSimpleForwardCheckExample.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationSimpleForwardCheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationSimpleForwardCheckExample.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.examples.finance;
+
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+import static com.opengamma.strata.function.StandardComponents.marketDataFactory;
+import static java.util.stream.Collectors.toMap;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.Trade;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
+import com.opengamma.strata.basics.market.ImmutableMarketData;
+import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.calc.CalculationRules;
+import com.opengamma.strata.calc.CalculationRunner;
+import com.opengamma.strata.calc.Column;
+import com.opengamma.strata.calc.config.MarketDataRule;
+import com.opengamma.strata.calc.config.MarketDataRules;
+import com.opengamma.strata.calc.config.Measure;
+import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
+import com.opengamma.strata.calc.marketdata.MarketEnvironment;
+import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
+import com.opengamma.strata.calc.runner.Results;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.io.ResourceLocator;
+import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.function.StandardComponents;
+import com.opengamma.strata.function.marketdata.mapping.MarketDataMappingsBuilder;
+import com.opengamma.strata.loader.csv.QuotesCsvLoader;
+import com.opengamma.strata.loader.csv.RatesCalibrationCsvLoader;
+import com.opengamma.strata.market.curve.CurveGroupDefinition;
+import com.opengamma.strata.market.curve.CurveGroupName;
+import com.opengamma.strata.market.curve.node.IborFixingDepositCurveNode;
+import com.opengamma.strata.market.id.QuoteId;
+
+/**
+ * Test for curve calibration with 2 curves in USD. 
+ * <p>
+ * One curve is used for Discounting and Fed Fund forward.
+ * The other curve is used for Libor 3M forward. 
+ * The Libor forward curve is interpolated directly on forward rates, not on discount factors or zero-rates.
+ * <p>
+ * Curve configuration and market data loaded from csv files.
+ * Tests that the trades used for calibration have a PV of 0.
+ */
+public class CalibrationSimpleForwardCheckExample {
+
+  /**
+   * The valuation date.
+   */
+  private static final LocalDate VAL_DATE = LocalDate.of(2015, 7, 21);
+
+  /**
+   * The tolerance to use.
+   */
+  private static final double TOLERANCE_PV = 1.0E-8;
+  /**
+   * The curve group name.
+   */
+  private static final CurveGroupName CURVE_GROUP_NAME = CurveGroupName.of("USD-DSCON-LIBOR3M");
+
+  /**
+   * The location of the data files.
+   */
+  private static final String PATH_CONFIG = "src/main/resources/example-calibration/";
+  /**
+   * The location of the curve calibration groups file.
+   */
+  private static final ResourceLocator GROUPS_RESOURCE =
+      ResourceLocator.of(ResourceLocator.FILE_URL_PREFIX + PATH_CONFIG + "curves/groups.csv");
+  /**
+   * The location of the curve calibration settings file.
+   */
+  private static final ResourceLocator SETTINGS_RESOURCE =
+      ResourceLocator.of(ResourceLocator.FILE_URL_PREFIX + PATH_CONFIG + "curves/settings-fwd.csv");
+  /**
+   * The location of the curve calibration nodes file.
+   */
+  private static final ResourceLocator CALIBRATION_RESOURCE =
+      ResourceLocator.of(ResourceLocator.FILE_URL_PREFIX + PATH_CONFIG + "curves/calibrations.csv");
+  /**
+   * The location of the market quotes file.
+   */
+  private static final ResourceLocator QUOTES_RESOURCE =
+      ResourceLocator.of(ResourceLocator.FILE_URL_PREFIX + PATH_CONFIG + "quotes/quotes.csv");
+
+  //-------------------------------------------------------------------------
+  /** 
+   * Runs the calibration and checks that all the trades used in the curve calibration have a PV of 0.
+   * 
+   * @param args  -p to run the performance estimate
+   */
+  public static void main(String[] args) {
+
+    System.out.println("Starting curve calibration: configuration and data loaded from files");
+    Pair<List<Trade>, Results> results = calculate();
+    System.out.println("Computed PV for all instruments used in the calibration set");
+
+    // check that all trades have a PV of near 0
+    for (int i = 0; i < results.getFirst().size(); i++) {
+      Trade trade = results.getFirst().get(i);
+      Result<?> pv = results.getSecond().getItems().get(i);
+      String output = "  |--> PV for " + trade.getClass().getSimpleName() + " computed: " + pv.isSuccess();
+      Object pvValue = pv.getValue();
+      ArgChecker.isTrue((pvValue instanceof MultiCurrencyAmount) || (pvValue instanceof CurrencyAmount), "result type");
+      if (pvValue instanceof CurrencyAmount) {
+        CurrencyAmount ca = (CurrencyAmount) pvValue;
+        ArgChecker.isTrue(Math.abs(ca.getAmount()) < TOLERANCE_PV, "PV should be small");
+        output = output + " with value: " + ca;
+      } else {
+        MultiCurrencyAmount pvMCA = (MultiCurrencyAmount) pvValue;
+        output = output + " with values: " + pvMCA;
+      }
+      System.out.println(output);
+    }
+
+    // optionally test performance
+    if (args.length > 0) {
+      if (args[0].equals("-p")) {
+        performance_calibration_pricing();
+      }
+    }
+    System.out.println("Checked PV for all instruments used in the calibration set are near to zero");
+  }
+
+  // Example of performance: loading data from file, calibration and PV
+  private static void performance_calibration_pricing() {
+    int nbTests = 10;
+    int nbRep = 3;
+    int count = 0;
+
+    for (int i = 0; i < nbRep; i++) {
+      long startTime = System.currentTimeMillis();
+      for (int looprep = 0; looprep < nbTests; looprep++) {
+        Results r = calculate().getSecond();
+        count += r.getColumnCount() + r.getRowCount();
+      }
+      long endTime = System.currentTimeMillis();
+      System.out.println("Performance: " + nbTests + " config load + curve calibrations + pv check (1 thread) in "
+          + (endTime - startTime) + " ms");
+      // Previous run: 400 ms for 10 cycles
+    }
+    if (count == 0) {
+      System.out.println("Avoiding hotspot: " + count);
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  // setup calculation runner component, which needs life-cycle management
+  // a typical application might use dependency injection to obtain the instance
+  private static Pair<List<Trade>, Results> calculate() {
+    try (CalculationRunner runner = CalculationRunner.ofMultiThreaded()) {
+      return calculate(runner);
+    }
+  }
+
+  // calculates the PV results for the instruments used in calibration from the config
+  private static Pair<List<Trade>, Results> calculate(CalculationRunner runner) {
+    // load quotes
+    ImmutableMap<QuoteId, Double> quotes = QuotesCsvLoader.load(VAL_DATE, QUOTES_RESOURCE);
+
+    // create the market data used for calculations
+    MarketEnvironment marketSnapshot = MarketEnvironment.builder()
+        .valuationDate(VAL_DATE)
+        .addValues(quotes)
+        .build();
+
+    // create the market data used for building trades
+    MarketData marketData = ImmutableMarketData.builder(VAL_DATE)
+        .addValuesById(quotes)
+        .build();
+
+    // load the curve definition
+    List<CurveGroupDefinition> defns =
+        RatesCalibrationCsvLoader.load(GROUPS_RESOURCE, SETTINGS_RESOURCE, CALIBRATION_RESOURCE);
+
+    Map<CurveGroupName, CurveGroupDefinition> defnMap = defns.stream().collect(toMap(def -> def.getName(), def -> def));
+    CurveGroupDefinition curveGroupDefinition = defnMap.get(CURVE_GROUP_NAME);
+
+    // extract the trades used for calibration
+    List<Trade> trades = curveGroupDefinition.getCurveDefinitions().stream()
+        .flatMap(defn -> defn.getNodes().stream())
+        // IborFixingDeposit is not a real trade, so there is no appropriate comparison
+        .filter(node -> !(node instanceof IborFixingDepositCurveNode))
+        .map(node -> node.trade(VAL_DATE, marketData))
+        .collect(toImmutableList());
+
+    // the columns, specifying the measures to be calculated
+    List<Column> columns = ImmutableList.of(
+        Column.of(Measure.PRESENT_VALUE));
+
+    // the configuration that defines how to create the curves when a curve group is requested
+    MarketDataConfig marketDataConfig = MarketDataConfig.builder()
+        .add(CURVE_GROUP_NAME, curveGroupDefinition)
+        .build();
+
+    // the configuration defining the curve group to use when finding a curve
+    MarketDataRules marketDataRules = MarketDataRules.of(
+        MarketDataRule.anyTarget(MarketDataMappingsBuilder.create()
+            .curveGroup(CURVE_GROUP_NAME)
+            .build()));
+
+    // the complete set of rules for calculating measures
+    CalculationRules rules = CalculationRules.builder()
+        .pricingRules(StandardComponents.pricingRules())
+        .marketDataRules(marketDataRules)
+        .build();
+
+    // calibrate the curves and calculate the results
+    MarketDataRequirements reqs = MarketDataRequirements.of(rules, trades, columns);
+    MarketEnvironment enhancedMarketData = marketDataFactory().buildMarketData(reqs, marketSnapshot, marketDataConfig);
+    Results results = runner.calculateSingleScenario(rules, trades, columns, enhancedMarketData);
+    return Pair.of(trades, results);
+  }
+
+}

--- a/examples/src/main/resources/example-calibration/curves/settings-fwd.csv
+++ b/examples/src/main/resources/example-calibration/curves/settings-fwd.csv
@@ -1,1 +1,1 @@
-Curve Name,Value Type,Day Count,Interpolator,Left Extrapolator,Right ExtrapolatorUSD-Disc,Zero,Act/365F,Linear,Flat,FlatUSD-3ML,Forward,Act/365F,Linear,Flat,Flat
+Curve Name,Value Type,Day Count,Interpolator,Left Extrapolator,Right ExtrapolatorUSD-Disc,Zero,Act/365F,Linear,Flat,FlatUSD-3ML,Forward,Act/365F,Linear,Flat,Flat

--- a/examples/src/main/resources/example-calibration/curves/settings-fwd.csv
+++ b/examples/src/main/resources/example-calibration/curves/settings-fwd.csv
@@ -1,0 +1,1 @@
+Curve Name,Value Type,Day Count,Interpolator,Left Extrapolator,Right ExtrapolatorUSD-Disc,Zero,Act/365F,Linear,Flat,FlatUSD-3ML,Forward,Act/365F,Linear,Flat,Flat

--- a/examples/src/test/java/com/opengamma/strata/examples/finance/ExamplesTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/finance/ExamplesTest.java
@@ -158,6 +158,20 @@ public class ExamplesTest {
     assertFalse(captured.contains("Exception"));
   }
 
+  public void test_calibration_eur3() throws Exception {
+    String captured = caputureSystemOut(() -> CalibrationEur3CheckExample.main(NO_ARGS));
+    assertTrue(captured.contains("Checked PV for all instruments used in the calibration set are near to zero"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
+  public void test_calibration_simple_forward() throws Exception {
+    String captured = caputureSystemOut(() -> CalibrationSimpleForwardCheckExample.main(NO_ARGS));
+    assertTrue(captured.contains("Checked PV for all instruments used in the calibration set are near to zero"));
+    assertFalse(captured.contains("ERROR"));
+    assertFalse(captured.contains("Exception"));
+  }
+
   //-------------------------------------------------------------------------
   private String[] toolArgs(String name) {
     return new String[] {

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
@@ -96,7 +96,8 @@ public final class RatesCurvesCsvLoader {
    */
   private static final Map<String, ValueType> VALUE_TYPE_MAP = ImmutableMap.of(
       "zero", ValueType.ZERO_RATE,
-      "df", ValueType.DISCOUNT_FACTOR);
+      "df", ValueType.DISCOUNT_FACTOR,
+      "forward", ValueType.FORWARD_RATE);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/market/src/main/java/com/opengamma/strata/market/ValueType.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/ValueType.java
@@ -45,11 +45,14 @@ public final class ValueType
    * Type used when each value is the number of months relative to a base month - 'Months'.
    */
   public static final ValueType MONTHS = of("Months");
-
   /**
    * Type used when each value is a zero rate - 'ZeroRate'.
    */
   public static final ValueType ZERO_RATE = of("ZeroRate");
+  /**
+   * Type used when each value is a forward rate - 'ForwardRate'.
+   */
+  public static final ValueType FORWARD_RATE = of("ForwardRate");
   /**
    * Type used when each value is a discount factor - 'DiscountFactor'.
    */

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNode.java
@@ -145,7 +145,7 @@ public final class FixedIborSwapCurveNode
 
   @Override
   public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
       return marketData.getValue(rateKey);
     }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNode.java
@@ -149,7 +149,7 @@ public final class FixedOvernightSwapCurveNode
 
   @Override
   public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
       return marketData.getValue(rateKey);
     }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FraCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FraCurveNode.java
@@ -141,7 +141,7 @@ public final class FraCurveNode
 
   @Override
   public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
       return marketData.getValue(rateKey);
     }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNode.java
@@ -149,7 +149,7 @@ public final class IborFixingDepositCurveNode
 
   @Override
   public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
       return marketData.getValue(rateKey);
     }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFutureCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFutureCurveNode.java
@@ -135,7 +135,7 @@ public final class IborFutureCurveNode
 
   @Override
   public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
       return 1d - marketData.getValue(rateKey);
     }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/TermDepositCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/TermDepositCurveNode.java
@@ -145,7 +145,7 @@ public final class TermDepositCurveNode
 
   @Override
   public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
-    if (ValueType.ZERO_RATE.equals(valueType)) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
       return marketData.getValue(rateKey);
     }
     if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/IborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/IborIndexRates.java
@@ -67,7 +67,9 @@ public interface IborIndexRates
       LocalDate valuationDate,
       Curve forwardCurve,
       LocalDateDoubleTimeSeries fixings) {
-
+    if (forwardCurve.getMetadata().getYValueType().equals(ValueType.FORWARD_RATE)) {
+      return SimpleIborIndexRates.of(index, valuationDate, forwardCurve, fixings);
+    }
     DiscountFactors discountFactors = DiscountFactors.of(index.getCurrency(), valuationDate, forwardCurve);
     return DiscountIborIndexRates.of(index, discountFactors, fixings);
   }

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/SimpleIborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/SimpleIborIndexRates.java
@@ -1,0 +1,597 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.market.view;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.PropertyDefinition;
+
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.index.IborIndex;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.Messages;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.Perturbation;
+import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivity;
+import com.opengamma.strata.market.curve.CurveInfoType;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.CurveUnitParameterSensitivity;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.OptionalDouble;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanBuilder;
+import org.joda.beans.ImmutableConstructor;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+/**
+ * An Ibor index curve providing rates directly from a forward rates curve.
+ * <p>
+ * This provides historic and forward rates for a single {@link IborIndex}, such as 'GBP-LIBOR-3M'.
+ * <p>
+ * This implementation is based on an underlying curve that is stored with fixing and direct forward rates.
+ */
+@BeanDefinition(builderScope = "private")
+public final class SimpleIborIndexRates
+    implements IborIndexRates, ImmutableBean, Serializable {
+
+  /**
+   * The index that the rates are for.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final IborIndex index;
+  /**
+   * The valuation date.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final LocalDate valuationDate;
+  /**
+   * The underlying forward curve.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final Curve curve;
+  /**
+   * The time-series of fixings, defaulted to an empty time-series.
+   * This includes the known historical fixings and may be empty.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final LocalDateDoubleTimeSeries fixings;
+  /**
+   * The day count convention of the curve.
+   */
+  private final DayCount dayCount;  // cached, not a property
+  
+  /**
+   * Obtains an instance from a curve, with an empty time-series of fixings.
+   * <p>
+   * The curve is specified by an instance of {@link Curve}, such as {@link InterpolatedNodalCurve}.
+   * The curve must have x-values of {@linkplain ValueType#YEAR_FRACTION year fractions} with
+   * the day count specified. The y-values must be {@linkplain ValueType#FORWARD_RATE forward rates}.
+   * In the curve the Ibor rates are indexed by the maturity date.
+   * 
+   * @param index  the index
+   * @param valuationDate  the valuation date for which the curve is valid
+   * @param curve  the curve of forward rates
+   * @return the rates view
+   */
+  public static SimpleIborIndexRates of(
+      IborIndex index,
+      LocalDate valuationDate,
+      Curve curve) {
+    return new SimpleIborIndexRates(index, valuationDate, curve, LocalDateDoubleTimeSeries.empty());
+  }
+  
+  /**
+   * Obtains an instance from a curve and time-series of fixing.
+   * <p>
+   * The curve is specified by an instance of {@link Curve}, such as {@link InterpolatedNodalCurve}.
+   * The curve must have x-values of {@linkplain ValueType#YEAR_FRACTION year fractions} with
+   * the day count specified. The y-values must be {@linkplain ValueType#FORWARD_RATE forward rates}.
+   * In the curve the Ibor rates are indexed by the maturity date.
+   * 
+   * @param index  the index
+   * @param valuationDate  the valuation date for which the curve is valid
+   * @param curve  the curve of forward rates
+   * @param fixings  the time-series of fixings 
+   * @return the rates view
+   */
+  public static SimpleIborIndexRates of(
+      IborIndex index,
+      LocalDate valuationDate,
+      Curve curve,
+      LocalDateDoubleTimeSeries fixings) {
+    return new SimpleIborIndexRates(index, valuationDate, curve, fixings);
+  }
+
+  @ImmutableConstructor
+  private SimpleIborIndexRates(
+      IborIndex index,
+      LocalDate valuationDate,
+      Curve curve,
+      LocalDateDoubleTimeSeries fixings) {
+
+    ArgChecker.notNull(index, "index");
+    ArgChecker.notNull(valuationDate, "valuationDate");
+    ArgChecker.notNull(curve, "curve");
+    curve.getMetadata().getXValueType().checkEquals(
+        ValueType.YEAR_FRACTION, "Incorrect x-value type for ibor curve");
+    curve.getMetadata().getYValueType().checkEquals(
+        ValueType.FORWARD_RATE, "Incorrect y-value type for ibor curve");
+    if (!curve.getMetadata().findInfo(CurveInfoType.DAY_COUNT).isPresent()) {
+      throw new IllegalArgumentException("Incorrect curve metadata, missing DayCount");
+    }
+    JodaBeanUtils.notNull(valuationDate, "valuationDate");
+    JodaBeanUtils.notNull(index, "index");
+    JodaBeanUtils.notNull(curve, "curve");
+    JodaBeanUtils.notNull(fixings, "fixings");
+    this.valuationDate = valuationDate;
+    this.index = index;
+    this.curve = curve;
+    this.fixings = fixings;
+    this.dayCount = curve.getMetadata().getInfo(CurveInfoType.DAY_COUNT);
+  }
+
+  @Override
+  public CurveName getCurveName() {
+    return curve.getName();
+  }
+
+  @Override
+  public int getParameterCount() {
+    return curve.getParameterCount();
+  }
+
+  @Override
+  public double rate(LocalDate fixingDate) {
+    if (!fixingDate.isAfter(getValuationDate())) {
+      return historicRate(fixingDate);
+    }
+    return rateIgnoringTimeSeries(fixingDate);
+  }
+
+  // historic rate
+  private double historicRate(LocalDate fixingDate) {
+    OptionalDouble fixedRate = fixings.get(fixingDate);
+    if (fixedRate.isPresent()) {
+      return fixedRate.getAsDouble();
+    } else if (fixingDate.isBefore(getValuationDate())) { // the fixing is required
+      if (fixings.isEmpty()) {
+        throw new IllegalArgumentException(
+            Messages.format("Unable to get fixing for {} on date {}, no time-series supplied", index, fixingDate));
+      }
+      throw new IllegalArgumentException(Messages.format("Unable to get fixing for {} on date {}", index, fixingDate));
+    } else {
+      return rateIgnoringTimeSeries(fixingDate);
+    }
+  }
+
+  @Override
+  public double rateIgnoringTimeSeries(LocalDate fixingDate) {
+    LocalDate effective = index.calculateEffectiveFromFixing(fixingDate);
+    LocalDate maturity = index.calculateMaturityFromEffective(effective);
+    double relativeYearFraction = relativeYearFraction(maturity);
+    return curve.yValue(relativeYearFraction);
+  }
+
+  @Override
+  public PointSensitivityBuilder ratePointSensitivity(LocalDate fixingDate) {
+    LocalDate valuationDate = getValuationDate();
+    if (fixingDate.isBefore(valuationDate) ||
+        (fixingDate.equals(valuationDate) && fixings.get(fixingDate).isPresent())) {
+      return PointSensitivityBuilder.none();
+    }
+    return IborRateSensitivity.of(index, fixingDate, 1d);
+  }
+
+  @Override
+  public PointSensitivityBuilder rateIgnoringTimeSeriesPointSensitivity(LocalDate fixingDate) {
+    return IborRateSensitivity.of(index, fixingDate, 1d);
+  }
+
+  @Override
+  public CurveCurrencyParameterSensitivities curveParameterSensitivity(IborRateSensitivity pointSensitivity) {
+    LocalDate fixingDate = pointSensitivity.getFixingDate();
+    LocalDate effective = index.calculateEffectiveFromFixing(fixingDate);
+    LocalDate maturity = index.calculateMaturityFromEffective(effective);
+    double relativeYearFraction = relativeYearFraction(maturity);
+    CurveUnitParameterSensitivity unitSensitivity = curve.yValueParameterSensitivity(relativeYearFraction);
+    CurveCurrencyParameterSensitivity sensitivity =  
+        unitSensitivity.multipliedBy(pointSensitivity.getCurrency(), pointSensitivity.getSensitivity());
+    return CurveCurrencyParameterSensitivities.of(sensitivity);
+  }
+
+  @Override
+  public SimpleIborIndexRates applyPerturbation(Perturbation<Curve> perturbation) {
+    return withCurve(curve.applyPerturbation(perturbation));
+  }
+
+  /**
+   * Returns a new instance with a different curve.
+   * 
+   * @param curve  the new curve
+   * @return the new instance
+   */
+  public SimpleIborIndexRates withCurve(Curve curve) {
+    return new SimpleIborIndexRates(index, valuationDate, curve, fixings);
+  }
+  
+  // calculate the relative time between the valuation date and the specified date
+  private double relativeYearFraction(LocalDate date) {
+    return dayCount.relativeYearFraction(valuationDate, date);
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code SimpleIborIndexRates}.
+   * @return the meta-bean, not null
+   */
+  public static SimpleIborIndexRates.Meta meta() {
+    return SimpleIborIndexRates.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(SimpleIborIndexRates.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public SimpleIborIndexRates.Meta metaBean() {
+    return SimpleIborIndexRates.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the index that the rates are for.
+   * @return the value of the property, not null
+   */
+  @Override
+  public IborIndex getIndex() {
+    return index;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the valuation date.
+   * @return the value of the property, not null
+   */
+  @Override
+  public LocalDate getValuationDate() {
+    return valuationDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the underlying forward curve.
+   * @return the value of the property, not null
+   */
+  public Curve getCurve() {
+    return curve;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the time-series of fixings, defaulted to an empty time-series.
+   * This includes the known historical fixings and may be empty.
+   * @return the value of the property, not null
+   */
+  @Override
+  public LocalDateDoubleTimeSeries getFixings() {
+    return fixings;
+  }
+
+  //-----------------------------------------------------------------------
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      SimpleIborIndexRates other = (SimpleIborIndexRates) obj;
+      return JodaBeanUtils.equal(index, other.index) &&
+          JodaBeanUtils.equal(valuationDate, other.valuationDate) &&
+          JodaBeanUtils.equal(curve, other.curve) &&
+          JodaBeanUtils.equal(fixings, other.fixings);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(index);
+    hash = hash * 31 + JodaBeanUtils.hashCode(valuationDate);
+    hash = hash * 31 + JodaBeanUtils.hashCode(curve);
+    hash = hash * 31 + JodaBeanUtils.hashCode(fixings);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(160);
+    buf.append("SimpleIborIndexRates{");
+    buf.append("index").append('=').append(index).append(',').append(' ');
+    buf.append("valuationDate").append('=').append(valuationDate).append(',').append(' ');
+    buf.append("curve").append('=').append(curve).append(',').append(' ');
+    buf.append("fixings").append('=').append(JodaBeanUtils.toString(fixings));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code SimpleIborIndexRates}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code index} property.
+     */
+    private final MetaProperty<IborIndex> index = DirectMetaProperty.ofImmutable(
+        this, "index", SimpleIborIndexRates.class, IborIndex.class);
+    /**
+     * The meta-property for the {@code valuationDate} property.
+     */
+    private final MetaProperty<LocalDate> valuationDate = DirectMetaProperty.ofImmutable(
+        this, "valuationDate", SimpleIborIndexRates.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code curve} property.
+     */
+    private final MetaProperty<Curve> curve = DirectMetaProperty.ofImmutable(
+        this, "curve", SimpleIborIndexRates.class, Curve.class);
+    /**
+     * The meta-property for the {@code fixings} property.
+     */
+    private final MetaProperty<LocalDateDoubleTimeSeries> fixings = DirectMetaProperty.ofImmutable(
+        this, "fixings", SimpleIborIndexRates.class, LocalDateDoubleTimeSeries.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "index",
+        "valuationDate",
+        "curve",
+        "fixings");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 100346066:  // index
+          return index;
+        case 113107279:  // valuationDate
+          return valuationDate;
+        case 95027439:  // curve
+          return curve;
+        case -843784602:  // fixings
+          return fixings;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public BeanBuilder<? extends SimpleIborIndexRates> builder() {
+      return new SimpleIborIndexRates.Builder();
+    }
+
+    @Override
+    public Class<? extends SimpleIborIndexRates> beanType() {
+      return SimpleIborIndexRates.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code index} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<IborIndex> index() {
+      return index;
+    }
+
+    /**
+     * The meta-property for the {@code valuationDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> valuationDate() {
+      return valuationDate;
+    }
+
+    /**
+     * The meta-property for the {@code curve} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Curve> curve() {
+      return curve;
+    }
+
+    /**
+     * The meta-property for the {@code fixings} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDateDoubleTimeSeries> fixings() {
+      return fixings;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 100346066:  // index
+          return ((SimpleIborIndexRates) bean).getIndex();
+        case 113107279:  // valuationDate
+          return ((SimpleIborIndexRates) bean).getValuationDate();
+        case 95027439:  // curve
+          return ((SimpleIborIndexRates) bean).getCurve();
+        case -843784602:  // fixings
+          return ((SimpleIborIndexRates) bean).getFixings();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code SimpleIborIndexRates}.
+   */
+  private static final class Builder extends DirectFieldsBeanBuilder<SimpleIborIndexRates> {
+
+    private IborIndex index;
+    private LocalDate valuationDate;
+    private Curve curve;
+    private LocalDateDoubleTimeSeries fixings;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 100346066:  // index
+          return index;
+        case 113107279:  // valuationDate
+          return valuationDate;
+        case 95027439:  // curve
+          return curve;
+        case -843784602:  // fixings
+          return fixings;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 100346066:  // index
+          this.index = (IborIndex) newValue;
+          break;
+        case 113107279:  // valuationDate
+          this.valuationDate = (LocalDate) newValue;
+          break;
+        case 95027439:  // curve
+          this.curve = (Curve) newValue;
+          break;
+        case -843784602:  // fixings
+          this.fixings = (LocalDateDoubleTimeSeries) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public SimpleIborIndexRates build() {
+      return new SimpleIborIndexRates(
+          index,
+          valuationDate,
+          curve,
+          fixings);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(160);
+      buf.append("SimpleIborIndexRates.Builder{");
+      buf.append("index").append('=').append(JodaBeanUtils.toString(index)).append(',').append(' ');
+      buf.append("valuationDate").append('=').append(JodaBeanUtils.toString(valuationDate)).append(',').append(' ');
+      buf.append("curve").append('=').append(JodaBeanUtils.toString(curve)).append(',').append(' ');
+      buf.append("fixings").append('=').append(JodaBeanUtils.toString(fixings));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNodeTest.java
@@ -119,6 +119,7 @@ public class FixedIborSwapCurveNodeTest {
     double rate = 0.035;
     MarketData marketData = ImmutableMarketData.builder(valuationDate).addValue(QUOTE_KEY, rate).build();
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.ZERO_RATE), rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.FORWARD_RATE), rate);
     double df = Math.exp(-TENOR_10Y.get(ChronoUnit.YEARS) * rate);
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.DISCOUNT_FACTOR), df, TOLERANCE_DF);
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.PRICE_INDEX), 0d);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNodeTest.java
@@ -117,6 +117,7 @@ public class FixedOvernightSwapCurveNodeTest {
     double rate = 0.035;
     MarketData marketData = ImmutableMarketData.builder(valuationDate).addValue(QUOTE_KEY, rate).build();
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.ZERO_RATE), rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.FORWARD_RATE), rate);
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.DISCOUNT_FACTOR),
         Math.exp(-rate * TENOR_10Y.getPeriod().toTotalMonths() / 12d), 1.0E-12);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FraCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FraCurveNodeTest.java
@@ -144,6 +144,7 @@ public class FraCurveNodeTest {
     double rate = 0.035;
     MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(QUOTE_KEY, rate).build();
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.ZERO_RATE), rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.FORWARD_RATE), rate);
     double approximateMaturity = TEMPLATE.getPeriodToEnd().toTotalMonths() / 12.0d;
     double df =  Math.exp(-approximateMaturity * rate);
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.DISCOUNT_FACTOR), df);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNodeTest.java
@@ -137,6 +137,7 @@ public class IborFixingDepositCurveNodeTest {
     double rate = 0.035;
     MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(QUOTE_KEY, rate).build();
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.ZERO_RATE), rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.FORWARD_RATE), rate);
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.DISCOUNT_FACTOR),
         Math.exp(-rate * 0.25d), 1.0E-12);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFutureCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFutureCurveNodeTest.java
@@ -118,6 +118,7 @@ public class IborFutureCurveNodeTest {
     double price = 0.99;
     MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(QUOTE_KEY, price).build();
     assertEquals(node.initialGuess(date, marketData, ValueType.ZERO_RATE), 1.0 - price, TOLERANCE_RATE);
+    assertEquals(node.initialGuess(date, marketData, ValueType.FORWARD_RATE), 1.0 - price, TOLERANCE_RATE);
     double approximateMaturity =
         TEMPLATE.getMinimumPeriod().plus(TEMPLATE.getConvention().getIndex().getTenor()).toTotalMonths() / 12.0d;
     double df = Math.exp(-approximateMaturity * (1.0 - price));

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
@@ -145,6 +145,7 @@ public class TermDepositCurveNodeTest {
     double rate = 0.035;
     MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(QUOTE_KEY, rate).build();
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.ZERO_RATE), rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.FORWARD_RATE), rate);
     assertEquals(node.initialGuess(valuationDate, marketData, ValueType.DISCOUNT_FACTOR),
         Math.exp(-rate * 0.25), 1.0e-12);
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/view/SimpleIborIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/view/SimpleIborIndexRatesTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.market.view;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.Perturbation;
+import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.DefaultCurveMetadata;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.interpolator.CurveInterpolator;
+import com.opengamma.strata.market.interpolator.CurveInterpolators;
+import com.opengamma.strata.market.sensitivity.IborRateSensitivity;
+import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+
+/**
+ * Tests {@link SimpleIborIndexRates}.
+ */
+@Test
+public class SimpleIborIndexRatesTest {
+
+  private static final LocalDate DATE_VAL = date(2015, 6, 4);
+  private static final LocalDate DATE_BEFORE = date(2015, 6, 3);
+  private static final LocalDate DATE_AFTER = date(2015, 7, 30);
+
+  private static final CurveInterpolator INTERPOLATOR = CurveInterpolators.LINEAR;
+  private static final CurveName NAME = CurveName.of("TestCurve");
+  private static final CurveMetadata METADATA = DefaultCurveMetadata.builder()
+      .xValueType(ValueType.YEAR_FRACTION)
+      .yValueType(ValueType.FORWARD_RATE)
+      .curveName(NAME).dayCount(ACT_365F).build();
+
+  private static final InterpolatedNodalCurve CURVE =
+      InterpolatedNodalCurve.of(METADATA, DoubleArray.of(0, 10), DoubleArray.of(1, 2), INTERPOLATOR);
+  private static final InterpolatedNodalCurve CURVE2 =
+      InterpolatedNodalCurve.of(METADATA, DoubleArray.of(0, 10), DoubleArray.of(2, 3), INTERPOLATOR);
+
+  private static final double RATE_BEFORE = 0.013d;
+  private static final double RATE_VAL = 0.014d;
+  private static final LocalDateDoubleTimeSeries SERIES = LocalDateDoubleTimeSeries.builder()
+      .put(DATE_BEFORE, RATE_BEFORE)
+      .put(DATE_VAL, RATE_VAL)
+      .build();
+  private static final LocalDateDoubleTimeSeries SERIES_MINIMAL = LocalDateDoubleTimeSeries.of(DATE_VAL, RATE_VAL);
+  private static final LocalDateDoubleTimeSeries SERIES_EMPTY = LocalDateDoubleTimeSeries.empty();
+
+  private static final double TOLERANCE_RATE = 1.0E-8;
+
+  //-------------------------------------------------------------------------
+  public void test_of_withoutFixings() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE);
+    assertEquals(test.getIndex(), GBP_LIBOR_3M);
+    assertEquals(test.getValuationDate(), DATE_VAL);
+    assertEquals(test.getFixings(), SERIES_EMPTY);
+    assertEquals(test.getCurve(), CURVE);
+    assertEquals(test.getCurveName(), NAME);
+    assertEquals(test.getParameterCount(), 2);
+  }
+
+  public void test_of_withFixings() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    assertEquals(test.getIndex(), GBP_LIBOR_3M);
+    assertEquals(test.getValuationDate(), DATE_VAL);
+    assertEquals(test.getFixings(), SERIES);
+    assertEquals(test.getCurve(), CURVE);
+    assertEquals(test.getCurveName(), NAME);
+    assertEquals(test.getParameterCount(), 2);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_applyPerturbation() {
+    Perturbation<Curve> perturbation = curve -> CURVE2;
+    SimpleIborIndexRates base = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    SimpleIborIndexRates test = base.applyPerturbation(perturbation);
+    assertEquals(test.getIndex(), GBP_LIBOR_3M);
+    assertEquals(test.getValuationDate(), DATE_VAL);
+    assertEquals(test.getFixings(), SERIES);
+    assertEquals(test.getCurve(), CURVE2);
+    assertEquals(test.getCurveName(), NAME);
+    assertEquals(test.getParameterCount(), 2);
+  }
+
+  public void test_withDiscountFactors() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    test = test.withCurve(CURVE2);
+    assertEquals(test.getIndex(), GBP_LIBOR_3M);
+    assertEquals(test.getValuationDate(), DATE_VAL);
+    assertEquals(test.getFixings(), SERIES);
+    assertEquals(test.getCurve(), CURVE2);
+    assertEquals(test.getCurveName(), NAME);
+    assertEquals(test.getParameterCount(), 2);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_rate_beforeValuation_fixing() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    assertEquals(test.rate(DATE_BEFORE), RATE_BEFORE);
+  }
+
+  public void test_rate_beforeValuation_noFixing_emptySeries() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES_EMPTY);
+    assertThrowsIllegalArg(() -> test.rate(DATE_BEFORE));
+  }
+
+  public void test_rate_beforeValuation_noFixing_notEmptySeries() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES_MINIMAL);
+    assertThrowsIllegalArg(() -> test.rate(DATE_BEFORE));
+  }
+
+  public void test_rate_onValuation_fixing() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    assertEquals(test.rate(DATE_VAL), RATE_VAL);
+  }
+
+  public void test_rateIgnoringTimeSeries_onValuation_fixing() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    LocalDate effective = GBP_LIBOR_3M.calculateEffectiveFromFixing(DATE_VAL);
+    LocalDate maturity = GBP_LIBOR_3M.calculateMaturityFromEffective(effective);
+    double time = GBP_LIBOR_3M.getDayCount().yearFraction(DATE_VAL, maturity);
+    double expected = CURVE.yValue(time);
+    assertEquals(test.rateIgnoringTimeSeries(DATE_VAL), expected, TOLERANCE_RATE);
+  }
+
+  public void test_rate_onValuation_noFixing() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES_EMPTY);
+    LocalDate effective = GBP_LIBOR_3M.calculateEffectiveFromFixing(DATE_VAL);
+    LocalDate maturity = GBP_LIBOR_3M.calculateMaturityFromEffective(effective);
+    double time = GBP_LIBOR_3M.getDayCount().yearFraction(DATE_VAL, maturity);
+    double expected = CURVE.yValue(time);
+    assertEquals(test.rate(DATE_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringTimeSeries(DATE_VAL), expected, TOLERANCE_RATE);
+  }
+
+  public void test_rate_afterValuation() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    LocalDate effective = GBP_LIBOR_3M.calculateEffectiveFromFixing(DATE_AFTER);
+    LocalDate maturity = GBP_LIBOR_3M.calculateMaturityFromEffective(effective);
+    double time = GBP_LIBOR_3M.getDayCount().yearFraction(DATE_VAL, maturity);
+    double expected = CURVE.yValue(time);
+    assertEquals(test.rate(DATE_AFTER), expected, TOLERANCE_RATE);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_ratePointSensitivity_fixing() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    assertEquals(test.ratePointSensitivity(DATE_BEFORE), PointSensitivityBuilder.none());
+    assertEquals(test.ratePointSensitivity(DATE_VAL), PointSensitivityBuilder.none());
+  }
+  
+  public void test_rateIgnoringTimeSeriesPointSensitivity_onValuation() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M, DATE_VAL, 1d);
+    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(DATE_VAL), expected);
+  }
+
+  public void test_ratePointSensitivity_onValuation_noFixing() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES_EMPTY);
+    IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M, DATE_VAL, 1d);
+    assertEquals(test.ratePointSensitivity(DATE_VAL), expected);
+    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(DATE_VAL), expected);
+  }
+
+  public void test_ratePointSensitivity_afterValuation() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M, DATE_AFTER, 1d);
+    assertEquals(test.ratePointSensitivity(DATE_AFTER), expected);
+  }
+
+  //-------------------------------------------------------------------------
+  // proper end-to-end tests are elsewhere
+  public void test_curveParameterSensitivity() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    IborRateSensitivity point = IborRateSensitivity.of(GBP_LIBOR_3M, DATE_AFTER, GBP, 1d);
+    assertEquals(test.curveParameterSensitivity(point).size(), 1);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
+    coverImmutableBean(test);
+    SimpleIborIndexRates test2 = SimpleIborIndexRates.of(USD_LIBOR_3M, DATE_AFTER, CURVE2, SERIES_EMPTY);
+    coverBeanEquals(test, test2);
+  }
+  
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
@@ -44,7 +44,6 @@ import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.view.DiscountFactors;
 import com.opengamma.strata.market.view.DiscountFxForwardRates;
 import com.opengamma.strata.market.view.DiscountFxIndexRates;
-import com.opengamma.strata.market.view.DiscountIborIndexRates;
 import com.opengamma.strata.market.view.DiscountOvernightIndexRates;
 import com.opengamma.strata.market.view.FxForwardRates;
 import com.opengamma.strata.market.view.FxIndexRates;
@@ -218,8 +217,7 @@ public final class ImmutableRatesProvider
   public IborIndexRates iborIndexRates(IborIndex index) {
     LocalDateDoubleTimeSeries fixings = timeSeries(index);
     Curve curve = indexCurve(index);
-    DiscountFactors dfc = DiscountFactors.of(index.getCurrency(), getValuationDate(), curve);
-    return DiscountIborIndexRates.of(index, dfc, fixings);
+    return IborIndexRates.of(index, valuationDate, curve, fixings);
   }
 
   @Override


### PR DESCRIPTION
Previously the only implementation of IborindexRates was based on discount factors. This new implementation is based on a direct description of the forward rates by a Curve with the Ibor rates indexed by their maturity date.
Further improvement to the CurveNode will be necessary to support "metadata" methods with reference date not based on maturity date.