### PR TITLE
Generate curve metadata once during calibration

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
@@ -173,6 +173,21 @@ public final class CurveGroupDefinition
 
   //-------------------------------------------------------------------------
   /**
+   * Creates the curve metadata for each definition.
+   * <p>
+   * This method returns a list of metadata, one for each curve definition.
+   *
+   * @param valuationDate  the valuation date
+   * @return the metadata
+   */
+  public ImmutableList<CurveMetadata> metadata(LocalDate valuationDate) {
+    return curveDefinitionsByName.values().stream()
+        .map(curveDef -> curveDef.metadata(valuationDate))
+        .collect(toImmutableList());
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Gets the total number of parameters in the group.
    * <p>
    * This returns the total number of parameters in the group, which equals the number of nodes.
@@ -213,7 +228,6 @@ public final class CurveGroupDefinition
    */
   public ImmutableList<Double> initialGuesses(LocalDate valuationDate, MarketData marketData) {
     ImmutableList.Builder<Double> result = ImmutableList.builder();
-
     for (NodalCurveDefinition defn : curveDefinitions) {
       ValueType valueType = defn.getYValueType();
       for (CurveNode node : defn.getNodes()) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveMetadata.java
@@ -6,9 +6,11 @@
 package com.opengamma.strata.market.curve;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.ValueType;
 
 /**
@@ -71,7 +73,7 @@ public interface CurveMetadata {
    */
   public default <T> T getInfo(CurveInfoType<T> type) {
     return findInfo(type).orElseThrow(() -> new IllegalArgumentException(
-        "Unable to find curve information of type " + type));
+        Messages.format("Curve info not found for type '{}'", type)));
   }
 
   /**
@@ -97,13 +99,29 @@ public interface CurveMetadata {
    */
   public abstract Optional<List<CurveParameterMetadata>> getParameterMetadata();
 
+  //-------------------------------------------------------------------------
+  /**
+   * Returns an instance where the specified additional information has been added.
+   * <p>
+   * The result will contain the specified additional information.
+   * If this metadata instance already contains additional info, the two maps will
+   * be merged, with the specified map taking priority, as per {@link Map#putAll(Map)}.
+   * <p>
+   * The map must contain no nulls. The value of each entry must match the parameterized
+   * type of the associated {@code CurveInfoType} key.
+   * 
+   * @param additionalInfo  the additional information to add
+   * @return the new curve metadata
+   */
+  public abstract CurveMetadata withInfo(Map<CurveInfoType<?>, Object> additionalInfo);
+
   /**
    * Returns an instance where the parameter metadata has been changed.
    * <p>
    * The result will contain the specified parameter metadata.
    * A null value is accepted and causes the result to have no parameter metadata.
    * 
-   * @param parameterMetadata  the new parameter metadata
+   * @param parameterMetadata  the new parameter metadata, may be null
    * @return the new curve metadata
    */
   public abstract CurveMetadata withParameterMetadata(List<CurveParameterMetadata> parameterMetadata);

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/DefaultCurveMetadata.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/DefaultCurveMetadata.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.market.ValueType;
 
 /**
@@ -124,10 +125,27 @@ public final class DefaultCurveMetadata
   }
 
   //-------------------------------------------------------------------------
+  @Override
+  public <T> T getInfo(CurveInfoType<T> type) {
+    // overridden for performance
+    @SuppressWarnings("unchecked")
+    T value = (T) info.get(type);
+    if (value == null) {
+      throw new IllegalArgumentException(Messages.format("Curve info not found for type '{}'", type));
+    }
+    return value;
+  }
+
   @SuppressWarnings("unchecked")
   @Override
   public <T> Optional<T> findInfo(CurveInfoType<T> type) {
     return Optional.ofNullable((T) info.get(type));
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public DefaultCurveMetadata withInfo(Map<CurveInfoType<?>, Object> additionalInfo) {
+    return toBuilder().addInfo(additionalInfo).build();
   }
 
   @Override
@@ -135,6 +153,7 @@ public final class DefaultCurveMetadata
     return toBuilder().parameterMetadata(parameterMetadata).build();
   }
 
+  //-------------------------------------------------------------------------
   /**
    * Returns a builder that allows this bean to be mutated.
    * 

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinition.java
@@ -143,14 +143,19 @@ public final class InterpolatedNodalCurveDefinition
 
   //-------------------------------------------------------------------------
   @Override
-  public NodalCurve curve(LocalDate valuationDate, DoubleArray parameters, Map<CurveInfoType<?>, Object> additionalInfo) {
-    CurveMetadata meta = metadata(valuationDate, additionalInfo);
+  public NodalCurve curve(
+      LocalDate valuationDate,
+      CurveMetadata metadata,
+      DoubleArray parameters,
+      Map<CurveInfoType<?>, Object> additionalInfo) {
+
+    CurveMetadata combinedMetadata = metadata.withInfo(additionalInfo);
     DoubleArray nodeTimes = DoubleArray.of(getParameterCount(), i -> {
-      LocalDate nodeDate = ((DatedCurveParameterMetadata) meta.getParameterMetadata().get().get(i)).getDate();
+      LocalDate nodeDate = ((DatedCurveParameterMetadata) combinedMetadata.getParameterMetadata().get().get(i)).getDate();
       return getDayCount().get().yearFraction(valuationDate, nodeDate);
     });
     return InterpolatedNodalCurve.builder()
-        .metadata(meta)
+        .metadata(combinedMetadata)
         .xValues(nodeTimes)
         .yValues(parameters)
         .extrapolatorLeft(extrapolatorLeft)

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/NodalCurveDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/NodalCurveDefinition.java
@@ -70,10 +70,10 @@ public interface NodalCurveDefinition {
    * The parameters might represent 1 day, 1 week, 1 month, 3 months, 6 months and 12 months.
    * The metadata could be used to describe each parameter in terms of a {@link Period}.
    * <p>
-   * The metadata includes an optional list of parameter metadata, however this must be present.
-   * If present, the size of the parameter metadata list will match the number of parameters of this curve.
+   * The optional parameter-level metadata will be populated on the resulting metadata.
+   * The size of the parameter-level metadata will match the number of parameters of this curve.
    *
-   * @param valuationDate  the valuation date used when calibrating the curve
+   * @param valuationDate  the valuation date
    * @return the metadata
    */
   public abstract CurveMetadata metadata(LocalDate valuationDate);
@@ -85,11 +85,12 @@ public interface NodalCurveDefinition {
    * The size of the array must match the {@linkplain #getParameterCount() count of parameters}.
    * 
    * @param valuationDate  the valuation date
+   * @param metadata  the curve metadata
    * @param parameters  the array of parameters
    * @return the curve
    */
-  public default NodalCurve curve(LocalDate valuationDate, DoubleArray parameters) {
-    return curve(valuationDate, parameters, ImmutableMap.of());
+  public default NodalCurve curve(LocalDate valuationDate, CurveMetadata metadata, DoubleArray parameters) {
+    return curve(valuationDate, metadata, parameters, ImmutableMap.of());
   }
 
   /**
@@ -100,12 +101,14 @@ public interface NodalCurveDefinition {
    * Any additional information may be added to the curve metadata.
    * 
    * @param valuationDate  the valuation date
+   * @param metadata  the curve metadata
    * @param parameters  the array of parameters
    * @param additionalInfo  the additional curve information, such as information about calibration
    * @return the curve
    */
   public abstract NodalCurve curve(
       LocalDate valuationDate,
+      CurveMetadata metadata,
       DoubleArray parameters,
       Map<CurveInfoType<?>, Object> additionalInfo);
 

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveCurrencyParameterSensitivityTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveCurrencyParameterSensitivityTest.java
@@ -36,6 +36,8 @@ public class CurveCurrencyParameterSensitivityTest {
   private static final FxRate FX_RATE = FxRate.of(EUR, USD, 1.5d);
   private static final CurveName NAME1 = CurveName.of("NAME-1");
   private static final CurveMetadata METADATA1 = DefaultCurveMetadata.of(NAME1);
+  private static final CurveMetadata METADATA1_PARAM = METADATA1
+      .withParameterMetadata(CurveParameterMetadata.listOfEmpty(VECTOR_USD1.size()));
   private static final CurveName NAME2 = CurveName.of("NAME-2");
   private static final CurveMetadata METADATA2 = DefaultCurveMetadata.of(NAME2);
 
@@ -43,6 +45,15 @@ public class CurveCurrencyParameterSensitivityTest {
   public void test_of_metadata() {
     CurveCurrencyParameterSensitivity test = CurveCurrencyParameterSensitivity.of(METADATA1, USD, VECTOR_USD1);
     assertThat(test.getMetadata()).isEqualTo(METADATA1);
+    assertThat(test.getCurrency()).isEqualTo(USD);
+    assertThat(test.getCurveName()).isEqualTo(NAME1);
+    assertThat(test.getParameterCount()).isEqualTo(VECTOR_USD1.size());
+    assertThat(test.getSensitivity()).isEqualTo(VECTOR_USD1);
+  }
+
+  public void test_of_metadata_withParameterMetadata() {
+    CurveCurrencyParameterSensitivity test = CurveCurrencyParameterSensitivity.of(METADATA1_PARAM, USD, VECTOR_USD1);
+    assertThat(test.getMetadata()).isEqualTo(METADATA1_PARAM);
     assertThat(test.getCurrency()).isEqualTo(USD);
     assertThat(test.getCurveName()).isEqualTo(NAME1);
     assertThat(test.getParameterCount()).isEqualTo(VECTOR_USD1.size());

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupDefinitionTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveGroupDefinitionTest.java
@@ -146,6 +146,18 @@ public class CurveGroupDefinitionTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_metadata() {
+    CurveGroupDefinition test = CurveGroupDefinition.builder()
+        .name(CurveGroupName.of("Test"))
+        .addCurve(CURVE_DEFN1, GBP, GBP_LIBOR_1M, GBP_LIBOR_3M)
+        .build();
+
+    LocalDate valuationDate = date(2015, 6, 30);
+    CurveMetadata meta = CURVE_DEFN1.metadata(valuationDate);
+    assertEquals(test.metadata(valuationDate), ImmutableList.of(meta));
+  }
+
+  //-------------------------------------------------------------------------
   public void test_tradesInitialGuesses() {
     CurveGroupDefinition test = CurveGroupDefinition.builder()
         .name(CurveGroupName.of("Test"))

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/DefaultCurveMetadataTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/DefaultCurveMetadataTest.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.market.curve;
 
 import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +86,7 @@ public class DefaultCurveMetadataTest {
     assertThat(test.getCurveName()).isEqualTo(CURVE_NAME);
     assertThat(test.getXValueType()).isEqualTo(ValueType.YEAR_FRACTION);
     assertThat(test.getYValueType()).isEqualTo(ValueType.DISCOUNT_FACTOR);
+    assertThat(test.getInfo(CurveInfoType.DAY_COUNT)).isEqualTo(ACT_360);
     assertThat(test.findInfo(CurveInfoType.DAY_COUNT)).isEqualTo(Optional.of(ACT_360));
     assertThat(test.getInfo(CurveInfoType.JACOBIAN)).isEqualTo(JACOBIAN_DATA);
     assertThat(test.findInfo(CurveInfoType.JACOBIAN)).isEqualTo(Optional.of(JACOBIAN_DATA));
@@ -106,6 +108,7 @@ public class DefaultCurveMetadataTest {
     assertThat(test.getCurveName()).isEqualTo(CURVE_NAME);
     assertThat(test.getXValueType()).isEqualTo(ValueType.YEAR_FRACTION);
     assertThat(test.getYValueType()).isEqualTo(ValueType.DISCOUNT_FACTOR);
+    assertThrowsIllegalArg(() -> test.getInfo(CurveInfoType.DAY_COUNT));
     assertThat(test.findInfo(CurveInfoType.DAY_COUNT)).isEqualTo(Optional.empty());
     assertThat(test.findInfo(CurveInfoType.JACOBIAN)).isEqualTo(Optional.empty());
     assertThat(test.findInfo(CurveInfoType.of("Rubbish"))).isEqualTo(Optional.empty());
@@ -123,6 +126,7 @@ public class DefaultCurveMetadataTest {
     assertThat(test.getCurveName()).isEqualTo(CURVE_NAME);
     assertThat(test.getXValueType()).isEqualTo(ValueType.YEAR_FRACTION);
     assertThat(test.getYValueType()).isEqualTo(ValueType.DISCOUNT_FACTOR);
+    assertThrowsIllegalArg(() -> test.getInfo(CurveInfoType.DAY_COUNT));
     assertThat(test.findInfo(CurveInfoType.DAY_COUNT)).isEqualTo(Optional.empty());
     assertThat(test.findInfo(CurveInfoType.JACOBIAN)).isEqualTo(Optional.empty());
     assertThat(test.findInfo(CurveInfoType.of("Rubbish"))).isEqualTo(Optional.empty());
@@ -147,6 +151,15 @@ public class DefaultCurveMetadataTest {
     assertThat(test.getParameterMetadata().isPresent()).isTrue();
     assertThat(test.getParameterMetadata().get()).containsExactly(
         CurveParameterMetadata.empty(), CurveParameterMetadata.empty());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_withInfo() {
+    DefaultCurveMetadata base = DefaultCurveMetadata.of(CURVE_NAME);
+    assertThat(base.findInfo(CurveInfoType.DAY_COUNT).isPresent()).isFalse();
+    DefaultCurveMetadata test = base.withInfo(ImmutableMap.of(CurveInfoType.DAY_COUNT, ACT_360));
+    assertThat(base.findInfo(CurveInfoType.DAY_COUNT).isPresent()).isFalse();
+    assertThat(test.findInfo(CurveInfoType.DAY_COUNT).isPresent()).isTrue();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinitionTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinitionTest.java
@@ -66,7 +66,7 @@ public class InterpolatedNodalCurveDefinitionTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_createMetadata() {
+  public void test_metadata() {
     InterpolatedNodalCurveDefinition test = InterpolatedNodalCurveDefinition.builder()
         .name(CURVE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -88,7 +88,7 @@ public class InterpolatedNodalCurveDefinitionTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_createCurve() {
+  public void test_curve() {
     InterpolatedNodalCurveDefinition test = InterpolatedNodalCurveDefinition.builder()
         .name(CURVE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -114,7 +114,7 @@ public class InterpolatedNodalCurveDefinitionTest {
         .extrapolatorLeft(CurveExtrapolators.FLAT)
         .extrapolatorRight(CurveExtrapolators.FLAT)
         .build();
-    assertEquals(test.curve(VAL_DATE, DoubleArray.of(1d, 1.5d)), expected);
+    assertEquals(test.curve(VAL_DATE, metadata, DoubleArray.of(1d, 1.5d)), expected);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveTest.java
@@ -75,6 +75,9 @@ public class InterpolatedNodalCurveTest {
     // parameter metadata size != node size
     assertThrowsIllegalArg(() -> InterpolatedNodalCurve.of(
         METADATA_ENTRIES, DoubleArray.of(1d, 3d), DoubleArray.of(1d, 3d), INTERPOLATOR));
+    // x not in order
+    assertThrowsIllegalArg(() -> InterpolatedNodalCurve.of(
+        METADATA, DoubleArray.of(2d, 1d), DoubleArray.of(2d, 3d), INTERPOLATOR));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/JacobianCalibrationMatrixTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/JacobianCalibrationMatrixTest.java
@@ -27,6 +27,7 @@ public class JacobianCalibrationMatrixTest {
 
   private static final CurveName NAME1 = CurveName.of("Test1");
   private static final CurveName NAME2 = CurveName.of("Test2");
+  private static final CurveName NAME3 = CurveName.of("Test3");
   private static final CurveParameterSize CPS1 = CurveParameterSize.of(NAME1, 3);
   private static final CurveParameterSize CPS2 = CurveParameterSize.of(NAME2, 2);
   private static final List<CurveParameterSize> CPS = ImmutableList.of(CPS1, CPS2);
@@ -40,6 +41,9 @@ public class JacobianCalibrationMatrixTest {
     assertEquals(test.getJacobianMatrix(), MATRIX);
     assertEquals(test.getCurveCount(), 2);
     assertEquals(test.getTotalParameterCount(), 5);
+    assertEquals(test.containsCurve(NAME1), true);
+    assertEquals(test.containsCurve(NAME2), true);
+    assertEquals(test.containsCurve(NAME3), false);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/CurveCalibrator.java
@@ -151,10 +151,10 @@ public final class CurveCalibrator {
    * The calibration is defined using {@link CurveGroupDefinition}.
    * Observable market data, time-series and FX are also needed to complete the calibration.
    *
-   * @param curveGroupDefn the curve group definition
-   * @param valuationDate the validation date
-   * @param marketData the market data required to build a trade for the instrument
-   * @param timeSeries the time-series
+   * @param curveGroupDefn  the curve group definition
+   * @param valuationDate  the validation date
+   * @param marketData  the market data required to build a trade for the instrument
+   * @param timeSeries  the time-series
    * @return the rates provider resulting from the calibration
    */
   public ImmutableRatesProvider calibrate(
@@ -178,9 +178,9 @@ public final class CurveCalibrator {
    * <p>
    * A curve must only exist in one group.
    *
-   * @param allGroupsDefn the curve group definitions
-   * @param knownData the starting data for the calibration
-   * @param marketData the market data required to build a trade for the instrument
+   * @param allGroupsDefn  the curve group definitions
+   * @param knownData  the starting data for the calibration
+   * @param marketData  the market data required to build a trade for the instrument
    * @return the rates provider resulting from the calibration
    */
   public ImmutableRatesProvider calibrate(

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/ImmutableRatesProviderGenerator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/ImmutableRatesProviderGenerator.java
@@ -24,6 +24,7 @@ import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
 import com.opengamma.strata.market.curve.CurveGroupEntry;
 import com.opengamma.strata.market.curve.CurveInfoType;
+import com.opengamma.strata.market.curve.CurveMetadata;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.JacobianCalibrationMatrix;
 import com.opengamma.strata.market.curve.NodalCurveDefinition;
@@ -44,19 +45,24 @@ public class ImmutableRatesProviderGenerator
    */
   private final ImmutableRatesProvider knownProvider;
   /**
-   * The curve templates for the new curves to be generated.
+   * The curve definitions for the new curves to be generated.
    */
   private final ImmutableList<NodalCurveDefinition> curveDefinitions;
   /**
+   * The list of curve metadata associated with each definition.
+   * The size of this list must match the size of the definition list.
+   */
+  private final ImmutableList<CurveMetadata> curveMetadata;
+  /**
    * The map between curve name and currencies for discounting.
-   * The map should contains all the curve in the template list but may have more names
-   * than the curve template list. Only the curves in the templates list are created.
+   * The map should contains all the curve in the definition list but may have more names
+   * than the curve definition list. Only the curves in the definitions list are created.
    */
   private final ImmutableSetMultimap<CurveName, Currency> discountCurveNames;
   /**
    * The map between curve name and indices for forward.
-   * The map should contains all the curve in the template list but may have more names
-   * than the curve template list. Only the curves in the templates list are created
+   * The map should contains all the curve in the definition list but may have more names
+   * than the curve definition list. Only the curves in the definitions list are created
    */
   private final ImmutableSetMultimap<CurveName, Index> forwardCurveNames;
 
@@ -72,11 +78,13 @@ public class ImmutableRatesProviderGenerator
       CurveGroupDefinition groupDefn) {
 
     List<NodalCurveDefinition> curveDefns = new ArrayList<>();
+    List<CurveMetadata> curveMetadata = new ArrayList<>();
     SetMultimap<CurveName, Currency> discountNames = HashMultimap.create();
     SetMultimap<CurveName, Index> indexNames = HashMultimap.create();
 
     for (NodalCurveDefinition curveDefn : groupDefn.getCurveDefinitions()) {
       curveDefns.add(curveDefn);
+      curveMetadata.add(curveDefn.metadata(knownProvider.getValuationDate()));
       CurveName curveName = curveDefn.getName();
       // A curve group is guaranteed to include an entry for every definition
       CurveGroupEntry entry = groupDefn.findEntry(curveName).get();
@@ -84,7 +92,7 @@ public class ImmutableRatesProviderGenerator
       discountNames.putAll(curveName, ccy);
       indexNames.putAll(curveName, entry.getIndices());
     }
-    return new ImmutableRatesProviderGenerator(knownProvider, curveDefns, discountNames, indexNames);
+    return new ImmutableRatesProviderGenerator(knownProvider, curveDefns, curveMetadata, discountNames, indexNames);
   }
 
   /**
@@ -92,17 +100,20 @@ public class ImmutableRatesProviderGenerator
    * 
    * @param knownProvider  the underlying known provider
    * @param curveDefinitions  the curve definitions
+   * @param curveMetadata  the curve metadata
    * @param discountCurveNames  the map of discount curves
    * @param forwardCurveNames  the map of index forward curves
    */
   private ImmutableRatesProviderGenerator(
       ImmutableRatesProvider knownProvider,
       List<NodalCurveDefinition> curveDefinitions,
+      List<CurveMetadata> curveMetadata,
       SetMultimap<CurveName, Currency> discountCurveNames,
       SetMultimap<CurveName, Index> forwardCurveNames) {
 
     this.knownProvider = ArgChecker.notNull(knownProvider, "knownProvider");
     this.curveDefinitions = ImmutableList.copyOf(ArgChecker.notNull(curveDefinitions, "curveDefinitions"));
+    this.curveMetadata = ImmutableList.copyOf(ArgChecker.notNull(curveMetadata, "curveMetadata"));
     this.discountCurveNames = ImmutableSetMultimap.copyOf(ArgChecker.notNull(discountCurveNames, "discountCurveNames"));
     this.forwardCurveNames = ImmutableSetMultimap.copyOf(ArgChecker.notNull(forwardCurveNames, "forwardCurveNames"));
   }
@@ -123,19 +134,21 @@ public class ImmutableRatesProviderGenerator
     int startIndex = 0;
     for (int i = 0; i < curveDefinitions.size(); i++) {
       NodalCurveDefinition curveDefn = curveDefinitions.get(i);
+      CurveMetadata metadata = curveMetadata.get(i);
+      CurveName name = curveDefn.getName();
       // extract parameters for the child curve
       int paramCount = curveDefn.getParameterCount();
       DoubleArray curveParams = parameters.subArray(startIndex, startIndex + paramCount);
       startIndex += paramCount;
       // create the child curve
       Map<CurveInfoType<?>, Object> infoMap = additionalInfoMap(curveDefn, jacobians);
-      Curve curve = curveDefn.curve(knownProvider.getValuationDate(), curveParams, infoMap);
+      Curve curve = curveDefn.curve(knownProvider.getValuationDate(), metadata, curveParams, infoMap);
       // put child curve into maps
-      Set<Currency> currencies = discountCurveNames.get(curveDefn.getName());
+      Set<Currency> currencies = discountCurveNames.get(name);
       for (Currency currency : currencies) {
         discountCurves.put(currency, curve);
       }
-      Set<Index> indices = forwardCurveNames.get(curveDefn.getName());
+      Set<Index> indices = forwardCurveNames.get(name);
       for (Index index : indices) {
         indexCurves.put(index, curve);
       }


### PR DESCRIPTION
Add metadata method to `CurveGroupDefinition`.
Alter signature of `NodalCurveDefinition.curve()` to take metadata.
Adjust `ImmutableRatesProviderGenerator` to create metadata.
Add tests and enhance other unrelated test coverage.