### PR TITLE
Correct simple df for sensitivity on the valuation date.

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/view/SimpleDiscountFactors.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/SimpleDiscountFactors.java
@@ -201,6 +201,9 @@ public final class SimpleDiscountFactors
   //-------------------------------------------------------------------------
   @Override
   public CurveUnitParameterSensitivities unitParameterSensitivity(LocalDate date) {
+    if(date.equals(valuationDate)) {
+      return CurveUnitParameterSensitivities.empty(); // Discount factor in 0 is always 1, no sensitivity.
+    }
     double relativeYearFraction = relativeYearFraction(date);
     double discountFactor = discountFactor(relativeYearFraction);
     return CurveUnitParameterSensitivities.of(curve.yValueParameterSensitivity(relativeYearFraction)

--- a/modules/market/src/test/java/com/opengamma/strata/market/view/SimpleDiscountFactorsTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/view/SimpleDiscountFactorsTest.java
@@ -215,6 +215,13 @@ public class SimpleDiscountFactorsTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_unitParameterSensitivity_val_date() {
+    // Discount factor at valuation date is always 0, no sensitivity.
+    SimpleDiscountFactors test = SimpleDiscountFactors.of(GBP, DATE_VAL, CURVE);
+    assertEquals(test.unitParameterSensitivity(DATE_VAL), CurveUnitParameterSensitivities.empty());
+  }
+
+  //-------------------------------------------------------------------------
   // proper end-to-end FD tests are elsewhere
   public void test_curveParameterSensitivity() {
     SimpleDiscountFactors test = SimpleDiscountFactors.of(GBP, DATE_VAL, CURVE);


### PR DESCRIPTION
Discounting factor sensitivity was throwing an error for sensitivity on the valuation date (divided by 0). The discount factor on the valuation date is always 1 and there should be no sensitivity.