### PR TITLE
MapStream enhancements

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.collect;
 
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -360,6 +361,38 @@ public final class Guavate {
         Collector.Characteristics.UNORDERED);
   }
 
+  /**
+   * Collector used at the end of a stream to build an immutable map.
+   * <p>
+   * A collector is used to gather data at the end of a stream operation.
+   * This method returns a collector allowing streams to be gathered into
+   * an {@link ImmutableMap}.
+   * <p>
+   * This returns a map by converting each stream element to a key and value.
+   * If the same key is generated more than once the merge function is applied to the
+   * values and the return value of the function is used as the value in the map.
+   *
+   * @param <T> the type of the stream elements
+   * @param <K> the type of the keys in the result map
+   * @param <V> the type of the values in the result map
+   * @param keyExtractor  function to produce keys from stream elements
+   * @param valueExtractor  function to produce values from stream elements
+   * @param mergeFn  function to merge values with the same key
+   * @return the immutable map collector
+   */
+  public static <T, K, V> Collector<T, Map<K, V>, ImmutableMap<K, V>> toImmutableMap(
+      Function<? super T, ? extends K> keyExtractor,
+      Function<? super T, ? extends V> valueExtractor,
+      BiFunction<? super V, ? super V, ? extends V> mergeFn) {
+
+    return Collector.of(
+        HashMap<K, V>::new,
+        (map, val) -> putWithMerge(map, keyExtractor.apply(val), valueExtractor.apply(val), mergeFn),
+        (m1, m2) -> mergeMaps(m1, m2, mergeFn),
+        map -> ImmutableMap.copyOf(map),
+        Collector.Characteristics.UNORDERED);
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Collector used at the end of a stream to build an immutable sorted map.
@@ -587,5 +620,65 @@ public final class Guavate {
    */
   public static <K, V> Collector<Pair<K, V>, ?, ImmutableMap<K, V>> pairsToImmutableMap() {
     return toImmutableMap(Pair::getFirst, Pair::getSecond);
+  }
+
+  //--------------------------------------------------------------------------------------------------
+
+  /**
+   * Helper method which puts a value into a mutable map.
+   * <p>
+   * If the map already contains a mapping for the key the merge function is applied to the existing value and
+   * the new value, and the return value is inserted.
+   *
+   * @param map  the map
+   * @param key  the key
+   * @param val  the value
+   * @param mergeFn  function applied to the existing and new values if the map contains the key
+   * @param <K>  the key type
+   * @param <V>  the value type
+   */
+  private static <K, V> void putWithMerge(
+      Map<K, V> map,
+      K key,
+      V val,
+      BiFunction<? super V, ? super V, ? extends V> mergeFn) {
+
+    V existingVal = map.get(key);
+
+    if (existingVal == null) {
+      map.put(key, val);
+    } else {
+      map.put(key, mergeFn.apply(existingVal, val));
+    }
+  }
+
+  /**
+   * Helper method to merge two mutable maps by inserting all values from {@code map2} into {@code map1}.
+   * <p>
+   * If {@code map1} already contains a mapping for a key the merge function is applied to the existing value and
+   * the new value, and the return value is inserted.
+   *
+   * @param map1  the map into which values are copied
+   * @param map2  the map from which values are copied
+   * @param mergeFn  function applied to the existing and new values if the map contains the key
+   * @param <K>  the key type
+   * @param <V>  the value type
+   * @return {@code map1} with the values from {@code map2} inserted
+   */
+  private static <K, V> Map<K, V> mergeMaps(
+      Map<K, V> map1,
+      Map<K, V> map2,
+      BiFunction<? super V, ? super V, ? extends V> mergeFn) {
+
+    for (Map.Entry<K, V> entry : map2.entrySet()) {
+      V existingValue = map1.get(entry.getKey());
+
+      if (existingValue == null) {
+        map1.put(entry.getKey(), entry.getValue());
+      } else {
+        map1.put(entry.getKey(), mergeFn.apply(existingValue, entry.getValue()));
+      }
+    }
+    return map1;
   }
 }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -387,7 +387,7 @@ public final class Guavate {
 
     return Collector.of(
         HashMap<K, V>::new,
-        (map, val) -> putWithMerge(map, keyExtractor.apply(val), valueExtractor.apply(val), mergeFn),
+        (map, val) -> map.merge(keyExtractor.apply(val), valueExtractor.apply(val), mergeFn),
         (m1, m2) -> mergeMaps(m1, m2, mergeFn),
         map -> ImmutableMap.copyOf(map),
         Collector.Characteristics.UNORDERED);
@@ -623,34 +623,6 @@ public final class Guavate {
   }
 
   //--------------------------------------------------------------------------------------------------
-
-  /**
-   * Helper method which puts a value into a mutable map.
-   * <p>
-   * If the map already contains a mapping for the key the merge function is applied to the existing value and
-   * the new value, and the return value is inserted.
-   *
-   * @param map  the map
-   * @param key  the key
-   * @param val  the value
-   * @param mergeFn  function applied to the existing and new values if the map contains the key
-   * @param <K>  the key type
-   * @param <V>  the value type
-   */
-  private static <K, V> void putWithMerge(
-      Map<K, V> map,
-      K key,
-      V val,
-      BiFunction<? super V, ? super V, ? extends V> mergeFn) {
-
-    V existingVal = map.get(key);
-
-    if (existingVal == null) {
-      map.put(key, val);
-    } else {
-      map.put(key, mergeFn.apply(existingVal, val));
-    }
-  }
 
   /**
    * Helper method to merge two mutable maps by inserting all values from {@code map2} into {@code map1}.

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.collect;
 
 import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
@@ -50,6 +51,18 @@ public final class MapStream<K, V>
    */
   public static <K, V> MapStream<K, V> of(Map<K, V> map) {
     return new MapStream<>(map.entrySet().stream());
+  }
+
+  /**
+   * Returns a stream of map entries where the values are taken from a collection and the keys are created by
+   * applying a function to each value.
+   *
+   * @param collection  the collection of values
+   * @param keyFunction  a function that returns the key for a value
+   * @return a stream of map entries derived from the values in the collection
+   */
+  public static <K, V> MapStream<K, V> of(Collection<V> collection, Function<V, K> keyFunction) {
+    return new MapStream<>(collection.stream().map(v -> entry(keyFunction.apply(v), v)));
   }
 
   /**
@@ -178,6 +191,19 @@ public final class MapStream<K, V>
    */
   public ImmutableMap<K, V> toMap() {
     return underlying.collect(Guavate.toImmutableMap(e -> e.getKey(), e -> e.getValue()));
+  }
+
+  /**
+   * Returns an immutable map built from the entries in the stream.
+   * <p>
+   * If the same key maps to multiple values the merge function is invoked with both values and the return
+   * value is used in the map.
+   *
+   * @param mergeFn  function used to merge values when the same key appears multiple times in the stream
+   * @return an immutable map built from the entries in the stream
+   */
+  public ImmutableMap<K, V> toMap(BiFunction<? super V, ? super V, ? extends V> mergeFn) {
+    return underlying.collect(Guavate.toImmutableMap(e -> e.getKey(), e -> e.getValue(), mergeFn));
   }
 
   /**

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -170,6 +170,14 @@ public class GuavateTest {
     list.stream().collect(Guavate.toImmutableMap(s -> s.length()));
   }
 
+  public void test_toImmutableMap_mergeFn() {
+    List<String> list = Arrays.asList("a", "b", "b", "b", "c", "a");
+    Map<String, Integer> result = list.stream()
+        .collect(Guavate.toImmutableMap(s -> s, s -> 1, (s1, s2) -> s1 + s2));
+    Map<String, Integer> expected = ImmutableMap.of("a", 2, "b", 3, "c", 1);
+    assertEquals(result, expected);
+  }
+
   public void test_toImmutableMap_keyValue() {
     List<String> list = Arrays.asList("a", "ab", "bob");
     ImmutableMap<Integer, String> test = list.stream()

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
@@ -83,8 +83,22 @@ public class MapStreamTest {
     assertThat(mutableMap).isEqualTo(map);
   }
 
+  public void ofCollection() {
+    List<String> letters = ImmutableList.of("a", "b", "c");
+    Map<String, String> expected = ImmutableMap.of("A", "a", "B", "b", "C", "c");
+    Map<String, String> result = MapStream.of(letters, letter -> letter.toUpperCase(Locale.ENGLISH)).toMap();
+    assertThat(result).isEqualTo(expected);
+  }
+
   public void toMapDuplicateKeys() {
     assertThrowsIllegalArg(() -> MapStream.of(map).mapKeys(k -> "key").toMap());
+  }
+
+  public void toMapWithMerge() {
+    Map<String, Integer> map = ImmutableMap.of("a", 1, "aa", 2, "b", 10, "bb", 20, "c", 1);
+    Map<String, Integer> expected = ImmutableMap.of("a", 3, "b", 30, "c", 1);
+    Map<String, Integer> result = MapStream.of(map).mapKeys(s -> s.substring(0, 1)).toMap((v1, v2) -> v1 + v2);
+    assertThat(result).isEqualTo(expected);
   }
 
   public void coverage() {


### PR DESCRIPTION
Add an override to `MapStream.of` to create a stream from a collection of values and a function which generates a key from each value.

Add an override to `MapStream.toMap` and `Guavate.toImmutableMap` which handles multiple mappings to the same key by applying a merging function to the values.