### PR TITLE
Add FX conversion flag to Measure

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/config/ImmutableMeasure.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/config/ImmutableMeasure.java
@@ -45,6 +45,12 @@ public final class ImmutableMeasure
   @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final String name;
 
+  /**
+   * Flag indicating whether measure values should be automatically converted to the reporting currency.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final boolean currencyConvertible;
+
   //--------------------------------------------------------------------------------------------------
 
   @ImmutableValidator
@@ -55,7 +61,7 @@ public final class ImmutableMeasure
   }
 
   /**
-   * Returns a measure with the specified name.
+   * Returns a measure with the specified name whose values will be automatically converted to the reporting currency.
    * <p>
    * Measure names must only contains the characters A-Z, a-z, 0-9 and -.
    *
@@ -63,7 +69,21 @@ public final class ImmutableMeasure
    * @return a measure with the specified name
    */
   public static ImmutableMeasure of(String name) {
-    return new ImmutableMeasure(name);
+    return new ImmutableMeasure(name, true);
+  }
+
+  /**
+   * Returns a measure with the specified name.
+   * <p>
+   * Measure names must only contains the characters A-Z, a-z, 0-9 and -.
+   *
+   * @param name  the measure name
+   * @param isCurrencyConvertible  flag indicating whether measure values should be automatically
+   * converted to the reporting currency.
+   * @return a measure with the specified name
+   */
+  public static ImmutableMeasure of(String name, boolean isCurrencyConvertible) {
+    return new ImmutableMeasure(name, isCurrencyConvertible);
   }
 
   @Override
@@ -99,9 +119,12 @@ public final class ImmutableMeasure
   }
 
   private ImmutableMeasure(
-      String name) {
+      String name,
+      boolean currencyConvertible) {
     JodaBeanUtils.notNull(name, "name");
+    JodaBeanUtils.notNull(currencyConvertible, "currencyConvertible");
     this.name = name;
+    this.currencyConvertible = currencyConvertible;
     validate();
   }
 
@@ -134,6 +157,16 @@ public final class ImmutableMeasure
 
   //-----------------------------------------------------------------------
   /**
+   * Gets flag indicating whether measure values should be automatically converted to the reporting currency.
+   * @return the value of the property, not null
+   */
+  @Override
+  public boolean isCurrencyConvertible() {
+    return currencyConvertible;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Returns a builder that allows this bean to be mutated.
    * @return the mutable builder, not null
    */
@@ -148,7 +181,8 @@ public final class ImmutableMeasure
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       ImmutableMeasure other = (ImmutableMeasure) obj;
-      return JodaBeanUtils.equal(name, other.name);
+      return JodaBeanUtils.equal(name, other.name) &&
+          (currencyConvertible == other.currencyConvertible);
     }
     return false;
   }
@@ -157,6 +191,7 @@ public final class ImmutableMeasure
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(name);
+    hash = hash * 31 + JodaBeanUtils.hashCode(currencyConvertible);
     return hash;
   }
 
@@ -176,11 +211,17 @@ public final class ImmutableMeasure
     private final MetaProperty<String> name = DirectMetaProperty.ofImmutable(
         this, "name", ImmutableMeasure.class, String.class);
     /**
+     * The meta-property for the {@code currencyConvertible} property.
+     */
+    private final MetaProperty<Boolean> currencyConvertible = DirectMetaProperty.ofImmutable(
+        this, "currencyConvertible", ImmutableMeasure.class, Boolean.TYPE);
+    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "name");
+        "name",
+        "currencyConvertible");
 
     /**
      * Restricted constructor.
@@ -193,6 +234,8 @@ public final class ImmutableMeasure
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
+        case 1098971060:  // currencyConvertible
+          return currencyConvertible;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -221,12 +264,22 @@ public final class ImmutableMeasure
       return name;
     }
 
+    /**
+     * The meta-property for the {@code currencyConvertible} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Boolean> currencyConvertible() {
+      return currencyConvertible;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return ((ImmutableMeasure) bean).getName();
+        case 1098971060:  // currencyConvertible
+          return ((ImmutableMeasure) bean).isCurrencyConvertible();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -249,6 +302,7 @@ public final class ImmutableMeasure
   public static final class Builder extends DirectFieldsBeanBuilder<ImmutableMeasure> {
 
     private String name;
+    private boolean currencyConvertible;
 
     /**
      * Restricted constructor.
@@ -262,6 +316,7 @@ public final class ImmutableMeasure
      */
     private Builder(ImmutableMeasure beanToCopy) {
       this.name = beanToCopy.getName();
+      this.currencyConvertible = beanToCopy.isCurrencyConvertible();
     }
 
     //-----------------------------------------------------------------------
@@ -270,6 +325,8 @@ public final class ImmutableMeasure
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
+        case 1098971060:  // currencyConvertible
+          return currencyConvertible;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -280,6 +337,9 @@ public final class ImmutableMeasure
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           this.name = (String) newValue;
+          break;
+        case 1098971060:  // currencyConvertible
+          this.currencyConvertible = (Boolean) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -314,7 +374,8 @@ public final class ImmutableMeasure
     @Override
     public ImmutableMeasure build() {
       return new ImmutableMeasure(
-          name);
+          name,
+          currencyConvertible);
     }
 
     //-----------------------------------------------------------------------
@@ -331,12 +392,24 @@ public final class ImmutableMeasure
       return this;
     }
 
+    /**
+     * Sets flag indicating whether measure values should be automatically converted to the reporting currency.
+     * @param currencyConvertible  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder currencyConvertible(boolean currencyConvertible) {
+      JodaBeanUtils.notNull(currencyConvertible, "currencyConvertible");
+      this.currencyConvertible = currencyConvertible;
+      return this;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(64);
+      StringBuilder buf = new StringBuilder(96);
       buf.append("ImmutableMeasure.Builder{");
-      buf.append("name").append('=').append(JodaBeanUtils.toString(name));
+      buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
+      buf.append("currencyConvertible").append('=').append(JodaBeanUtils.toString(currencyConvertible));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/config/Measure.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/config/Measure.java
@@ -28,7 +28,7 @@ public interface Measure extends Named {
    * Obtains an instance from the specified unique name.
    *
    * @param uniqueName  the unique name
-   * @return the convention
+   * @return the measure
    * @throws IllegalArgumentException if the name is not known
    */
   @FromString
@@ -37,10 +37,21 @@ public interface Measure extends Named {
     return extendedEnum().lookup(uniqueName);
   }
 
+  //--------------------------------------------------------------------------------------------------
+
+  /**
+   * Flag indicating whether measure values should be automatically converted to the reporting currency.
+   *
+   * @return true if measure values should be automatically converted to the reporting currency
+   */
+  public abstract boolean isCurrencyConvertible();
+
+  //--------------------------------------------------------------------------------------------------
+
   /**
    * Gets the extended enum helper.
    * <p>
-   * This helper allows instances of the convention to be looked up.
+   * This helper allows instances of the measure to be looked up.
    * It also provides the complete set of available instances.
    *
    * @return the extended enum helper

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/config/Measures.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/config/Measures.java
@@ -69,6 +69,13 @@ public final class Measures {
    */
   public static final Measure PRESENT_VALUE = Measure.of(StandardMeasures.PRESENT_VALUE.getName());
   /**
+   * Measure representing the present value of the calculation target.
+   * <p>
+   * Calculated values are not converted to the reporting currency and may contain values in multiple currencies
+   * if the target contains multiple currencies.
+   */
+  public static final Measure PRESENT_VALUE_MULTI_CCY = Measure.of(StandardMeasures.PRESENT_VALUE_MULTI_CURRENCY.getName());
+  /**
    * Measure representing the present value of each leg of the calculation target.
    */
   public static final Measure LEG_PRESENT_VALUE = Measure.of(StandardMeasures.LEG_PRESENT_VALUE.getName());

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/config/StandardMeasures.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/config/StandardMeasures.java
@@ -54,6 +54,13 @@ final class StandardMeasures {
    */
   public static final Measure PRESENT_VALUE = ImmutableMeasure.of("PresentValue");
   /**
+   * Measure representing the present value of the calculation target.
+   * <p>
+   * Calculated values are not converted to the reporting currency and may contain values in multiple currencies
+   * if the target contains multiple currencies.
+   */
+  public static final Measure PRESENT_VALUE_MULTI_CURRENCY = ImmutableMeasure.of("PresentValueMultiCurrency", false);
+  /**
    * Measure representing the present value of each leg of the calculation target.
    */
   public static final Measure LEG_PRESENT_VALUE = ImmutableMeasure.of("LegPresentValue");

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
@@ -255,6 +255,9 @@ public final class CalculationTask {
     if (!result.isSuccess()) {
       return result;
     }
+    if (!measure.isCurrencyConvertible()) {
+      return result;
+    }
     Object value = result.getValue();
 
     if (!(value instanceof CurrencyConvertible)) {

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/function/FunctionUtils.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/function/FunctionUtils.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.calc.runner.function;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
 
@@ -14,12 +15,14 @@ import com.google.common.collect.ImmutableList;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.FxConvertible;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
+import com.opengamma.strata.calc.config.Measure;
 import com.opengamma.strata.calc.runner.function.result.CurrencyValuesArray;
 import com.opengamma.strata.calc.runner.function.result.DefaultScenarioResult;
 import com.opengamma.strata.calc.runner.function.result.FxConvertibleList;
 import com.opengamma.strata.calc.runner.function.result.MultiCurrencyValuesArray;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.calc.runner.function.result.ValuesArray;
+import com.opengamma.strata.collect.result.Result;
 
 /**
  * Static utility methods useful when writing calculation functions.
@@ -148,7 +151,7 @@ public final class FunctionUtils {
   }
 
   /**
-   * Returns a collector that builds a scenerio result based on {@code Double}.
+   * Returns a collector that builds a scenario result based on {@code Double}.
    * <p>
    * This is used at the end of a stream to collect per-scenario instances of {@code Double}
    * into a single instance of {@link ValuesArray}, which is designed to be space-efficient.
@@ -167,6 +170,22 @@ public final class FunctionUtils {
           return l;
         },
         list -> ValuesArray.of(list));
+  }
+
+  /**
+   * Checks if a map of results contains a value for a key, and if it does inserts it into the map for a different key.
+   *
+   * @param existingKey  a key for which the map possibly contains a value
+   * @param newKey  the key which is inserted into the map
+   * @param mutableMeasureMap  a mutable map of values, keyed by measure
+   */
+  public static void duplicateResult(Measure existingKey, Measure newKey, Map<Measure, Result<?>> mutableMeasureMap) {
+    Result<?> result = mutableMeasureMap.get(existingKey);
+
+    if (result == null) {
+      return;
+    }
+    mutableMeasureMap.put(newKey, result);
   }
 
 }

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/credit/CdsFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/credit/CdsFunctionGroups.java
@@ -24,6 +24,7 @@ public final class CdsFunctionGroups {
   private static final FunctionGroup<CdsTrade> DISCOUNTING_GROUP =
       DefaultFunctionGroup.builder(CdsTrade.class).name("CdsDiscounting")
           .addFunction(Measures.PRESENT_VALUE, CdsCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, CdsCalculationFunction.class)
           .addFunction(Measures.PAR_RATE, CdsCalculationFunction.class)
           .addFunction(Measures.IR01_PARALLEL_ZERO, CdsCalculationFunction.class)
           .addFunction(Measures.IR01_BUCKETED_ZERO, CdsCalculationFunction.class)
@@ -51,6 +52,7 @@ public final class CdsFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PAR_RATE Par rate}
    *   <li>{@linkplain Measures#IR01_PARALLEL_ZERO Scalar IR01, based on zero rates}
    *   <li>{@linkplain Measures#IR01_BUCKETED_ZERO Vector curve node IR01, based on zero rates}

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/deposit/TermDepositCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/deposit/TermDepositCalculationFunction.java
@@ -18,6 +18,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -35,6 +36,7 @@ import com.opengamma.strata.product.deposit.TermDepositTrade;
  *   <li>{@linkplain Measures#PAR_RATE Par rate}
  *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01 PV01}
  *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
  * </ul>
@@ -54,6 +56,11 @@ public class TermDepositCalculationFunction
           .put(Measures.BUCKETED_PV01, TermDepositMeasureCalculations::bucketedPv01)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -63,7 +70,7 @@ public class TermDepositCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -101,6 +108,8 @@ public class TermDepositCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, product, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/deposit/TermDepositFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/deposit/TermDepositFunctionGroups.java
@@ -26,6 +26,7 @@ public final class TermDepositFunctionGroups {
           .addFunction(Measures.PAR_RATE, TermDepositCalculationFunction.class)
           .addFunction(Measures.PAR_SPREAD, TermDepositCalculationFunction.class)
           .addFunction(Measures.PRESENT_VALUE, TermDepositCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, TermDepositCalculationFunction.class)
           .addFunction(Measures.PV01, TermDepositCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, TermDepositCalculationFunction.class)
           .build();
@@ -46,6 +47,7 @@ public final class TermDepositFunctionGroups {
    *   <li>{@linkplain Measures#PAR_RATE Par rate}
    *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    * </ul>

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fra/FraCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fra/FraCalculationFunction.java
@@ -25,6 +25,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -44,6 +45,7 @@ import com.opengamma.strata.product.fra.FraTrade;
  *   <li>{@linkplain Measures#PAR_RATE Par rate}
  *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#EXPLAIN_PRESENT_VALUE Explain present value}
  *   <li>{@linkplain Measures#CASH_FLOWS Cash flows}
  *   <li>{@linkplain Measures#PV01 PV01}
@@ -69,6 +71,11 @@ public class FraCalculationFunction
           .put(Measures.BUCKETED_GAMMA_PV01, FraMeasureCalculations::bucketedGammaPv01)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -78,7 +85,7 @@ public class FraCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -135,6 +142,8 @@ public class FraCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, product, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fra/FraFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fra/FraFunctionGroups.java
@@ -26,6 +26,7 @@ public final class FraFunctionGroups {
           .addFunction(Measures.PAR_RATE, FraCalculationFunction.class)
           .addFunction(Measures.PAR_SPREAD, FraCalculationFunction.class)
           .addFunction(Measures.PRESENT_VALUE, FraCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, FraCalculationFunction.class)
           .addFunction(Measures.EXPLAIN_PRESENT_VALUE, FraCalculationFunction.class)
           .addFunction(Measures.CASH_FLOWS, FraCalculationFunction.class)
           .addFunction(Measures.PV01, FraCalculationFunction.class)
@@ -49,6 +50,7 @@ public final class FraFunctionGroups {
    *   <li>{@linkplain Measures#PAR_RATE Par rate}
    *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#EXPLAIN_PRESENT_VALUE Explain present value}
    *   <li>{@linkplain Measures#CASH_FLOWS Cash flows}
    *   <li>{@linkplain Measures#PV01 PV01}

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureCalculationFunction.java
@@ -18,6 +18,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -30,6 +31,7 @@ import com.opengamma.strata.product.future.GenericFutureTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  * </ul>
  */
 public class GenericFutureCalculationFunction
@@ -43,6 +45,11 @@ public class GenericFutureCalculationFunction
           .put(Measures.PRESENT_VALUE, GenericFutureMeasureCalculations::presentValue)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -52,7 +59,7 @@ public class GenericFutureCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -83,6 +90,8 @@ public class GenericFutureCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureFunctionGroups.java
@@ -40,6 +40,7 @@ public final class GenericFutureFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    * </ul>
    * 
    * @return the function group

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureOptionCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureOptionCalculationFunction.java
@@ -18,6 +18,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -30,6 +31,7 @@ import com.opengamma.strata.product.future.GenericFutureOptionTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  * </ul>
  */
 public class GenericFutureOptionCalculationFunction
@@ -43,6 +45,11 @@ public class GenericFutureOptionCalculationFunction
           .put(Measures.PRESENT_VALUE, GenericFutureOptionMeasureCalculations::presentValue)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -52,7 +59,7 @@ public class GenericFutureOptionCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -83,6 +90,8 @@ public class GenericFutureOptionCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureOptionFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/future/GenericFutureOptionFunctionGroups.java
@@ -24,6 +24,7 @@ public final class GenericFutureOptionFunctionGroups {
   private static final FunctionGroup<GenericFutureOptionTrade> MARKET_GROUP =
       DefaultFunctionGroup.builder(GenericFutureOptionTrade.class).name("GenericFutureOptionTradeMarket")
           .addFunction(Measures.PRESENT_VALUE, GenericFutureOptionCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, GenericFutureOptionCalculationFunction.class)
           .build();
 
   /**

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxNdfCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxNdfCalculationFunction.java
@@ -18,6 +18,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -33,6 +34,7 @@ import com.opengamma.strata.product.fx.FxNdfTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01 PV01}
  *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
  *   <li>{@linkplain Measures#CURRENCY_EXPOSURE Currency exposure}
@@ -58,6 +60,11 @@ public class FxNdfCalculationFunction
           .put(Measures.FORWARD_FX_RATE, FxNdfMeasureCalculations::forwardFxRate)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -67,7 +74,7 @@ public class FxNdfCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -107,6 +114,8 @@ public class FxNdfCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, product, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxNdfFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxNdfFunctionGroups.java
@@ -24,6 +24,7 @@ public final class FxNdfFunctionGroups {
   private static final FunctionGroup<FxNdfTrade> DISCOUNTING_GROUP =
       DefaultFunctionGroup.builder(FxNdfTrade.class).name("FxNdfDiscounting")
           .addFunction(Measures.PRESENT_VALUE, FxNdfCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, FxNdfCalculationFunction.class)
           .addFunction(Measures.PV01, FxNdfCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, FxNdfCalculationFunction.class)
           .addFunction(Measures.CURRENCY_EXPOSURE, FxNdfCalculationFunction.class)
@@ -45,6 +46,7 @@ public final class FxNdfFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    *   <li>{@linkplain Measures#CURRENCY_EXPOSURE Currency exposure}

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSingleCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSingleCalculationFunction.java
@@ -19,6 +19,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -35,6 +36,7 @@ import com.opengamma.strata.product.fx.FxSingleTrade;
  * <ul>
  *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01 PV01}
  *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
  *   <li>{@linkplain Measures#CURRENCY_EXPOSURE Currency exposure}
@@ -61,6 +63,11 @@ public class FxSingleCalculationFunction
           .put(Measures.FORWARD_FX_RATE, FxSingleMeasureCalculations::forwardFxRate)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -70,7 +77,7 @@ public class FxSingleCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -113,6 +120,8 @@ public class FxSingleCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, product, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSingleFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSingleFunctionGroups.java
@@ -25,6 +25,7 @@ public final class FxSingleFunctionGroups {
       DefaultFunctionGroup.builder(FxSingleTrade.class).name("FxSingleDiscounting")
           .addFunction(Measures.PAR_SPREAD, FxSingleCalculationFunction.class)
           .addFunction(Measures.PRESENT_VALUE, FxSingleCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, FxSingleCalculationFunction.class)
           .addFunction(Measures.PV01, FxSingleCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, FxSingleCalculationFunction.class)
           .addFunction(Measures.CURRENCY_EXPOSURE, FxSingleCalculationFunction.class)
@@ -47,6 +48,7 @@ public final class FxSingleFunctionGroups {
    * <ul>
    *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    *   <li>{@linkplain Measures#CURRENCY_EXPOSURE Currency exposure}

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSwapCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSwapCalculationFunction.java
@@ -19,6 +19,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -35,6 +36,7 @@ import com.opengamma.strata.product.fx.FxSwapTrade;
  * <ul>
  *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01 PV01}
  *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
  *   <li>{@linkplain Measures#CURRENCY_EXPOSURE Currency exposure}
@@ -60,6 +62,11 @@ public class FxSwapCalculationFunction
           .put(Measures.CURRENT_CASH, FxSwapMeasureCalculations::currentCash)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -69,7 +76,7 @@ public class FxSwapCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -112,6 +119,8 @@ public class FxSwapCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, product, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSwapFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/fx/FxSwapFunctionGroups.java
@@ -25,6 +25,7 @@ public final class FxSwapFunctionGroups {
       DefaultFunctionGroup.builder(FxSwapTrade.class).name("FxSwapDiscounting")
           .addFunction(Measures.PAR_SPREAD, FxSwapCalculationFunction.class)
           .addFunction(Measures.PRESENT_VALUE, FxSwapCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, FxSwapCalculationFunction.class)
           .addFunction(Measures.PV01, FxSwapCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, FxSwapCalculationFunction.class)
           .addFunction(Measures.CURRENCY_EXPOSURE, FxSwapCalculationFunction.class)
@@ -45,6 +46,7 @@ public final class FxSwapFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    *   <li>{@linkplain Measures#PAR_SPREAD Par spread}

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/index/IborFutureFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/index/IborFutureFunctionGroups.java
@@ -25,6 +25,7 @@ public final class IborFutureFunctionGroups {
       DefaultFunctionGroup.builder(IborFutureTrade.class).name("IborFutureDiscounting")
           .addFunction(Measures.PAR_SPREAD, IborFutureCalculationFunction.class)
           .addFunction(Measures.PRESENT_VALUE, IborFutureCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, IborFutureCalculationFunction.class)
           .addFunction(Measures.PV01, IborFutureCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, IborFutureCalculationFunction.class)
           .build();
@@ -44,6 +45,7 @@ public final class IborFutureFunctionGroups {
    * <ul>
    *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    * </ul>

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/payment/BulletPaymentCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/payment/BulletPaymentCalculationFunction.java
@@ -19,6 +19,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -35,6 +36,7 @@ import com.opengamma.strata.product.payment.BulletPaymentTrade;
  *   <li>{@linkplain Measures#PAR_RATE Par rate}
  *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01 PV01}
  *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
  * </ul>
@@ -52,6 +54,11 @@ public class BulletPaymentCalculationFunction
           .put(Measures.BUCKETED_PV01, BulletPaymentMeasureCalculations::bucketedPv01)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -61,7 +68,7 @@ public class BulletPaymentCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -99,6 +106,8 @@ public class BulletPaymentCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, payment, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/payment/BulletPaymentFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/payment/BulletPaymentFunctionGroups.java
@@ -24,6 +24,7 @@ public final class BulletPaymentFunctionGroups {
   private static final FunctionGroup<BulletPaymentTrade> DISCOUNTING_GROUP =
       DefaultFunctionGroup.builder(BulletPaymentTrade.class).name("BulletPaymentDiscounting")
           .addFunction(Measures.PRESENT_VALUE, BulletPaymentCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, BulletPaymentCalculationFunction.class)
           .addFunction(Measures.PV01, BulletPaymentCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, BulletPaymentCalculationFunction.class)
           .build();
@@ -42,6 +43,7 @@ public final class BulletPaymentFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    * </ul>

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/DeliverableSwapFutureCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/DeliverableSwapFutureCalculationFunction.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -40,6 +41,7 @@ import com.opengamma.strata.product.swap.DeliverableSwapFutureTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01 PV01}
  *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
  * </ul>
@@ -59,6 +61,11 @@ public class DeliverableSwapFutureCalculationFunction
           .put(Measures.BUCKETED_PV01, DeliverableSwapFutureMeasureCalculations::bucketedPv01)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -68,7 +75,7 @@ public class DeliverableSwapFutureCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -116,6 +123,8 @@ public class DeliverableSwapFutureCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/DeliverableSwapFutureFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/DeliverableSwapFutureFunctionGroups.java
@@ -24,6 +24,7 @@ public final class DeliverableSwapFutureFunctionGroups {
   private static final FunctionGroup<DeliverableSwapFutureTrade> DISCOUNTING_GROUP =
       DefaultFunctionGroup.builder(DeliverableSwapFutureTrade.class).name("DeliverableSwapFutureDiscounting")
           .addFunction(Measures.PRESENT_VALUE, DeliverableSwapFutureCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, DeliverableSwapFutureCalculationFunction.class)
           .addFunction(Measures.PV01, DeliverableSwapFutureCalculationFunction.class)
           .addFunction(Measures.BUCKETED_PV01, DeliverableSwapFutureCalculationFunction.class)
           .build();
@@ -42,6 +43,7 @@ public final class DeliverableSwapFutureFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#PV01 PV01}
    *   <li>{@linkplain Measures#BUCKETED_PV01 Bucketed PV01}
    * </ul>

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/SwapCalculationFunction.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/SwapCalculationFunction.java
@@ -24,6 +24,7 @@ import com.opengamma.strata.calc.config.Measures;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
 import com.opengamma.strata.calc.marketdata.FunctionRequirements;
 import com.opengamma.strata.calc.runner.function.CalculationFunction;
+import com.opengamma.strata.calc.runner.function.FunctionUtils;
 import com.opengamma.strata.calc.runner.function.result.ScenarioResult;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -44,6 +45,7 @@ import com.opengamma.strata.product.swap.SwapTrade;
  *   <li>{@linkplain Measures#PAR_RATE Par rate}
  *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#EXPLAIN_PRESENT_VALUE Explain present value}
  *   <li>{@linkplain Measures#CASH_FLOWS Cash flows}
  *   <li>{@linkplain Measures#PV01 PV01}
@@ -81,6 +83,11 @@ public class SwapCalculationFunction
           .put(Measures.CURRENT_CASH, SwapMeasureCalculations::currentCash)
           .build();
 
+  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
+      .addAll(CALCULATORS.keySet())
+      .add(Measures.PRESENT_VALUE_MULTI_CCY)
+      .build();
+
   /**
    * Creates an instance.
    */
@@ -90,7 +97,7 @@ public class SwapCalculationFunction
   //-------------------------------------------------------------------------
   @Override
   public Set<Measure> supportedMeasures() {
-    return CALCULATORS.keySet();
+    return MEASURES;
   }
 
   @Override
@@ -148,6 +155,8 @@ public class SwapCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, product, scenarioMarketData));
     }
+    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
+    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/SwapFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/swap/SwapFunctionGroups.java
@@ -27,6 +27,7 @@ public final class SwapFunctionGroups {
           .addFunction(Measures.PAR_SPREAD, SwapCalculationFunction.class)
           .addFunction(Measures.LEG_INITIAL_NOTIONAL, SwapCalculationFunction.class)
           .addFunction(Measures.PRESENT_VALUE, SwapCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, SwapCalculationFunction.class)
           .addFunction(Measures.EXPLAIN_PRESENT_VALUE, SwapCalculationFunction.class)
           .addFunction(Measures.CASH_FLOWS, SwapCalculationFunction.class)
           .addFunction(Measures.LEG_PRESENT_VALUE, SwapCalculationFunction.class)
@@ -54,6 +55,7 @@ public final class SwapFunctionGroups {
    *   <li>{@linkplain Measures#PAR_RATE Par rate}
    *   <li>{@linkplain Measures#PAR_SPREAD Par spread}
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    *   <li>{@linkplain Measures#EXPLAIN_PRESENT_VALUE Explain present value}
    *   <li>{@linkplain Measures#CASH_FLOWS Cash flows}
    *   <li>{@linkplain Measures#PV01 PV01}

--- a/modules/function/src/main/java/com/opengamma/strata/function/calculation/swaption/SwaptionFunctionGroups.java
+++ b/modules/function/src/main/java/com/opengamma/strata/function/calculation/swaption/SwaptionFunctionGroups.java
@@ -24,6 +24,7 @@ public final class SwaptionFunctionGroups {
   private static final FunctionGroup<SwaptionTrade> STANDARD_GROUP =
       DefaultFunctionGroup.builder(SwaptionTrade.class).name("Swaption")
           .addFunction(Measures.PRESENT_VALUE, SwaptionCalculationFunction.class)
+          .addFunction(Measures.PRESENT_VALUE_MULTI_CCY, SwaptionCalculationFunction.class)
           .build();
 
   /**
@@ -40,6 +41,7 @@ public final class SwaptionFunctionGroups {
    * The supported built-in measures are:
    * <ul>
    *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+   *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
    * </ul>
    * 
    * @return the function group

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/deposit/TermDepositCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/deposit/TermDepositCalculationFunctionTest.java
@@ -103,10 +103,16 @@ public class TermDepositCalculationFunctionTest {
     double expectedParRate = pricer.parRate(TRADE.getProduct(), provider);
     double expectedParSpread = pricer.parSpread(TRADE.getProduct(), provider);
 
-    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE, Measures.PAR_RATE, Measures.PAR_SPREAD);
+    Set<Measure> measures = ImmutableSet.of(
+        Measures.PRESENT_VALUE,
+        Measures.PRESENT_VALUE_MULTI_CCY,
+        Measures.PAR_RATE,
+        Measures.PAR_SPREAD);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_RATE, Result.success(ValuesArray.of(ImmutableList.of(expectedParRate))))
         .containsEntry(

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/fra/FraCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/fra/FraCalculationFunctionTest.java
@@ -104,6 +104,8 @@ public class FraCalculationFunctionTest {
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
             Measures.PAR_RATE, Result.success(ValuesArray.of(ImmutableList.of(expectedParRate))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))))

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/future/GenericFutureCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/future/GenericFutureCalculationFunctionTest.java
@@ -99,6 +99,8 @@ public class GenericFutureCalculationFunctionTest {
     Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/future/GenericFutureOptionCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/future/GenericFutureOptionCalculationFunctionTest.java
@@ -99,6 +99,8 @@ public class GenericFutureOptionCalculationFunctionTest {
     Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/fx/FxNdfCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/fx/FxNdfCalculationFunctionTest.java
@@ -107,10 +107,16 @@ public class FxNdfCalculationFunctionTest {
     FxRate expectedForwardFx = pricer.forwardFxRate(TRADE.getProduct(), provider);
 
     Set<Measure> measures = ImmutableSet.of(
-        Measures.PRESENT_VALUE, Measures.CURRENCY_EXPOSURE, Measures.CURRENT_CASH, Measures.FORWARD_FX_RATE);
+        Measures.PRESENT_VALUE,
+        Measures.PRESENT_VALUE_MULTI_CCY,
+        Measures.CURRENCY_EXPOSURE,
+        Measures.CURRENT_CASH,
+        Measures.FORWARD_FX_RATE);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.CURRENCY_EXPOSURE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedCurrencyExp))))
         .containsEntry(

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/fx/FxSingleCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/fx/FxSingleCalculationFunctionTest.java
@@ -97,10 +97,17 @@ public class FxSingleCalculationFunctionTest {
     FxRate expectedForwardFx = pricer.forwardFxRate(TRADE.getProduct(), provider);
 
     Set<Measure> measures = ImmutableSet.of(
-        Measures.PRESENT_VALUE, Measures.PAR_SPREAD, Measures.CURRENCY_EXPOSURE, Measures.CURRENT_CASH, Measures.FORWARD_FX_RATE);
+        Measures.PRESENT_VALUE,
+        Measures.PRESENT_VALUE_MULTI_CCY,
+        Measures.PAR_SPREAD,
+        Measures.CURRENCY_EXPOSURE,
+        Measures.CURRENT_CASH,
+        Measures.FORWARD_FX_RATE);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))))
         .containsEntry(

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/fx/FxSwapCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/fx/FxSwapCalculationFunctionTest.java
@@ -104,10 +104,17 @@ public class FxSwapCalculationFunctionTest {
     MultiCurrencyAmount expectedCash = pricer.currentCash(TRADE.getProduct(), provider.getValuationDate());
 
     Set<Measure> measures = ImmutableSet.of(
-        Measures.PRESENT_VALUE, Measures.PAR_SPREAD, Measures.CURRENCY_EXPOSURE, Measures.CURRENT_CASH, Measures.FORWARD_FX_RATE);
+        Measures.PRESENT_VALUE,
+        Measures.PRESENT_VALUE_MULTI_CCY,
+        Measures.PAR_SPREAD,
+        Measures.CURRENCY_EXPOSURE,
+        Measures.CURRENT_CASH,
+        Measures.FORWARD_FX_RATE);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))))
         .containsEntry(

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/index/IborFutureCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/index/IborFutureCalculationFunctionTest.java
@@ -86,10 +86,15 @@ public class IborFutureCalculationFunctionTest {
     CurrencyAmount expectedPv = DiscountingIborFutureTradePricer.DEFAULT.presentValue(TRADE, provider, MARKET_PRICE / 100);
     double expectedParSpread = DiscountingIborFutureTradePricer.DEFAULT.parSpread(TRADE, provider, MARKET_PRICE / 100);
 
-    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE, Measures.PAR_SPREAD);
+    Set<Measure> measures = ImmutableSet.of(
+        Measures.PRESENT_VALUE,
+        Measures.PRESENT_VALUE_MULTI_CCY,
+        Measures.PAR_SPREAD);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))));
   }

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/payment/BulletPaymentCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/payment/BulletPaymentCalculationFunctionTest.java
@@ -97,10 +97,12 @@ public class BulletPaymentCalculationFunctionTest {
     DiscountingPaymentPricer pricer = DiscountingPaymentPricer.DEFAULT;
     CurrencyAmount expectedPv = pricer.presentValue(TRADE.getProduct().expandToPayment(), provider);
 
-    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
+    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
-            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
+            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 
   public void test_pv01() {

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/swap/DeliverableSwapFutureCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/swap/DeliverableSwapFutureCalculationFunctionTest.java
@@ -138,10 +138,12 @@ public class DeliverableSwapFutureCalculationFunctionTest {
     DiscountingDeliverableSwapFutureTradePricer pricer = DiscountingDeliverableSwapFutureTradePricer.DEFAULT;
     CurrencyAmount expectedPv = pricer.presentValue(TRADE, provider, REF_PRICE);
 
-    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
+    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
-            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
+            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 
   public void test_pv01() {

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/swap/SwapCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/swap/SwapCalculationFunctionTest.java
@@ -111,12 +111,17 @@ public class SwapCalculationFunctionTest {
     MultiCurrencyAmount expectedExposure = pricer.currencyExposure(TRADE.getProduct(), provider);
     MultiCurrencyAmount expectedCash = pricer.currentCash(TRADE.getProduct(), provider);
 
-    Set<Measure> measures = ImmutableSet.of(
-        Measures.PRESENT_VALUE, Measures.PAR_RATE, Measures.PAR_SPREAD, Measures.EXPLAIN_PRESENT_VALUE,
+    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE,
+        Measures.PRESENT_VALUE_MULTI_CCY,
+        Measures.PAR_RATE,
+        Measures.PAR_SPREAD,
+        Measures.EXPLAIN_PRESENT_VALUE,
         Measures.CASH_FLOWS, Measures.CURRENCY_EXPOSURE, Measures.CURRENT_CASH);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_RATE, Result.success(ValuesArray.of(ImmutableList.of(expectedParRate))))
         .containsEntry(

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/swaption/SwaptionCalculationFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/swaption/SwaptionCalculationFunctionTest.java
@@ -124,10 +124,12 @@ public class SwaptionCalculationFunctionTest {
     VolatilitySwaptionPhysicalProductPricer pricer = VolatilitySwaptionPhysicalProductPricer.DEFAULT;
     CurrencyAmount expectedPv = pricer.presentValue(TRADE.getProduct(), provider, NORMAL_VOL_SWAPTION_PROVIDER_USD);
 
-    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
+    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY);
     assertThat(function.calculate(TRADE, measures, md))
         .containsEntry(
-            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
+            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
+        .containsEntry(
+            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Add a flag to `Measure` specifying whether the calculated values should be automatically converted to the reporting currency.

Add a measure `PRESENT_VALUE_MULTI_CCY` representing present value with no currency conversion applied.