### PR TITLE
Allow double arrays to be used when building time series

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilder.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilder.java
@@ -188,6 +188,30 @@ public final class LocalDateDoubleTimeSeriesBuilder {
   }
 
   /**
+   * Puts all the specified dates and values into this builder.
+   * <p>
+   * The date collection and value array must be the same size.
+   * <p>
+   * The date-value pairs are added one by one.
+   * If a date is duplicated it will overwrite an earlier entry.
+   *
+   * @param dates  the dates to be added
+   * @param values  the values to be added
+   * @return this builder
+   */
+  public LocalDateDoubleTimeSeriesBuilder putAll(Collection<LocalDate> dates, double[] values) {
+    ArgChecker.noNulls(dates, "dates");
+    ArgChecker.notNull(values, "values");
+    ArgChecker.isTrue(dates.size() == values.length,
+        "Arrays are of different sizes - dates: {}, values: {}", dates.size(), values.length);
+    Iterator<LocalDate> itDate = dates.iterator();
+    for (int i = 0; i < dates.size(); i++) {
+      put(itDate.next(), values[i]);
+    }
+    return this;
+  }
+
+  /**
    * Puts all the specified points into this builder.
    * <p>
    * The points are added one by one.

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -133,7 +133,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
   public void test_of_collectionCollection_valueCollectionNull() {
     Collection<LocalDate> dates = dates(DATE_2011_01_01, DATE_2012_01_01);
 
-    LocalDateDoubleTimeSeries.builder().putAll(dates, null).build();
+    LocalDateDoubleTimeSeries.builder().putAll(dates, (double[]) null).build();
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilderTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilderTest.java
@@ -68,6 +68,16 @@ public class LocalDateDoubleTimeSeriesBuilderTest {
     assertEquals(test.get(date(2014, 1, 1)), OptionalDouble.of(3d));
   }
 
+  public void test_putAll_collection_array() {
+    Collection<LocalDate> dates = Arrays.asList(date(2013, 1, 1), date(2014, 1, 1));
+    double[] values = new double[]{2d, 3d};
+    LocalDateDoubleTimeSeriesBuilder test = LocalDateDoubleTimeSeries.builder();
+    test.putAll(dates, values);
+
+    assertEquals(test.get(date(2013, 1, 1)), OptionalDouble.of(2d));
+    assertEquals(test.get(date(2014, 1, 1)), OptionalDouble.of(3d));
+  }
+
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void test_putAll_collectionsMismatch() {
     LocalDateDoubleTimeSeriesBuilder test = LocalDateDoubleTimeSeries.builder();


### PR DESCRIPTION
This PR adds an overloaded version of `LocalDateDoubleTimeSeriesBuilder.putAll` with a `double[]` parameter for the values. This saves boxing and unboxing for callers which already have the data in a primitive array.