### PR TITLE
Periodic curve: parameter sensitivity

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/view/DiscountFactors.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/DiscountFactors.java
@@ -213,10 +213,11 @@ public interface DiscountFactors
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the unit parameter sensitivity of the forward rate at the specified fixing date.
+   * Calculates the unit parameter sensitivity at the specified fixing date.
    * <p>
-   * This returns the unit sensitivity to each parameter on the underlying curve at the specified date.
-   * The sensitivity refers to the result of {@link #discountFactor(LocalDate)}.
+   * This returns the unit sensitivity of the zero-coupon rate continuously compounded to each parameter on 
+   * the underlying curve at the specified date. The zero-rate continuously compounded is associated to 
+   * the result of {@link #discountFactor(LocalDate)}.
    * 
    * @param date  the date to find the sensitivity for
    * @return the parameter sensitivity

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/DiscountFactors.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/DiscountFactors.java
@@ -230,6 +230,7 @@ public interface DiscountFactors
    * <p>
    * This is used to convert a single point sensitivity to curve parameter sensitivity.
    * The calculation typically involves multiplying the point and unit sensitivities.
+   * This returns the sensitivity of the value referred in the point sensitivity to the curve parameters.
    * 
    * @param pointSensitivity  the point sensitivity to convert
    * @return the parameter sensitivity

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/ZeroRatePeriodicDiscountFactors.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/ZeroRatePeriodicDiscountFactors.java
@@ -36,6 +36,7 @@ import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
 import com.opengamma.strata.market.curve.CurveInfoType;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.CurveUnitParameterSensitivities;
+import com.opengamma.strata.market.curve.CurveUnitParameterSensitivity;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
 import com.opengamma.strata.market.sensitivity.ZeroRateSensitivity;
 import com.opengamma.strata.market.value.CompoundedRateType;
@@ -202,7 +203,12 @@ public final class ZeroRatePeriodicDiscountFactors
   @Override
   public CurveUnitParameterSensitivities unitParameterSensitivity(LocalDate date) {
     double relativeYearFraction = relativeYearFraction(date);
-    return CurveUnitParameterSensitivities.of(curve.yValueParameterSensitivity(relativeYearFraction));
+    double rp = curve.yValue(relativeYearFraction);
+    //    double rc = _compoundingPeriodsPerYear * Math.log(1 + rp / _compoundingPeriodsPerYear);
+    double rcBar = 1.0;
+    double rpBar = 1.0 / (1 + rp / frequency) * rcBar;
+    CurveUnitParameterSensitivity drpdp = curve.yValueParameterSensitivity(relativeYearFraction);
+    return CurveUnitParameterSensitivities.of(drpdp.multipliedBy(rpBar));
   }
 
   @Override

--- a/modules/market/src/test/java/com/opengamma/strata/market/view/ZeroRatePeriodicDiscountFactorsTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/view/ZeroRatePeriodicDiscountFactorsTest.java
@@ -21,16 +21,16 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
-import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.Perturbation;
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.curve.Curve;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivity;
 import com.opengamma.strata.market.curve.CurveInfoType;
 import com.opengamma.strata.market.curve.CurveMetadata;
 import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.CurveUnitParameterSensitivities;
-import com.opengamma.strata.market.curve.CurveUnitParameterSensitivity;
 import com.opengamma.strata.market.curve.Curves;
 import com.opengamma.strata.market.curve.DefaultCurveMetadata;
 import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
@@ -77,7 +77,7 @@ public class ZeroRatePeriodicDiscountFactorsTest {
     assertEquals(test.getValuationDate(), DATE_VAL);
     assertEquals(test.getCurve(), CURVE);
     assertEquals(test.getCurveName(), NAME);
-    assertEquals(test.getParameterCount(), 2);
+    assertEquals(test.getParameterCount(), X.size());
   }
 
   public void test_of_badCurve() {
@@ -243,15 +243,19 @@ public class ZeroRatePeriodicDiscountFactorsTest {
           / relativeYearFraction;
       assertEquals(sensi0.get(i), (zrP - zrM) / (2 * shift), TOLERANCE_DELTA_FD);
     }
-    
   }
 
   //-------------------------------------------------------------------------
-  // proper end-to-end FD tests are elsewhere
   public void test_curveParameterSensitivity() {
     ZeroRatePeriodicDiscountFactors test = ZeroRatePeriodicDiscountFactors.of(GBP, DATE_VAL, CURVE);
-    ZeroRateSensitivity point = ZeroRateSensitivity.of(GBP, DATE_AFTER, 1d);
-    assertEquals(test.curveParameterSensitivity(point).size(), 1);
+    double sensiValue = 25d;
+    ZeroRateSensitivity point = ZeroRateSensitivity.of(GBP, DATE_AFTER, sensiValue);
+    CurveCurrencyParameterSensitivities sensiObject = test.curveParameterSensitivity(point);
+    assertEquals(sensiObject.size(), 1);
+    CurveCurrencyParameterSensitivity sensi1 = sensiObject.getSensitivities().get(0);
+    assertEquals(sensi1.getCurrency(), GBP);
+    assertTrue(sensiObject.equalWithTolerance(
+        test.unitParameterSensitivity(DATE_AFTER).multipliedBy(GBP, sensiValue), TOLERANCE_DELTA));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/QuantileCalculationMethod.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/QuantileCalculationMethod.java
@@ -17,8 +17,8 @@ public abstract class QuantileCalculationMethod {
    * Compute the quantile estimation.
    * <p>
    * The quantile level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
-   * This is measured from the bottom, that is, Thus the quantile estimation with the level 99% corresponds to 
-   * the smallest 99% observations.
+   * This is measured from the bottom, that is, the quantile estimation with the level 99% corresponds to 
+   * the smallest 99% observations and 1% of the observation are above that level.
    * <p>
    * If index value computed from the level is outside of the sample data range, 
    * {@code IllegalArgumentException} is thrown. 
@@ -37,8 +37,8 @@ public abstract class QuantileCalculationMethod {
    * Compute the quantile estimation.
    * <p>
    * The quantile level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
-   * This is measured from the bottom, that is, Thus the quantile estimation with the level 99% corresponds to 
-   * the smallest 99% observations.
+   * This is measured from the bottom, that is, the quantile estimation with the level 99% corresponds to 
+   * the smallest 99% observations and 1% of the observation are above that level.
    * <p>
    * If index value computed from the level is outside of the sample data range, 
    * {@code IllegalArgumentException} is thrown. 
@@ -57,8 +57,8 @@ public abstract class QuantileCalculationMethod {
    * Compute the quantile estimation.
    * <p>
    * The quantile level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
-   * This is measured from the bottom, that is, Thus the quantile estimation with the level 99% corresponds to 
-   * the smallest 99% observations.
+   * This is measured from the bottom, that is, the quantile estimation with the level 99% corresponds to 
+   * the smallest 99% observations and 1% of the observation are above that level.
    * <p>
    * If index value computed from the level is outside of the sample data range, the nearest data point is used, i.e., 
    * quantile is computed with flat extrapolation.  
@@ -77,8 +77,8 @@ public abstract class QuantileCalculationMethod {
    * Compute the quantile estimation.
    * <p>
    * The quantile level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
-   * This is measured from the bottom, that is, Thus the quantile estimation with the level 99% corresponds to 
-   * the smallest 99% observations.
+   * This is measured from the bottom, that is, the quantile estimation with the level 99% corresponds to 
+   * the smallest 99% observations and 1% of the observation are above that level.
    * <p>
    * If index value computed from the level is outside of the sample data range, the nearest data point is used, i.e., 
    * quantile is computed with flat extrapolation. 
@@ -97,9 +97,9 @@ public abstract class QuantileCalculationMethod {
   /**
    * Compute the expected shortfall.
    * <p>
-   * The quantile level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
-   * This is measured from the bottom, that is, Thus the expected shortfall with the level 99% corresponds to 
-   * the smallest 99% observations.
+   * The shortfall level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
+   * This is measured from the bottom, that is, the expected shortfall with the level 99% corresponds to 
+   * the average of the smallest 99% of the observations.
    * <p>
    * If index value computed from the level is outside of the sample data range, the nearest data point is used, i.e., 
    * expected short fall is computed with flat extrapolation.  
@@ -120,7 +120,7 @@ public abstract class QuantileCalculationMethod {
    * <p>
    * The quantile level is in decimal, i.e. 99% = 0.99 and 0 < level < 1 should be satisfied.
    * This is measured from the bottom, that is, Thus the expected shortfall with the level 99% corresponds to 
-   * the smallest 99% observations.
+   * the average of the smallest 99% of the observations.
    * <p>
    * If index value computed from the level is outside of the sample data range, the nearest data point is used, i.e., 
    * expected short fall is computed with flat extrapolation.  


### PR DESCRIPTION
- Corrected parameter sensitivity for periodic curve. Unit sensitivity now represent the sensitivity of the zero-rate to the curve parameter. Improved tests.
- Clarified quantile calculation javadoc.