### PR TITLE
Add overload of ResourceLocator.ofClasspath taking a Class

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceLocator.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceLocator.java
@@ -107,6 +107,28 @@ public final class ResourceLocator {
   }
 
   /**
+   * Creates a resource locator for a classpath resource which is associated with a class.
+   * <p>
+   * The classpath is searched using the same method as {@code Class.getResource}.
+   * <ul>
+   *   <li>If the resource name starts with '/' it is treated as an absolute path relative to the classpath root</li>
+   *   <li>Otherwise the resource name is treated as a path relative to the package containing the class</li>
+   * </ul>
+   *
+   * @param cls  the class
+   * @param resourceName  the resource name
+   * @return the resource
+   */
+  public static ResourceLocator ofClasspath(Class cls, String resourceName) {
+    ArgChecker.notNull(resourceName, "classpathLocator");
+    URL url = cls.getResource(resourceName);
+    if (url == null) {
+      throw new IllegalArgumentException("Resource not found: " + resourceName);
+    }
+    return ofClasspathUrl(url);
+  }
+
+  /**
    * Creates a resource from a {@code URL}.
    * 
    * @param url  the URL to wrap

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
@@ -78,6 +78,17 @@ public class ResourceLocatorTest {
     assertEquals(test.toString().endsWith("com/opengamma/strata/config/base/TestFile.txt"), true);
   }
 
+  public void test_ofClasspath_relative() throws Exception {
+    ResourceLocator test = ResourceLocator.ofClasspath(ResourceLocator.class, "TestFile.txt");
+    assertEquals(test.getLocator().startsWith("classpath"), true);
+    assertEquals(test.getLocator().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
+    assertEquals(test.getByteSource().read()[0], 'H');
+    assertEquals(test.getCharSource().readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.getCharSource(StandardCharsets.UTF_8).readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.toString().startsWith("classpath"), true);
+    assertEquals(test.toString().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
+  }
+
   public void test_ofClasspathUrl() throws Exception {
     URL url = Resources.getResource("com/opengamma/strata/config/base/TestFile.txt");
     ResourceLocator test = ResourceLocator.ofClasspathUrl(url);

--- a/modules/collect/src/test/resources/com/opengamma/strata/collect/io/TestFile.txt
+++ b/modules/collect/src/test/resources/com/opengamma/strata/collect/io/TestFile.txt
@@ -1,0 +1,1 @@
+HelloWorld


### PR DESCRIPTION
This has the same search semantics as `Class.getResource` and is useful for resources associated with a class and stored in the same package.

Fixes #856