### PR TITLE
Add swap payment schedule adjustments

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/SchedulePeriod.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/SchedulePeriod.java
@@ -257,6 +257,43 @@ public final class SchedulePeriod
 
   //-------------------------------------------------------------------------
   /**
+   * Converts this period to one where the start and end dates are adjusted using the specified adjustment.
+   * <p>
+   * The start date of the result will be the start date of this period as altered by the specified adjustment.
+   * The end date of the result will be the end date of this period as altered by the specified adjustment.
+   * The unadjusted start date and unadjusted end date will be the same as in this period.
+   * 
+   * @param businessDayAdjustment  the adjustment to use
+   * @return the adjusted schedule period
+   */
+  public SchedulePeriod toAdjusted(BusinessDayAdjustment businessDayAdjustment) {
+    // implementation needs to return 'this' if unchanged to optimize downstream code
+    LocalDate resultStart = businessDayAdjustment.adjust(startDate);
+    LocalDate resultEnd = businessDayAdjustment.adjust(endDate);
+    if (resultStart.equals(startDate) && resultEnd.equals(endDate)) {
+      return this;
+    }
+    return of(resultStart, resultEnd, unadjustedStartDate, unadjustedEndDate);
+  }
+
+  /**
+   * Converts this period to one where the start and end dates are set to the unadjusted dates.
+   * <p>
+   * The start date of the result will be the unadjusted start date of this period.
+   * The end date of the result will be the unadjusted end date of this period.
+   * The unadjusted start date and unadjusted end date will be the same as in this period.
+   * 
+   * @return the unadjusted schedule period
+   */
+  public SchedulePeriod toUnadjusted() {
+    if (unadjustedStartDate.equals(startDate) && unadjustedEndDate.equals(endDate)) {
+      return this;
+    }
+    return of(unadjustedStartDate, unadjustedEndDate);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Compares this period to another by unadjusted start date, then unadjusted end date.
    * 
    * @param other  the other period

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/SchedulePeriodTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/SchedulePeriodTest.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.basics.schedule;
 
+import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.strata.basics.date.HolidayCalendars.SAT_SUN;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P2M;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
@@ -33,7 +35,7 @@ import com.opengamma.strata.basics.date.DayCounts;
 @Test
 public class SchedulePeriodTest {
 
-  private static final LocalDate JUN_15 = date(2014, JUNE, 15);
+  private static final LocalDate JUN_15 = date(2014, JUNE, 15);  // Sunday
   private static final LocalDate JUN_16 = date(2014, JUNE, 16);
   private static final LocalDate JUN_17 = date(2014, JUNE, 17);
   private static final LocalDate JUN_18 = date(2014, JUNE, 18);
@@ -41,7 +43,8 @@ public class SchedulePeriodTest {
   private static final LocalDate JUL_05 = date(2014, JULY, 5);
   private static final LocalDate JUL_17 = date(2014, JULY, 17);
   private static final LocalDate JUL_18 = date(2014, JULY, 18);
-  private static final LocalDate AUG_17 = date(2014, AUGUST, 17);
+  private static final LocalDate AUG_17 = date(2014, AUGUST, 17);  // Sunday
+  private static final LocalDate AUG_18 = date(2014, AUGUST, 18);  // Sunday
   private static final LocalDate SEP_17 = date(2014, SEPTEMBER, 17);
   private static final double TOLERANCE = 1.0E-6;
 
@@ -186,6 +189,23 @@ public class SchedulePeriodTest {
     assertThrowsIllegalArg(() -> test.subSchedule(P1M, RollConventions.DAY_17, null, BusinessDayAdjustment.NONE));
     assertThrowsIllegalArg(() -> test.subSchedule(P1M, RollConventions.DAY_17, StubConvention.NONE, null));
     assertThrowsIllegalArg(() -> test.subSchedule(null, null, null, null));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_toAdjusted() {
+    SchedulePeriod test1 = SchedulePeriod.of(JUN_15, SEP_17);
+    assertEquals(test1.toAdjusted(BusinessDayAdjustment.NONE), test1);
+    assertEquals(test1.toAdjusted(BusinessDayAdjustment.of(FOLLOWING, SAT_SUN)),
+        SchedulePeriod.of(JUN_16, SEP_17, JUN_15, SEP_17));
+    SchedulePeriod test2 = SchedulePeriod.of(JUN_16, AUG_17);
+    assertEquals(test2.toAdjusted(BusinessDayAdjustment.of(FOLLOWING, SAT_SUN)),
+        SchedulePeriod.of(JUN_16, AUG_18, JUN_16, AUG_17));
+  }
+
+  public void test_toUnadjusted() {
+    assertEquals(SchedulePeriod.of(JUN_15, SEP_17).toUnadjusted(), SchedulePeriod.of(JUN_15, SEP_17));
+    assertEquals(SchedulePeriod.of(JUN_16, SEP_17, JUN_15, SEP_17).toUnadjusted(), SchedulePeriod.of(JUN_15, SEP_17));
+    assertEquals(SchedulePeriod.of(JUN_16, JUL_18, JUN_16, JUL_17).toUnadjusted(), SchedulePeriod.of(JUN_16, JUL_17));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/SchedulePeriodTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/SchedulePeriodTest.java
@@ -44,7 +44,7 @@ public class SchedulePeriodTest {
   private static final LocalDate JUL_17 = date(2014, JULY, 17);
   private static final LocalDate JUL_18 = date(2014, JULY, 18);
   private static final LocalDate AUG_17 = date(2014, AUGUST, 17);  // Sunday
-  private static final LocalDate AUG_18 = date(2014, AUGUST, 18);  // Sunday
+  private static final LocalDate AUG_18 = date(2014, AUGUST, 18);  // Monday
   private static final LocalDate SEP_17 = date(2014, SEPTEMBER, 17);
   private static final double TOLERANCE = 1.0E-6;
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.basics.schedule;
 
+import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.strata.basics.date.HolidayCalendars.SAT_SUN;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P2M;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
@@ -18,6 +20,7 @@ import static com.opengamma.strata.collect.TestHelper.date;
 import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JULY;
+import static java.time.Month.JUNE;
 import static java.time.Month.NOVEMBER;
 import static java.time.Month.OCTOBER;
 import static java.time.Month.SEPTEMBER;
@@ -29,6 +32,7 @@ import java.util.Optional;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 
 /**
  * Test {@link Schedule}.
@@ -36,6 +40,8 @@ import com.google.common.collect.ImmutableList;
 @Test
 public class ScheduleTest {
 
+  private static final LocalDate JUN_15 = date(2014, JUNE, 15);
+  private static final LocalDate JUN_16 = date(2014, JUNE, 16);
   private static final LocalDate JUL_04 = date(2014, JULY, 4);
   private static final LocalDate JUL_16 = date(2014, JULY, 16);
   private static final LocalDate JUL_17 = date(2014, JULY, 17);
@@ -407,6 +413,22 @@ public class ScheduleTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_toAdjusted() {
+    SchedulePeriod period1 = SchedulePeriod.of(JUN_15, SEP_17);
+    SchedulePeriod period2 = SchedulePeriod.of(SEP_17, SEP_30);
+    Schedule test = Schedule.builder()
+        .periods(period1, period2)
+        .frequency(P3M)
+        .rollConvention(DAY_17)
+        .build();
+    assertEquals(test.toAdjusted(BusinessDayAdjustment.NONE), test);
+    assertEquals(test.toAdjusted(BusinessDayAdjustment.of(FOLLOWING, SAT_SUN)), Schedule.builder()
+        .periods(SchedulePeriod.of(JUN_16, SEP_17, JUN_15, SEP_17), period2)
+        .frequency(P3M)
+        .rollConvention(DAY_17)
+        .build());
+  }
+
   public void test_toUnadjusted() {
     SchedulePeriod a = SchedulePeriod.of(JUL_17, OCT_17, JUL_16, OCT_15);
     SchedulePeriod b = SchedulePeriod.of(JUL_16, OCT_15, JUL_16, OCT_15);

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/ExpandedSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/ExpandedSwapLeg.java
@@ -126,10 +126,10 @@ public final class ExpandedSwapLeg
 
   //-------------------------------------------------------------------------
   /**
-   * Gets the start date of the leg.
+   * Gets the accrual start date of the leg.
    * <p>
    * This is the first accrual date in the leg, often known as the effective date.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the start date of the leg
    */
@@ -139,10 +139,10 @@ public final class ExpandedSwapLeg
   }
 
   /**
-   * Gets the end date of the leg.
+   * Gets the accrual end date of the leg.
    * <p>
-   * This is the last accrual date in the leg, often known as the maturity date.
-   * This date has been adjusted to be a valid business day.
+   * This is the last accrual date in the leg, often known as the termination date.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the end date of the leg
    */
@@ -165,10 +165,12 @@ public final class ExpandedSwapLeg
 
   //-------------------------------------------------------------------------
   /**
-   * Finds the payment period applicable on the specified date.
+   * Finds the payment period applicable for the specified accrual date.
    * <p>
-   * Each payment period is considered to contain the end date but not the start date.
-   * If no payment period contains the date, an empty optional is returned.
+   * Each payment period contains one or more accrual periods.
+   * This method finds the matching accrual period and returns the payment period that holds it.
+   * Periods are considered to contain the end date but not the start date
+   * If no accrual period contains the date, an empty optional is returned.
    * 
    * @param date  the date to find
    * @return the payment period applicable at the date

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/KnownAmountSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/KnownAmountSwapLeg.java
@@ -117,10 +117,10 @@ public final class KnownAmountSwapLeg
   }
 
   /**
-   * Gets the start date of the leg.
+   * Gets the accrual start date of the leg.
    * <p>
    * This is the first accrual date in the leg, often known as the effective date.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the start date of the period
    */
@@ -131,10 +131,10 @@ public final class KnownAmountSwapLeg
   }
 
   /**
-   * Gets the end date of the leg.
+   * Gets the accrual end date of the leg.
    * <p>
-   * This is the last accrual date in the leg, often known as the maturity date.
-   * This date has been adjusted to be a valid business day.
+   * This is the last accrual date in the leg, often known as the termination date.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the end date of the period
    */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/RateCalculationSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/RateCalculationSwapLeg.java
@@ -106,10 +106,12 @@ public final class RateCalculationSwapLeg
   }
 
   /**
-   * Gets the start date of the leg.
+   * Gets the accrual start date of the leg.
    * <p>
    * This is the first accrual date in the leg, often known as the effective date.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
+   * <p>
+   * Defined as the effective date by the 2006 ISDA definitions article 3.2.
    * 
    * @return the start date of the period
    */
@@ -120,10 +122,12 @@ public final class RateCalculationSwapLeg
   }
 
   /**
-   * Gets the end date of the leg.
+   * Gets the accrual end date of the leg.
    * <p>
-   * This is the last accrual date in the leg, often known as the maturity date.
-   * This date has been adjusted to be a valid business day.
+   * This is the last accrual date in the leg, often known as the termination date.
+   * This date has been typically adjusted to be a valid business day.
+   * <p>
+   * Defined as the termination date by the 2006 ISDA definitions article 3.3.
    * 
    * @return the end date of the period
    */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/RatePaymentPeriod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/RatePaymentPeriod.java
@@ -141,10 +141,10 @@ public final class RatePaymentPeriod
 
   //-------------------------------------------------------------------------
   /**
-   * Gets the start date of the period.
+   * Gets the accrual start date of the period.
    * <p>
    * This is the first accrual date in the period.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the start date of the period
    */
@@ -154,10 +154,10 @@ public final class RatePaymentPeriod
   }
 
   /**
-   * Gets the end date of the period.
+   * Gets the accrual end date of the period.
    * <p>
    * This is the last accrual date in the period.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the end date of the period
    */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/RatePeriodSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/RatePeriodSwapLeg.java
@@ -194,10 +194,10 @@ public final class RatePeriodSwapLeg
 
   //-------------------------------------------------------------------------
   /**
-   * Gets the start date of the leg.
+   * Gets the accrual start date of the leg.
    * <p>
    * This is the first accrual date in the leg, often known as the effective date.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the start date of the leg
    */
@@ -207,10 +207,10 @@ public final class RatePeriodSwapLeg
   }
 
   /**
-   * Gets the end date of the leg.
+   * Gets the accrual end date of the leg.
    * <p>
-   * This is the last accrual date in the leg, often known as the maturity date.
-   * This date has been adjusted to be a valid business day.
+   * This is the last accrual date in the leg, often known as the termination date.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the end date of the leg
    */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/Swap.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/Swap.java
@@ -139,10 +139,10 @@ public final class Swap
 
   //-------------------------------------------------------------------------
   /**
-   * Gets the start date of the swap.
+   * Gets the accrual start date of the swap.
    * <p>
    * This is the earliest accrual date of the legs, often known as the effective date.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the start date of the swap
    */
@@ -155,10 +155,10 @@ public final class Swap
   }
 
   /**
-   * Gets the end date of the swap.
+   * Gets the accrual end date of the swap.
    * <p>
-   * This is the latest accrual date of the legs, often known as the maturity date.
-   * This date has been adjusted to be a valid business day.
+   * This is the latest accrual date of the legs, often known as the termination date.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the end date of the swap
    */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/SwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/SwapLeg.java
@@ -54,20 +54,20 @@ public interface SwapLeg {
   public abstract PayReceive getPayReceive();
 
   /**
-   * Gets the start date of the leg.
+   * Gets the accrual start date of the leg.
    * <p>
    * This is the first accrual date in the leg, often known as the effective date.
-   * This date has been adjusted to be a valid business day.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the start date of the leg
    */
   public abstract LocalDate getStartDate();
 
   /**
-   * Gets the end date of the leg.
+   * Gets the accrual end date of the leg.
    * <p>
-   * This is the last accrual date in the leg, often known as the maturity date.
-   * This date has been adjusted to be a valid business day.
+   * This is the last accrual date in the leg, often known as the termination date.
+   * This date has typically been adjusted to be a valid business day.
    * 
    * @return the end date of the leg
    */

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/PaymentScheduleTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/PaymentScheduleTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product.swap;
 
+import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.HolidayCalendars.GBLO;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P2M;
@@ -22,10 +23,13 @@ import static com.opengamma.strata.product.swap.PaymentRelativeTo.PERIOD_START;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.HolidayCalendars;
 import com.opengamma.strata.basics.schedule.RollConventions;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
@@ -46,6 +50,8 @@ public class PaymentScheduleTest {
   private static final LocalDate DATE_04_07 = date(2014, 4, 7);
   private static final LocalDate DATE_05_05 = date(2014, 5, 5);
   private static final LocalDate DATE_05_06 = date(2014, 5, 6);
+  private static final BusinessDayAdjustment BDA = BusinessDayAdjustment.of(
+      MODIFIED_FOLLOWING, HolidayCalendars.SAT_SUN);
 
   private static final SchedulePeriod ACCRUAL1STUB = SchedulePeriod.of(DATE_01_08, DATE_02_05, DATE_01_08, DATE_02_05);
   private static final SchedulePeriod ACCRUAL1 = SchedulePeriod.of(DATE_01_06, DATE_02_05, DATE_01_05, DATE_02_05);
@@ -91,6 +97,7 @@ public class PaymentScheduleTest {
         .paymentDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
         .build();
     assertEquals(test.getPaymentFrequency(), P1M);
+    assertEquals(test.getBusinessDayAdjustment(), Optional.empty());
     assertEquals(test.getPaymentDateOffset(), DaysAdjustment.ofBusinessDays(2, GBLO));
     assertEquals(test.getPaymentRelativeTo(), PERIOD_END);
     assertEquals(test.getCompoundingMethod(), NONE);
@@ -205,6 +212,7 @@ public class PaymentScheduleTest {
     coverImmutableBean(test);
     PaymentSchedule test2 = PaymentSchedule.builder()
         .paymentFrequency(P3M)
+        .businessDayAdjustment(BDA)
         .paymentDateOffset(DaysAdjustment.ofBusinessDays(3, GBLO))
         .paymentRelativeTo(PERIOD_START)
         .compoundingMethod(STRAIGHT)

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapTest.java
@@ -7,6 +7,11 @@ package com.opengamma.strata.product.swap;
 
 import static com.opengamma.strata.basics.PayReceive.PAY;
 import static com.opengamma.strata.basics.PayReceive.RECEIVE;
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
+import static com.opengamma.strata.basics.date.HolidayCalendars.SAT_SUN;
+import static com.opengamma.strata.collect.TestHelper.assertEqualsBean;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
@@ -31,12 +36,20 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.PeriodicSchedule;
+import com.opengamma.strata.product.rate.FixedRateObservation;
 
 /**
  * Test.
  */
 @Test
 public class SwapTest {
+
+  private static final double RATE = 0.01d;
+  private static final double NOTIONAL = 100_000d;
 
   public void test_builder_list() {
     Swap test = Swap.builder()
@@ -134,6 +147,91 @@ public class SwapTest {
         .legs(ImmutableList.of(MOCK_GBP1, MOCK_USD1))
         .build();
     assertEquals(test.expand(), ExpandedSwap.of(MOCK_EXPANDED_GBP1, MOCK_EXPANDED_USD1));
+  }
+
+  public void test_expand_unadjustedAccrualAdjustedPayment() {
+    Swap test = Swap.builder()
+        .legs(RateCalculationSwapLeg.builder()
+            .payReceive(RECEIVE)
+            .accrualSchedule(PeriodicSchedule.builder()
+                .startDate(date(2016, 1, 3))
+                .endDate(date(2016, 5, 3))
+                .frequency(Frequency.P1M)  // Jan + Apr are Sunday
+                .businessDayAdjustment(BusinessDayAdjustment.NONE)
+                .build())
+            .paymentSchedule(PaymentSchedule.builder()
+                .paymentFrequency(Frequency.P1M)
+                .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, SAT_SUN))
+                .paymentDateOffset(DaysAdjustment.ofBusinessDays(2, SAT_SUN))
+                .build())
+            .notionalSchedule(NotionalSchedule.of(GBP, NOTIONAL))
+            .calculation(FixedRateCalculation.of(RATE, ACT_360))
+            .build())
+        .build();
+    RatePaymentPeriod pp1 = RatePaymentPeriod.builder()
+        .paymentDate(date(2016, 2, 5))  // 3rd plus two days
+        .accrualPeriods(RateAccrualPeriod.builder()
+            .startDate(date(2016, 1, 3))
+            .unadjustedStartDate(date(2016, 1, 3))
+            .endDate(date(2016, 2, 3))
+            .unadjustedEndDate(date(2016, 2, 3))
+            .yearFraction(ACT_360.yearFraction(date(2016, 1, 3), date(2016, 2, 3)))
+            .rateObservation(FixedRateObservation.of(RATE))
+            .build())
+        .dayCount(ACT_360)
+        .currency(GBP)
+        .notional(NOTIONAL)
+        .build();
+    RatePaymentPeriod pp2 = RatePaymentPeriod.builder()
+        .paymentDate(date(2016, 3, 7))  // 3rd plus two days is Saturday, Monday is 7th
+        .accrualPeriods(RateAccrualPeriod.builder()
+            .startDate(date(2016, 2, 3))
+            .unadjustedStartDate(date(2016, 2, 3))
+            .endDate(date(2016, 3, 3))
+            .unadjustedEndDate(date(2016, 3, 3))
+            .yearFraction(ACT_360.yearFraction(date(2016, 2, 3), date(2016, 3, 3)))
+            .rateObservation(FixedRateObservation.of(RATE))
+            .build())
+        .dayCount(ACT_360)
+        .currency(GBP)
+        .notional(NOTIONAL)
+        .build();
+    RatePaymentPeriod pp3 = RatePaymentPeriod.builder()
+        .paymentDate(date(2016, 4, 6))  // 3rd is Sunday, bumped to Monday by schedule, then plus two days
+        .accrualPeriods(RateAccrualPeriod.builder()
+            .startDate(date(2016, 3, 3))
+            .unadjustedStartDate(date(2016, 3, 3))
+            .endDate(date(2016, 4, 3))
+            .unadjustedEndDate(date(2016, 4, 3))
+            .yearFraction(ACT_360.yearFraction(date(2016, 3, 3), date(2016, 4, 3)))
+            .rateObservation(FixedRateObservation.of(RATE))
+            .build())
+        .dayCount(ACT_360)
+        .currency(GBP)
+        .notional(NOTIONAL)
+        .build();
+    RatePaymentPeriod pp4 = RatePaymentPeriod.builder()
+        .paymentDate(date(2016, 5, 5))  // 3rd plus two days
+        .accrualPeriods(RateAccrualPeriod.builder()
+            .startDate(date(2016, 4, 3))
+            .unadjustedStartDate(date(2016, 4, 3))
+            .endDate(date(2016, 5, 3))
+            .unadjustedEndDate(date(2016, 5, 3))
+            .yearFraction(ACT_360.yearFraction(date(2016, 4, 3), date(2016, 5, 3)))
+            .rateObservation(FixedRateObservation.of(RATE))
+            .build())
+        .dayCount(ACT_360)
+        .currency(GBP)
+        .notional(NOTIONAL)
+        .build();
+    ExpandedSwap expected = ExpandedSwap.builder()
+        .legs(ExpandedSwapLeg.builder()
+            .paymentPeriods(pp1, pp2, pp3, pp4)
+            .payReceive(RECEIVE)
+            .type(FIXED)
+            .build())
+        .build();
+    assertEqualsBean(test.expand(), expected);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Process the additional adjustment.
Clarify that dates are from the accrual schedule where unclear.

Reading closely, it seems that FpML will not use this, however it could produce different dates in certain edge cases, so it is a useful addition.