### PR TITLE
Replace containsValue with findValue on market data containers

### DIFF
--- a/examples/src/test/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilderTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilderTest.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.examples.marketdata;
 
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
@@ -242,14 +243,14 @@ public class ExampleMarketDataBuilderTest {
     assertEquals(MARKET_DATA_DATE, snapshot.getValuationDate().getSingleValue());
 
     for (ObservableId id : TIME_SERIES) {
-      assertTrue(snapshot.containsTimeSeries(id), "Time-series not found: " + id);
+      assertFalse(snapshot.getTimeSeries(id).isEmpty(), "Time-series not found: " + id);
     }
     assertEquals(snapshot.getTimeSeries().size(), TIME_SERIES.size(),
         Messages.format("Snapshot contained unexpected time-series: {}",
             Sets.difference(snapshot.getTimeSeries().keySet(), TIME_SERIES)));
 
     for (MarketDataId<?> id : VALUES) {
-      assertTrue(snapshot.containsValue(id), "Id not found: " + id);
+      assertTrue(snapshot.findValue(id).isPresent(), "Id not found: " + id);
     }
     MarketDataBox<CurveGroup> curveGroupBox = snapshot.getValue(CurveGroupId.of(DEFAULT_CURVE_GROUP));
     assertTrue(curveGroupBox.isSingleValue());

--- a/examples/src/test/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilderTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilderTest.java
@@ -250,7 +250,7 @@ public class ExampleMarketDataBuilderTest {
             Sets.difference(snapshot.getTimeSeries().keySet(), TIME_SERIES)));
 
     for (MarketDataId<?> id : VALUES) {
-      assertTrue(snapshot.findValue(id).isPresent(), "Id not found: " + id);
+      assertTrue(snapshot.containsValue(id), "Id not found: " + id);
     }
     MarketDataBox<CurveGroup> curveGroupBox = snapshot.getValue(CurveGroupId.of(DEFAULT_CURVE_GROUP));
     assertTrue(curveGroupBox.isSingleValue());

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/ImmutableMarketData.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/ImmutableMarketData.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import org.joda.beans.Bean;
@@ -106,14 +107,12 @@ public final class ImmutableMarketData
   }
 
   //-------------------------------------------------------------------------
-  @Override
-  public boolean containsValue(MarketDataKey<?> key) {
-    return values.containsKey(key);
-  }
 
+  @SuppressWarnings("unchecked")
   @Override
-  public boolean containsTimeSeries(ObservableKey key) {
-    return timeSeries.containsKey(key);
+  public <T> Optional<T> findValue(MarketDataKey<T> key) {
+    Object value = values.get(key);
+    return Optional.ofNullable((T) value);
   }
 
   @SuppressWarnings("unchecked")

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/ImmutableMarketData.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/ImmutableMarketData.java
@@ -108,6 +108,11 @@ public final class ImmutableMarketData
 
   //-------------------------------------------------------------------------
 
+  @Override
+  public boolean containsValue(MarketDataKey<?> key) {
+    return values.containsKey(key);
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public <T> Optional<T> findValue(MarketDataKey<T> key) {

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketData.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketData.java
@@ -50,6 +50,7 @@ public interface MarketData {
   }
 
   //-------------------------------------------------------------------------
+
   /**
    * Gets the valuation date of the market data.
    * <p>
@@ -60,6 +61,15 @@ public interface MarketData {
   public abstract LocalDate getValuationDate();
 
   //-------------------------------------------------------------------------
+
+  /**
+   * Checks if this set of data contains a value for the specified key.
+   *
+   * @param key  the key identifying the item of market data
+   * @return true if this set of data contains a value for the specified key
+   */
+  public abstract boolean containsValue(MarketDataKey<?> key);
+
   /**
    * Returns a value for the specified ID if available.
    *

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketData.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketData.java
@@ -61,10 +61,10 @@ public interface MarketData {
 
   //-------------------------------------------------------------------------
   /**
-   * Returns a box containing values for the specified ID if available.
+   * Returns a value for the specified ID if available.
    *
    * @param key  the key identifying the item of market data
-   * @return a box containing values for the specified ID if available
+   * @return a value for the specified ID if available
    */
   public abstract <T> Optional<T> findValue(MarketDataKey<T> key);
 

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketData.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketData.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.basics.market;
 
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Optional;
 
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 
@@ -60,12 +61,12 @@ public interface MarketData {
 
   //-------------------------------------------------------------------------
   /**
-   * Checks if this set of data contains a value for the specified key.
+   * Returns a box containing values for the specified ID if available.
    *
    * @param key  the key identifying the item of market data
-   * @return true if this set of data contains a value for the specified key
+   * @return a box containing values for the specified ID if available
    */
-  public abstract boolean containsValue(MarketDataKey<?> key);
+  public abstract <T> Optional<T> findValue(MarketDataKey<T> key);
 
   /**
    * Gets the market data value identified by the specified key.
@@ -80,13 +81,6 @@ public interface MarketData {
   public abstract <T> T getValue(MarketDataKey<T> key);
 
   //-------------------------------------------------------------------------
-  /**
-   * Checks if this set of data contains a time-series for the specified key.
-   *
-   * @param key  the key identifying the item of market data
-   * @return true if this set of data contains a time-series of market data for the specified key
-   */
-  public abstract boolean containsTimeSeries(ObservableKey key);
 
   /**
    * Gets the time-series identified by the specified key, empty if not found.

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/ImmutableMarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/ImmutableMarketDataTest.java
@@ -65,6 +65,8 @@ public class ImmutableMarketDataTest {
   }
 
   public void containsValue() {
+    assertThat(DATA.containsValue(KEY1)).isTrue();
+    assertThat(DATA.containsValue(KEY2)).isFalse();
     assertThat(DATA.findValue(KEY1)).isPresent();
     assertThat(DATA.findValue(KEY2)).isEmpty();
   }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/ImmutableMarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/ImmutableMarketDataTest.java
@@ -65,13 +65,8 @@ public class ImmutableMarketDataTest {
   }
 
   public void containsValue() {
-    assertThat(DATA.containsValue(KEY1)).isTrue();
-    assertThat(DATA.containsValue(KEY2)).isFalse();
-  }
-
-  public void containsTimeSeries() {
-    assertThat(DATA.containsTimeSeries(KEY1)).isFalse();
-    assertThat(DATA.containsTimeSeries(KEY2)).isTrue();
+    assertThat(DATA.findValue(KEY1)).isPresent();
+    assertThat(DATA.findValue(KEY2)).isEmpty();
   }
 
   public void getValue() {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/MarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/MarketDataTest.java
@@ -35,6 +35,8 @@ public class MarketDataTest {
     Map<MarketDataKey<?>, Object> dataMap = ImmutableMap.of(KEY1, 123d);
     MarketData test = MarketData.of(VAL_DATE, dataMap);
     assertThat(test.getValuationDate()).isEqualTo(VAL_DATE);
+    assertThat(test.containsValue(KEY1)).isTrue();
+    assertThat(test.containsValue(KEY2)).isFalse();
     assertThat(test.findValue(KEY1)).isPresent();
     assertThat(test.findValue(KEY2)).isEmpty();
     assertThat(test.getValue(KEY1)).isEqualTo(123d);
@@ -45,6 +47,8 @@ public class MarketDataTest {
     Map<ObservableKey, LocalDateDoubleTimeSeries> tsMap = ImmutableMap.of(KEY2, TIME_SERIES);
     MarketData test = MarketData.of(VAL_DATE, dataMap, tsMap);
     assertThat(test.getValuationDate()).isEqualTo(VAL_DATE);
+    assertThat(test.containsValue(KEY1)).isTrue();
+    assertThat(test.containsValue(KEY2)).isFalse();
     assertThat(test.findValue(KEY1)).isPresent();
     assertThat(test.findValue(KEY2)).isEmpty();
     assertThat(test.getValue(KEY1)).isEqualTo(123d);

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/MarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/MarketDataTest.java
@@ -35,10 +35,9 @@ public class MarketDataTest {
     Map<MarketDataKey<?>, Object> dataMap = ImmutableMap.of(KEY1, 123d);
     MarketData test = MarketData.of(VAL_DATE, dataMap);
     assertThat(test.getValuationDate()).isEqualTo(VAL_DATE);
-    assertThat(test.containsValue(KEY1)).isTrue();
-    assertThat(test.containsValue(KEY2)).isFalse();
+    assertThat(test.findValue(KEY1)).isPresent();
+    assertThat(test.findValue(KEY2)).isEmpty();
     assertThat(test.getValue(KEY1)).isEqualTo(123d);
-    assertThat(test.containsTimeSeries(KEY2)).isFalse();
   }
 
   public void of_3arg() {
@@ -46,10 +45,9 @@ public class MarketDataTest {
     Map<ObservableKey, LocalDateDoubleTimeSeries> tsMap = ImmutableMap.of(KEY2, TIME_SERIES);
     MarketData test = MarketData.of(VAL_DATE, dataMap, tsMap);
     assertThat(test.getValuationDate()).isEqualTo(VAL_DATE);
-    assertThat(test.containsValue(KEY1)).isTrue();
-    assertThat(test.containsValue(KEY2)).isFalse();
+    assertThat(test.findValue(KEY1)).isPresent();
+    assertThat(test.findValue(KEY2)).isEmpty();
     assertThat(test.getValue(KEY1)).isEqualTo(123d);
-    assertThat(test.containsTimeSeries(KEY2)).isTrue();
     assertThat(test.getTimeSeries(KEY2)).isEqualTo(TIME_SERIES);
   }
 

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationEnvironment.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationEnvironment.java
@@ -9,6 +9,7 @@ import static com.opengamma.strata.collect.Guavate.toImmutableMap;
 
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -40,12 +41,12 @@ public interface CalculationEnvironment {
 
   //-------------------------------------------------------------------------
   /**
-   * Checks if this set of data contains a value for the specified ID.
+   * Returns a box containing values for the specified ID if available.
    *
    * @param id  the ID identifying the item of market data
-   * @return true if this set of data contains a value for the specified ID and it is of the expected type
+   * @return a box containing values for the specified ID if available
    */
-  public abstract boolean containsValue(MarketDataId<?> id);
+  public abstract <T> Optional<MarketDataBox<T>> findValue(MarketDataId<T> id);
 
   /**
    * Gets a box that can provide an item of market data for a scenario.
@@ -75,13 +76,6 @@ public interface CalculationEnvironment {
   }
 
   //-------------------------------------------------------------------------
-  /**
-   * Checks if this set of data contains a time-series for the specified ID.
-   *
-   * @param id  the ID identifying the item of market data
-   * @return true if this set of data contains a time-series for the specified ID
-   */
-  public abstract boolean containsTimeSeries(ObservableId id);
 
   /**
    * Gets the time-series identified by the specified key, empty if not found.

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationEnvironment.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationEnvironment.java
@@ -41,6 +41,14 @@ public interface CalculationEnvironment {
 
   //-------------------------------------------------------------------------
   /**
+   * Checks if this set of data contains a value for the specified ID.
+   *
+   * @param id  the ID identifying the item of market data
+   * @return true if this set of data contains a value for the specified ID and it is of the expected type
+   */
+  public abstract boolean containsValue(MarketDataId<?> id);
+
+  /**
    * Returns a box containing values for the specified ID if available.
    *
    * @param id  the ID identifying the item of market data

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationMarketData.java
@@ -80,6 +80,14 @@ public interface CalculationMarketData {
 
   //-------------------------------------------------------------------------
   /**
+   * Checks if this set of data contains a value for the specified key.
+   *
+   * @param key  the key identifying the item of market data
+   * @return true if this set of data contains a value for the specified key
+   */
+  public abstract boolean containsValue(MarketDataKey<?> key);
+
+  /**
    * Returns a box containing values for the specified ID if available.
    *
    * @param key  the key identifying the item of market data

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationMarketData.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.calc.marketdata;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.opengamma.strata.basics.market.MarketData;
@@ -79,12 +80,12 @@ public interface CalculationMarketData {
 
   //-------------------------------------------------------------------------
   /**
-   * Checks if this set of data contains a value for the specified key.
+   * Returns a box containing values for the specified ID if available.
    *
    * @param key  the key identifying the item of market data
-   * @return true if this set of data contains a value for the specified key
+   * @return a box containing values for the specified ID if available
    */
-  public abstract boolean containsValue(MarketDataKey<?> key);
+  public abstract <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key);
 
   /**
    * Gets a box that can provide an item of market data for a scenario.
@@ -134,13 +135,6 @@ public interface CalculationMarketData {
   }
 
   //-------------------------------------------------------------------------
-  /**
-   * Checks if this set of data contains a time-series for the specified key.
-   *
-   * @param key  the key identifying the item of market data
-   * @return true if this set of data contains a time-series of market data for the specified key
-   */
-  public abstract boolean containsTimeSeries(ObservableKey key);
 
   /**
    * Gets the time-series identified by the specified key, empty if not found.

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DefaultCalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DefaultCalculationMarketData.java
@@ -87,9 +87,13 @@ public final class DefaultCalculationMarketData implements CalculationMarketData
 
   //-------------------------------------------------------------------------
   @Override
+  public boolean containsValue(MarketDataKey<?> key) {
+    return marketDataMappings.containsValue(key, marketData);
+  }
+
+  @Override
   public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key) {
-    MarketDataId<T> id = marketDataMappings.getIdForKey(key);
-    return marketData.findValue(id);
+    return marketDataMappings.findValue(key, marketData);
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DefaultCalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DefaultCalculationMarketData.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.calc.marketdata;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -13,7 +14,6 @@ import com.opengamma.strata.basics.market.MarketData;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataId;
 import com.opengamma.strata.basics.market.MarketDataKey;
-import com.opengamma.strata.basics.market.ObservableId;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.calc.marketdata.mapping.MarketDataMappings;
 import com.opengamma.strata.calc.runner.SingleCalculationMarketData;
@@ -87,20 +87,14 @@ public final class DefaultCalculationMarketData implements CalculationMarketData
 
   //-------------------------------------------------------------------------
   @Override
-  public boolean containsValue(MarketDataKey<?> key) {
-    MarketDataId<?> id = marketDataMappings.getIdForKey(key);
-    return marketData.containsValue(id);
+  public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key) {
+    MarketDataId<T> id = marketDataMappings.getIdForKey(key);
+    return marketData.findValue(id);
   }
 
   @Override
   public <T> MarketDataBox<T> getValue(MarketDataKey<T> key) {
     return marketDataMappings.getValue(key, marketData);
-  }
-
-  @Override
-  public boolean containsTimeSeries(ObservableKey key) {
-    ObservableId id = marketDataMappings.getIdForObservableKey(key);
-    return marketData.containsTimeSeries(id);
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DefaultMarketDataFactory.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DefaultMarketDataFactory.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.calc.marketdata;
 
+import static com.opengamma.strata.collect.Guavate.not;
 import static com.opengamma.strata.collect.Guavate.toImmutableMap;
 import static com.opengamma.strata.collect.Guavate.toImmutableSet;
 
@@ -178,8 +179,8 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
 
       // Filter out IDs for the data that is already available
       Set<ObservableId> observableIds = leafRequirements.getObservables().stream()
-          .filter(id -> !marketData.findValue(id).isPresent())
-          .filter(id -> !suppliedData.findValue(id).isPresent())
+          .filter(not(marketData::containsValue))
+          .filter(not(suppliedData::containsValue))
           .collect(toImmutableSet());
 
       // Observable data is built in bulk so it can be efficiently requested from data provider in one operation
@@ -188,15 +189,15 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
 
       // Copy observable data from the supplied data to the builder, applying any matching perturbations
       leafRequirements.getObservables().stream()
-          .filter(id -> suppliedData.findValue(id).isPresent())
+          .filter(suppliedData::containsValue)
           .forEach(id -> addValue(id, suppliedData.getValue(id), scenarioDefinition, dataBuilder));
 
       // Non-observable data -----------------------------------------------------------------------
 
       // Filter out IDs for the data that is already available and build the rest
       Set<MarketDataId<?>> nonObservableIds = leafRequirements.getNonObservables().stream()
-          .filter(id -> !marketData.findValue(id).isPresent())
-          .filter(id -> !suppliedData.findValue(id).isPresent())
+          .filter(not(marketData::containsValue))
+          .filter(not(suppliedData::containsValue))
           .collect(toImmutableSet());
 
       Map<MarketDataId<?>, Result<MarketDataBox<?>>> nonObservableResults =
@@ -206,7 +207,7 @@ public final class DefaultMarketDataFactory implements MarketDataFactory {
 
       // Copy supplied data to the scenario data after applying perturbations
       leafRequirements.getNonObservables().stream()
-          .filter(id -> suppliedData.findValue(id).isPresent())
+          .filter(suppliedData::containsValue)
           .forEach(id -> addValue(id, suppliedData.getValue(id), scenarioDefinition, dataBuilder));
 
       // --------------------------------------------------------------------------------------------

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DependencyTreeBuilder.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DependencyTreeBuilder.java
@@ -167,9 +167,9 @@ class DependencyTreeBuilder {
 
     switch (dataType) {
       case TIME_SERIES:
-        return (id instanceof ObservableId) && suppliedData.containsTimeSeries((ObservableId) id);
+        return (id instanceof ObservableId) && !suppliedData.getTimeSeries((ObservableId) id).isEmpty();
       case SINGLE_VALUE:
-        return suppliedData.containsValue(id);
+        return suppliedData.findValue(id).isPresent();
       default:
         throw new IllegalArgumentException("Unexpected data type " + dataType);
     }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DependencyTreeBuilder.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/DependencyTreeBuilder.java
@@ -169,7 +169,7 @@ class DependencyTreeBuilder {
       case TIME_SERIES:
         return (id instanceof ObservableId) && !suppliedData.getTimeSeries((ObservableId) id).isEmpty();
       case SINGLE_VALUE:
-        return suppliedData.findValue(id).isPresent();
+        return suppliedData.containsValue(id);
       default:
         throw new IllegalArgumentException("Unexpected data type " + dataType);
     }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
@@ -122,6 +122,12 @@ public final class MarketEnvironment implements ImmutableBean, CalculationEnviro
   }
 
   //-------------------------------------------------------------------------
+
+  @Override
+  public boolean containsValue(MarketDataId<?> id) {
+    return values.containsKey(id);
+  }
+
   @Override
   public <T> Optional<MarketDataBox<T>> findValue(MarketDataId<T> id) {
     @SuppressWarnings("unchecked")

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import org.joda.beans.Bean;
@@ -122,8 +123,10 @@ public final class MarketEnvironment implements ImmutableBean, CalculationEnviro
 
   //-------------------------------------------------------------------------
   @Override
-  public boolean containsValue(MarketDataId<?> id) {
-    return values.containsKey(id);
+  public <T> Optional<MarketDataBox<T>> findValue(MarketDataId<T> id) {
+    @SuppressWarnings("unchecked")
+    MarketDataBox<T> marketDataBox = (MarketDataBox<T>) values.get(id);
+    return Optional.ofNullable(marketDataBox);
   }
 
   @SuppressWarnings("unchecked")
@@ -165,11 +168,6 @@ public final class MarketEnvironment implements ImmutableBean, CalculationEnviro
               value));
     }
     return value;
-  }
-
-  @Override
-  public boolean containsTimeSeries(ObservableId id) {
-    return timeSeries.containsKey(id);
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappings.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappings.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import org.joda.beans.Bean;
@@ -116,27 +117,25 @@ public final class DefaultMarketDataMappings implements MarketDataMappings, Immu
     return key.toMarketDataId(marketDataFeed);
   }
 
+
+
   @SuppressWarnings("rawtypes")
   @Override
-  public boolean containsValue(MarketDataKey<?> key, CalculationEnvironment marketData) {
+  public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key, CalculationEnvironment marketData) {
     if (key instanceof ObservableKey) {
-      return marketData.containsValue(getIdForObservableKey((ObservableKey) key));
+      ObservableId observableId = getIdForObservableKey((ObservableKey) key);
+      return marketData.findValue((MarketDataId<T>) observableId);
     }
     if (key instanceof SimpleMarketDataKey) {
-      return marketData.containsValue(((SimpleMarketDataKey) key).toMarketDataId(marketDataFeed));
+      return marketData.findValue(((SimpleMarketDataKey) key).toMarketDataId(marketDataFeed));
     }
     MarketDataMapping mapping = mappings.get(key.getClass());
 
     if (mapping == null) {
-      return false;
+      return Optional.empty();
     }
-    MarketDataId<?> id = mapping.getIdForKey(key);
-    return marketData.containsValue(id);
-  }
-
-  @Override
-  public boolean containsTimeSeries(ObservableKey key, CalculationEnvironment marketData) {
-    return marketData.containsTimeSeries(getIdForObservableKey(key));
+    MarketDataId<T> id = mapping.getIdForKey(key);
+    return marketData.findValue(id);
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappings.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappings.java
@@ -117,7 +117,24 @@ public final class DefaultMarketDataMappings implements MarketDataMappings, Immu
     return key.toMarketDataId(marketDataFeed);
   }
 
+  @SuppressWarnings("rawtypes")
+  @Override
+  public boolean containsValue(MarketDataKey<?> key, CalculationEnvironment marketData) {
+    if (key instanceof ObservableKey) {
+      ObservableId observableId = ((ObservableKey) key).toMarketDataId(marketDataFeed);
+      return marketData.containsValue(observableId);
+    }
+    if (key instanceof SimpleMarketDataKey) {
+      return marketData.containsValue(((SimpleMarketDataKey) key).toMarketDataId(marketDataFeed));
+    }
+    MarketDataMapping mapping = mappings.get(key.getClass());
 
+    if (mapping == null) {
+      return false;
+    }
+    MarketDataId<?> id = mapping.getIdForKey(key);
+    return marketData.containsValue(id);
+  }
 
   @SuppressWarnings("rawtypes")
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/MarketDataMappings.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/MarketDataMappings.java
@@ -114,7 +114,30 @@ public interface MarketDataMappings {
   public abstract LocalDateDoubleTimeSeries getTimeSeries(ObservableKey key, CalculationEnvironment marketData);
 
   /**
-   * Returns a box containing values for the specified ID if available.
+   * Checks whether this set of mappings contains a mapping from the key to a piece of market data
+   * available in the calculation environment.
+   * <p>
+   * This method returns true if both of the following are true:
+   * <ul>
+   *   <li>A market data ID can be found for the key</li>
+   *   <li>The market data contains a value for the ID</li>
+   * </ul>
+   *
+   * @param key  a market data key
+   * @param marketData  a set of market data
+   * @return true if this set of mappings is able to return an ID for the key and the market data contains a
+   * value for the ID
+   */
+  public abstract boolean containsValue(MarketDataKey<?> key, CalculationEnvironment marketData);
+
+  /**
+   * Returns a market data box containing values for the specified ID if available.
+   * <p>
+   * This method returns a market data box if both of the following are true:
+   * <ul>
+   *   <li>A market data ID can be found for the key</li>
+   *   <li>The market data contains a data for the ID</li>
+   * </ul>
    *
    * @param key  a market data key
    * @param marketData  a set of market data

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/MarketDataMappings.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/mapping/MarketDataMappings.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.calc.marketdata.mapping;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataFeed;
@@ -102,46 +103,22 @@ public interface MarketDataMappings {
   public abstract <T> MarketDataBox<T> getValue(MarketDataKey<T> key, CalculationEnvironment marketData);
 
   /**
-   * Returns a time series from a calculation environment given a key identifying the data in the series.
+   * Returns a time series from a calculation environment given a key identifying the data in the series or
+   * an empty series if there is no data for the key.
    *
    * @param key  a key identifying a time series of market data
    * @param marketData  a set of market data
-   * @return a time series from the calculation environment identified by the key
-   * @throws IllegalArgumentException if there is no data available for the key
+   * @return a time series from the calculation environment identified by the key, empty if there is no data for
+   * the key
    */
   public abstract LocalDateDoubleTimeSeries getTimeSeries(ObservableKey key, CalculationEnvironment marketData);
 
   /**
-   * Checks whether this set of mappings contains a mapping from the key to a piece of market data
-   * available in the calculation environment.
-   * <p>
-   * This method returns true if both of the following are true:
-   * <ul>
-   *   <li>A market data ID can be found for the key</li>
-   *   <li>The market data contains a value for the ID</li>
-   * </ul>
+   * Returns a box containing values for the specified ID if available.
    *
    * @param key  a market data key
    * @param marketData  a set of market data
-   * @return true if this set of mappings is able to return an ID for the key and the market data contains a
-   * value for the ID
+   * @return a box containing values for the specified ID if available
    */
-  public abstract boolean containsValue(MarketDataKey<?> key, CalculationEnvironment marketData);
-
-  /**
-   * Checks whether this set of mappings contains a mapping from the key to a time series of market data
-   * available in the calculation environment.
-   * <p>
-   * This method returns true if both of the following are true:
-   * <ul>
-   *   <li>A market data ID can be found for the key</li>
-   *   <li>The market data contains a time series of values for the ID</li>
-   * </ul>
-   *
-   * @param key  a market data key
-   * @param marketData  a set of market data
-   * @return true if this set of mappings is able to return an ID for the key and the market data contains a
-   * time series of values for the ID
-   */
-  public abstract boolean containsTimeSeries(ObservableKey key, CalculationEnvironment marketData);
+  public abstract <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key, CalculationEnvironment marketData);
 }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/NoMatchingRuleMappings.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/NoMatchingRuleMappings.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.calc.runner;
 
+import java.util.Optional;
+
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.basics.market.MarketDataId;
@@ -52,13 +54,8 @@ class NoMatchingRuleMappings implements MarketDataMappings {
   }
 
   @Override
-  public boolean containsValue(MarketDataKey<?> key, CalculationEnvironment marketData) {
-    return false;
-  }
-
-  @Override
-  public boolean containsTimeSeries(ObservableKey key, CalculationEnvironment marketData) {
-    return false;
+  public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key, CalculationEnvironment marketData) {
+    return Optional.empty();
   }
 
   @Override
@@ -68,6 +65,6 @@ class NoMatchingRuleMappings implements MarketDataMappings {
 
   @Override
   public LocalDateDoubleTimeSeries getTimeSeries(ObservableKey key, CalculationEnvironment marketData) {
-    throw new IllegalArgumentException("No market data available for key " + key);
+    return LocalDateDoubleTimeSeries.empty();
   }
 }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/NoMatchingRuleMappings.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/NoMatchingRuleMappings.java
@@ -54,6 +54,11 @@ class NoMatchingRuleMappings implements MarketDataMappings {
   }
 
   @Override
+  public boolean containsValue(MarketDataKey<?> key, CalculationEnvironment marketData) {
+    return false;
+  }
+
+  @Override
   public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key, CalculationEnvironment marketData) {
     return Optional.empty();
   }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/SingleCalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/SingleCalculationMarketData.java
@@ -6,8 +6,10 @@
 package com.opengamma.strata.calc.runner;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataKey;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.calc.marketdata.CalculationMarketData;
@@ -58,18 +60,14 @@ public final class SingleCalculationMarketData implements MarketData {
   }
 
   @Override
-  public boolean containsValue(MarketDataKey<?> key) {
-    return marketData.containsValue(key);
+  public <T> Optional<T> findValue(MarketDataKey<T> key) {
+    Optional<MarketDataBox<T>> optionalBox = marketData.findValue(key);
+    return optionalBox.map(box -> box.getValue(scenarioIndex));
   }
 
   @Override
   public <T> T getValue(MarketDataKey<T> key) {
     return marketData.getValue(key).getValue(scenarioIndex);
-  }
-
-  @Override
-  public boolean containsTimeSeries(ObservableKey key) {
-    return marketData.containsTimeSeries(key);
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/SingleCalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/SingleCalculationMarketData.java
@@ -60,6 +60,11 @@ public final class SingleCalculationMarketData implements MarketData {
   }
 
   @Override
+  public boolean containsValue(MarketDataKey<?> key) {
+    return marketData.containsValue(key);
+  }
+
+  @Override
   public <T> Optional<T> findValue(MarketDataKey<T> key) {
     Optional<MarketDataBox<T>> optionalBox = marketData.findValue(key);
     return optionalBox.map(box -> box.getValue(scenarioIndex));

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/CalculationMarketDataTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/CalculationMarketDataTest.java
@@ -131,6 +131,11 @@ public class CalculationMarketDataTest {
     }
 
     @Override
+    public boolean containsValue(MarketDataKey<?> key) {
+      throw new UnsupportedOperationException("containsValue(MarketDataKey) not implemented");
+    }
+
+    @Override
     public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key) {
       throw new UnsupportedOperationException("findValue not implemented");
     }

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/CalculationMarketDataTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/CalculationMarketDataTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.calc.marketdata;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.testng.annotations.Test;
@@ -130,19 +131,14 @@ public class CalculationMarketDataTest {
     }
 
     @Override
-    public boolean containsValue(MarketDataKey<?> key) {
-      throw new UnsupportedOperationException("containsValue(MarketDataKey) not implemented");
+    public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key) {
+      throw new UnsupportedOperationException("findValue not implemented");
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <T> MarketDataBox<T> getValue(MarketDataKey<T> key) {
       return (MarketDataBox<T>) value;
-    }
-
-    @Override
-    public boolean containsTimeSeries(ObservableKey key) {
-      throw new UnsupportedOperationException("containsTimeSeries(ObservableKey) not implemented");
     }
 
     @Override

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentTest.java
@@ -103,6 +103,8 @@ public class MarketEnvironmentTest {
         .build()
         .filter(requirements);
 
+    assertThat(marketData.containsValue(TEST_ID1)).isTrue();
+    assertThat(marketData.containsValue(TEST_ID2)).isFalse();
     assertThat(marketData.findValue(TEST_ID1)).isPresent();
     assertThat(marketData.findValue(TEST_ID2)).isEmpty();
     assertThat(marketData.getValue(TEST_ID1).getSingleValue()).isEqualTo(1d);

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentTest.java
@@ -103,11 +103,9 @@ public class MarketEnvironmentTest {
         .build()
         .filter(requirements);
 
-    assertThat(marketData.containsValue(TEST_ID1)).isTrue();
-    assertThat(marketData.containsValue(TEST_ID2)).isFalse();
+    assertThat(marketData.findValue(TEST_ID1)).isPresent();
+    assertThat(marketData.findValue(TEST_ID2)).isEmpty();
     assertThat(marketData.getValue(TEST_ID1).getSingleValue()).isEqualTo(1d);
-    assertThat(marketData.containsTimeSeries(TEST_ID1)).isFalse();
-    assertThat(marketData.containsTimeSeries(TEST_ID2)).isTrue();
     assertThat(marketData.getTimeSeries(TEST_ID2)).isEqualTo(timeSeries2);
   }
 

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappingsTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappingsTest.java
@@ -72,12 +72,18 @@ public class DefaultMarketDataMappingsTest {
   }
 
   public void containsMapping() {
+    assertThat(mappings.containsValue(testKey, calculationEnvironment)).isTrue();
+    assertThat(mappings.containsValue(testSimpleKey, calculationEnvironment)).isTrue();
+    assertThat(mappings.containsValue(testObservableKey, calculationEnvironment)).isTrue();
     assertThat(mappings.findValue(testKey, calculationEnvironment)).isPresent();
     assertThat(mappings.findValue(testSimpleKey, calculationEnvironment)).isPresent();
     assertThat(mappings.findValue(testObservableKey, calculationEnvironment)).isPresent();
   }
 
   public void containsMappingNoData() {
+    assertThat(mappings.containsValue(testKey, CalculationEnvironment.empty())).isFalse();
+    assertThat(mappings.containsValue(testSimpleKey, CalculationEnvironment.empty())).isFalse();
+    assertThat(mappings.containsValue(testObservableKey, CalculationEnvironment.empty())).isFalse();
     assertThat(mappings.findValue(testKey, CalculationEnvironment.empty())).isEmpty();
     assertThat(mappings.findValue(testSimpleKey, CalculationEnvironment.empty())).isEmpty();
     assertThat(mappings.findValue(testObservableKey, CalculationEnvironment.empty())).isEmpty();
@@ -85,6 +91,7 @@ public class DefaultMarketDataMappingsTest {
 
   public void containsMappingNoMarketDataMapping() {
     MarketDataMappings testMappings = DefaultMarketDataMappings.of(marketDataFeed);
+    assertThat(testMappings.containsValue(testKey, calculationEnvironment)).isFalse();
     assertThat(testMappings.findValue(testKey, calculationEnvironment)).isEmpty();
   }
 

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappingsTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappingsTest.java
@@ -72,28 +72,20 @@ public class DefaultMarketDataMappingsTest {
   }
 
   public void containsMapping() {
-    assertThat(mappings.containsValue(testKey, calculationEnvironment)).isTrue();
-    assertThat(mappings.containsValue(testSimpleKey, calculationEnvironment)).isTrue();
-    assertThat(mappings.containsValue(testObservableKey, calculationEnvironment)).isTrue();
+    assertThat(mappings.findValue(testKey, calculationEnvironment)).isPresent();
+    assertThat(mappings.findValue(testSimpleKey, calculationEnvironment)).isPresent();
+    assertThat(mappings.findValue(testObservableKey, calculationEnvironment)).isPresent();
   }
 
   public void containsMappingNoData() {
-    assertThat(mappings.containsValue(testKey, CalculationEnvironment.empty())).isFalse();
-    assertThat(mappings.containsValue(testSimpleKey, CalculationEnvironment.empty())).isFalse();
-    assertThat(mappings.containsValue(testObservableKey, CalculationEnvironment.empty())).isFalse();
+    assertThat(mappings.findValue(testKey, CalculationEnvironment.empty())).isEmpty();
+    assertThat(mappings.findValue(testSimpleKey, CalculationEnvironment.empty())).isEmpty();
+    assertThat(mappings.findValue(testObservableKey, CalculationEnvironment.empty())).isEmpty();
   }
 
   public void containsMappingNoMarketDataMapping() {
     MarketDataMappings testMappings = DefaultMarketDataMappings.of(marketDataFeed);
-    assertThat(testMappings.containsValue(testKey, calculationEnvironment)).isFalse();
-  }
-
-  public void containsTimeSeries() {
-    assertThat(mappings.containsTimeSeries(testObservableKey, calculationEnvironment)).isTrue();
-  }
-
-  public void containsTimeSeriesNoData() {
-    assertThat(mappings.containsTimeSeries(testObservableKey, CalculationEnvironment.empty())).isFalse();
+    assertThat(testMappings.findValue(testKey, calculationEnvironment)).isEmpty();
   }
 
   public void getValue() {

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/TestMarketDataMap.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/TestMarketDataMap.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.function.marketdata.curve;
 
 import java.time.LocalDate;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -61,8 +62,10 @@ public final class TestMarketDataMap implements CalculationMarketData {
   }
 
   @Override
-  public boolean containsValue(MarketDataKey<?> key) {
-    return valueMap.containsKey(key);
+  public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key) {
+    @SuppressWarnings("unchecked")
+    T value = (T) valueMap.get(key);
+    return value == null ? Optional.empty() : Optional.of(MarketDataBox.ofSingleValue(value));
   }
 
   @SuppressWarnings("unchecked")
@@ -74,11 +77,6 @@ public final class TestMarketDataMap implements CalculationMarketData {
     } else {
       throw new IllegalArgumentException("No market data for " + key);
     }
-  }
-
-  @Override
-  public boolean containsTimeSeries(ObservableKey key) {
-    return timeSeriesMap.containsKey(key);
   }
 
   @Override

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/TestMarketDataMap.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/TestMarketDataMap.java
@@ -62,6 +62,11 @@ public final class TestMarketDataMap implements CalculationMarketData {
   }
 
   @Override
+  public boolean containsValue(MarketDataKey<?> key) {
+    return valueMap.containsKey(key);
+  }
+
+  @Override
   public <T> Optional<MarketDataBox<T>> findValue(MarketDataKey<T> key) {
     @SuppressWarnings("unchecked")
     T value = (T) valueMap.get(key);


### PR DESCRIPTION
Replace the boolean-returning `containsValue` methods on the market data containers with `findValue` returning an `Optional`. This is more consistent with the approach elsewhere in the codebase, and it gets rid of the need for two map lookups in the cases where a call to `containsValue` is immediately followed by a call to `getValue`.

The `containsTimeSeries` method has been removed. Originally the behaviour of `getTimeSeries` was the same as `getValue` in that it threw an exception if there was no data available. That was changed so `getTimeSeries` returns an empty series if no data is available. That made `containsTimeSeries` redundant, but it wasn't removed at the time.