### PR TITLE
Handle all-stub schedules

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -99,6 +99,10 @@ import com.opengamma.strata.collect.ArgChecker;
  * All calculated dates will match the roll convention.
  * If this is not possible due to the dates specified then an exception will be thrown during schedule creation.
  * <p>
+ * It is permitted to have 'firstRegularStartDate' equal to 'endDate', or 'lastRegularEndDate' equal to 'startDate'.
+ * In both cases, the effect is to define a schedule that is entirely "stub" and has no regular periods.
+ * The resulting schedule will retain the frequency specified here, even though it is not used.
+ * <p>
  * The schedule operates primarily on "unadjusted" dates.
  * An unadjusted date can be any day, including non-business days.
  * When the unadjusted schedule has been determined, the appropriate business day adjustment
@@ -441,6 +445,10 @@ public final class PeriodicSchedule
     LocalDate regEnd = getEffectiveLastRegularEndDate();
     boolean explicitInitialStub = !startDate.equals(regStart);
     boolean explicitFinalStub = !endDate.equals(regEnd);
+    // handle case where whole period is stub
+    if (regStart.equals(endDate) || regEnd.equals(startDate)) {
+      return ImmutableList.of(effectiveStartDate, endDate);
+    }
     // handle TERM frequency
     if (frequency == Frequency.TERM) {
       if (explicitInitialStub || explicitFinalStub) {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -11,6 +11,7 @@ import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_P
 import static com.opengamma.strata.basics.date.BusinessDayConventions.PRECEDING;
 import static com.opengamma.strata.basics.date.HolidayCalendars.NO_HOLIDAYS;
 import static com.opengamma.strata.basics.date.HolidayCalendars.SAT_SUN;
+import static com.opengamma.strata.basics.schedule.Frequency.P12M;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P2M;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
@@ -345,6 +346,13 @@ public class PeriodicScheduleTest {
 
         // TERM period
         {JUN_04, SEP_17, TERM, STUB_NONE, null, null, null,
+            ImmutableList.of(JUN_04, SEP_17),
+            ImmutableList.of(JUN_04, SEP_17)},
+        // TERM period defined as a stub and no regular periods
+        {JUN_04, SEP_17, P12M, SHORT_INITIAL, null, SEP_17, null,
+            ImmutableList.of(JUN_04, SEP_17),
+            ImmutableList.of(JUN_04, SEP_17)},
+        {JUN_04, SEP_17, P12M, SHORT_INITIAL, null, null, JUN_04,
             ImmutableList.of(JUN_04, SEP_17),
             ImmutableList.of(JUN_04, SEP_17)},
 
@@ -817,8 +825,8 @@ public class PeriodicScheduleTest {
     PeriodicSchedule f = of(
         start, end, freq, BDA, stubConv == STUB_NONE ? SHORT_FINAL : STUB_NONE, rollConv, firstReg, lastReg, null, null, null);
     PeriodicSchedule g = of(start, end, freq, BDA, stubConv, SFE, firstReg, lastReg, null, null, null);
-    PeriodicSchedule h = of(start, end, freq, BDA, stubConv, rollConv, start.plusDays(1), lastReg, null, null, null);
-    PeriodicSchedule i = of(start, end, freq, BDA, stubConv, rollConv, firstReg, end.minusDays(1), null, null, null);
+    PeriodicSchedule h = of(start, end, freq, BDA, stubConv, rollConv, start.plusDays(1), null, null, null, null);
+    PeriodicSchedule i = of(start, end, freq, BDA, stubConv, rollConv, null, end.minusDays(1), null, null, null);
     PeriodicSchedule j = of(start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, BDA, null, null);
     PeriodicSchedule k = of(start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, BDA, null);
     PeriodicSchedule m = of(


### PR DESCRIPTION
A schedule could be defined to be all stub, with no regular periods
While weird, there is no reason not to handle it