### PR TITLE
Rename properties in bond/stir model

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/StirFuturePricingExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/StirFuturePricingExample.java
@@ -105,7 +105,7 @@ public class StirFuturePricingExample {
             .settlementDate(LocalDate.of(2014, 9, 14))
             .build())
         .quantity(20)
-        .initialPrice(0.9997)
+        .price(0.9997)
         .build();
   }
 
@@ -122,7 +122,7 @@ public class StirFuturePricingExample {
             .settlementDate(LocalDate.of(2014, 9, 14))
             .build())
         .quantity(20)
-        .initialPrice(0.9997)
+        .price(0.9997)
         .build();
   }
 

--- a/examples/src/main/resources/example-portfolios/stir-future-portfolio.xml
+++ b/examples/src/main/resources/example-portfolios/stir-future-portfolio.xml
@@ -27,7 +27,7 @@
     </target>
    </securityLink>
    <quantity>20</quantity>
-   <initialPrice>0.9997</initialPrice>
+   <price>0.9997</price>
   </item>
   <item type="IborFutureTrade">
    <tradeInfo>
@@ -55,7 +55,7 @@
     </target>
    </securityLink>
    <quantity>20</quantity>
-   <initialPrice>0.9997</initialPrice>
+   <price>0.9997</price>
   </item>
  </trades>
 </bean>

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/BondFutureOptionMarginedTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/BondFutureOptionMarginedTradePricer.java
@@ -86,7 +86,7 @@ public abstract class BondFutureOptionMarginedTradePricer {
     double marginReferencePrice = lastClosingPrice;
     LocalDate tradeDate = tradeDateOpt.get();
     if (tradeDate.equals(valuationDate)) {
-      OptionalDouble tradePrice = trade.getInitialPrice();
+      OptionalDouble tradePrice = trade.getPrice();
       ArgChecker.isTrue(tradePrice.isPresent(), "trade price not present");
       marginReferencePrice = tradePrice.getAsDouble();
     }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingBondFutureProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingBondFutureProductPricer.java
@@ -64,7 +64,7 @@ public final class DiscountingBondFutureProductPricer extends AbstractBondFuture
       double dirtyPrice = bondPricer.dirtyPriceFromCurves(
           bond, bondSec.getSecond(), provider, future.getLastDeliveryDate());
       priceBonds[i] = bondPricer.cleanPriceFromDirtyPrice(
-          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactor().get(i);
+          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactors().get(i);
     }
     return Doubles.min(priceBonds);
   }
@@ -100,7 +100,7 @@ public final class DiscountingBondFutureProductPricer extends AbstractBondFuture
       double dirtyPrice = bondPricer.dirtyPriceFromCurvesWithZSpread(
           bond, bondSec.getSecond(), provider, zSpread, compoundedRateType, periodPerYear, future.getLastDeliveryDate());
       priceBonds[i] = bondPricer.cleanPriceFromDirtyPrice(
-          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactor().get(i);
+          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactors().get(i);
     }
     return Doubles.min(priceBonds);
   }
@@ -129,7 +129,7 @@ public final class DiscountingBondFutureProductPricer extends AbstractBondFuture
       double dirtyPrice = bondPricer.dirtyPriceFromCurves(
           bond, bondSec.getSecond(), provider, future.getLastDeliveryDate());
       priceBonds[i] = bondPricer.cleanPriceFromDirtyPrice(
-          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactor().get(i);
+          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactors().get(i);
       if (priceBonds[i] < priceMin) {
         priceMin = priceBonds[i];
         indexCTD = i;
@@ -139,7 +139,7 @@ public final class DiscountingBondFutureProductPricer extends AbstractBondFuture
     ResolvedFixedCouponBond bond = bondSec.getFirst();
     PointSensitivityBuilder pointSensi = bondPricer.dirtyPriceSensitivity(
         bond, bondSec.getSecond(), provider, future.getLastDeliveryDate());
-    return pointSensi.multipliedBy(1d / future.getConversionFactor().get(indexCTD)).build();
+    return pointSensi.multipliedBy(1d / future.getConversionFactors().get(indexCTD)).build();
   }
 
   /**
@@ -177,7 +177,7 @@ public final class DiscountingBondFutureProductPricer extends AbstractBondFuture
       double dirtyPrice = bondPricer.dirtyPriceFromCurvesWithZSpread(
           bond, bondSec.getSecond(), provider, zSpread, compoundedRateType, periodPerYear, future.getLastDeliveryDate());
       priceBonds[i] = bondPricer.cleanPriceFromDirtyPrice(
-          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactor().get(i);
+          bond, future.getLastDeliveryDate(), dirtyPrice) / future.getConversionFactors().get(i);
       if (priceBonds[i] < priceMin) {
         priceMin = priceBonds[i];
         indexCTD = i;
@@ -187,7 +187,7 @@ public final class DiscountingBondFutureProductPricer extends AbstractBondFuture
     ResolvedFixedCouponBond bond = bondSec.getFirst();
     PointSensitivityBuilder pointSensi = bondPricer.dirtyPriceSensitivityWithZspread(
         bond, bondSec.getSecond(), provider, zSpread, compoundedRateType, periodPerYear, future.getLastDeliveryDate());
-    return pointSensi.multipliedBy(1d / future.getConversionFactor().get(indexCTD)).build();
+    return pointSensi.multipliedBy(1d / future.getConversionFactors().get(indexCTD)).build();
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/AbstractIborFutureTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/AbstractIborFutureTradePricer.java
@@ -66,7 +66,7 @@ public abstract class AbstractIborFutureTradePricer {
     ArgChecker.notNull(valuationDate, "valuation date");
     LocalDate tradeDate = trade.getTradeInfo().getTradeDate()
         .orElseThrow(() -> new IllegalArgumentException("Trade date should be populated"));
-    return (tradeDate.equals(valuationDate) ? trade.getInitialPrice() : lastMarginPrice);
+    return (tradeDate.equals(valuationDate) ? trade.getPrice() : lastMarginPrice);
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/IborFutureOptionMarginedTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/IborFutureOptionMarginedTradePricer.java
@@ -86,7 +86,7 @@ public abstract class IborFutureOptionMarginedTradePricer {
     double marginReferencePrice = lastClosingPrice;
     LocalDate tradeDate = tradeDateOpt.get();
     if (tradeDate.equals(valuationDate)) {
-      OptionalDouble tradePrice = trade.getInitialPrice();
+      OptionalDouble tradePrice = trade.getPrice();
       ArgChecker.isTrue(tradePrice.isPresent(), "trade price not present");
       marginReferencePrice = tradePrice.getAsDouble();
     }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/BlackBondFutureOptionMarginedTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/BlackBondFutureOptionMarginedTradePricerTest.java
@@ -146,7 +146,7 @@ public class BlackBondFutureOptionMarginedTradePricerTest {
     LocalDate valuationDate2 = LocalDate.of(2014, 3, 31); // equal to trade date
     CurrencyAmount computed2 =
         OPTION_TRADE_PRICER.presentValue(OPTION_TRADE, valuationDate2, currentPrice, lastClosingPrice);
-    double expected = NOTIONAL * QUANTITY * (currentPrice - OPTION_TRADE.getInitialPrice().getAsDouble());
+    double expected = NOTIONAL * QUANTITY * (currentPrice - OPTION_TRADE.getPrice().getAsDouble());
     assertEquals(computed2.getCurrency(), Currency.EUR);
     assertEquals(computed2.getAmount(), expected, TOL * NOTIONAL * QUANTITY);
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/BondDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/BondDataSets.java
@@ -99,7 +99,7 @@ public final class BondDataSets {
   private static final LocalDate LAST_NOTICE_DATE_USD = LocalDate.of(2011, 10, 4);
   /** Bond future product */
   public static final BondFuture FUTURE_PRODUCT_USD = BondFuture.builder()
-      .conversionFactor(CONVERSION_FACTOR_USD)
+      .conversionFactors(CONVERSION_FACTOR_USD)
       .deliveryBasket(BOND_SECURITY_LINK_USD)
       .firstNoticeDate(FIRST_NOTICE_DATE_USD)
       .lastNoticeDate(LAST_NOTICE_DATE_USD)
@@ -116,7 +116,7 @@ public final class BondDataSets {
   public static final long QUANTITY_USD = 1234l;
   /** Bond future trade */
   public static final BondFutureTrade FUTURE_TRADE_USD = BondFutureTrade.builder()
-      .initialPrice(1.1d)
+      .price(1.1d)
       .quantity(QUANTITY_USD)
       .securityLink(FUTURE_SECURITY_LINK_USD)
       .tradeInfo(TRADE_INFO_USD)
@@ -173,7 +173,7 @@ public final class BondDataSets {
   private static final LocalDate FIRST_NOTICE_DATE_EUR = LocalDate.of(2014, 6, 6);
   private static final LocalDate LAST_NOTICE_DATE_EUR = LocalDate.of(2014, 6, 6);
   private static final BondFuture FUTURE_PRODUCT_EUR = BondFuture.builder()
-      .conversionFactor(CONVERSION_FACTOR_EUR)
+      .conversionFactors(CONVERSION_FACTOR_EUR)
       .deliveryBasket(SECURITY_LINK_EUR)
       .firstNoticeDate(FIRST_NOTICE_DATE_EUR)
       .lastNoticeDate(LAST_NOTICE_DATE_EUR)
@@ -219,7 +219,7 @@ public final class BondDataSets {
       .resolved(UnitSecurity.builder(FUTURE_OPTION_PRODUCT_EUR_115).standardId(OPTION_SECURITY_ID).build());
   /** Bond future option trade */
   public static final BondFutureOptionTrade FUTURE_OPTION_TRADE_EUR = BondFutureOptionTrade.builder()
-      .initialPrice(0.01)
+      .price(0.01)
       .quantity(QUANTITY_EUR)
       .securityLink(OPTION_SECURITY_LINK)
       .tradeInfo(TRADE_INFO)

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/e2e/BondFuturesJpyEnd2EndTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/e2e/BondFuturesJpyEnd2EndTest.java
@@ -144,7 +144,7 @@ public class BondFuturesJpyEnd2EndTest {
   private static final LocalDate FIRST_NOTICE_DATE_SEP = LAST_TRADE_ADJUST.adjust(LAST_DELIVERY_DATE_SEP, REF_DATA);
   private static final LocalDate LAST_NOTICE_DATE_SEP = LAST_TRADE_ADJUST.adjust(LAST_DELIVERY_DATE_SEP, REF_DATA);
   private static final ResolvedBondFuture FUTURE_PRODUCT_SEP = BondFuture.builder()
-      .conversionFactor(CF_SEP)
+      .conversionFactors(CF_SEP)
       .deliveryBasket(UND_BOND_SECURITY_SEP)
       .firstNoticeDate(FIRST_NOTICE_DATE_SEP)
       .lastNoticeDate(LAST_NOTICE_DATE_SEP)
@@ -177,7 +177,7 @@ public class BondFuturesJpyEnd2EndTest {
   private static final LocalDate FIRST_NOTICE_DATE_JUN = LAST_TRADE_ADJUST.adjust(LAST_DELIVERY_DATE_JUN, REF_DATA);
   private static final LocalDate LAST_NOTICE_DATE_JUN = LAST_TRADE_ADJUST.adjust(LAST_DELIVERY_DATE_JUN, REF_DATA);
   private static final ResolvedBondFuture FUTURE_PRODUCT_JUN = BondFuture.builder()
-      .conversionFactor(CF_JUN)
+      .conversionFactors(CF_JUN)
       .deliveryBasket(UND_BOND_SECURITY_JUN)
       .firstNoticeDate(FIRST_NOTICE_DATE_JUN)
       .lastNoticeDate(LAST_NOTICE_DATE_JUN)
@@ -205,7 +205,7 @@ public class BondFuturesJpyEnd2EndTest {
   private static final LocalDate FIRST_NOTICE_DATE_MAR = LAST_TRADE_ADJUST.adjust(LAST_DELIVERY_DATE_MAR, REF_DATA);
   private static final LocalDate LAST_NOTICE_DATE_MAR = LAST_TRADE_ADJUST.adjust(LAST_DELIVERY_DATE_MAR, REF_DATA);
   private static final ResolvedBondFuture FUTURE_PRODUCT_MAR = BondFuture.builder()
-      .conversionFactor(CF_MAR)
+      .conversionFactors(CF_MAR)
       .deliveryBasket(UND_BOND_SECURITY)
       .firstNoticeDate(FIRST_NOTICE_DATE_MAR)
       .lastNoticeDate(LAST_NOTICE_DATE_MAR)

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/AbstractIborFutureTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/AbstractIborFutureTradePricerTest.java
@@ -54,7 +54,7 @@ public class AbstractIborFutureTradePricerTest {
     LocalDate valuationDate = tradeDate;
     double lastMarginPrice = 0.995;
     double referencePrice = PRICER.referencePrice(FUTURE_TRADE, valuationDate, lastMarginPrice);
-    assertEquals(referencePrice, FUTURE_TRADE.getInitialPrice());
+    assertEquals(referencePrice, FUTURE_TRADE.getPrice());
   }
   
   public void test_reference_price_val_date_not_null() {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/DiscountingIborFutureTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/DiscountingIborFutureTradePricerTest.java
@@ -70,7 +70,7 @@ public class DiscountingIborFutureTradePricerTest {
     when(mockIbor.rate(FUTURE.getIborRate().getObservation())).thenReturn(RATE);
 
     double lastClosingPrice = 0.99;
-    double parSpreadExpected = PRICER_TRADE.price(FUTURE_TRADE, prov) - FUTURE_TRADE.getInitialPrice();
+    double parSpreadExpected = PRICER_TRADE.price(FUTURE_TRADE, prov) - FUTURE_TRADE.getPrice();
     double parSpreadComputed = PRICER_TRADE.parSpread(FUTURE_TRADE, prov, lastClosingPrice);
     assertEquals(parSpreadComputed, parSpreadExpected, TOLERANCE_PRICE);
   }
@@ -101,7 +101,7 @@ public class DiscountingIborFutureTradePricerTest {
 
     double lastClosingPrice = 1.025;
     DiscountingIborFutureTradePricer pricerFn = DiscountingIborFutureTradePricer.DEFAULT;
-    double expected = ((1.0 - RATE) - FUTURE_TRADE.getInitialPrice()) *
+    double expected = ((1.0 - RATE) - FUTURE_TRADE.getPrice()) *
         FUTURE.getAccrualFactor() * FUTURE.getNotional() * FUTURE_TRADE.getQuantity();
     CurrencyAmount computed = pricerFn.presentValue(FUTURE_TRADE, prov, lastClosingPrice);
     assertEquals(computed.getAmount(), expected, TOLERANCE_PV);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/HullWhiteIborFutureDataSet.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/HullWhiteIborFutureDataSet.java
@@ -120,7 +120,7 @@ public class HullWhiteIborFutureDataSet {
   private static final TradeInfo TRADE_INFO = TradeInfo.builder().tradeDate(TRADE_DATE).build();
   /** Ibor future trade */
   public static final IborFutureTrade IBOR_FUTURE_TRADE = IborFutureTrade.builder()
-      .initialPrice(REFERENCE_PRICE)
+      .price(REFERENCE_PRICE)
       .quantity(QUANTITY)
       .securityLink(SECURITY_LINK)
       .tradeInfo(TRADE_INFO)

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/IborFutureDummyData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/IborFutureDummyData.java
@@ -75,7 +75,7 @@ public class IborFutureDummyData {
       .tradeInfo(TradeInfo.builder().tradeDate(TRADE_DATE).build())
       .securityLink(SecurityLink.resolved(IBOR_FUTURE_SECURITY))
       .quantity(FUTURE_QUANTITY)
-      .initialPrice(FUTURE_INITIAL_PRICE)
+      .price(FUTURE_INITIAL_PRICE)
       .build();
 
   /**
@@ -120,7 +120,7 @@ public class IborFutureDummyData {
           .tradeInfo(TradeInfo.builder().tradeDate(TRADE_DATE).build())
           .securityLink(SecurityLink.resolved(IBOR_FUTURE_OPTION_SECURITY))
           .quantity(OPTION_QUANTITY)
-          .initialPrice(OPTION_INITIAL_PRICE)
+          .price(OPTION_INITIAL_PRICE)
           .build();
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/IborFutureOptionMarginedTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/IborFutureOptionMarginedTradePricerTest.java
@@ -41,7 +41,7 @@ public class IborFutureOptionMarginedTradePricerTest {
       .product(OPTION)
       .securityStandardId(OPTION_ID)
       .quantity(OPTION_QUANTITY)
-      .initialPrice(TRADE_PRICE)
+      .price(TRADE_PRICE)
       .build();
   private static final ResolvedIborFutureOptionTrade OPTION_TRADE = ResolvedIborFutureOptionTrade.builder()
       .tradeInfo(TradeInfo.builder()
@@ -50,7 +50,7 @@ public class IborFutureOptionMarginedTradePricerTest {
       .product(OPTION)
       .securityStandardId(OPTION_ID)
       .quantity(OPTION_QUANTITY)
-      .initialPrice(TRADE_PRICE)
+      .price(TRADE_PRICE)
       .build();
 
   private static final DiscountingIborFutureProductPricer FUTURE_PRICER = DiscountingIborFutureProductPricer.DEFAULT;
@@ -70,7 +70,7 @@ public class IborFutureOptionMarginedTradePricerTest {
         .product(OPTION)
         .securityStandardId(OPTION_ID)
         .quantity(OPTION_QUANTITY)
-        .initialPrice(TRADE_PRICE)
+        .price(TRADE_PRICE)
         .build();
     assertThrowsIllegalArg(() -> OPTION_TRADE_PRICER.presentValue(trade, VAL_DATE, optionPrice, lastClosingPrice));
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedTradePricerTest.java
@@ -77,7 +77,7 @@ public class NormalIborFutureOptionMarginedTradePricerTest {
       .product(OPTION)
       .securityStandardId(OPTION_ID)
       .quantity(OPTION_QUANTITY)
-      .initialPrice(TRADE_PRICE)
+      .price(TRADE_PRICE)
       .build();
   private static final ResolvedIborFutureOptionTrade FUTURE_OPTION_TRADE = ResolvedIborFutureOptionTrade.builder()
       .tradeInfo(TradeInfo.builder()
@@ -86,7 +86,7 @@ public class NormalIborFutureOptionMarginedTradePricerTest {
       .product(OPTION)
       .securityStandardId(OPTION_ID)
       .quantity(OPTION_QUANTITY)
-      .initialPrice(TRADE_PRICE)
+      .price(TRADE_PRICE)
       .build();
 
   private static final double RATE = 0.015;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/e2e/IborFuturesJpyEnd2EndTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/e2e/IborFuturesJpyEnd2EndTest.java
@@ -101,7 +101,7 @@ public class IborFuturesJpyEnd2EndTest {
       .tradeInfo(TRADE_INFO)
       .product(FUTURE_PRODUCT_MAR)
       .securityStandardId(FUTURE_SECURITY_ID_MAR)
-      .initialPrice(REF_PRICE_MAR * ONE_PERCENT)
+      .price(REF_PRICE_MAR * ONE_PERCENT)
       .quantity(QUANTITY)
       .build();
   // futures in June 2016
@@ -121,7 +121,7 @@ public class IborFuturesJpyEnd2EndTest {
       .tradeInfo(TRADE_INFO)
       .product(FUTURE_PRODUCT_JUN)
       .securityStandardId(FUTURE_SECURITY_ID_JUN)
-      .initialPrice(REF_PRICE_JUN * ONE_PERCENT)
+      .price(REF_PRICE_JUN * ONE_PERCENT)
       .quantity(QUANTITY)
       .build();
   // futures in September 2016
@@ -141,7 +141,7 @@ public class IborFuturesJpyEnd2EndTest {
       .tradeInfo(TRADE_INFO)
       .product(FUTURE_PRODUCT_SEP)
       .securityStandardId(FUTURE_SECURITY_ID_SEP)
-      .initialPrice(REF_PRICE_SEP * ONE_PERCENT)
+      .price(REF_PRICE_SEP * ONE_PERCENT)
       .quantity(QUANTITY)
       .build();
   // futures in June 2017
@@ -162,7 +162,7 @@ public class IborFuturesJpyEnd2EndTest {
       .tradeInfo(TRADE_INFO)
       .product(FUTURE_PRODUCT_JUN_MID)
       .securityStandardId(FUTURE_SECURITY_ID_JUN_MID)
-      .initialPrice(REF_PRICE_JUN_MID * ONE_PERCENT)
+      .price(REF_PRICE_JUN_MID * ONE_PERCENT)
       .quantity(QUANTITY)
       .build();
   // futures in March 2020
@@ -183,7 +183,7 @@ public class IborFuturesJpyEnd2EndTest {
       .tradeInfo(TRADE_INFO)
       .product(FUTURE_PRODUCT_MAR_LONG)
       .securityStandardId(FUTURE_SECURITY_ID_MAR_LONG)
-      .initialPrice(REF_PRICE_MAR_LONG * ONE_PERCENT)
+      .price(REF_PRICE_MAR_LONG * ONE_PERCENT)
       .quantity(QUANTITY)
       .build();
   // pricers
@@ -266,23 +266,23 @@ public class IborFuturesJpyEnd2EndTest {
   public void presentValue() {
     // March 2016
     CurrencyAmount pvMar = TRADE_PRICER.presentValue(FUTURE_TRADE_MAR, RATES_PROVIDER,
-        FUTURE_TRADE_MAR.getInitialPrice());
+        FUTURE_TRADE_MAR.getPrice());
     assertEquals(pvMar.getAmount(), -9738.418878056109, TOL * NOTIONAL);
     // June 2016
     CurrencyAmount pvJun = TRADE_PRICER.presentValue(FUTURE_TRADE_JUN, RATES_PROVIDER,
-        FUTURE_TRADE_JUN.getInitialPrice());
+        FUTURE_TRADE_JUN.getPrice());
     assertEquals(pvJun.getAmount(), -3812.1182441189885, TOL * NOTIONAL);
     // September 2016
     CurrencyAmount pvSep = TRADE_PRICER.presentValue(FUTURE_TRADE_SEP, RATES_PROVIDER,
-        FUTURE_TRADE_SEP.getInitialPrice());
+        FUTURE_TRADE_SEP.getPrice());
     assertEquals(pvSep.getAmount(), -5689.603123847395, TOL * NOTIONAL);
     // June 2017
     CurrencyAmount pvJunMid =
-        TRADE_PRICER.presentValue(FUTURE_TRADE_JUN_MID, RATES_PROVIDER, FUTURE_TRADE_JUN_MID.getInitialPrice());
+        TRADE_PRICER.presentValue(FUTURE_TRADE_JUN_MID, RATES_PROVIDER, FUTURE_TRADE_JUN_MID.getPrice());
     assertEquals(pvJunMid.getAmount(), 4022.2380772829056, TOL * NOTIONAL);
     // March 2020
     CurrencyAmount pvMarLong =
-        TRADE_PRICER.presentValue(FUTURE_TRADE_MAR_LONG, RATES_PROVIDER, FUTURE_TRADE_MAR_LONG.getInitialPrice());
+        TRADE_PRICER.presentValue(FUTURE_TRADE_MAR_LONG, RATES_PROVIDER, FUTURE_TRADE_MAR_LONG.getPrice());
     assertEquals(pvMarLong.getAmount(), 35818.328803278506, TOL * NOTIONAL);
   }
 
@@ -333,21 +333,21 @@ public class IborFuturesJpyEnd2EndTest {
 
   public void parSpread() {
     // March 2016
-    double psMar = TRADE_PRICER.parSpread(FUTURE_TRADE_MAR, RATES_PROVIDER, FUTURE_TRADE_MAR.getInitialPrice()) * HUNDRED;
+    double psMar = TRADE_PRICER.parSpread(FUTURE_TRADE_MAR, RATES_PROVIDER, FUTURE_TRADE_MAR.getPrice()) * HUNDRED;
     assertEquals(psMar, -0.038953675512221064, TOL * HUNDRED);
     // June 2016
-    double psJun = TRADE_PRICER.parSpread(FUTURE_TRADE_JUN, RATES_PROVIDER, FUTURE_TRADE_JUN.getInitialPrice()) * HUNDRED;
+    double psJun = TRADE_PRICER.parSpread(FUTURE_TRADE_JUN, RATES_PROVIDER, FUTURE_TRADE_JUN.getPrice()) * HUNDRED;
     assertEquals(psJun, -0.01524847297647014, TOL * HUNDRED);
     // September 2016
-    double psSep = TRADE_PRICER.parSpread(FUTURE_TRADE_SEP, RATES_PROVIDER, FUTURE_TRADE_SEP.getInitialPrice()) * HUNDRED;
+    double psSep = TRADE_PRICER.parSpread(FUTURE_TRADE_SEP, RATES_PROVIDER, FUTURE_TRADE_SEP.getPrice()) * HUNDRED;
     assertEquals(psSep, -0.022758412495393898, TOL * HUNDRED);
     // June 2017
     double psJunMid =
-        TRADE_PRICER.parSpread(FUTURE_TRADE_JUN_MID, RATES_PROVIDER, FUTURE_TRADE_JUN_MID.getInitialPrice()) * HUNDRED;
+        TRADE_PRICER.parSpread(FUTURE_TRADE_JUN_MID, RATES_PROVIDER, FUTURE_TRADE_JUN_MID.getPrice()) * HUNDRED;
     assertEquals(psJunMid, 0.01608895230913454, TOL * HUNDRED);
     // March 2020
     double psMarLong =
-        TRADE_PRICER.parSpread(FUTURE_TRADE_MAR_LONG, RATES_PROVIDER, FUTURE_TRADE_MAR_LONG.getInitialPrice()) * HUNDRED;
+        TRADE_PRICER.parSpread(FUTURE_TRADE_MAR_LONG, RATES_PROVIDER, FUTURE_TRADE_MAR_LONG.getPrice()) * HUNDRED;
     assertEquals(psMarLong, 0.14327331521311049, TOL * HUNDRED);
   }
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/BondFuture.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/BondFuture.java
@@ -76,7 +76,7 @@ public final class BondFuture
    * All of the underlying bonds must have the same notional and currency.
    */
   @PropertyDefinition(validate = "notEmpty")
-  private final ImmutableList<Double> conversionFactor;
+  private final ImmutableList<Double> conversionFactors;
   /**
    * The last trading date.
    * <p>
@@ -103,7 +103,7 @@ public final class BondFuture
    * <p>
    * The first date on which the underlying is delivered.
    * <p>
-   * If not specified, thw date will be computed from {@code firstNoticeDate} by using
+   * If not specified, the date will be computed from {@code firstNoticeDate} by using
    * {@code settlementDateOffset} in the first element of the delivery basket.
    */
   @PropertyDefinition(get = "optional")
@@ -138,7 +138,7 @@ public final class BondFuture
   @ImmutableValidator
   private void validate() {
     int size = deliveryBasket.size();
-    ArgChecker.isTrue(size == conversionFactor.size(),
+    ArgChecker.isTrue(size == conversionFactors.size(),
         "The delivery basket size should be the same as the conversion factor size");
     ArgChecker.inOrderOrEqual(firstNoticeDate, lastNoticeDate, "firstNoticeDate", "lastNoticeDate");
     if (firstDeliveryDate != null && lastDeliveryDate != null) {
@@ -233,7 +233,7 @@ public final class BondFuture
     DaysAdjustment settleOffset = product0.getSettlementDateOffset();
     return ResolvedBondFuture.builder()
         .deliveryBasket(basket)
-        .conversionFactor(conversionFactor)
+        .conversionFactors(conversionFactors)
         .lastTradeDate(lastTradeDate)
         .firstNoticeDate(firstNoticeDate)
         .lastNoticeDate(lastNoticeDate)
@@ -272,7 +272,7 @@ public final class BondFuture
 
   private BondFuture(
       List<SecurityLink<FixedCouponBond>> deliveryBasket,
-      List<Double> conversionFactor,
+      List<Double> conversionFactors,
       LocalDate lastTradeDate,
       LocalDate firstNoticeDate,
       LocalDate lastNoticeDate,
@@ -280,13 +280,13 @@ public final class BondFuture
       LocalDate lastDeliveryDate,
       Rounding rounding) {
     JodaBeanUtils.notEmpty(deliveryBasket, "deliveryBasket");
-    JodaBeanUtils.notEmpty(conversionFactor, "conversionFactor");
+    JodaBeanUtils.notEmpty(conversionFactors, "conversionFactors");
     JodaBeanUtils.notNull(lastTradeDate, "lastTradeDate");
     JodaBeanUtils.notNull(firstNoticeDate, "firstNoticeDate");
     JodaBeanUtils.notNull(lastNoticeDate, "lastNoticeDate");
     JodaBeanUtils.notNull(rounding, "rounding");
     this.deliveryBasket = ImmutableList.copyOf(deliveryBasket);
-    this.conversionFactor = ImmutableList.copyOf(conversionFactor);
+    this.conversionFactors = ImmutableList.copyOf(conversionFactors);
     this.lastTradeDate = lastTradeDate;
     this.firstNoticeDate = firstNoticeDate;
     this.lastNoticeDate = lastNoticeDate;
@@ -335,8 +335,8 @@ public final class BondFuture
    * All of the underlying bonds must have the same notional and currency.
    * @return the value of the property, not empty
    */
-  public ImmutableList<Double> getConversionFactor() {
-    return conversionFactor;
+  public ImmutableList<Double> getConversionFactors() {
+    return conversionFactors;
   }
 
   //-----------------------------------------------------------------------
@@ -378,7 +378,7 @@ public final class BondFuture
    * <p>
    * The first date on which the underlying is delivered.
    * <p>
-   * If not specified, thw date will be computed from {@code firstNoticeDate} by using
+   * If not specified, the date will be computed from {@code firstNoticeDate} by using
    * {@code settlementDateOffset} in the first element of the delivery basket.
    * @return the optional value of the property, not null
    */
@@ -431,7 +431,7 @@ public final class BondFuture
     if (obj != null && obj.getClass() == this.getClass()) {
       BondFuture other = (BondFuture) obj;
       return JodaBeanUtils.equal(deliveryBasket, other.deliveryBasket) &&
-          JodaBeanUtils.equal(conversionFactor, other.conversionFactor) &&
+          JodaBeanUtils.equal(conversionFactors, other.conversionFactors) &&
           JodaBeanUtils.equal(lastTradeDate, other.lastTradeDate) &&
           JodaBeanUtils.equal(firstNoticeDate, other.firstNoticeDate) &&
           JodaBeanUtils.equal(lastNoticeDate, other.lastNoticeDate) &&
@@ -446,7 +446,7 @@ public final class BondFuture
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(deliveryBasket);
-    hash = hash * 31 + JodaBeanUtils.hashCode(conversionFactor);
+    hash = hash * 31 + JodaBeanUtils.hashCode(conversionFactors);
     hash = hash * 31 + JodaBeanUtils.hashCode(lastTradeDate);
     hash = hash * 31 + JodaBeanUtils.hashCode(firstNoticeDate);
     hash = hash * 31 + JodaBeanUtils.hashCode(lastNoticeDate);
@@ -461,7 +461,7 @@ public final class BondFuture
     StringBuilder buf = new StringBuilder(288);
     buf.append("BondFuture{");
     buf.append("deliveryBasket").append('=').append(deliveryBasket).append(',').append(' ');
-    buf.append("conversionFactor").append('=').append(conversionFactor).append(',').append(' ');
+    buf.append("conversionFactors").append('=').append(conversionFactors).append(',').append(' ');
     buf.append("lastTradeDate").append('=').append(lastTradeDate).append(',').append(' ');
     buf.append("firstNoticeDate").append('=').append(firstNoticeDate).append(',').append(' ');
     buf.append("lastNoticeDate").append('=').append(lastNoticeDate).append(',').append(' ');
@@ -489,11 +489,11 @@ public final class BondFuture
     private final MetaProperty<ImmutableList<SecurityLink<FixedCouponBond>>> deliveryBasket = DirectMetaProperty.ofImmutable(
         this, "deliveryBasket", BondFuture.class, (Class) ImmutableList.class);
     /**
-     * The meta-property for the {@code conversionFactor} property.
+     * The meta-property for the {@code conversionFactors} property.
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
-    private final MetaProperty<ImmutableList<Double>> conversionFactor = DirectMetaProperty.ofImmutable(
-        this, "conversionFactor", BondFuture.class, (Class) ImmutableList.class);
+    private final MetaProperty<ImmutableList<Double>> conversionFactors = DirectMetaProperty.ofImmutable(
+        this, "conversionFactors", BondFuture.class, (Class) ImmutableList.class);
     /**
      * The meta-property for the {@code lastTradeDate} property.
      */
@@ -530,7 +530,7 @@ public final class BondFuture
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "deliveryBasket",
-        "conversionFactor",
+        "conversionFactors",
         "lastTradeDate",
         "firstNoticeDate",
         "lastNoticeDate",
@@ -549,8 +549,8 @@ public final class BondFuture
       switch (propertyName.hashCode()) {
         case 1999764186:  // deliveryBasket
           return deliveryBasket;
-        case 1438876165:  // conversionFactor
-          return conversionFactor;
+        case 1655488270:  // conversionFactors
+          return conversionFactors;
         case -1041950404:  // lastTradeDate
           return lastTradeDate;
         case -1085415050:  // firstNoticeDate
@@ -592,11 +592,11 @@ public final class BondFuture
     }
 
     /**
-     * The meta-property for the {@code conversionFactor} property.
+     * The meta-property for the {@code conversionFactors} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<ImmutableList<Double>> conversionFactor() {
-      return conversionFactor;
+    public MetaProperty<ImmutableList<Double>> conversionFactors() {
+      return conversionFactors;
     }
 
     /**
@@ -653,8 +653,8 @@ public final class BondFuture
       switch (propertyName.hashCode()) {
         case 1999764186:  // deliveryBasket
           return ((BondFuture) bean).getDeliveryBasket();
-        case 1438876165:  // conversionFactor
-          return ((BondFuture) bean).getConversionFactor();
+        case 1655488270:  // conversionFactors
+          return ((BondFuture) bean).getConversionFactors();
         case -1041950404:  // lastTradeDate
           return ((BondFuture) bean).getLastTradeDate();
         case -1085415050:  // firstNoticeDate
@@ -689,7 +689,7 @@ public final class BondFuture
   public static final class Builder extends DirectFieldsBeanBuilder<BondFuture> {
 
     private List<SecurityLink<FixedCouponBond>> deliveryBasket = ImmutableList.of();
-    private List<Double> conversionFactor = ImmutableList.of();
+    private List<Double> conversionFactors = ImmutableList.of();
     private LocalDate lastTradeDate;
     private LocalDate firstNoticeDate;
     private LocalDate lastNoticeDate;
@@ -710,7 +710,7 @@ public final class BondFuture
      */
     private Builder(BondFuture beanToCopy) {
       this.deliveryBasket = beanToCopy.getDeliveryBasket();
-      this.conversionFactor = beanToCopy.getConversionFactor();
+      this.conversionFactors = beanToCopy.getConversionFactors();
       this.lastTradeDate = beanToCopy.getLastTradeDate();
       this.firstNoticeDate = beanToCopy.getFirstNoticeDate();
       this.lastNoticeDate = beanToCopy.getLastNoticeDate();
@@ -725,8 +725,8 @@ public final class BondFuture
       switch (propertyName.hashCode()) {
         case 1999764186:  // deliveryBasket
           return deliveryBasket;
-        case 1438876165:  // conversionFactor
-          return conversionFactor;
+        case 1655488270:  // conversionFactors
+          return conversionFactors;
         case -1041950404:  // lastTradeDate
           return lastTradeDate;
         case -1085415050:  // firstNoticeDate
@@ -751,8 +751,8 @@ public final class BondFuture
         case 1999764186:  // deliveryBasket
           this.deliveryBasket = (List<SecurityLink<FixedCouponBond>>) newValue;
           break;
-        case 1438876165:  // conversionFactor
-          this.conversionFactor = (List<Double>) newValue;
+        case 1655488270:  // conversionFactors
+          this.conversionFactors = (List<Double>) newValue;
           break;
         case -1041950404:  // lastTradeDate
           this.lastTradeDate = (LocalDate) newValue;
@@ -806,7 +806,7 @@ public final class BondFuture
     public BondFuture build() {
       return new BondFuture(
           deliveryBasket,
-          conversionFactor,
+          conversionFactors,
           lastTradeDate,
           firstNoticeDate,
           lastNoticeDate,
@@ -849,23 +849,23 @@ public final class BondFuture
      * This must not be empty, and its size must be the same as the size of {@code deliveryBasket}.
      * <p>
      * All of the underlying bonds must have the same notional and currency.
-     * @param conversionFactor  the new value, not empty
+     * @param conversionFactors  the new value, not empty
      * @return this, for chaining, not null
      */
-    public Builder conversionFactor(List<Double> conversionFactor) {
-      JodaBeanUtils.notEmpty(conversionFactor, "conversionFactor");
-      this.conversionFactor = conversionFactor;
+    public Builder conversionFactors(List<Double> conversionFactors) {
+      JodaBeanUtils.notEmpty(conversionFactors, "conversionFactors");
+      this.conversionFactors = conversionFactors;
       return this;
     }
 
     /**
-     * Sets the {@code conversionFactor} property in the builder
+     * Sets the {@code conversionFactors} property in the builder
      * from an array of objects.
-     * @param conversionFactor  the new value, not empty
+     * @param conversionFactors  the new value, not empty
      * @return this, for chaining, not null
      */
-    public Builder conversionFactor(Double... conversionFactor) {
-      return conversionFactor(ImmutableList.copyOf(conversionFactor));
+    public Builder conversionFactors(Double... conversionFactors) {
+      return conversionFactors(ImmutableList.copyOf(conversionFactors));
     }
 
     /**
@@ -912,7 +912,7 @@ public final class BondFuture
      * <p>
      * The first date on which the underlying is delivered.
      * <p>
-     * If not specified, thw date will be computed from {@code firstNoticeDate} by using
+     * If not specified, the date will be computed from {@code firstNoticeDate} by using
      * {@code settlementDateOffset} in the first element of the delivery basket.
      * @param firstDeliveryDate  the new value
      * @return this, for chaining, not null
@@ -959,7 +959,7 @@ public final class BondFuture
       StringBuilder buf = new StringBuilder(288);
       buf.append("BondFuture.Builder{");
       buf.append("deliveryBasket").append('=').append(JodaBeanUtils.toString(deliveryBasket)).append(',').append(' ');
-      buf.append("conversionFactor").append('=').append(JodaBeanUtils.toString(conversionFactor)).append(',').append(' ');
+      buf.append("conversionFactors").append('=').append(JodaBeanUtils.toString(conversionFactors)).append(',').append(' ');
       buf.append("lastTradeDate").append('=').append(JodaBeanUtils.toString(lastTradeDate)).append(',').append(' ');
       buf.append("firstNoticeDate").append('=').append(JodaBeanUtils.toString(firstNoticeDate)).append(',').append(' ');
       buf.append("lastNoticeDate").append('=').append(JodaBeanUtils.toString(lastNoticeDate)).append(',').append(' ');

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/BondFutureOptionTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/BondFutureOptionTrade.java
@@ -74,7 +74,7 @@ public final class BondFutureOptionTrade
    * This property should be set if the option has daily margining.
    */
   @PropertyDefinition(get = "optional")
-  private final Double initialPrice;
+  private final Double price;
 
   //-------------------------------------------------------------------------
   @SuppressWarnings({"rawtypes", "unchecked"})
@@ -96,7 +96,7 @@ public final class BondFutureOptionTrade
         .product(getProduct().resolve(refData))
         .securityStandardId(getSecurity().getStandardId())
         .quantity(quantity)
-        .initialPrice(initialPrice)
+        .price(price)
         .build();
   }
 
@@ -131,12 +131,12 @@ public final class BondFutureOptionTrade
       TradeInfo tradeInfo,
       SecurityLink<BondFutureOption> securityLink,
       long quantity,
-      Double initialPrice) {
+      Double price) {
     JodaBeanUtils.notNull(securityLink, "securityLink");
     this.tradeInfo = tradeInfo;
     this.securityLink = securityLink;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -200,8 +200,8 @@ public final class BondFutureOptionTrade
    * This property should be set if the option has daily margining.
    * @return the optional value of the property, not null
    */
-  public OptionalDouble getInitialPrice() {
-    return initialPrice != null ? OptionalDouble.of(initialPrice) : OptionalDouble.empty();
+  public OptionalDouble getPrice() {
+    return price != null ? OptionalDouble.of(price) : OptionalDouble.empty();
   }
 
   //-----------------------------------------------------------------------
@@ -223,7 +223,7 @@ public final class BondFutureOptionTrade
       return JodaBeanUtils.equal(tradeInfo, other.tradeInfo) &&
           JodaBeanUtils.equal(securityLink, other.securityLink) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -234,7 +234,7 @@ public final class BondFutureOptionTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(tradeInfo);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityLink);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -245,7 +245,7 @@ public final class BondFutureOptionTrade
     buf.append("tradeInfo").append('=').append(tradeInfo).append(',').append(' ');
     buf.append("securityLink").append('=').append(securityLink).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -277,10 +277,10 @@ public final class BondFutureOptionTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", BondFutureOptionTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", BondFutureOptionTrade.class, Double.class);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", BondFutureOptionTrade.class, Double.class);
     /**
      * The meta-properties.
      */
@@ -289,7 +289,7 @@ public final class BondFutureOptionTrade
         "tradeInfo",
         "securityLink",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -306,8 +306,8 @@ public final class BondFutureOptionTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -353,11 +353,11 @@ public final class BondFutureOptionTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -370,8 +370,8 @@ public final class BondFutureOptionTrade
           return ((BondFutureOptionTrade) bean).getSecurityLink();
         case -1285004149:  // quantity
           return ((BondFutureOptionTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((BondFutureOptionTrade) bean).initialPrice;
+        case 106934601:  // price
+          return ((BondFutureOptionTrade) bean).price;
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -396,7 +396,7 @@ public final class BondFutureOptionTrade
     private TradeInfo tradeInfo;
     private SecurityLink<BondFutureOption> securityLink;
     private long quantity;
-    private Double initialPrice;
+    private Double price;
 
     /**
      * Restricted constructor.
@@ -413,7 +413,7 @@ public final class BondFutureOptionTrade
       this.tradeInfo = beanToCopy.getTradeInfo();
       this.securityLink = beanToCopy.getSecurityLink();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.initialPrice;
+      this.price = beanToCopy.price;
     }
 
     //-----------------------------------------------------------------------
@@ -426,8 +426,8 @@ public final class BondFutureOptionTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -446,8 +446,8 @@ public final class BondFutureOptionTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -485,7 +485,7 @@ public final class BondFutureOptionTrade
           tradeInfo,
           securityLink,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -534,11 +534,11 @@ public final class BondFutureOptionTrade
      * This is the price agreed when the trade occurred.
      * <p>
      * This property should be set if the option has daily margining.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(Double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(Double price) {
+      this.price = price;
       return this;
     }
 
@@ -550,7 +550,7 @@ public final class BondFutureOptionTrade
       buf.append("tradeInfo").append('=').append(JodaBeanUtils.toString(tradeInfo)).append(',').append(' ');
       buf.append("securityLink").append('=').append(JodaBeanUtils.toString(securityLink)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/BondFutureTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/BondFutureTrade.java
@@ -73,7 +73,7 @@ public final class BondFutureTrade
    * This is the price agreed when the trade occurred.
    */
   @PropertyDefinition
-  private final double initialPrice;
+  private final double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -94,7 +94,7 @@ public final class BondFutureTrade
         .product(getProduct().resolve(refData))
         .securityStandardId(getSecurity().getStandardId())
         .quantity(quantity)
-        .initialPrice(initialPrice)
+        .price(price)
         .build();
   }
 
@@ -129,12 +129,12 @@ public final class BondFutureTrade
       TradeInfo tradeInfo,
       SecurityLink<BondFuture> securityLink,
       long quantity,
-      double initialPrice) {
+      double price) {
     JodaBeanUtils.notNull(securityLink, "securityLink");
     this.tradeInfo = tradeInfo;
     this.securityLink = securityLink;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -196,8 +196,8 @@ public final class BondFutureTrade
    * This is the price agreed when the trade occurred.
    * @return the value of the property
    */
-  public double getInitialPrice() {
-    return initialPrice;
+  public double getPrice() {
+    return price;
   }
 
   //-----------------------------------------------------------------------
@@ -219,7 +219,7 @@ public final class BondFutureTrade
       return JodaBeanUtils.equal(tradeInfo, other.tradeInfo) &&
           JodaBeanUtils.equal(securityLink, other.securityLink) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -230,7 +230,7 @@ public final class BondFutureTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(tradeInfo);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityLink);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -241,7 +241,7 @@ public final class BondFutureTrade
     buf.append("tradeInfo").append('=').append(tradeInfo).append(',').append(' ');
     buf.append("securityLink").append('=').append(securityLink).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -273,10 +273,10 @@ public final class BondFutureTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", BondFutureTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", BondFutureTrade.class, Double.TYPE);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", BondFutureTrade.class, Double.TYPE);
     /**
      * The meta-properties.
      */
@@ -285,7 +285,7 @@ public final class BondFutureTrade
         "tradeInfo",
         "securityLink",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -302,8 +302,8 @@ public final class BondFutureTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -349,11 +349,11 @@ public final class BondFutureTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -366,8 +366,8 @@ public final class BondFutureTrade
           return ((BondFutureTrade) bean).getSecurityLink();
         case -1285004149:  // quantity
           return ((BondFutureTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((BondFutureTrade) bean).getInitialPrice();
+        case 106934601:  // price
+          return ((BondFutureTrade) bean).getPrice();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -392,7 +392,7 @@ public final class BondFutureTrade
     private TradeInfo tradeInfo;
     private SecurityLink<BondFuture> securityLink;
     private long quantity;
-    private double initialPrice;
+    private double price;
 
     /**
      * Restricted constructor.
@@ -409,7 +409,7 @@ public final class BondFutureTrade
       this.tradeInfo = beanToCopy.getTradeInfo();
       this.securityLink = beanToCopy.getSecurityLink();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.getInitialPrice();
+      this.price = beanToCopy.getPrice();
     }
 
     //-----------------------------------------------------------------------
@@ -422,8 +422,8 @@ public final class BondFutureTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -442,8 +442,8 @@ public final class BondFutureTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -481,7 +481,7 @@ public final class BondFutureTrade
           tradeInfo,
           securityLink,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -528,11 +528,11 @@ public final class BondFutureTrade
      * Sets the price that was traded, in decimal form.
      * <p>
      * This is the price agreed when the trade occurred.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(double price) {
+      this.price = price;
       return this;
     }
 
@@ -544,7 +544,7 @@ public final class BondFutureTrade
       buf.append("tradeInfo").append('=').append(JodaBeanUtils.toString(tradeInfo)).append(',').append(' ');
       buf.append("securityLink").append('=').append(JodaBeanUtils.toString(securityLink)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedBondFuture.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedBondFuture.java
@@ -71,7 +71,7 @@ public final class ResolvedBondFuture
    * All of the underlying bonds must have the same notional and currency.
    */
   @PropertyDefinition(validate = "notEmpty")
-  private final ImmutableList<Double> conversionFactor;
+  private final ImmutableList<Double> conversionFactors;
   /**
    * The last trading date.
    * <p>
@@ -131,7 +131,7 @@ public final class ResolvedBondFuture
   @ImmutableValidator
   private void validate() {
     int size = deliveryBasket.size();
-    ArgChecker.isTrue(size == conversionFactor.size(),
+    ArgChecker.isTrue(size == conversionFactors.size(),
         "The delivery basket size should be the same as the conversion factor size");
     ArgChecker.inOrderOrEqual(firstNoticeDate, lastNoticeDate, "firstNoticeDate", "lastNoticeDate");
     ArgChecker.inOrderOrEqual(firstDeliveryDate, lastDeliveryDate, "firstDeliveryDate", "lastDeliveryDate");
@@ -200,7 +200,7 @@ public final class ResolvedBondFuture
 
   private ResolvedBondFuture(
       List<Pair<ResolvedFixedCouponBond, StandardId>> deliveryBasket,
-      List<Double> conversionFactor,
+      List<Double> conversionFactors,
       LocalDate lastTradeDate,
       LocalDate firstNoticeDate,
       LocalDate lastNoticeDate,
@@ -208,7 +208,7 @@ public final class ResolvedBondFuture
       LocalDate lastDeliveryDate,
       Rounding rounding) {
     JodaBeanUtils.notEmpty(deliveryBasket, "deliveryBasket");
-    JodaBeanUtils.notEmpty(conversionFactor, "conversionFactor");
+    JodaBeanUtils.notEmpty(conversionFactors, "conversionFactors");
     JodaBeanUtils.notNull(lastTradeDate, "lastTradeDate");
     JodaBeanUtils.notNull(firstNoticeDate, "firstNoticeDate");
     JodaBeanUtils.notNull(lastNoticeDate, "lastNoticeDate");
@@ -216,7 +216,7 @@ public final class ResolvedBondFuture
     JodaBeanUtils.notNull(lastDeliveryDate, "lastDeliveryDate");
     JodaBeanUtils.notNull(rounding, "rounding");
     this.deliveryBasket = ImmutableList.copyOf(deliveryBasket);
-    this.conversionFactor = ImmutableList.copyOf(conversionFactor);
+    this.conversionFactors = ImmutableList.copyOf(conversionFactors);
     this.lastTradeDate = lastTradeDate;
     this.firstNoticeDate = firstNoticeDate;
     this.lastNoticeDate = lastNoticeDate;
@@ -265,8 +265,8 @@ public final class ResolvedBondFuture
    * All of the underlying bonds must have the same notional and currency.
    * @return the value of the property, not empty
    */
-  public ImmutableList<Double> getConversionFactor() {
-    return conversionFactor;
+  public ImmutableList<Double> getConversionFactors() {
+    return conversionFactors;
   }
 
   //-----------------------------------------------------------------------
@@ -359,7 +359,7 @@ public final class ResolvedBondFuture
     if (obj != null && obj.getClass() == this.getClass()) {
       ResolvedBondFuture other = (ResolvedBondFuture) obj;
       return JodaBeanUtils.equal(deliveryBasket, other.deliveryBasket) &&
-          JodaBeanUtils.equal(conversionFactor, other.conversionFactor) &&
+          JodaBeanUtils.equal(conversionFactors, other.conversionFactors) &&
           JodaBeanUtils.equal(lastTradeDate, other.lastTradeDate) &&
           JodaBeanUtils.equal(firstNoticeDate, other.firstNoticeDate) &&
           JodaBeanUtils.equal(lastNoticeDate, other.lastNoticeDate) &&
@@ -374,7 +374,7 @@ public final class ResolvedBondFuture
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(deliveryBasket);
-    hash = hash * 31 + JodaBeanUtils.hashCode(conversionFactor);
+    hash = hash * 31 + JodaBeanUtils.hashCode(conversionFactors);
     hash = hash * 31 + JodaBeanUtils.hashCode(lastTradeDate);
     hash = hash * 31 + JodaBeanUtils.hashCode(firstNoticeDate);
     hash = hash * 31 + JodaBeanUtils.hashCode(lastNoticeDate);
@@ -389,7 +389,7 @@ public final class ResolvedBondFuture
     StringBuilder buf = new StringBuilder(288);
     buf.append("ResolvedBondFuture{");
     buf.append("deliveryBasket").append('=').append(deliveryBasket).append(',').append(' ');
-    buf.append("conversionFactor").append('=').append(conversionFactor).append(',').append(' ');
+    buf.append("conversionFactors").append('=').append(conversionFactors).append(',').append(' ');
     buf.append("lastTradeDate").append('=').append(lastTradeDate).append(',').append(' ');
     buf.append("firstNoticeDate").append('=').append(firstNoticeDate).append(',').append(' ');
     buf.append("lastNoticeDate").append('=').append(lastNoticeDate).append(',').append(' ');
@@ -417,11 +417,11 @@ public final class ResolvedBondFuture
     private final MetaProperty<ImmutableList<Pair<ResolvedFixedCouponBond, StandardId>>> deliveryBasket = DirectMetaProperty.ofImmutable(
         this, "deliveryBasket", ResolvedBondFuture.class, (Class) ImmutableList.class);
     /**
-     * The meta-property for the {@code conversionFactor} property.
+     * The meta-property for the {@code conversionFactors} property.
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
-    private final MetaProperty<ImmutableList<Double>> conversionFactor = DirectMetaProperty.ofImmutable(
-        this, "conversionFactor", ResolvedBondFuture.class, (Class) ImmutableList.class);
+    private final MetaProperty<ImmutableList<Double>> conversionFactors = DirectMetaProperty.ofImmutable(
+        this, "conversionFactors", ResolvedBondFuture.class, (Class) ImmutableList.class);
     /**
      * The meta-property for the {@code lastTradeDate} property.
      */
@@ -458,7 +458,7 @@ public final class ResolvedBondFuture
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "deliveryBasket",
-        "conversionFactor",
+        "conversionFactors",
         "lastTradeDate",
         "firstNoticeDate",
         "lastNoticeDate",
@@ -477,8 +477,8 @@ public final class ResolvedBondFuture
       switch (propertyName.hashCode()) {
         case 1999764186:  // deliveryBasket
           return deliveryBasket;
-        case 1438876165:  // conversionFactor
-          return conversionFactor;
+        case 1655488270:  // conversionFactors
+          return conversionFactors;
         case -1041950404:  // lastTradeDate
           return lastTradeDate;
         case -1085415050:  // firstNoticeDate
@@ -520,11 +520,11 @@ public final class ResolvedBondFuture
     }
 
     /**
-     * The meta-property for the {@code conversionFactor} property.
+     * The meta-property for the {@code conversionFactors} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<ImmutableList<Double>> conversionFactor() {
-      return conversionFactor;
+    public MetaProperty<ImmutableList<Double>> conversionFactors() {
+      return conversionFactors;
     }
 
     /**
@@ -581,8 +581,8 @@ public final class ResolvedBondFuture
       switch (propertyName.hashCode()) {
         case 1999764186:  // deliveryBasket
           return ((ResolvedBondFuture) bean).getDeliveryBasket();
-        case 1438876165:  // conversionFactor
-          return ((ResolvedBondFuture) bean).getConversionFactor();
+        case 1655488270:  // conversionFactors
+          return ((ResolvedBondFuture) bean).getConversionFactors();
         case -1041950404:  // lastTradeDate
           return ((ResolvedBondFuture) bean).getLastTradeDate();
         case -1085415050:  // firstNoticeDate
@@ -617,7 +617,7 @@ public final class ResolvedBondFuture
   public static final class Builder extends DirectFieldsBeanBuilder<ResolvedBondFuture> {
 
     private List<Pair<ResolvedFixedCouponBond, StandardId>> deliveryBasket = ImmutableList.of();
-    private List<Double> conversionFactor = ImmutableList.of();
+    private List<Double> conversionFactors = ImmutableList.of();
     private LocalDate lastTradeDate;
     private LocalDate firstNoticeDate;
     private LocalDate lastNoticeDate;
@@ -638,7 +638,7 @@ public final class ResolvedBondFuture
      */
     private Builder(ResolvedBondFuture beanToCopy) {
       this.deliveryBasket = beanToCopy.getDeliveryBasket();
-      this.conversionFactor = beanToCopy.getConversionFactor();
+      this.conversionFactors = beanToCopy.getConversionFactors();
       this.lastTradeDate = beanToCopy.getLastTradeDate();
       this.firstNoticeDate = beanToCopy.getFirstNoticeDate();
       this.lastNoticeDate = beanToCopy.getLastNoticeDate();
@@ -653,8 +653,8 @@ public final class ResolvedBondFuture
       switch (propertyName.hashCode()) {
         case 1999764186:  // deliveryBasket
           return deliveryBasket;
-        case 1438876165:  // conversionFactor
-          return conversionFactor;
+        case 1655488270:  // conversionFactors
+          return conversionFactors;
         case -1041950404:  // lastTradeDate
           return lastTradeDate;
         case -1085415050:  // firstNoticeDate
@@ -679,8 +679,8 @@ public final class ResolvedBondFuture
         case 1999764186:  // deliveryBasket
           this.deliveryBasket = (List<Pair<ResolvedFixedCouponBond, StandardId>>) newValue;
           break;
-        case 1438876165:  // conversionFactor
-          this.conversionFactor = (List<Double>) newValue;
+        case 1655488270:  // conversionFactors
+          this.conversionFactors = (List<Double>) newValue;
           break;
         case -1041950404:  // lastTradeDate
           this.lastTradeDate = (LocalDate) newValue;
@@ -734,7 +734,7 @@ public final class ResolvedBondFuture
     public ResolvedBondFuture build() {
       return new ResolvedBondFuture(
           deliveryBasket,
-          conversionFactor,
+          conversionFactors,
           lastTradeDate,
           firstNoticeDate,
           lastNoticeDate,
@@ -777,23 +777,23 @@ public final class ResolvedBondFuture
      * This must not be empty, and its size must be the same as the size of {@code deliveryBasket}.
      * <p>
      * All of the underlying bonds must have the same notional and currency.
-     * @param conversionFactor  the new value, not empty
+     * @param conversionFactors  the new value, not empty
      * @return this, for chaining, not null
      */
-    public Builder conversionFactor(List<Double> conversionFactor) {
-      JodaBeanUtils.notEmpty(conversionFactor, "conversionFactor");
-      this.conversionFactor = conversionFactor;
+    public Builder conversionFactors(List<Double> conversionFactors) {
+      JodaBeanUtils.notEmpty(conversionFactors, "conversionFactors");
+      this.conversionFactors = conversionFactors;
       return this;
     }
 
     /**
-     * Sets the {@code conversionFactor} property in the builder
+     * Sets the {@code conversionFactors} property in the builder
      * from an array of objects.
-     * @param conversionFactor  the new value, not empty
+     * @param conversionFactors  the new value, not empty
      * @return this, for chaining, not null
      */
-    public Builder conversionFactor(Double... conversionFactor) {
-      return conversionFactor(ImmutableList.copyOf(conversionFactor));
+    public Builder conversionFactors(Double... conversionFactors) {
+      return conversionFactors(ImmutableList.copyOf(conversionFactors));
     }
 
     /**
@@ -887,7 +887,7 @@ public final class ResolvedBondFuture
       StringBuilder buf = new StringBuilder(288);
       buf.append("ResolvedBondFuture.Builder{");
       buf.append("deliveryBasket").append('=').append(JodaBeanUtils.toString(deliveryBasket)).append(',').append(' ');
-      buf.append("conversionFactor").append('=').append(JodaBeanUtils.toString(conversionFactor)).append(',').append(' ');
+      buf.append("conversionFactors").append('=').append(JodaBeanUtils.toString(conversionFactors)).append(',').append(' ');
       buf.append("lastTradeDate").append('=').append(JodaBeanUtils.toString(lastTradeDate)).append(',').append(' ');
       buf.append("firstNoticeDate").append('=').append(JodaBeanUtils.toString(firstNoticeDate)).append(',').append(' ');
       buf.append("lastNoticeDate").append('=').append(JodaBeanUtils.toString(lastNoticeDate)).append(',').append(' ');

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedBondFutureOptionTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedBondFutureOptionTrade.java
@@ -79,7 +79,7 @@ public final class ResolvedBondFutureOptionTrade
    * This property should be set if the option has daily margining.
    */
   @PropertyDefinition(get = "optional")
-  private final Double initialPrice;
+  private final Double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -119,14 +119,14 @@ public final class ResolvedBondFutureOptionTrade
       ResolvedBondFutureOption product,
       StandardId securityStandardId,
       long quantity,
-      Double initialPrice) {
+      Double price) {
     JodaBeanUtils.notNull(product, "product");
     JodaBeanUtils.notNull(securityStandardId, "securityStandardId");
     this.tradeInfo = tradeInfo;
     this.product = product;
     this.securityStandardId = securityStandardId;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -198,8 +198,8 @@ public final class ResolvedBondFutureOptionTrade
    * This property should be set if the option has daily margining.
    * @return the optional value of the property, not null
    */
-  public OptionalDouble getInitialPrice() {
-    return initialPrice != null ? OptionalDouble.of(initialPrice) : OptionalDouble.empty();
+  public OptionalDouble getPrice() {
+    return price != null ? OptionalDouble.of(price) : OptionalDouble.empty();
   }
 
   //-----------------------------------------------------------------------
@@ -222,7 +222,7 @@ public final class ResolvedBondFutureOptionTrade
           JodaBeanUtils.equal(product, other.product) &&
           JodaBeanUtils.equal(securityStandardId, other.securityStandardId) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -234,7 +234,7 @@ public final class ResolvedBondFutureOptionTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(product);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityStandardId);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -246,7 +246,7 @@ public final class ResolvedBondFutureOptionTrade
     buf.append("product").append('=').append(product).append(',').append(' ');
     buf.append("securityStandardId").append('=').append(securityStandardId).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -282,10 +282,10 @@ public final class ResolvedBondFutureOptionTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", ResolvedBondFutureOptionTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", ResolvedBondFutureOptionTrade.class, Double.class);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", ResolvedBondFutureOptionTrade.class, Double.class);
     /**
      * The meta-properties.
      */
@@ -295,7 +295,7 @@ public final class ResolvedBondFutureOptionTrade
         "product",
         "securityStandardId",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -314,8 +314,8 @@ public final class ResolvedBondFutureOptionTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -369,11 +369,11 @@ public final class ResolvedBondFutureOptionTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -388,8 +388,8 @@ public final class ResolvedBondFutureOptionTrade
           return ((ResolvedBondFutureOptionTrade) bean).getSecurityStandardId();
         case -1285004149:  // quantity
           return ((ResolvedBondFutureOptionTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((ResolvedBondFutureOptionTrade) bean).initialPrice;
+        case 106934601:  // price
+          return ((ResolvedBondFutureOptionTrade) bean).price;
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -415,7 +415,7 @@ public final class ResolvedBondFutureOptionTrade
     private ResolvedBondFutureOption product;
     private StandardId securityStandardId;
     private long quantity;
-    private Double initialPrice;
+    private Double price;
 
     /**
      * Restricted constructor.
@@ -433,7 +433,7 @@ public final class ResolvedBondFutureOptionTrade
       this.product = beanToCopy.getProduct();
       this.securityStandardId = beanToCopy.getSecurityStandardId();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.initialPrice;
+      this.price = beanToCopy.price;
     }
 
     //-----------------------------------------------------------------------
@@ -448,8 +448,8 @@ public final class ResolvedBondFutureOptionTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -470,8 +470,8 @@ public final class ResolvedBondFutureOptionTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -510,7 +510,7 @@ public final class ResolvedBondFutureOptionTrade
           product,
           securityStandardId,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -569,11 +569,11 @@ public final class ResolvedBondFutureOptionTrade
      * This is the price agreed when the trade occurred.
      * <p>
      * This property should be set if the option has daily margining.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(Double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(Double price) {
+      this.price = price;
       return this;
     }
 
@@ -586,7 +586,7 @@ public final class ResolvedBondFutureOptionTrade
       buf.append("product").append('=').append(JodaBeanUtils.toString(product)).append(',').append(' ');
       buf.append("securityStandardId").append('=').append(JodaBeanUtils.toString(securityStandardId)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedBondFutureTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedBondFutureTrade.java
@@ -76,7 +76,7 @@ public final class ResolvedBondFutureTrade
    * This is the price agreed when the trade occurred.
    */
   @PropertyDefinition
-  private final double initialPrice;
+  private final double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -116,14 +116,14 @@ public final class ResolvedBondFutureTrade
       ResolvedBondFuture product,
       StandardId securityStandardId,
       long quantity,
-      double initialPrice) {
+      double price) {
     JodaBeanUtils.notNull(product, "product");
     JodaBeanUtils.notNull(securityStandardId, "securityStandardId");
     this.tradeInfo = tradeInfo;
     this.product = product;
     this.securityStandardId = securityStandardId;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -193,8 +193,8 @@ public final class ResolvedBondFutureTrade
    * This is the price agreed when the trade occurred.
    * @return the value of the property
    */
-  public double getInitialPrice() {
-    return initialPrice;
+  public double getPrice() {
+    return price;
   }
 
   //-----------------------------------------------------------------------
@@ -217,7 +217,7 @@ public final class ResolvedBondFutureTrade
           JodaBeanUtils.equal(product, other.product) &&
           JodaBeanUtils.equal(securityStandardId, other.securityStandardId) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -229,7 +229,7 @@ public final class ResolvedBondFutureTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(product);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityStandardId);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -241,7 +241,7 @@ public final class ResolvedBondFutureTrade
     buf.append("product").append('=').append(product).append(',').append(' ');
     buf.append("securityStandardId").append('=').append(securityStandardId).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -277,10 +277,10 @@ public final class ResolvedBondFutureTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", ResolvedBondFutureTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", ResolvedBondFutureTrade.class, Double.TYPE);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", ResolvedBondFutureTrade.class, Double.TYPE);
     /**
      * The meta-properties.
      */
@@ -290,7 +290,7 @@ public final class ResolvedBondFutureTrade
         "product",
         "securityStandardId",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -309,8 +309,8 @@ public final class ResolvedBondFutureTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -364,11 +364,11 @@ public final class ResolvedBondFutureTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -383,8 +383,8 @@ public final class ResolvedBondFutureTrade
           return ((ResolvedBondFutureTrade) bean).getSecurityStandardId();
         case -1285004149:  // quantity
           return ((ResolvedBondFutureTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((ResolvedBondFutureTrade) bean).getInitialPrice();
+        case 106934601:  // price
+          return ((ResolvedBondFutureTrade) bean).getPrice();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -410,7 +410,7 @@ public final class ResolvedBondFutureTrade
     private ResolvedBondFuture product;
     private StandardId securityStandardId;
     private long quantity;
-    private double initialPrice;
+    private double price;
 
     /**
      * Restricted constructor.
@@ -428,7 +428,7 @@ public final class ResolvedBondFutureTrade
       this.product = beanToCopy.getProduct();
       this.securityStandardId = beanToCopy.getSecurityStandardId();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.getInitialPrice();
+      this.price = beanToCopy.getPrice();
     }
 
     //-----------------------------------------------------------------------
@@ -443,8 +443,8 @@ public final class ResolvedBondFutureTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -465,8 +465,8 @@ public final class ResolvedBondFutureTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -505,7 +505,7 @@ public final class ResolvedBondFutureTrade
           product,
           securityStandardId,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -562,11 +562,11 @@ public final class ResolvedBondFutureTrade
      * Sets the price that was traded, in decimal form.
      * <p>
      * This is the price agreed when the trade occurred.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(double price) {
+      this.price = price;
       return this;
     }
 
@@ -579,7 +579,7 @@ public final class ResolvedBondFutureTrade
       buf.append("product").append('=').append(JodaBeanUtils.toString(product)).append(',').append(' ');
       buf.append("securityStandardId").append('=').append(JodaBeanUtils.toString(securityStandardId)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/IborFutureOptionTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/IborFutureOptionTrade.java
@@ -76,7 +76,7 @@ public final class IborFutureOptionTrade
    * This property should be set if the option has daily margining.
    */
   @PropertyDefinition(get = "optional")
-  private final Double initialPrice;
+  private final Double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -97,7 +97,7 @@ public final class IborFutureOptionTrade
         .product(getProduct().resolve(refData))
         .securityStandardId(getSecurity().getStandardId())
         .quantity(quantity)
-        .initialPrice(initialPrice)
+        .price(price)
         .build();
   }
 
@@ -132,12 +132,12 @@ public final class IborFutureOptionTrade
       TradeInfo tradeInfo,
       SecurityLink<IborFutureOption> securityLink,
       long quantity,
-      Double initialPrice) {
+      Double price) {
     JodaBeanUtils.notNull(securityLink, "securityLink");
     this.tradeInfo = tradeInfo;
     this.securityLink = securityLink;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -201,8 +201,8 @@ public final class IborFutureOptionTrade
    * This property should be set if the option has daily margining.
    * @return the optional value of the property, not null
    */
-  public OptionalDouble getInitialPrice() {
-    return initialPrice != null ? OptionalDouble.of(initialPrice) : OptionalDouble.empty();
+  public OptionalDouble getPrice() {
+    return price != null ? OptionalDouble.of(price) : OptionalDouble.empty();
   }
 
   //-----------------------------------------------------------------------
@@ -224,7 +224,7 @@ public final class IborFutureOptionTrade
       return JodaBeanUtils.equal(tradeInfo, other.tradeInfo) &&
           JodaBeanUtils.equal(securityLink, other.securityLink) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -235,7 +235,7 @@ public final class IborFutureOptionTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(tradeInfo);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityLink);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -246,7 +246,7 @@ public final class IborFutureOptionTrade
     buf.append("tradeInfo").append('=').append(tradeInfo).append(',').append(' ');
     buf.append("securityLink").append('=').append(securityLink).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -278,10 +278,10 @@ public final class IborFutureOptionTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", IborFutureOptionTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", IborFutureOptionTrade.class, Double.class);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", IborFutureOptionTrade.class, Double.class);
     /**
      * The meta-properties.
      */
@@ -290,7 +290,7 @@ public final class IborFutureOptionTrade
         "tradeInfo",
         "securityLink",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -307,8 +307,8 @@ public final class IborFutureOptionTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -354,11 +354,11 @@ public final class IborFutureOptionTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -371,8 +371,8 @@ public final class IborFutureOptionTrade
           return ((IborFutureOptionTrade) bean).getSecurityLink();
         case -1285004149:  // quantity
           return ((IborFutureOptionTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((IborFutureOptionTrade) bean).initialPrice;
+        case 106934601:  // price
+          return ((IborFutureOptionTrade) bean).price;
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -397,7 +397,7 @@ public final class IborFutureOptionTrade
     private TradeInfo tradeInfo;
     private SecurityLink<IborFutureOption> securityLink;
     private long quantity;
-    private Double initialPrice;
+    private Double price;
 
     /**
      * Restricted constructor.
@@ -414,7 +414,7 @@ public final class IborFutureOptionTrade
       this.tradeInfo = beanToCopy.getTradeInfo();
       this.securityLink = beanToCopy.getSecurityLink();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.initialPrice;
+      this.price = beanToCopy.price;
     }
 
     //-----------------------------------------------------------------------
@@ -427,8 +427,8 @@ public final class IborFutureOptionTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -447,8 +447,8 @@ public final class IborFutureOptionTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -486,7 +486,7 @@ public final class IborFutureOptionTrade
           tradeInfo,
           securityLink,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -535,11 +535,11 @@ public final class IborFutureOptionTrade
      * This is the price agreed when the trade occurred.
      * <p>
      * This property should be set if the option has daily margining.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(Double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(Double price) {
+      this.price = price;
       return this;
     }
 
@@ -551,7 +551,7 @@ public final class IborFutureOptionTrade
       buf.append("tradeInfo").append('=').append(JodaBeanUtils.toString(tradeInfo)).append(',').append(' ');
       buf.append("securityLink").append('=').append(JodaBeanUtils.toString(securityLink)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/IborFutureTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/IborFutureTrade.java
@@ -74,7 +74,7 @@ public final class IborFutureTrade
    * As such, the common market price of 99.3 for a 0.7% rate must be input as 0.993.
    */
   @PropertyDefinition
-  private final double initialPrice;
+  private final double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -95,7 +95,7 @@ public final class IborFutureTrade
         .product(getProduct().resolve(refData))
         .securityStandardId(getSecurity().getStandardId())
         .quantity(quantity)
-        .initialPrice(initialPrice)
+        .price(price)
         .build();
   }
 
@@ -130,12 +130,12 @@ public final class IborFutureTrade
       TradeInfo tradeInfo,
       SecurityLink<IborFuture> securityLink,
       long quantity,
-      double initialPrice) {
+      double price) {
     JodaBeanUtils.notNull(securityLink, "securityLink");
     this.tradeInfo = tradeInfo;
     this.securityLink = securityLink;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -199,8 +199,8 @@ public final class IborFutureTrade
    * As such, the common market price of 99.3 for a 0.7% rate must be input as 0.993.
    * @return the value of the property
    */
-  public double getInitialPrice() {
-    return initialPrice;
+  public double getPrice() {
+    return price;
   }
 
   //-----------------------------------------------------------------------
@@ -222,7 +222,7 @@ public final class IborFutureTrade
       return JodaBeanUtils.equal(tradeInfo, other.tradeInfo) &&
           JodaBeanUtils.equal(securityLink, other.securityLink) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -233,7 +233,7 @@ public final class IborFutureTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(tradeInfo);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityLink);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -244,7 +244,7 @@ public final class IborFutureTrade
     buf.append("tradeInfo").append('=').append(tradeInfo).append(',').append(' ');
     buf.append("securityLink").append('=').append(securityLink).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -276,10 +276,10 @@ public final class IborFutureTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", IborFutureTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", IborFutureTrade.class, Double.TYPE);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", IborFutureTrade.class, Double.TYPE);
     /**
      * The meta-properties.
      */
@@ -288,7 +288,7 @@ public final class IborFutureTrade
         "tradeInfo",
         "securityLink",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -305,8 +305,8 @@ public final class IborFutureTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -352,11 +352,11 @@ public final class IborFutureTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -369,8 +369,8 @@ public final class IborFutureTrade
           return ((IborFutureTrade) bean).getSecurityLink();
         case -1285004149:  // quantity
           return ((IborFutureTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((IborFutureTrade) bean).getInitialPrice();
+        case 106934601:  // price
+          return ((IborFutureTrade) bean).getPrice();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -395,7 +395,7 @@ public final class IborFutureTrade
     private TradeInfo tradeInfo;
     private SecurityLink<IborFuture> securityLink;
     private long quantity;
-    private double initialPrice;
+    private double price;
 
     /**
      * Restricted constructor.
@@ -412,7 +412,7 @@ public final class IborFutureTrade
       this.tradeInfo = beanToCopy.getTradeInfo();
       this.securityLink = beanToCopy.getSecurityLink();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.getInitialPrice();
+      this.price = beanToCopy.getPrice();
     }
 
     //-----------------------------------------------------------------------
@@ -425,8 +425,8 @@ public final class IborFutureTrade
           return securityLink;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -445,8 +445,8 @@ public final class IborFutureTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -484,7 +484,7 @@ public final class IborFutureTrade
           tradeInfo,
           securityLink,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -533,11 +533,11 @@ public final class IborFutureTrade
      * This is the price agreed when the trade occurred.
      * This must be represented in decimal form, {@code (1.0 - decimalRate)}.
      * As such, the common market price of 99.3 for a 0.7% rate must be input as 0.993.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(double price) {
+      this.price = price;
       return this;
     }
 
@@ -549,7 +549,7 @@ public final class IborFutureTrade
       buf.append("tradeInfo").append('=').append(JodaBeanUtils.toString(tradeInfo)).append(',').append(' ');
       buf.append("securityLink").append('=').append(JodaBeanUtils.toString(securityLink)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/ResolvedIborFutureOptionTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/ResolvedIborFutureOptionTrade.java
@@ -79,7 +79,7 @@ public final class ResolvedIborFutureOptionTrade
    * This property should be set if the option has daily margining.
    */
   @PropertyDefinition(get = "optional")
-  private final Double initialPrice;
+  private final Double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -119,14 +119,14 @@ public final class ResolvedIborFutureOptionTrade
       ResolvedIborFutureOption product,
       StandardId securityStandardId,
       long quantity,
-      Double initialPrice) {
+      Double price) {
     JodaBeanUtils.notNull(product, "product");
     JodaBeanUtils.notNull(securityStandardId, "securityStandardId");
     this.tradeInfo = tradeInfo;
     this.product = product;
     this.securityStandardId = securityStandardId;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -198,8 +198,8 @@ public final class ResolvedIborFutureOptionTrade
    * This property should be set if the option has daily margining.
    * @return the optional value of the property, not null
    */
-  public OptionalDouble getInitialPrice() {
-    return initialPrice != null ? OptionalDouble.of(initialPrice) : OptionalDouble.empty();
+  public OptionalDouble getPrice() {
+    return price != null ? OptionalDouble.of(price) : OptionalDouble.empty();
   }
 
   //-----------------------------------------------------------------------
@@ -222,7 +222,7 @@ public final class ResolvedIborFutureOptionTrade
           JodaBeanUtils.equal(product, other.product) &&
           JodaBeanUtils.equal(securityStandardId, other.securityStandardId) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -234,7 +234,7 @@ public final class ResolvedIborFutureOptionTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(product);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityStandardId);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -246,7 +246,7 @@ public final class ResolvedIborFutureOptionTrade
     buf.append("product").append('=').append(product).append(',').append(' ');
     buf.append("securityStandardId").append('=').append(securityStandardId).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -282,10 +282,10 @@ public final class ResolvedIborFutureOptionTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", ResolvedIborFutureOptionTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", ResolvedIborFutureOptionTrade.class, Double.class);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", ResolvedIborFutureOptionTrade.class, Double.class);
     /**
      * The meta-properties.
      */
@@ -295,7 +295,7 @@ public final class ResolvedIborFutureOptionTrade
         "product",
         "securityStandardId",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -314,8 +314,8 @@ public final class ResolvedIborFutureOptionTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -369,11 +369,11 @@ public final class ResolvedIborFutureOptionTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -388,8 +388,8 @@ public final class ResolvedIborFutureOptionTrade
           return ((ResolvedIborFutureOptionTrade) bean).getSecurityStandardId();
         case -1285004149:  // quantity
           return ((ResolvedIborFutureOptionTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((ResolvedIborFutureOptionTrade) bean).initialPrice;
+        case 106934601:  // price
+          return ((ResolvedIborFutureOptionTrade) bean).price;
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -415,7 +415,7 @@ public final class ResolvedIborFutureOptionTrade
     private ResolvedIborFutureOption product;
     private StandardId securityStandardId;
     private long quantity;
-    private Double initialPrice;
+    private Double price;
 
     /**
      * Restricted constructor.
@@ -433,7 +433,7 @@ public final class ResolvedIborFutureOptionTrade
       this.product = beanToCopy.getProduct();
       this.securityStandardId = beanToCopy.getSecurityStandardId();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.initialPrice;
+      this.price = beanToCopy.price;
     }
 
     //-----------------------------------------------------------------------
@@ -448,8 +448,8 @@ public final class ResolvedIborFutureOptionTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -470,8 +470,8 @@ public final class ResolvedIborFutureOptionTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -510,7 +510,7 @@ public final class ResolvedIborFutureOptionTrade
           product,
           securityStandardId,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -569,11 +569,11 @@ public final class ResolvedIborFutureOptionTrade
      * This is the price agreed when the trade occurred.
      * <p>
      * This property should be set if the option has daily margining.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(Double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(Double price) {
+      this.price = price;
       return this;
     }
 
@@ -586,7 +586,7 @@ public final class ResolvedIborFutureOptionTrade
       buf.append("product").append('=').append(JodaBeanUtils.toString(product)).append(',').append(' ');
       buf.append("securityStandardId").append('=').append(JodaBeanUtils.toString(securityStandardId)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/ResolvedIborFutureTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/ResolvedIborFutureTrade.java
@@ -78,7 +78,7 @@ public final class ResolvedIborFutureTrade
    * As such, the common market price of 99.3 for a 0.7% rate must be input as 0.993.
    */
   @PropertyDefinition
-  private final double initialPrice;
+  private final double price;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
@@ -118,14 +118,14 @@ public final class ResolvedIborFutureTrade
       ResolvedIborFuture product,
       StandardId securityStandardId,
       long quantity,
-      double initialPrice) {
+      double price) {
     JodaBeanUtils.notNull(product, "product");
     JodaBeanUtils.notNull(securityStandardId, "securityStandardId");
     this.tradeInfo = tradeInfo;
     this.product = product;
     this.securityStandardId = securityStandardId;
     this.quantity = quantity;
-    this.initialPrice = initialPrice;
+    this.price = price;
   }
 
   @Override
@@ -197,8 +197,8 @@ public final class ResolvedIborFutureTrade
    * As such, the common market price of 99.3 for a 0.7% rate must be input as 0.993.
    * @return the value of the property
    */
-  public double getInitialPrice() {
-    return initialPrice;
+  public double getPrice() {
+    return price;
   }
 
   //-----------------------------------------------------------------------
@@ -221,7 +221,7 @@ public final class ResolvedIborFutureTrade
           JodaBeanUtils.equal(product, other.product) &&
           JodaBeanUtils.equal(securityStandardId, other.securityStandardId) &&
           (quantity == other.quantity) &&
-          JodaBeanUtils.equal(initialPrice, other.initialPrice);
+          JodaBeanUtils.equal(price, other.price);
     }
     return false;
   }
@@ -233,7 +233,7 @@ public final class ResolvedIborFutureTrade
     hash = hash * 31 + JodaBeanUtils.hashCode(product);
     hash = hash * 31 + JodaBeanUtils.hashCode(securityStandardId);
     hash = hash * 31 + JodaBeanUtils.hashCode(quantity);
-    hash = hash * 31 + JodaBeanUtils.hashCode(initialPrice);
+    hash = hash * 31 + JodaBeanUtils.hashCode(price);
     return hash;
   }
 
@@ -245,7 +245,7 @@ public final class ResolvedIborFutureTrade
     buf.append("product").append('=').append(product).append(',').append(' ');
     buf.append("securityStandardId").append('=').append(securityStandardId).append(',').append(' ');
     buf.append("quantity").append('=').append(quantity).append(',').append(' ');
-    buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+    buf.append("price").append('=').append(JodaBeanUtils.toString(price));
     buf.append('}');
     return buf.toString();
   }
@@ -281,10 +281,10 @@ public final class ResolvedIborFutureTrade
     private final MetaProperty<Long> quantity = DirectMetaProperty.ofImmutable(
         this, "quantity", ResolvedIborFutureTrade.class, Long.TYPE);
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      */
-    private final MetaProperty<Double> initialPrice = DirectMetaProperty.ofImmutable(
-        this, "initialPrice", ResolvedIborFutureTrade.class, Double.TYPE);
+    private final MetaProperty<Double> price = DirectMetaProperty.ofImmutable(
+        this, "price", ResolvedIborFutureTrade.class, Double.TYPE);
     /**
      * The meta-properties.
      */
@@ -294,7 +294,7 @@ public final class ResolvedIborFutureTrade
         "product",
         "securityStandardId",
         "quantity",
-        "initialPrice");
+        "price");
 
     /**
      * Restricted constructor.
@@ -313,8 +313,8 @@ public final class ResolvedIborFutureTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -368,11 +368,11 @@ public final class ResolvedIborFutureTrade
     }
 
     /**
-     * The meta-property for the {@code initialPrice} property.
+     * The meta-property for the {@code price} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<Double> initialPrice() {
-      return initialPrice;
+    public MetaProperty<Double> price() {
+      return price;
     }
 
     //-----------------------------------------------------------------------
@@ -387,8 +387,8 @@ public final class ResolvedIborFutureTrade
           return ((ResolvedIborFutureTrade) bean).getSecurityStandardId();
         case -1285004149:  // quantity
           return ((ResolvedIborFutureTrade) bean).getQuantity();
-        case -423406491:  // initialPrice
-          return ((ResolvedIborFutureTrade) bean).getInitialPrice();
+        case 106934601:  // price
+          return ((ResolvedIborFutureTrade) bean).getPrice();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -414,7 +414,7 @@ public final class ResolvedIborFutureTrade
     private ResolvedIborFuture product;
     private StandardId securityStandardId;
     private long quantity;
-    private double initialPrice;
+    private double price;
 
     /**
      * Restricted constructor.
@@ -432,7 +432,7 @@ public final class ResolvedIborFutureTrade
       this.product = beanToCopy.getProduct();
       this.securityStandardId = beanToCopy.getSecurityStandardId();
       this.quantity = beanToCopy.getQuantity();
-      this.initialPrice = beanToCopy.getInitialPrice();
+      this.price = beanToCopy.getPrice();
     }
 
     //-----------------------------------------------------------------------
@@ -447,8 +447,8 @@ public final class ResolvedIborFutureTrade
           return securityStandardId;
         case -1285004149:  // quantity
           return quantity;
-        case -423406491:  // initialPrice
-          return initialPrice;
+        case 106934601:  // price
+          return price;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -469,8 +469,8 @@ public final class ResolvedIborFutureTrade
         case -1285004149:  // quantity
           this.quantity = (Long) newValue;
           break;
-        case -423406491:  // initialPrice
-          this.initialPrice = (Double) newValue;
+        case 106934601:  // price
+          this.price = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -509,7 +509,7 @@ public final class ResolvedIborFutureTrade
           product,
           securityStandardId,
           quantity,
-          initialPrice);
+          price);
     }
 
     //-----------------------------------------------------------------------
@@ -568,11 +568,11 @@ public final class ResolvedIborFutureTrade
      * This is the price agreed when the trade occurred.
      * This must be represented in decimal form, {@code (1.0 - decimalRate)}.
      * As such, the common market price of 99.3 for a 0.7% rate must be input as 0.993.
-     * @param initialPrice  the new value
+     * @param price  the new value
      * @return this, for chaining, not null
      */
-    public Builder initialPrice(double initialPrice) {
-      this.initialPrice = initialPrice;
+    public Builder price(double price) {
+      this.price = price;
       return this;
     }
 
@@ -585,7 +585,7 @@ public final class ResolvedIborFutureTrade
       buf.append("product").append('=').append(JodaBeanUtils.toString(product)).append(',').append(' ');
       buf.append("securityStandardId").append('=').append(JodaBeanUtils.toString(securityStandardId)).append(',').append(' ');
       buf.append("quantity").append('=').append(JodaBeanUtils.toString(quantity)).append(',').append(' ');
-      buf.append("initialPrice").append('=').append(JodaBeanUtils.toString(initialPrice));
+      buf.append("price").append('=').append(JodaBeanUtils.toString(price));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/ImmutableIborFutureConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/ImmutableIborFutureConvention.java
@@ -148,7 +148,11 @@ public final class ImmutableIborFutureConvention
     SecurityLink<IborFuture> securityLink = SecurityLink.resolved(security);
     TradeInfo info = TradeInfo.builder().tradeDate(tradeDate).build();
     return IborFutureTrade.builder()
-        .quantity(quantity).initialPrice(price).securityLink(securityLink).tradeInfo(info).build();
+        .tradeInfo(info)
+        .securityLink(securityLink)
+        .quantity(quantity)
+        .price(price)
+        .build();
   }
 
   @Override

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/BondFutureOptionTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/BondFutureOptionTradeTest.java
@@ -77,7 +77,7 @@ public class BondFutureOptionTradeTest {
 
   private static final TradeInfo TRADE_INFO = TradeInfo.builder().tradeDate(TRADE_DATE).build();
   private static final long QUANTITY = 1234;
-  private static final Double INITIAL_PRICE = 0.01;
+  private static final Double PRICE = 0.01;
   private static final StandardId OPTION_SECURITY_ID = StandardId.of("OG-Ticker", "GOVT1-BOND-FUT-OPT");
   private static final StandardId OPTION_SECURITY_ID2 = StandardId.of("OG-Ticker", "GOVT1-BOND-FUT-OPT2");
   private static final Security<BondFutureOption> OPTION_SECURITY_RESOLVED = UnitSecurity
@@ -118,12 +118,12 @@ public class BondFutureOptionTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(OPTION_RESOLVABLE_FUTURE_RESOLVABLE)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getSecurityLink(), OPTION_RESOLVABLE_FUTURE_RESOLVABLE);
     assertEquals(test.getQuantity(), QUANTITY);
-    assertEquals(test.getInitialPrice(), OptionalDouble.of(INITIAL_PRICE));
+    assertEquals(test.getPrice(), OptionalDouble.of(PRICE));
     assertThrows(() -> test.getSecurity(), IllegalStateException.class);
   }
 
@@ -136,7 +136,7 @@ public class BondFutureOptionTradeTest {
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getSecurityLink(), OPTION_RESOLVED_FUTURE_RESOLVED);
     assertEquals(test.getQuantity(), QUANTITY);
-    assertEquals(test.getInitialPrice(), OptionalDouble.empty());
+    assertEquals(test.getPrice(), OptionalDouble.empty());
     assertEquals(test.getSecurity(), OPTION_SECURITY_RESOLVED);
   }
 
@@ -145,12 +145,12 @@ public class BondFutureOptionTradeTest {
     BondFutureOptionTrade test = BondFutureOptionTrade.builder()
         .securityLink(OPTION_RESOLVABLE_FUTURE_RESOLVABLE)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     BondFutureOptionTrade expected = BondFutureOptionTrade.builder()
         .securityLink(OPTION_RESOLVED_FUTURE_RESOLVED)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.resolveLinks(RESOLVER), expected);
   }
@@ -159,12 +159,12 @@ public class BondFutureOptionTradeTest {
     BondFutureOptionTrade test = BondFutureOptionTrade.builder()
         .securityLink(OPTION_RESOLVED_FUTURE_RESOLVABLE)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     BondFutureOptionTrade expected = BondFutureOptionTrade.builder()
         .securityLink(OPTION_RESOLVED_FUTURE_RESOLVED)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.resolveLinks(RESOLVER), expected);
   }
@@ -173,7 +173,7 @@ public class BondFutureOptionTradeTest {
     BondFutureOptionTrade test = BondFutureOptionTrade.builder()
         .securityLink(OPTION_RESOLVED_FUTURE_RESOLVED)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.resolveLinks(RESOLVER), test);
   }
@@ -184,7 +184,7 @@ public class BondFutureOptionTradeTest {
         .product(OPTION_PRODUCT_RESOLVED.resolve(REF_DATA))
         .securityStandardId(OPTION_SECURITY_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(sut().resolve(REF_DATA), expected);
   }
@@ -205,7 +205,7 @@ public class BondFutureOptionTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(OPTION_RESOLVED_FUTURE_RESOLVED)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/BondFutureTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/BondFutureTest.java
@@ -104,7 +104,7 @@ public class BondFutureTest {
   public void test_builder_full() {
     BondFuture test = BondFuture.builder()
         .deliveryBasket(SECURITY_LINK)
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .firstDeliveryDate(FIRST_DELIVERY_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
@@ -113,7 +113,7 @@ public class BondFutureTest {
         .rounding(ROUNDING)
         .build();
     assertEquals(test.getBondProductBasket(), ImmutableList.copyOf(BOND_PRODUCT));
-    assertEquals(test.getConversionFactor(), ImmutableList.copyOf(CONVERSION_FACTOR));
+    assertEquals(test.getConversionFactors(), ImmutableList.copyOf(CONVERSION_FACTOR));
     assertEquals(test.getCurrency(), USD);
     assertEquals(test.getDeliveryBasket(), ImmutableList.copyOf(SECURITY_LINK));
     assertEquals(test.getNotional(), NOTIONAL);
@@ -128,14 +128,14 @@ public class BondFutureTest {
   public void test_builder_noDeliveryDate() {
     BondFuture test = BondFuture.builder()
         .deliveryBasket(SECURITY_LINK)
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
         .rounding(ROUNDING)
         .build();
     assertEquals(test.getBondProductBasket(), ImmutableList.copyOf(BOND_PRODUCT));
-    assertEquals(test.getConversionFactor(), ImmutableList.copyOf(CONVERSION_FACTOR));
+    assertEquals(test.getConversionFactors(), ImmutableList.copyOf(CONVERSION_FACTOR));
     assertEquals(test.getCurrency(), USD);
     assertEquals(test.getDeliveryBasket(), ImmutableList.copyOf(SECURITY_LINK));
     assertEquals(test.getNotional(), NOTIONAL);
@@ -152,7 +152,7 @@ public class BondFutureTest {
     // wrong size
     assertThrowsIllegalArg(() -> BondFuture.builder()
         .deliveryBasket(SECURITY_LINK[0])
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
@@ -161,7 +161,7 @@ public class BondFutureTest {
     // first notice date missing
     assertThrowsIllegalArg(() -> BondFuture.builder()
         .deliveryBasket(SECURITY_LINK)
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
         .rounding(ROUNDING)
@@ -169,14 +169,14 @@ public class BondFutureTest {
     // last notice date missing
     assertThrowsIllegalArg(() -> BondFuture.builder()
         .deliveryBasket(SECURITY_LINK)
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
         .rounding(ROUNDING)
         .build());
     // basket list empty
     assertThrowsIllegalArg(() -> BondFuture.builder()
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
@@ -201,7 +201,7 @@ public class BondFutureTest {
     SecurityLink<FixedCouponBond> securityLinkNotional = SecurityLink.resolved(securityNotional);
     assertThrowsIllegalArg(() -> BondFuture.builder()
         .deliveryBasket(SECURITY_LINK[0], securityLinkNotional)
-        .conversionFactor(CONVERSION_FACTOR[0], CONVERSION_FACTOR[1])
+        .conversionFactors(CONVERSION_FACTOR[0], CONVERSION_FACTOR[1])
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
@@ -223,7 +223,7 @@ public class BondFutureTest {
     SecurityLink<FixedCouponBond> securityLinkCurrency = SecurityLink.resolved(securityCurrency);
     assertThrowsIllegalArg(() -> BondFuture.builder()
         .deliveryBasket(SECURITY_LINK[0], securityLinkCurrency)
-        .conversionFactor(CONVERSION_FACTOR[0], CONVERSION_FACTOR[1])
+        .conversionFactors(CONVERSION_FACTOR[0], CONVERSION_FACTOR[1])
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
@@ -234,7 +234,7 @@ public class BondFutureTest {
   public void test_getBondSecurityBasket() {
     BondFuture test = BondFuture.builder()
         .deliveryBasket(SECURITY_LINK)
-        .conversionFactor(ImmutableList.copyOf(CONVERSION_FACTOR))
+        .conversionFactors(ImmutableList.copyOf(CONVERSION_FACTOR))
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
         .lastTradeDate(LAST_TRADING_DATE)
@@ -251,7 +251,7 @@ public class BondFutureTest {
   public void test_resolve() {
     ResolvedBondFuture expected = ResolvedBondFuture.builder()
         .deliveryBasket(RESOLVED_BASKET)
-        .conversionFactor(CONVERSION_FACTOR)
+        .conversionFactors(CONVERSION_FACTOR)
         .lastTradeDate(LAST_TRADING_DATE)
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
@@ -276,7 +276,7 @@ public class BondFutureTest {
   static BondFuture sut() {
     return BondFuture.builder()
         .deliveryBasket(SECURITY_LINK)
-        .conversionFactor(ImmutableList.copyOf(CONVERSION_FACTOR))
+        .conversionFactors(ImmutableList.copyOf(CONVERSION_FACTOR))
         .firstNoticeDate(FIRST_NOTICE_DATE)
         .firstDeliveryDate(FIRST_DELIVERY_DATE)
         .lastNoticeDate(LAST_NOTICE_DATE)
@@ -288,7 +288,7 @@ public class BondFutureTest {
 
   static BondFuture sut2() {
     return BondFuture.builder()
-        .conversionFactor(0.9187)
+        .conversionFactors(0.9187)
         .deliveryBasket(SECURITY_LINK[3])
         .firstNoticeDate(FIRST_NOTICE_DATE.plusDays(7))
         .lastNoticeDate(LAST_NOTICE_DATE.plusDays(7))

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/BondFutureTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/BondFutureTradeTest.java
@@ -52,12 +52,12 @@ public class BondFutureTradeTest {
   private static final LocalDate TRADE_DATE = LocalDate.of(2011, 6, 20);
   private static final TradeInfo TRADE_INFO = TradeInfo.builder().tradeDate(TRADE_DATE).build();
   private static final long QUANTITY = 1234L;
-  private static final double INITIAL_PRICE = 1.2345;
+  private static final double PRICE = 1.2345;
 
   //-------------------------------------------------------------------------
   public void test_of_resolved() {
     BondFutureTrade test = sut();
-    assertEquals(test.getInitialPrice(), INITIAL_PRICE);
+    assertEquals(test.getPrice(), PRICE);
     assertEquals(test.getProduct(), FUTURE_PRODUCT);
     assertEquals(test.getQuantity(), QUANTITY);
     assertEquals(test.getSecurity(), FUTURE_SECURITY);
@@ -70,9 +70,9 @@ public class BondFutureTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(FUTURE_SECURITY_LINK_RESOLVABLE)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
-    assertEquals(test.getInitialPrice(), INITIAL_PRICE);
+    assertEquals(test.getPrice(), PRICE);
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getQuantity(), QUANTITY);
     assertEquals(test.getSecurityLink(), FUTURE_SECURITY_LINK_RESOLVABLE);
@@ -90,7 +90,7 @@ public class BondFutureTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(FUTURE_SECURITY_LINK_RESOLVABLE)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(base.resolveLinks(RESOLVER), sut());
   }
@@ -101,7 +101,7 @@ public class BondFutureTradeTest {
         .product(FUTURE_PRODUCT.resolve(REF_DATA))
         .securityStandardId(FUTURE_SECURITY_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(sut().resolve(REF_DATA), expected);
   }
@@ -121,7 +121,7 @@ public class BondFutureTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(FUTURE_SECURITY_LINK_RESOLVED)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedBondFutureOptionTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedBondFutureOptionTradeTest.java
@@ -25,7 +25,7 @@ public class ResolvedBondFutureOptionTradeTest {
   //-------------------------------------------------------------------------
   public void test_getters() {
     ResolvedBondFutureOptionTrade test = sut();
-    assertEquals(test.getInitialPrice(), BondFutureOptionTradeTest.sut().getInitialPrice());
+    assertEquals(test.getPrice(), BondFutureOptionTradeTest.sut().getPrice());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedBondFutureTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedBondFutureTest.java
@@ -28,7 +28,7 @@ public class ResolvedBondFutureTest {
     ResolvedBondFuture base = sut();
     ResolvedBondFuture test = ResolvedBondFuture.builder()
         .deliveryBasket(base.getDeliveryBasket())
-        .conversionFactor(base.getConversionFactor())
+        .conversionFactors(base.getConversionFactors())
         .firstNoticeDate(base.getFirstNoticeDate())
         .lastNoticeDate(base.getLastNoticeDate())
         .firstDeliveryDate(base.getFirstDeliveryDate())
@@ -44,7 +44,7 @@ public class ResolvedBondFutureTest {
     // wrong size
     assertThrowsIllegalArg(() -> ResolvedBondFuture.builder()
         .deliveryBasket(base.getDeliveryBasket().subList(0, 1))
-        .conversionFactor(base.getConversionFactor())
+        .conversionFactors(base.getConversionFactors())
         .firstNoticeDate(base.getFirstNoticeDate())
         .lastNoticeDate(base.getLastNoticeDate())
         .lastTradeDate(base.getLastTradeDate())
@@ -52,14 +52,14 @@ public class ResolvedBondFutureTest {
     // first notice date missing
     assertThrowsIllegalArg(() -> ResolvedBondFuture.builder()
         .deliveryBasket(base.getDeliveryBasket())
-        .conversionFactor(base.getConversionFactor())
+        .conversionFactors(base.getConversionFactors())
         .lastNoticeDate(base.getLastNoticeDate())
         .lastTradeDate(base.getLastTradeDate())
         .build());
     // last notice date missing
     assertThrowsIllegalArg(() -> ResolvedBondFuture.builder()
         .deliveryBasket(base.getDeliveryBasket())
-        .conversionFactor(base.getConversionFactor())
+        .conversionFactors(base.getConversionFactors())
         .firstNoticeDate(base.getFirstNoticeDate())
         .lastTradeDate(base.getLastTradeDate())
         .build());

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedBondFutureTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedBondFutureTradeTest.java
@@ -25,7 +25,7 @@ public class ResolvedBondFutureTradeTest {
   //-------------------------------------------------------------------------
   public void test_getters() {
     ResolvedBondFutureTrade test = sut();
-    assertEquals(test.getInitialPrice(), BondFutureTradeTest.sut().getInitialPrice());
+    assertEquals(test.getPrice(), BondFutureTradeTest.sut().getPrice());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/IborFutureOptionTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/IborFutureOptionTradeTest.java
@@ -45,7 +45,7 @@ public class IborFutureOptionTradeTest {
   private static final LocalDate TRADE_DATE = date(2015, 2, 17);
   private static final TradeInfo TRADE_INFO = TradeInfo.builder().tradeDate(TRADE_DATE).build();
   private static final long QUANTITY = 35;
-  private static final double INITIAL_PRICE = 0.015;
+  private static final double PRICE = 0.015;
   private static final StandardId FUTURE_ID = StandardId.of("OG-Ticker", "Future1");
   private static final StandardId OPTION_ID = StandardId.of("OG-Ticker", "Option1");
 
@@ -95,12 +95,12 @@ public class IborFutureOptionTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(RESOLVABLE_OPTION_LINK)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getSecurityLink(), RESOLVABLE_OPTION_LINK);
     assertEquals(test.getQuantity(), QUANTITY);
-    assertEquals(test.getInitialPrice(), OptionalDouble.of(INITIAL_PRICE));
+    assertEquals(test.getPrice(), OptionalDouble.of(PRICE));
     assertThrows(() -> test.getSecurity(), IllegalStateException.class);
   }
 
@@ -113,7 +113,7 @@ public class IborFutureOptionTradeTest {
     assertEquals(test.getTradeInfo(), TRADE_INFO);
     assertEquals(test.getSecurityLink(), PARTLY_RESOLVED_OPTION_LINK);
     assertEquals(test.getQuantity(), QUANTITY);
-    assertEquals(test.getInitialPrice(), OptionalDouble.empty());
+    assertEquals(test.getPrice(), OptionalDouble.empty());
     assertEquals(test.getSecurity(), OPTION_SECURITY);
   }
 
@@ -122,12 +122,12 @@ public class IborFutureOptionTradeTest {
     IborFutureOptionTrade test = IborFutureOptionTrade.builder()
         .securityLink(RESOLVABLE_OPTION_LINK)
         .quantity(100)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     IborFutureOptionTrade expected = IborFutureOptionTrade.builder()
         .securityLink(FULLY_RESOLVED_OPTION_LINK)
         .quantity(100)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     LinkResolver resolver = new LinkResolver() {
       @SuppressWarnings("unchecked")
@@ -147,12 +147,12 @@ public class IborFutureOptionTradeTest {
     IborFutureOptionTrade test = IborFutureOptionTrade.builder()
         .securityLink(PARTLY_RESOLVED_OPTION_LINK)
         .quantity(100)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     IborFutureOptionTrade expected = IborFutureOptionTrade.builder()
         .securityLink(FULLY_RESOLVED_OPTION_LINK)
         .quantity(100)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     LinkResolver resolver = new LinkResolver() {
       @SuppressWarnings("unchecked")
@@ -169,7 +169,7 @@ public class IborFutureOptionTradeTest {
     IborFutureOptionTrade test = IborFutureOptionTrade.builder()
         .securityLink(FULLY_RESOLVED_OPTION_LINK)
         .quantity(100)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     LinkResolver resolver = new LinkResolver() {
       @Override
@@ -186,7 +186,7 @@ public class IborFutureOptionTradeTest {
     IborFutureOptionTrade test = IborFutureOptionTrade.builder()
         .tradeInfo(TRADE_INFO)
         .securityLink(FULLY_RESOLVED_OPTION_LINK)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .quantity(QUANTITY)
         .build();
     ResolvedIborFutureOptionTrade resolved = test.resolve(REF_DATA);
@@ -194,7 +194,7 @@ public class IborFutureOptionTradeTest {
     assertEquals(resolved.getProduct(), RESOLVED_OPTION.resolve(REF_DATA));
     assertEquals(resolved.getSecurityStandardId(), OPTION_ID);
     assertEquals(resolved.getQuantity(), QUANTITY);
-    assertEquals(resolved.getInitialPrice(), OptionalDouble.of(INITIAL_PRICE));
+    assertEquals(resolved.getPrice(), OptionalDouble.of(PRICE));
   }
 
   //-------------------------------------------------------------------------
@@ -213,7 +213,7 @@ public class IborFutureOptionTradeTest {
         .tradeInfo(TRADE_INFO)
         .securityLink(PARTLY_RESOLVED_OPTION_LINK)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/IborFutureTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/IborFutureTradeTest.java
@@ -38,7 +38,7 @@ public class IborFutureTradeTest {
   private static final TradeInfo TRADE_INFO = TradeInfo.builder().tradeDate(date(2015, 3, 18)).build();
   private static final LocalDate TRADE_DATE = date(2015, 2, 17);
   private static final long QUANTITY = 35;
-  private static final double INITIAL_PRICE = 1.015;
+  private static final double PRICE = 1.015;
   private static final IborFuture PRODUCT = IborFutureTest.sut();
   private static final StandardId SECURITY_ID = StandardId.of("OG-Ticker", "OG");
   private static final Security<IborFuture> SECURITY = UnitSecurity.builder(PRODUCT)
@@ -54,7 +54,7 @@ public class IborFutureTradeTest {
     IborFutureTrade test = sut();
     assertEquals(test.getTradeInfo(), TradeInfo.builder().tradeDate(TRADE_DATE).build());
     assertEquals(test.getSecurityLink(), RESOLVABLE_LINK);
-    assertEquals(test.getInitialPrice(), INITIAL_PRICE);
+    assertEquals(test.getPrice(), PRICE);
     assertEquals(test.getQuantity(), QUANTITY);
     assertThrows(() -> test.getSecurity(), IllegalStateException.class);
     assertThrows(() -> test.getProduct(), IllegalStateException.class);
@@ -64,12 +64,12 @@ public class IborFutureTradeTest {
     IborFutureTrade test = IborFutureTrade.builder()
         .tradeInfo(TradeInfo.builder().tradeDate(TRADE_DATE).build())
         .securityLink(RESOLVED_LINK)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .quantity(QUANTITY)
         .build();
     assertEquals(test.getTradeInfo(), TradeInfo.builder().tradeDate(TRADE_DATE).build());
     assertEquals(test.getSecurityLink(), RESOLVED_LINK);
-    assertEquals(test.getInitialPrice(), INITIAL_PRICE);
+    assertEquals(test.getPrice(), PRICE);
     assertEquals(test.getQuantity(), QUANTITY);
     assertEquals(test.getSecurity(), SECURITY);
     assertEquals(test.getProduct(), PRODUCT);
@@ -116,7 +116,7 @@ public class IborFutureTradeTest {
     IborFutureTrade test = IborFutureTrade.builder()
         .tradeInfo(TRADE_INFO)
         .securityLink(RESOLVED_LINK)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .quantity(QUANTITY)
         .build();
     ResolvedIborFutureTrade resolved = test.resolve(REF_DATA);
@@ -124,7 +124,7 @@ public class IborFutureTradeTest {
     assertEquals(resolved.getProduct(), PRODUCT.resolve(REF_DATA));
     assertEquals(resolved.getSecurityStandardId(), SECURITY_ID);
     assertEquals(resolved.getQuantity(), QUANTITY);
-    assertEquals(resolved.getInitialPrice(), INITIAL_PRICE);
+    assertEquals(resolved.getPrice(), PRICE);
   }
 
   //-------------------------------------------------------------------------
@@ -142,7 +142,7 @@ public class IborFutureTradeTest {
     return IborFutureTrade.builder()
         .tradeInfo(TradeInfo.builder().tradeDate(TRADE_DATE).build())
         .securityLink(RESOLVABLE_LINK)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .quantity(QUANTITY)
         .build();
   }
@@ -151,7 +151,7 @@ public class IborFutureTradeTest {
     return IborFutureTrade.builder()
         .tradeInfo(TRADE_INFO)
         .securityLink(SecurityLink.resolvable(StandardId.of("OG-Ticker", "OG2"), IborFuture.class))
-        .initialPrice(1.1)
+        .price(1.1)
         .quantity(100)
         .build();
   }

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/ResolvedIborFutureOptionTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/ResolvedIborFutureOptionTradeTest.java
@@ -36,7 +36,7 @@ public class ResolvedIborFutureOptionTradeTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
   private static final LocalDate TRADE_DATE = date(2015, 2, 17);
   private static final long QUANTITY = 35;
-  private static final double INITIAL_PRICE = 0.015;
+  private static final double PRICE = 0.015;
   private static final StandardId OPTION_ID = StandardId.of("OG-Ticker", "Option1");
   private static final StandardId OPTION_ID2 = StandardId.of("OG-Ticker", "Option2");
 
@@ -60,13 +60,13 @@ public class ResolvedIborFutureOptionTradeTest {
         .product(OPTION)
         .securityStandardId(OPTION_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.getTradeInfo(), TradeInfo.builder().tradeDate(TRADE_DATE).build());
     assertEquals(test.getProduct(), OPTION);
     assertEquals(test.getSecurityStandardId(), OPTION_ID);
     assertEquals(test.getQuantity(), QUANTITY);
-    assertEquals(test.getInitialPrice(), OptionalDouble.of(INITIAL_PRICE));
+    assertEquals(test.getPrice(), OptionalDouble.of(PRICE));
   }
 
   //-------------------------------------------------------------------------
@@ -76,7 +76,7 @@ public class ResolvedIborFutureOptionTradeTest {
         .product(OPTION)
         .securityStandardId(OPTION_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     coverImmutableBean(test);
     ResolvedIborFutureOptionTrade test2 = ResolvedIborFutureOptionTrade.builder()
@@ -84,7 +84,7 @@ public class ResolvedIborFutureOptionTradeTest {
         .product(OPTION)
         .securityStandardId(OPTION_ID2)
         .quantity(QUANTITY + 1)
-        .initialPrice(INITIAL_PRICE + 0.1)
+        .price(PRICE + 0.1)
         .build();
     coverBeanEquals(test, test2);
   }
@@ -95,7 +95,7 @@ public class ResolvedIborFutureOptionTradeTest {
         .product(OPTION)
         .securityStandardId(OPTION_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertSerialization(test);
   }

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/ResolvedIborFutureTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/ResolvedIborFutureTradeTest.java
@@ -31,7 +31,7 @@ public class ResolvedIborFutureTradeTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
   private static final LocalDate TRADE_DATE = date(2015, 2, 17);
   private static final long QUANTITY = 35;
-  private static final double INITIAL_PRICE = 1.015;
+  private static final double PRICE = 1.015;
   private static final StandardId FUTURE_ID = StandardId.of("OG-Ticker", "Future1");
   private static final StandardId FUTURE_ID2 = StandardId.of("OG-Ticker", "Future2");
 
@@ -48,13 +48,13 @@ public class ResolvedIborFutureTradeTest {
         .product(FUTURE)
         .securityStandardId(FUTURE_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertEquals(test.getTradeInfo(), TradeInfo.builder().tradeDate(TRADE_DATE).build());
     assertEquals(test.getProduct(), FUTURE);
     assertEquals(test.getSecurityStandardId(), FUTURE_ID);
     assertEquals(test.getQuantity(), QUANTITY);
-    assertEquals(test.getInitialPrice(), INITIAL_PRICE);
+    assertEquals(test.getPrice(), PRICE);
   }
 
   //-------------------------------------------------------------------------
@@ -64,7 +64,7 @@ public class ResolvedIborFutureTradeTest {
         .product(FUTURE)
         .securityStandardId(FUTURE_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     coverImmutableBean(test);
     ResolvedIborFutureTrade test2 = ResolvedIborFutureTrade.builder()
@@ -72,7 +72,7 @@ public class ResolvedIborFutureTradeTest {
         .product(FUTURE)
         .securityStandardId(FUTURE_ID2)
         .quantity(QUANTITY + 1)
-        .initialPrice(INITIAL_PRICE + 0.1)
+        .price(PRICE + 0.1)
         .build();
     coverBeanEquals(test, test2);
   }
@@ -83,7 +83,7 @@ public class ResolvedIborFutureTradeTest {
         .product(FUTURE)
         .securityStandardId(FUTURE_ID)
         .quantity(QUANTITY)
-        .initialPrice(INITIAL_PRICE)
+        .price(PRICE)
         .build();
     assertSerialization(test);
   }

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/type/IborFutureConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/type/IborFutureConventionTest.java
@@ -76,7 +76,7 @@ public class IborFutureConventionTest {
     long quantity = 3;
     double price = 0.99;
     IborFutureTrade trade = convention.createTrade(date, start, number, quantity, NOTIONAL_1M, price, REF_DATA);
-    assertEquals(trade.getInitialPrice(), price);
+    assertEquals(trade.getPrice(), price);
     assertEquals(trade.getProduct().getFixingDate(), LocalDate.of(2016, 6, 13));
     assertEquals(trade.getQuantity(), quantity);
     assertEquals(trade.getProduct().getIndex(), USD_LIBOR_3M);


### PR DESCRIPTION
Rename `initialPrice` to `price`.
Rename `conversionFactor` to `conversionFactors`