### PR TITLE
Add firstIndexValue to inflation

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/SwapFpmlParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/SwapFpmlParserPlugin.java
@@ -502,11 +502,11 @@ final class SwapFpmlParserPlugin
     //  'calculationPeriodAmount/calculation/inflationRateCalculation/floatingRateMultiplierSchedule?'
     //  'calculationPeriodAmount/calculation/inflationRateCalculation/inflationLag'
     //  'calculationPeriodAmount/calculation/inflationRateCalculation/interpolationMethod'
+    //  'calculationPeriodAmount/calculation/inflationRateCalculation/initialIndexLevel?'
     //  'calculationPeriodAmount/calculation/dayCountFraction'
     // ignored elements:
     // 'calculationPeriodAmount/calculation/inflationRateCalculation/indexSource'
     // 'calculationPeriodAmount/calculation/inflationRateCalculation/mainPublication'
-    // 'calculationPeriodAmount/calculation/inflationRateCalculation/initialIndexLevel'
     // 'calculationPeriodAmount/calculation/inflationRateCalculation/fallbackBondApplicable'
     //  'calculationPeriodAmount/calculation/floatingRateCalculation/initialRate?'
     //  'calculationPeriodAmount/calculation/floatingRateCalculation/finalRateRounding?'
@@ -532,6 +532,10 @@ final class SwapFpmlParserPlugin
     // interpolation
     String interpStr = inflationEl.getChild("interpolationMethod").getContent();
     builder.interpolated(interpStr.toLowerCase(Locale.ENGLISH).contains("linear"));
+    // initial index
+    inflationEl.findChild("initialIndexLevel").ifPresent(el -> {
+      builder.firstIndexValue(document.parseDecimal(el));
+    });
     // gearing
     inflationEl.findChild("floatingRateMultiplierSchedule").ifPresent(el -> {
       builder.gearing(parseSchedule(el, document));

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondProductPricer.java
@@ -621,7 +621,7 @@ public class DiscountingCapitalIndexedBondProductPricer {
       RateObservation obs = period.getRateObservation();
       LocalDateDoubleTimeSeries ts = ratesProvider.priceIndexValues(bond.getRateCalculation().getIndex()).getFixings();
       YearMonth lastKnownFixingMonth = YearMonth.from(ts.getLatestDate());
-      double indexRatio = ts.getLatestValue() / bond.getStartIndexValue();
+      double indexRatio = ts.getLatestValue() / bond.getFirstIndexValue();
       YearMonth endFixingMonth = null;
       if (obs instanceof InflationEndInterpolatedRateObservation) {
         endFixingMonth = ((InflationEndInterpolatedRateObservation) obs).getEndSecondObservation().getFixingMonth();
@@ -1162,8 +1162,7 @@ public class DiscountingCapitalIndexedBondProductPricer {
   double indexRatio(ResolvedCapitalIndexedBond bond, RatesProvider ratesProvider, LocalDate settlementDate) {
     LocalDate endReferenceDate = settlementDate.isBefore(ratesProvider.getValuationDate()) ?
         ratesProvider.getValuationDate() : settlementDate;
-    RateObservation modifiedObservation =
-        bond.getRateCalculation().createRateObservation(endReferenceDate, bond.getStartIndexValue());
+    RateObservation modifiedObservation = bond.getRateCalculation().createRateObservation(endReferenceDate);
     return 1d + periodPricer.getRateObservationFn().rate(
         modifiedObservation,
         bond.getUnadjustedStartDate(), // dates not used
@@ -1178,8 +1177,7 @@ public class DiscountingCapitalIndexedBondProductPricer {
 
     LocalDate endReferenceDate = settlementDate.isBefore(ratesProvider.getValuationDate()) ?
         ratesProvider.getValuationDate() : settlementDate;
-    RateObservation modifiedObservation =
-        bond.getRateCalculation().createRateObservation(endReferenceDate, bond.getStartIndexValue());
+    RateObservation modifiedObservation = bond.getRateCalculation().createRateObservation(endReferenceDate);
     return periodPricer.getRateObservationFn().rateSensitivity(
         modifiedObservation,
         bond.getUnadjustedStartDate(), // dates not used

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondProductPricerTest.java
@@ -71,6 +71,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .index(US_CPI_U)
       .lag(Period.ofMonths(3))
       .interpolated(true)
+      .firstIndexValue(START_INDEX)
       .build();
   private static final BusinessDayAdjustment EX_COUPON_ADJ =
       BusinessDayAdjustment.of(BusinessDayConventions.PRECEDING, USNY);
@@ -94,7 +95,6 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .yieldConvention(US_IL_REAL)
       .settlementDateOffset(SETTLE_OFFSET)
       .accrualSchedule(SCHEDULE)
-      .startIndexValue(START_INDEX)
       .build()
       .resolve(REF_DATA);
   private static final DaysAdjustment EX_COUPON = DaysAdjustment.ofCalendarDays(-5, EX_COUPON_ADJ);
@@ -109,7 +109,6 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .settlementDateOffset(SETTLE_OFFSET)
       .accrualSchedule(SCHEDULE)
       .exCouponPeriod(EX_COUPON)
-      .startIndexValue(START_INDEX)
       .build()
       .resolve(REF_DATA);
   // detachment date (for nonzero ex-coupon days) < valuation date < payment date
@@ -511,7 +510,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
     double realPrice = 1.055;
     LocalDate refDate = LocalDate.of(2014, 6, 10);
     double nominalPrice = PRICER.nominalPriceFromRealPrice(PRODUCT, RATES_PROVIDER_ON_PAY, refDate, realPrice);
-    RateObservation obs = RATE_CALC.createRateObservation(refDate, START_INDEX);
+    RateObservation obs = RATE_CALC.createRateObservation(refDate);
     double refRate = RateObservationFn.instance().rate(obs, null, null, RATES_PROVIDER_ON_PAY);
     double expected = realPrice * (refRate + 1d);
     assertEquals(nominalPrice, expected, TOL);
@@ -523,7 +522,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
     double realPrice = 1.055;
     LocalDate refDate = LocalDate.of(2014, 6, 10);
     double nominalPrice = PRICER.nominalPriceFromRealPrice(PRODUCT, RATES_PROVIDER, refDate, realPrice);
-    RateObservation obs = RATE_CALC.createRateObservation(VALUATION, START_INDEX);
+    RateObservation obs = RATE_CALC.createRateObservation(VALUATION);
     double refRate = RateObservationFn.instance().rate(obs, null, null, RATES_PROVIDER);
     double expected = realPrice * (refRate + 1d);
     assertEquals(nominalPrice, expected, TOL);
@@ -535,7 +534,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
     LocalDate refDate = LocalDate.of(2014, 6, 10);
     double cleanNominalPrice =
         PRICER.cleanNominalPriceFromDirtyNominalPrice(PRODUCT, RATES_PROVIDER, refDate, dirtyNominalPrice);
-    RateObservation obs = RATE_CALC.createRateObservation(VALUATION, START_INDEX);
+    RateObservation obs = RATE_CALC.createRateObservation(VALUATION);
     double refRate = RateObservationFn.instance().rate(obs, null, null, RATES_PROVIDER);
     double expected = dirtyNominalPrice - PRODUCT.accruedInterest(refDate) * (refRate + 1d) / NOTIONAL;
     assertEquals(cleanNominalPrice, expected, TOL);
@@ -559,6 +558,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .index(US_CPI_U)
       .lag(Period.ofMonths(3))
       .interpolated(true)
+      .firstIndexValue(START_INDEX_US)
       .build();
   private static final LocalDate START_USD = LocalDate.of(2010, 7, 15);
   private static final LocalDate END_USD = LocalDate.of(2020, 7, 15);
@@ -575,7 +575,6 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .yieldConvention(US_IL_REAL)
       .settlementDateOffset(SETTLE_OFFSET_US)
       .accrualSchedule(SCHEDULE_US)
-      .startIndexValue(START_INDEX_US)
       .build()
       .resolve(REF_DATA);
   private static final double YIELD_US = -0.00189;
@@ -652,6 +651,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .index(GB_RPI)
       .lag(Period.ofMonths(8))
       .interpolated(false)
+      .firstIndexValue(START_INDEX_GOV)
       .build();
   private static final LocalDate START_GOV = LocalDate.of(1983, 10, 16);
   private static final LocalDate END_GOV = LocalDate.of(2020, 4, 16);
@@ -674,7 +674,6 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .settlementDateOffset(SETTLE_OFFSET_GB)
       .accrualSchedule(SCHEDULE_GOV)
       .exCouponPeriod(EX_COUPON_GOV)
-      .startIndexValue(START_INDEX_GOV)
       .build()
       .resolve(REF_DATA);
   private static final double YIELD_GOV = -0.01532;
@@ -689,13 +688,12 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .notional(NTNL)
       .currency(GBP)
       .dayCount(ACT_ACT_ICMA)
-      .rateCalculation(RATE_CALC_GOV)
+      .rateCalculation(RATE_CALC_GOV.toBuilder().firstIndexValue(START_INDEX_GOV_OP).build())
       .legalEntityId(LEGAL_ENTITY)
       .yieldConvention(INDEX_LINKED_FLOAT)
       .settlementDateOffset(SETTLE_OFFSET_GB)
       .accrualSchedule(SCHEDULE_GOV_OP)
       .exCouponPeriod(EX_COUPON_GOV)
-      .startIndexValue(START_INDEX_GOV_OP)
       .build()
       .resolve(REF_DATA);
   private static final double YIELD_GOV_OP = -0.0244;
@@ -767,6 +765,7 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .index(GB_RPI)
       .lag(Period.ofMonths(3))
       .interpolated(true)
+      .firstIndexValue(START_INDEX_CORP)
       .build();
   private static final LocalDate START_CORP = LocalDate.of(2010, 3, 22);
   private static final LocalDate END_CORP = LocalDate.of(2040, 3, 22);
@@ -789,7 +788,6 @@ public class DiscountingCapitalIndexedBondProductPricerTest {
       .settlementDateOffset(SETTLE_OFFSET_GB)
       .accrualSchedule(SCHEDULE_CORP)
       .exCouponPeriod(EX_COUPON_CORP)
-      .startIndexValue(START_INDEX_CORP)
       .build()
       .resolve(REF_DATA);
   private static final double YIELD_CORP = -0.00842;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricerTest.java
@@ -83,6 +83,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
       .index(US_CPI_U)
       .lag(Period.ofMonths(3))
       .interpolated(true)
+      .firstIndexValue(START_INDEX)
       .build();
   private static final BusinessDayAdjustment EX_COUPON_ADJ =
       BusinessDayAdjustment.of(BusinessDayConventions.PRECEDING, USNY);
@@ -106,7 +107,6 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
       .yieldConvention(US_IL_REAL)
       .settlementDateOffset(SETTLE_OFFSET)
       .accrualSchedule(SCHEDULE)
-      .startIndexValue(START_INDEX)
       .build();
   private static final ResolvedCapitalIndexedBond RPRODUCT = PRODUCT.resolve(REF_DATA);
   private static final DaysAdjustment EX_COUPON = DaysAdjustment.ofCalendarDays(-5, EX_COUPON_ADJ);
@@ -121,7 +121,6 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
       .settlementDateOffset(SETTLE_OFFSET)
       .accrualSchedule(SCHEDULE)
       .exCouponPeriod(EX_COUPON)
-      .startIndexValue(START_INDEX)
       .build();
   private static final ResolvedCapitalIndexedBond RPRODUCT_EX_COUPON = PRODUCT_EX_COUPON.resolve(REF_DATA);
   private static final CapitalIndexedBond PRODUCT_ILF = CapitalIndexedBond.builder()
@@ -134,7 +133,6 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
       .yieldConvention(INDEX_LINKED_FLOAT)
       .settlementDateOffset(SETTLE_OFFSET)
       .accrualSchedule(SCHEDULE)
-      .startIndexValue(START_INDEX)
       .build();
   private static final ResolvedCapitalIndexedBond RPRODUCT_ILF = PRODUCT_ILF.resolve(REF_DATA);
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/CapitalIndexedBondSecurity.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/CapitalIndexedBondSecurity.java
@@ -79,17 +79,11 @@ public final class CapitalIndexedBondSecurity
    * The inflation rate calculation.
    * <p>
    * The reference index is interpolated index or monthly index.
-   * Real coupons are represented by {@code gearing} in this field.
+   * Real coupons are represented by {@code gearing} in the calculation.
+   * The price index value at the start of the bond is represented by {@code firstIndexValue} in the calculation.
    */
   @PropertyDefinition(validate = "notNull")
   private final InflationRateCalculation rateCalculation;
-  /**
-   * Start index value. 
-   * <p>
-   * The price index value at the start of the bond. 
-   */
-  @PropertyDefinition(validate = "ArgChecker.notNegativeOrZero")
-  private final double startIndexValue;
   /**
    * The day count convention applicable.
    * <p>
@@ -147,9 +141,21 @@ public final class CapitalIndexedBondSecurity
     ArgChecker.isTrue(settlementDateOffset.getDays() >= 0, "The settlement date offset must be non-negative");
     ArgChecker.isTrue(exCouponPeriod.getDays() <= 0,
         "The ex-coupon period is measured from the payment date, thus the days must be non-positive");
+    ArgChecker.isTrue(rateCalculation.getFirstIndexValue().isPresent(), "Rate calculation must specify first index value");
   }
 
   //-------------------------------------------------------------------------
+  /**
+   * Gets the first index value
+   * <p>
+   * This is the price index value at the start of the bond.
+   * 
+   * @return the first index value
+   */
+  public double getFirstIndexValue() {
+    return rateCalculation.getFirstIndexValue().getAsDouble();  // validated in constructor
+  }
+
   @Override
   public ImmutableSet<SecurityId> getUnderlyingIds() {
     return ImmutableSet.of();
@@ -164,7 +170,6 @@ public final class CapitalIndexedBondSecurity
         notional,
         accrualSchedule,
         rateCalculation,
-        startIndexValue,
         dayCount,
         yieldConvention,
         legalEntityId,
@@ -210,7 +215,6 @@ public final class CapitalIndexedBondSecurity
       double notional,
       PeriodicSchedule accrualSchedule,
       InflationRateCalculation rateCalculation,
-      double startIndexValue,
       DayCount dayCount,
       CapitalIndexedBondYieldConvention yieldConvention,
       StandardId legalEntityId,
@@ -221,7 +225,6 @@ public final class CapitalIndexedBondSecurity
     ArgChecker.notNegativeOrZero(notional, "notional");
     JodaBeanUtils.notNull(accrualSchedule, "accrualSchedule");
     JodaBeanUtils.notNull(rateCalculation, "rateCalculation");
-    ArgChecker.notNegativeOrZero(startIndexValue, "startIndexValue");
     JodaBeanUtils.notNull(dayCount, "dayCount");
     JodaBeanUtils.notNull(yieldConvention, "yieldConvention");
     JodaBeanUtils.notNull(legalEntityId, "legalEntityId");
@@ -232,7 +235,6 @@ public final class CapitalIndexedBondSecurity
     this.notional = notional;
     this.accrualSchedule = accrualSchedule;
     this.rateCalculation = rateCalculation;
-    this.startIndexValue = startIndexValue;
     this.dayCount = dayCount;
     this.yieldConvention = yieldConvention;
     this.legalEntityId = legalEntityId;
@@ -307,22 +309,12 @@ public final class CapitalIndexedBondSecurity
    * Gets the inflation rate calculation.
    * <p>
    * The reference index is interpolated index or monthly index.
-   * Real coupons are represented by {@code gearing} in this field.
+   * Real coupons are represented by {@code gearing} in the calculation.
+   * The price index value at the start of the bond is represented by {@code firstIndexValue} in the calculation.
    * @return the value of the property, not null
    */
   public InflationRateCalculation getRateCalculation() {
     return rateCalculation;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets start index value.
-   * <p>
-   * The price index value at the start of the bond.
-   * @return the value of the property
-   */
-  public double getStartIndexValue() {
-    return startIndexValue;
   }
 
   //-----------------------------------------------------------------------
@@ -411,7 +403,6 @@ public final class CapitalIndexedBondSecurity
           JodaBeanUtils.equal(notional, other.notional) &&
           JodaBeanUtils.equal(accrualSchedule, other.accrualSchedule) &&
           JodaBeanUtils.equal(rateCalculation, other.rateCalculation) &&
-          JodaBeanUtils.equal(startIndexValue, other.startIndexValue) &&
           JodaBeanUtils.equal(dayCount, other.dayCount) &&
           JodaBeanUtils.equal(yieldConvention, other.yieldConvention) &&
           JodaBeanUtils.equal(legalEntityId, other.legalEntityId) &&
@@ -429,7 +420,6 @@ public final class CapitalIndexedBondSecurity
     hash = hash * 31 + JodaBeanUtils.hashCode(notional);
     hash = hash * 31 + JodaBeanUtils.hashCode(accrualSchedule);
     hash = hash * 31 + JodaBeanUtils.hashCode(rateCalculation);
-    hash = hash * 31 + JodaBeanUtils.hashCode(startIndexValue);
     hash = hash * 31 + JodaBeanUtils.hashCode(dayCount);
     hash = hash * 31 + JodaBeanUtils.hashCode(yieldConvention);
     hash = hash * 31 + JodaBeanUtils.hashCode(legalEntityId);
@@ -440,14 +430,13 @@ public final class CapitalIndexedBondSecurity
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(384);
+    StringBuilder buf = new StringBuilder(352);
     buf.append("CapitalIndexedBondSecurity{");
     buf.append("info").append('=').append(info).append(',').append(' ');
     buf.append("currency").append('=').append(currency).append(',').append(' ');
     buf.append("notional").append('=').append(notional).append(',').append(' ');
     buf.append("accrualSchedule").append('=').append(accrualSchedule).append(',').append(' ');
     buf.append("rateCalculation").append('=').append(rateCalculation).append(',').append(' ');
-    buf.append("startIndexValue").append('=').append(startIndexValue).append(',').append(' ');
     buf.append("dayCount").append('=').append(dayCount).append(',').append(' ');
     buf.append("yieldConvention").append('=').append(yieldConvention).append(',').append(' ');
     buf.append("legalEntityId").append('=').append(legalEntityId).append(',').append(' ');
@@ -493,11 +482,6 @@ public final class CapitalIndexedBondSecurity
     private final MetaProperty<InflationRateCalculation> rateCalculation = DirectMetaProperty.ofImmutable(
         this, "rateCalculation", CapitalIndexedBondSecurity.class, InflationRateCalculation.class);
     /**
-     * The meta-property for the {@code startIndexValue} property.
-     */
-    private final MetaProperty<Double> startIndexValue = DirectMetaProperty.ofImmutable(
-        this, "startIndexValue", CapitalIndexedBondSecurity.class, Double.TYPE);
-    /**
      * The meta-property for the {@code dayCount} property.
      */
     private final MetaProperty<DayCount> dayCount = DirectMetaProperty.ofImmutable(
@@ -532,7 +516,6 @@ public final class CapitalIndexedBondSecurity
         "notional",
         "accrualSchedule",
         "rateCalculation",
-        "startIndexValue",
         "dayCount",
         "yieldConvention",
         "legalEntityId",
@@ -558,8 +541,6 @@ public final class CapitalIndexedBondSecurity
           return accrualSchedule;
         case -521703991:  // rateCalculation
           return rateCalculation;
-        case -1656407615:  // startIndexValue
-          return startIndexValue;
         case 1905311443:  // dayCount
           return dayCount;
         case -1895216418:  // yieldConvention
@@ -631,14 +612,6 @@ public final class CapitalIndexedBondSecurity
     }
 
     /**
-     * The meta-property for the {@code startIndexValue} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<Double> startIndexValue() {
-      return startIndexValue;
-    }
-
-    /**
      * The meta-property for the {@code dayCount} property.
      * @return the meta-property, not null
      */
@@ -692,8 +665,6 @@ public final class CapitalIndexedBondSecurity
           return ((CapitalIndexedBondSecurity) bean).getAccrualSchedule();
         case -521703991:  // rateCalculation
           return ((CapitalIndexedBondSecurity) bean).getRateCalculation();
-        case -1656407615:  // startIndexValue
-          return ((CapitalIndexedBondSecurity) bean).getStartIndexValue();
         case 1905311443:  // dayCount
           return ((CapitalIndexedBondSecurity) bean).getDayCount();
         case -1895216418:  // yieldConvention
@@ -730,7 +701,6 @@ public final class CapitalIndexedBondSecurity
     private double notional;
     private PeriodicSchedule accrualSchedule;
     private InflationRateCalculation rateCalculation;
-    private double startIndexValue;
     private DayCount dayCount;
     private CapitalIndexedBondYieldConvention yieldConvention;
     private StandardId legalEntityId;
@@ -754,7 +724,6 @@ public final class CapitalIndexedBondSecurity
       this.notional = beanToCopy.getNotional();
       this.accrualSchedule = beanToCopy.getAccrualSchedule();
       this.rateCalculation = beanToCopy.getRateCalculation();
-      this.startIndexValue = beanToCopy.getStartIndexValue();
       this.dayCount = beanToCopy.getDayCount();
       this.yieldConvention = beanToCopy.getYieldConvention();
       this.legalEntityId = beanToCopy.getLegalEntityId();
@@ -776,8 +745,6 @@ public final class CapitalIndexedBondSecurity
           return accrualSchedule;
         case -521703991:  // rateCalculation
           return rateCalculation;
-        case -1656407615:  // startIndexValue
-          return startIndexValue;
         case 1905311443:  // dayCount
           return dayCount;
         case -1895216418:  // yieldConvention
@@ -810,9 +777,6 @@ public final class CapitalIndexedBondSecurity
           break;
         case -521703991:  // rateCalculation
           this.rateCalculation = (InflationRateCalculation) newValue;
-          break;
-        case -1656407615:  // startIndexValue
-          this.startIndexValue = (Double) newValue;
           break;
         case 1905311443:  // dayCount
           this.dayCount = (DayCount) newValue;
@@ -867,7 +831,6 @@ public final class CapitalIndexedBondSecurity
           notional,
           accrualSchedule,
           rateCalculation,
-          startIndexValue,
           dayCount,
           yieldConvention,
           legalEntityId,
@@ -932,26 +895,14 @@ public final class CapitalIndexedBondSecurity
      * Sets the inflation rate calculation.
      * <p>
      * The reference index is interpolated index or monthly index.
-     * Real coupons are represented by {@code gearing} in this field.
+     * Real coupons are represented by {@code gearing} in the calculation.
+     * The price index value at the start of the bond is represented by {@code firstIndexValue} in the calculation.
      * @param rateCalculation  the new value, not null
      * @return this, for chaining, not null
      */
     public Builder rateCalculation(InflationRateCalculation rateCalculation) {
       JodaBeanUtils.notNull(rateCalculation, "rateCalculation");
       this.rateCalculation = rateCalculation;
-      return this;
-    }
-
-    /**
-     * Sets start index value.
-     * <p>
-     * The price index value at the start of the bond.
-     * @param startIndexValue  the new value
-     * @return this, for chaining, not null
-     */
-    public Builder startIndexValue(double startIndexValue) {
-      ArgChecker.notNegativeOrZero(startIndexValue, "startIndexValue");
-      this.startIndexValue = startIndexValue;
       return this;
     }
 
@@ -1033,14 +984,13 @@ public final class CapitalIndexedBondSecurity
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(384);
+      StringBuilder buf = new StringBuilder(352);
       buf.append("CapitalIndexedBondSecurity.Builder{");
       buf.append("info").append('=').append(JodaBeanUtils.toString(info)).append(',').append(' ');
       buf.append("currency").append('=').append(JodaBeanUtils.toString(currency)).append(',').append(' ');
       buf.append("notional").append('=').append(JodaBeanUtils.toString(notional)).append(',').append(' ');
       buf.append("accrualSchedule").append('=').append(JodaBeanUtils.toString(accrualSchedule)).append(',').append(' ');
       buf.append("rateCalculation").append('=').append(JodaBeanUtils.toString(rateCalculation)).append(',').append(' ');
-      buf.append("startIndexValue").append('=').append(JodaBeanUtils.toString(startIndexValue)).append(',').append(' ');
       buf.append("dayCount").append('=').append(JodaBeanUtils.toString(dayCount)).append(',').append(' ');
       buf.append("yieldConvention").append('=').append(JodaBeanUtils.toString(yieldConvention)).append(',').append(' ');
       buf.append("legalEntityId").append('=').append(JodaBeanUtils.toString(legalEntityId)).append(',').append(' ');

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/CapitalIndexedBondTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/CapitalIndexedBondTrade.java
@@ -102,8 +102,7 @@ public final class CapitalIndexedBondTrade
               product.getAccrualSchedule().getStartDate(),
               settlementDate));
     } else {
-      RateObservation rateObservation =
-          product.getRateCalculation().createRateObservation(settlementDate, product.getStartIndexValue());
+      RateObservation rateObservation = product.getRateCalculation().createRateObservation(settlementDate);
       settlement = CapitalIndexedBondPaymentPeriod.builder()
           .startDate(resolvedProduct.getStartDate())
           .unadjustedStartDate(product.getAccrualSchedule().getStartDate())

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/FixedCouponBondPaymentPeriod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/FixedCouponBondPaymentPeriod.java
@@ -55,7 +55,7 @@ public final class FixedCouponBondPaymentPeriod
   @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final Currency currency;
   /**
-   * The notional amount, must be positive. 
+   * The notional amount, must be positive.
    * <p>
    * The notional amount applicable during the period.
    * The currency of the notional is specified by {@code currency}.
@@ -108,7 +108,7 @@ public final class FixedCouponBondPaymentPeriod
   @PropertyDefinition(validate = "notNull")
   private final LocalDate detachmentDate;
   /**
-   * The fixed coupon rate. 
+   * The fixed coupon rate.
    * <p>
    * The single payment is based on this fixed coupon rate.
    */

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedCapitalIndexedBond.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/ResolvedCapitalIndexedBond.java
@@ -138,17 +138,11 @@ public final class ResolvedCapitalIndexedBond
    * The inflation rate calculation.
    * <p>
    * The reference index is interpolated index or monthly index.
-   * Real coupons are represented by {@code gearing} in this field.
+   * Real coupons are represented by {@code gearing} in the calculation.
+   * The price index value at the start of the bond is represented by {@code firstIndexValue} in the calculation.
    */
   @PropertyDefinition(validate = "notNull")
   private final InflationRateCalculation rateCalculation;
-  /**
-   * Start index value.
-   * <p>
-   * The price index value at the start of the bond.
-   */
-  @PropertyDefinition(validate = "ArgChecker.notNegativeOrZero")
-  private final double startIndexValue;
 
   //-------------------------------------------------------------------------
   @ImmutableValidator
@@ -158,6 +152,7 @@ public final class ResolvedCapitalIndexedBond
         periodicPayments.stream().map(CapitalIndexedBondPaymentPeriod::getCurrency).collect(Collectors.toSet());
     currencies.add(currencyNominal);
     ArgChecker.isTrue(currencies.size() == 1, "Product must have a single currency, found: " + currencies);
+    ArgChecker.isTrue(rateCalculation.getFirstIndexValue().isPresent(), "Rate calculation must specify first index value");
   }
 
   //-------------------------------------------------------------------------
@@ -237,6 +232,17 @@ public final class ResolvedCapitalIndexedBond
    */
   public boolean hasExCouponPeriod() {
     return periodicPayments.get(0).hasExCouponPeriod();
+  }
+
+  /**
+   * Gets the first index value
+   * <p>
+   * This is the price index value at the start of the bond.
+   * 
+   * @return the first index value
+   */
+  public double getFirstIndexValue() {
+    return rateCalculation.getFirstIndexValue().getAsDouble();  // validated in constructor
   }
 
   //-------------------------------------------------------------------------
@@ -398,8 +404,7 @@ public final class ResolvedCapitalIndexedBond
       CapitalIndexedBondYieldConvention yieldConvention,
       StandardId legalEntityId,
       DaysAdjustment settlementDateOffset,
-      InflationRateCalculation rateCalculation,
-      double startIndexValue) {
+      InflationRateCalculation rateCalculation) {
     JodaBeanUtils.notNull(securityId, "securityId");
     JodaBeanUtils.notNull(nominalPayment, "nominalPayment");
     JodaBeanUtils.notNull(periodicPayments, "periodicPayments");
@@ -410,7 +415,6 @@ public final class ResolvedCapitalIndexedBond
     JodaBeanUtils.notNull(legalEntityId, "legalEntityId");
     JodaBeanUtils.notNull(settlementDateOffset, "settlementDateOffset");
     JodaBeanUtils.notNull(rateCalculation, "rateCalculation");
-    ArgChecker.notNegativeOrZero(startIndexValue, "startIndexValue");
     this.securityId = securityId;
     this.nominalPayment = nominalPayment;
     this.periodicPayments = ImmutableList.copyOf(periodicPayments);
@@ -421,7 +425,6 @@ public final class ResolvedCapitalIndexedBond
     this.legalEntityId = legalEntityId;
     this.settlementDateOffset = settlementDateOffset;
     this.rateCalculation = rateCalculation;
-    this.startIndexValue = startIndexValue;
     validate();
   }
 
@@ -548,22 +551,12 @@ public final class ResolvedCapitalIndexedBond
    * Gets the inflation rate calculation.
    * <p>
    * The reference index is interpolated index or monthly index.
-   * Real coupons are represented by {@code gearing} in this field.
+   * Real coupons are represented by {@code gearing} in the calculation.
+   * The price index value at the start of the bond is represented by {@code firstIndexValue} in the calculation.
    * @return the value of the property, not null
    */
   public InflationRateCalculation getRateCalculation() {
     return rateCalculation;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets start index value.
-   * <p>
-   * The price index value at the start of the bond.
-   * @return the value of the property
-   */
-  public double getStartIndexValue() {
-    return startIndexValue;
   }
 
   //-----------------------------------------------------------------------
@@ -591,8 +584,7 @@ public final class ResolvedCapitalIndexedBond
           JodaBeanUtils.equal(yieldConvention, other.yieldConvention) &&
           JodaBeanUtils.equal(legalEntityId, other.legalEntityId) &&
           JodaBeanUtils.equal(settlementDateOffset, other.settlementDateOffset) &&
-          JodaBeanUtils.equal(rateCalculation, other.rateCalculation) &&
-          JodaBeanUtils.equal(startIndexValue, other.startIndexValue);
+          JodaBeanUtils.equal(rateCalculation, other.rateCalculation);
     }
     return false;
   }
@@ -610,13 +602,12 @@ public final class ResolvedCapitalIndexedBond
     hash = hash * 31 + JodaBeanUtils.hashCode(legalEntityId);
     hash = hash * 31 + JodaBeanUtils.hashCode(settlementDateOffset);
     hash = hash * 31 + JodaBeanUtils.hashCode(rateCalculation);
-    hash = hash * 31 + JodaBeanUtils.hashCode(startIndexValue);
     return hash;
   }
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(384);
+    StringBuilder buf = new StringBuilder(352);
     buf.append("ResolvedCapitalIndexedBond{");
     buf.append("securityId").append('=').append(securityId).append(',').append(' ');
     buf.append("nominalPayment").append('=').append(nominalPayment).append(',').append(' ');
@@ -627,8 +618,7 @@ public final class ResolvedCapitalIndexedBond
     buf.append("yieldConvention").append('=').append(yieldConvention).append(',').append(' ');
     buf.append("legalEntityId").append('=').append(legalEntityId).append(',').append(' ');
     buf.append("settlementDateOffset").append('=').append(settlementDateOffset).append(',').append(' ');
-    buf.append("rateCalculation").append('=').append(rateCalculation).append(',').append(' ');
-    buf.append("startIndexValue").append('=').append(JodaBeanUtils.toString(startIndexValue));
+    buf.append("rateCalculation").append('=').append(JodaBeanUtils.toString(rateCalculation));
     buf.append('}');
     return buf.toString();
   }
@@ -695,11 +685,6 @@ public final class ResolvedCapitalIndexedBond
     private final MetaProperty<InflationRateCalculation> rateCalculation = DirectMetaProperty.ofImmutable(
         this, "rateCalculation", ResolvedCapitalIndexedBond.class, InflationRateCalculation.class);
     /**
-     * The meta-property for the {@code startIndexValue} property.
-     */
-    private final MetaProperty<Double> startIndexValue = DirectMetaProperty.ofImmutable(
-        this, "startIndexValue", ResolvedCapitalIndexedBond.class, Double.TYPE);
-    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
@@ -713,8 +698,7 @@ public final class ResolvedCapitalIndexedBond
         "yieldConvention",
         "legalEntityId",
         "settlementDateOffset",
-        "rateCalculation",
-        "startIndexValue");
+        "rateCalculation");
 
     /**
      * Restricted constructor.
@@ -745,8 +729,6 @@ public final class ResolvedCapitalIndexedBond
           return settlementDateOffset;
         case -521703991:  // rateCalculation
           return rateCalculation;
-        case -1656407615:  // startIndexValue
-          return startIndexValue;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -847,14 +829,6 @@ public final class ResolvedCapitalIndexedBond
       return rateCalculation;
     }
 
-    /**
-     * The meta-property for the {@code startIndexValue} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<Double> startIndexValue() {
-      return startIndexValue;
-    }
-
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
@@ -879,8 +853,6 @@ public final class ResolvedCapitalIndexedBond
           return ((ResolvedCapitalIndexedBond) bean).getSettlementDateOffset();
         case -521703991:  // rateCalculation
           return ((ResolvedCapitalIndexedBond) bean).getRateCalculation();
-        case -1656407615:  // startIndexValue
-          return ((ResolvedCapitalIndexedBond) bean).getStartIndexValue();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -912,7 +884,6 @@ public final class ResolvedCapitalIndexedBond
     private StandardId legalEntityId;
     private DaysAdjustment settlementDateOffset;
     private InflationRateCalculation rateCalculation;
-    private double startIndexValue;
 
     /**
      * Restricted constructor.
@@ -935,7 +906,6 @@ public final class ResolvedCapitalIndexedBond
       this.legalEntityId = beanToCopy.getLegalEntityId();
       this.settlementDateOffset = beanToCopy.getSettlementDateOffset();
       this.rateCalculation = beanToCopy.getRateCalculation();
-      this.startIndexValue = beanToCopy.getStartIndexValue();
     }
 
     //-----------------------------------------------------------------------
@@ -962,8 +932,6 @@ public final class ResolvedCapitalIndexedBond
           return settlementDateOffset;
         case -521703991:  // rateCalculation
           return rateCalculation;
-        case -1656407615:  // startIndexValue
-          return startIndexValue;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -1002,9 +970,6 @@ public final class ResolvedCapitalIndexedBond
           break;
         case -521703991:  // rateCalculation
           this.rateCalculation = (InflationRateCalculation) newValue;
-          break;
-        case -1656407615:  // startIndexValue
-          this.startIndexValue = (Double) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -1048,8 +1013,7 @@ public final class ResolvedCapitalIndexedBond
           yieldConvention,
           legalEntityId,
           settlementDateOffset,
-          rateCalculation,
-          startIndexValue);
+          rateCalculation);
     }
 
     //-----------------------------------------------------------------------
@@ -1188,7 +1152,8 @@ public final class ResolvedCapitalIndexedBond
      * Sets the inflation rate calculation.
      * <p>
      * The reference index is interpolated index or monthly index.
-     * Real coupons are represented by {@code gearing} in this field.
+     * Real coupons are represented by {@code gearing} in the calculation.
+     * The price index value at the start of the bond is represented by {@code firstIndexValue} in the calculation.
      * @param rateCalculation  the new value, not null
      * @return this, for chaining, not null
      */
@@ -1198,23 +1163,10 @@ public final class ResolvedCapitalIndexedBond
       return this;
     }
 
-    /**
-     * Sets start index value.
-     * <p>
-     * The price index value at the start of the bond.
-     * @param startIndexValue  the new value
-     * @return this, for chaining, not null
-     */
-    public Builder startIndexValue(double startIndexValue) {
-      ArgChecker.notNegativeOrZero(startIndexValue, "startIndexValue");
-      this.startIndexValue = startIndexValue;
-      return this;
-    }
-
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(384);
+      StringBuilder buf = new StringBuilder(352);
       buf.append("ResolvedCapitalIndexedBond.Builder{");
       buf.append("securityId").append('=').append(JodaBeanUtils.toString(securityId)).append(',').append(' ');
       buf.append("nominalPayment").append('=').append(JodaBeanUtils.toString(nominalPayment)).append(',').append(' ');
@@ -1225,8 +1177,7 @@ public final class ResolvedCapitalIndexedBond
       buf.append("yieldConvention").append('=').append(JodaBeanUtils.toString(yieldConvention)).append(',').append(' ');
       buf.append("legalEntityId").append('=').append(JodaBeanUtils.toString(legalEntityId)).append(',').append(' ');
       buf.append("settlementDateOffset").append('=').append(JodaBeanUtils.toString(settlementDateOffset)).append(',').append(' ');
-      buf.append("rateCalculation").append('=').append(JodaBeanUtils.toString(rateCalculation)).append(',').append(' ');
-      buf.append("startIndexValue").append('=').append(JodaBeanUtils.toString(startIndexValue));
+      buf.append("rateCalculation").append('=').append(JodaBeanUtils.toString(rateCalculation));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondSecurityTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondSecurityTest.java
@@ -51,7 +51,7 @@ public class CapitalIndexedBondSecurityTest {
   private static final CapitalIndexedBondYieldConvention YIELD_CONVENTION = INDEX_LINKED_FLOAT;
   private static final StandardId LEGAL_ENTITY = StandardId.of("OG-Ticker", "BUN EUR");
   private static final double NOTIONAL = 1.0e7;
-  private static final InflationRateCalculation RATE = InflationRateCalculation.of(GB_HICP, 3, false);
+  private static final InflationRateCalculation RATE = InflationRateCalculation.of(GB_HICP, 3, false, 120d);
   private static final DaysAdjustment DATE_OFFSET = DaysAdjustment.ofBusinessDays(3, EUTA);
   private static final DayCount DAY_COUNT = DayCounts.ACT_365F;
   private static final LocalDate START_DATE = LocalDate.of(2015, 4, 12);
@@ -69,6 +69,7 @@ public class CapitalIndexedBondSecurityTest {
     assertEquals(test.getSecurityId(), PRODUCT.getSecurityId());
     assertEquals(test.getCurrency(), PRODUCT.getCurrency());
     assertEquals(test.getUnderlyingIds(), ImmutableSet.of());
+    assertEquals(test.getFirstIndexValue(), PRODUCT.getFirstIndexValue());
   }
 
   public void test_builder_fail() {
@@ -76,7 +77,6 @@ public class CapitalIndexedBondSecurityTest {
         .info(INFO)
         .dayCount(DAY_COUNT)
         .rateCalculation(RATE)
-        .startIndexValue(120)
         .legalEntityId(LEGAL_ENTITY)
         .currency(EUR)
         .notional(NOTIONAL)
@@ -89,7 +89,6 @@ public class CapitalIndexedBondSecurityTest {
         .info(INFO)
         .dayCount(DAY_COUNT)
         .rateCalculation(RATE)
-        .startIndexValue(120)
         .legalEntityId(LEGAL_ENTITY)
         .currency(EUR)
         .notional(NOTIONAL)
@@ -139,7 +138,6 @@ public class CapitalIndexedBondSecurityTest {
         .notional(product.getNotional())
         .accrualSchedule(product.getAccrualSchedule())
         .rateCalculation(product.getRateCalculation())
-        .startIndexValue(product.getStartIndexValue())
         .dayCount(product.getDayCount())
         .yieldConvention(product.getYieldConvention())
         .legalEntityId(product.getLegalEntityId())

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondTest.java
@@ -69,6 +69,7 @@ public class CapitalIndexedBondTest {
       .index(US_CPI_U)
       .lag(Period.ofMonths(3))
       .interpolated(true)
+      .firstIndexValue(START_INDEX)
       .build();
   private static final BusinessDayAdjustment EX_COUPON_ADJ =
       BusinessDayAdjustment.of(BusinessDayConventions.PRECEDING, USNY);
@@ -93,9 +94,9 @@ public class CapitalIndexedBondTest {
     assertEquals(test.getNotional(), NOTIONAL);
     assertEquals(test.getAccrualSchedule(), SCHEDULE);
     assertEquals(test.getRateCalculation(), RATE_CALC);
+    assertEquals(test.getFirstIndexValue(), RATE_CALC.getFirstIndexValue().getAsDouble());
     assertEquals(test.getSettlementDateOffset(), SETTLE_OFFSET);
     assertEquals(test.getYieldConvention(), US_IL_REAL);
-    assertEquals(test.getStartIndexValue(), START_INDEX);
   }
 
   public void test_builder_min() {
@@ -109,7 +110,6 @@ public class CapitalIndexedBondTest {
         .yieldConvention(US_IL_REAL)
         .settlementDateOffset(SETTLE_OFFSET)
         .accrualSchedule(SCHEDULE)
-        .startIndexValue(START_INDEX)
         .build();
     assertEquals(test.getSecurityId(), SECURITY_ID);
     assertEquals(test.getCurrency(), USD);
@@ -121,7 +121,6 @@ public class CapitalIndexedBondTest {
     assertEquals(test.getRateCalculation(), RATE_CALC);
     assertEquals(test.getSettlementDateOffset(), SETTLE_OFFSET);
     assertEquals(test.getYieldConvention(), US_IL_REAL);
-    assertEquals(test.getStartIndexValue(), START_INDEX);
   }
 
   public void test_builder_fail() {
@@ -137,7 +136,6 @@ public class CapitalIndexedBondTest {
         .yieldConvention(US_IL_REAL)
         .settlementDateOffset(DaysAdjustment.ofBusinessDays(-2, USNY))
         .accrualSchedule(SCHEDULE)
-        .startIndexValue(START_INDEX)
         .build());
     // positive ex-coupon days
     assertThrowsIllegalArg(() -> CapitalIndexedBond.builder()
@@ -152,7 +150,6 @@ public class CapitalIndexedBondTest {
         .yieldConvention(US_IL_REAL)
         .settlementDateOffset(SETTLE_OFFSET)
         .accrualSchedule(SCHEDULE)
-        .startIndexValue(START_INDEX)
         .build());
   }
 
@@ -165,7 +162,7 @@ public class CapitalIndexedBondTest {
       LocalDate start = SCHEDULE_ADJ.adjust(unAdjDates[i], REF_DATA);
       LocalDate end = SCHEDULE_ADJ.adjust(unAdjDates[i + 1], REF_DATA);
       LocalDate detachment = EX_COUPON.adjust(end, REF_DATA);
-      RateObservation obs = RATE_CALC.createRateObservation(end, START_INDEX);
+      RateObservation obs = RATE_CALC.createRateObservation(end);
       periodic[i] = CapitalIndexedBondPaymentPeriod.builder()
           .currency(USD)
           .startDate(start)
@@ -191,7 +188,6 @@ public class CapitalIndexedBondTest {
         .settlementDateOffset(SETTLE_OFFSET)
         .yieldConvention(US_IL_REAL)
         .rateCalculation(base.getRateCalculation())
-        .startIndexValue(base.getStartIndexValue())
         .build();
     assertEquals(base.resolve(REF_DATA), expected);
   }
@@ -219,7 +215,6 @@ public class CapitalIndexedBondTest {
         .yieldConvention(US_IL_REAL)
         .settlementDateOffset(SETTLE_OFFSET)
         .accrualSchedule(SCHEDULE)
-        .startIndexValue(START_INDEX)
         .build();
   }
 
@@ -235,7 +230,6 @@ public class CapitalIndexedBondTest {
         .yieldConvention(INDEX_LINKED_FLOAT)
         .settlementDateOffset(SETTLE_OFFSET)
         .accrualSchedule(SCHEDULE)
-        .startIndexValue(START_INDEX)
         .build();
   }
 
@@ -250,12 +244,12 @@ public class CapitalIndexedBondTest {
                 .index(GB_RPI)
                 .lag(Period.ofMonths(2))
                 .interpolated(true)
+                .firstIndexValue(124.556)
                 .build())
         .exCouponPeriod(EX_COUPON)
         .legalEntityId(StandardId.of("OG-Ticker", "US-Govt-1"))
         .yieldConvention(INDEX_LINKED_FLOAT)
         .settlementDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
-        .startIndexValue(124.556)
         .accrualSchedule(
             PeriodicSchedule.of(
                 START, END, FREQUENCY,

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondTradeTest.java
@@ -65,7 +65,7 @@ public class CapitalIndexedBondTradeTest {
       .unadjustedStartDate(START)
       .endDate(SETTLEMENT_DATE)
       .currency(USD)
-      .rateObservation(PRODUCT.getRateCalculation().createRateObservation(SETTLEMENT_DATE, PRODUCT.getStartIndexValue()))
+      .rateObservation(PRODUCT.getRateCalculation().createRateObservation(SETTLEMENT_DATE))
       .notional(
           -PRODUCT.getNotional() * QUANTITY *
               (PRICE + PRODUCT.resolve(REF_DATA).accruedInterest(SETTLEMENT_DATE) / PRODUCT.getNotional()))

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedCapitalIndexedBondTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedCapitalIndexedBondTest.java
@@ -56,9 +56,9 @@ public class ResolvedCapitalIndexedBondTest {
       .index(US_CPI_U)
       .lag(Period.ofMonths(3))
       .interpolated(true)
+      .firstIndexValue(198.475)
       .build();
   private static final double NOTIONAL = 10_000_000d;
-  private static final double START_INDEX = 198.475;
   private static final BusinessDayAdjustment SCHEDULE_ADJ =
       BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, USNY);
   private static final DaysAdjustment SETTLE_OFFSET = DaysAdjustment.ofBusinessDays(2, USNY);
@@ -70,7 +70,7 @@ public class ResolvedCapitalIndexedBondTest {
     for (int i = 0; i < 4; ++i) {
       LocalDate start = SCHEDULE_ADJ.adjust(unAdjDates[i], REF_DATA);
       LocalDate end = SCHEDULE_ADJ.adjust(unAdjDates[i + 1], REF_DATA);
-      RateObservation obs = RATE_CALC.createRateObservation(end, START_INDEX);
+      RateObservation obs = RATE_CALC.createRateObservation(end);
       PERIODIC[i] = CapitalIndexedBondPaymentPeriod.builder()
           .currency(USD)
           .startDate(start)
@@ -102,6 +102,7 @@ public class ResolvedCapitalIndexedBondTest {
     assertEquals(test.getSettlementDateOffset(), SETTLE_OFFSET);
     assertEquals(test.getYieldConvention(), US_IL_REAL);
     assertEquals(test.hasExCouponPeriod(), false);
+    assertEquals(test.getFirstIndexValue(), RATE_CALC.getFirstIndexValue().getAsDouble());
     assertEquals(test.findPeriod(PERIODIC[0].getUnadjustedStartDate()), Optional.of(test.getPeriodicPayments().get(0)));
     assertEquals(test.findPeriod(LocalDate.MIN), Optional.empty());
     assertEquals(test.findPeriodIndex(PERIODIC[0].getUnadjustedStartDate()), OptionalInt.of(0));
@@ -183,8 +184,7 @@ public class ResolvedCapitalIndexedBondTest {
         .rollConvention(CapitalIndexedBondTest.sut().getAccrualSchedule().calculatedRollConvention())
         .settlementDateOffset(SETTLE_OFFSET)
         .yieldConvention(US_IL_REAL)
-        .rateCalculation(CapitalIndexedBondTest.sut().getRateCalculation())
-        .startIndexValue(CapitalIndexedBondTest.sut().getStartIndexValue())
+        .rateCalculation(RATE_CALC)
         .build();
   }
 
@@ -200,7 +200,6 @@ public class ResolvedCapitalIndexedBondTest {
         .settlementDateOffset(DaysAdjustment.ofBusinessDays(3, GBLO))
         .yieldConvention(INDEX_LINKED_FLOAT)
         .rateCalculation(CapitalIndexedBondTest.sut2().getRateCalculation())
-        .startIndexValue(CapitalIndexedBondTest.sut2().getStartIndexValue())
         .build();
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedCapitalIndexedBondTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedCapitalIndexedBondTradeTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.product.bond;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
@@ -20,6 +21,12 @@ import com.opengamma.strata.basics.market.ReferenceData;
 public class ResolvedCapitalIndexedBondTradeTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
+
+  //-------------------------------------------------------------------------
+  public void test_builder() {
+    ResolvedCapitalIndexedBondTrade test = sut();
+    assertEquals(test.getSettlementDate(), test.getInfo().getSettlementDate().get());
+  }
 
   //-------------------------------------------------------------------------
   public void coverage() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedFixedCouponBondTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/ResolvedFixedCouponBondTradeTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.product.bond;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
@@ -20,6 +21,12 @@ import com.opengamma.strata.basics.market.ReferenceData;
 public class ResolvedFixedCouponBondTradeTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
+
+  //-------------------------------------------------------------------------
+  public void test_builder() {
+    ResolvedFixedCouponBondTrade test = sut();
+    assertEquals(test.getSettlementDate(), test.getInfo().getSettlementDate().get());
+  }
 
   //-------------------------------------------------------------------------
   public void coverage() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/InflationRateCalculationTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/InflationRateCalculationTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.product.swap;
 import static com.opengamma.strata.basics.index.PriceIndices.CH_CPI;
 import static com.opengamma.strata.basics.index.PriceIndices.GB_HICP;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.time.YearMonth;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 import org.testng.annotations.Test;
 
@@ -44,19 +46,18 @@ import com.opengamma.strata.product.rate.InflationMonthlyRateObservation;
 public class InflationRateCalculationTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
-  private static final LocalDate DATE_2014_01_05 = date(2014, 1, 5);
-  private static final LocalDate DATE_2015_01_06 = date(2015, 1, 6);
   private static final LocalDate DATE_2015_01_05 = date(2015, 1, 5);
-  private static final LocalDate DATE_2016_01_05 = date(2016, 1, 5);
-  private static final LocalDate DATE_2016_01_07 = date(2016, 1, 7);
-  private static final LocalDate DATE_2017_01_05 = date(2017, 1, 5);
+  private static final LocalDate DATE_2015_02_05 = date(2015, 2, 5);
+  private static final LocalDate DATE_2015_03_05 = date(2015, 3, 5);
+  private static final LocalDate DATE_2015_03_07 = date(2015, 3, 7);
+  private static final LocalDate DATE_2015_04_05 = date(2015, 4, 5);
 
   private static final SchedulePeriod ACCRUAL1 =
-      SchedulePeriod.of(DATE_2014_01_05, DATE_2015_01_06, DATE_2014_01_05, DATE_2015_01_05);
+      SchedulePeriod.of(DATE_2015_01_05, DATE_2015_02_05, DATE_2015_01_05, DATE_2015_02_05);
   private static final SchedulePeriod ACCRUAL2 =
-      SchedulePeriod.of(DATE_2015_01_06, DATE_2016_01_07, DATE_2015_01_05, DATE_2016_01_05);
+      SchedulePeriod.of(DATE_2015_02_05, DATE_2015_03_07, DATE_2015_02_05, DATE_2015_03_05);
   private static final SchedulePeriod ACCRUAL3 =
-      SchedulePeriod.of(DATE_2016_01_07, DATE_2017_01_05, DATE_2016_01_05, DATE_2017_01_05);
+      SchedulePeriod.of(DATE_2015_03_07, DATE_2015_04_05, DATE_2015_03_05, DATE_2015_04_05);
   private static final Schedule ACCRUAL_SCHEDULE = Schedule.builder()
       .periods(ACCRUAL1, ACCRUAL2, ACCRUAL3)
       .frequency(Frequency.P1M)
@@ -72,6 +73,17 @@ public class InflationRateCalculationTest {
     assertEquals(test1.getIndex(), CH_CPI);
     assertEquals(test1.getLag(), Period.ofMonths(3));
     assertEquals(test1.isInterpolated(), false);
+    assertEquals(test1.getFirstIndexValue(), OptionalDouble.empty());
+    assertEquals(test1.getGearing(), Optional.empty());
+    assertEquals(test1.getType(), SwapLegType.INFLATION);
+  }
+
+  public void test_of_firstIndexValue() {
+    InflationRateCalculation test1 = InflationRateCalculation.of(CH_CPI, 3, false, 123d);
+    assertEquals(test1.getIndex(), CH_CPI);
+    assertEquals(test1.getLag(), Period.ofMonths(3));
+    assertEquals(test1.isInterpolated(), false);
+    assertEquals(test1.getFirstIndexValue(), OptionalDouble.of(123d));
     assertEquals(test1.getGearing(), Optional.empty());
     assertEquals(test1.getType(), SwapLegType.INFLATION);
   }
@@ -82,11 +94,13 @@ public class InflationRateCalculationTest {
         .index(CH_CPI)
         .lag(Period.ofMonths(3))
         .interpolated(false)
+        .firstIndexValue(123d)
         .build();
     assertEquals(test1.getIndex(), CH_CPI);
     assertEquals(test1.getLag(), Period.ofMonths(3));
     assertEquals(test1.isInterpolated(), false);
     assertEquals(test1.getGearing(), Optional.empty());
+    assertEquals(test1.getFirstIndexValue(), OptionalDouble.of(123d));
     assertEquals(test1.getType(), SwapLegType.INFLATION);
     InflationRateCalculation test2 = InflationRateCalculation.builder()
         .index(GB_HICP)
@@ -97,6 +111,7 @@ public class InflationRateCalculationTest {
     assertEquals(test2.getIndex(), GB_HICP);
     assertEquals(test2.getLag(), Period.ofMonths(4));
     assertEquals(test2.isInterpolated(), true);
+    assertEquals(test2.getFirstIndexValue(), OptionalDouble.empty());
     assertEquals(test2.getGearing().get(), GEARING);
     assertEquals(test2.getType(), SwapLegType.INFLATION);
   }
@@ -129,7 +144,7 @@ public class InflationRateCalculationTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_expand_Monthly() {
+  public void test_createAccrualPeriods_Monthly() {
     InflationRateCalculation test = InflationRateCalculation.builder()
         .index(GB_HICP)
         .lag(Period.ofMonths(3))
@@ -140,46 +155,45 @@ public class InflationRateCalculationTest {
         .rateObservation(
             InflationMonthlyRateObservation.of(
                 GB_HICP,
-                YearMonth.from(DATE_2014_01_05).minusMonths(3),
-                YearMonth.from(DATE_2015_01_06).minusMonths(3)))
+                YearMonth.from(DATE_2015_01_05).minusMonths(3),
+                YearMonth.from(DATE_2015_02_05).minusMonths(3)))
         .build();
     RateAccrualPeriod rap2 = RateAccrualPeriod.builder(ACCRUAL2)
         .yearFraction(1.0)
         .rateObservation(
             InflationMonthlyRateObservation.of(
                 GB_HICP,
-                YearMonth.from(DATE_2015_01_06).minusMonths(3),
-                YearMonth.from(DATE_2016_01_07).minusMonths(3)))
+                YearMonth.from(DATE_2015_02_05).minusMonths(3),
+                YearMonth.from(DATE_2015_03_07).minusMonths(3)))
         .build();
     RateAccrualPeriod rap3 = RateAccrualPeriod.builder(ACCRUAL3)
         .yearFraction(1.0)
         .rateObservation(
             InflationMonthlyRateObservation.of(
                 GB_HICP,
-                YearMonth.from(DATE_2016_01_07).minusMonths(3),
-                YearMonth.from(DATE_2017_01_05).minusMonths(3)))
+                YearMonth.from(DATE_2015_03_07).minusMonths(3),
+                YearMonth.from(DATE_2015_04_05).minusMonths(3)))
         .build();
     ImmutableList<RateAccrualPeriod> periods = test.createAccrualPeriods(ACCRUAL_SCHEDULE, ACCRUAL_SCHEDULE, REF_DATA);
     assertEquals(periods, ImmutableList.of(rap1, rap2, rap3));
   }
 
-  @Test
-  public void test_expand_Interpolated() {
+  public void test_createAccrualPeriods_Interpolated() {
     InflationRateCalculation test = InflationRateCalculation.builder()
         .index(CH_CPI)
         .lag(Period.ofMonths(3))
         .interpolated(true)
         .build();
-    double weight1 = 1.0 - 5.0 / 31.0;
+    double weight1 = 1.0 - 4.0 / 28.0;
     double weight2 = 1.0 - 6.0 / 31.0;
-    double weight3 = 1.0 - 4.0 / 31.0;
+    double weight3 = 1.0 - 4.0 / 30.0;
     RateAccrualPeriod rap1 = RateAccrualPeriod
         .builder(ACCRUAL1)
         .yearFraction(1.0)
         .rateObservation(InflationInterpolatedRateObservation.of(
             CH_CPI,
-            YearMonth.from(DATE_2014_01_05).minusMonths(3),
-            YearMonth.from(DATE_2015_01_06).minusMonths(3),
+            YearMonth.from(DATE_2015_01_05).minusMonths(3),
+            YearMonth.from(DATE_2015_02_05).minusMonths(3),
             weight1))
         .build();
     RateAccrualPeriod rap2 = RateAccrualPeriod
@@ -187,8 +201,8 @@ public class InflationRateCalculationTest {
         .yearFraction(1.0)
         .rateObservation(InflationInterpolatedRateObservation.of(
             CH_CPI,
-            YearMonth.from(DATE_2015_01_06).minusMonths(3),
-            YearMonth.from(DATE_2016_01_07).minusMonths(3),
+            YearMonth.from(DATE_2015_02_05).minusMonths(3),
+            YearMonth.from(DATE_2015_03_07).minusMonths(3),
             weight2))
         .build();
     RateAccrualPeriod rap3 = RateAccrualPeriod
@@ -196,9 +210,44 @@ public class InflationRateCalculationTest {
         .yearFraction(1.0)
         .rateObservation(InflationInterpolatedRateObservation.of(
             CH_CPI,
-            YearMonth.from(DATE_2016_01_07).minusMonths(3),
-            YearMonth.from(DATE_2017_01_05).minusMonths(3),
+            YearMonth.from(DATE_2015_03_07).minusMonths(3),
+            YearMonth.from(DATE_2015_04_05).minusMonths(3),
             weight3))
+        .build();
+    ImmutableList<RateAccrualPeriod> periods = test.createAccrualPeriods(ACCRUAL_SCHEDULE, ACCRUAL_SCHEDULE, REF_DATA);
+    assertEquals(periods, ImmutableList.of(rap1, rap2, rap3));
+  }
+
+  public void test_createAccrualPeriods_Monthly_firstKnown() {
+    InflationRateCalculation test = InflationRateCalculation.builder()
+        .index(GB_HICP)
+        .lag(Period.ofMonths(3))
+        .interpolated(false)
+        .firstIndexValue(123d)
+        .build();
+    RateAccrualPeriod rap1 = RateAccrualPeriod.builder(ACCRUAL1)
+        .yearFraction(1.0)
+        .rateObservation(
+            InflationEndMonthRateObservation.of(
+                GB_HICP,
+                123d,
+                YearMonth.from(DATE_2015_02_05).minusMonths(3)))
+        .build();
+    RateAccrualPeriod rap2 = RateAccrualPeriod.builder(ACCRUAL2)
+        .yearFraction(1.0)
+        .rateObservation(
+            InflationMonthlyRateObservation.of(
+                GB_HICP,
+                YearMonth.from(DATE_2015_02_05).minusMonths(3),
+                YearMonth.from(DATE_2015_03_07).minusMonths(3)))
+        .build();
+    RateAccrualPeriod rap3 = RateAccrualPeriod.builder(ACCRUAL3)
+        .yearFraction(1.0)
+        .rateObservation(
+            InflationMonthlyRateObservation.of(
+                GB_HICP,
+                YearMonth.from(DATE_2015_03_07).minusMonths(3),
+                YearMonth.from(DATE_2015_04_05).minusMonths(3)))
         .build();
     ImmutableList<RateAccrualPeriod> periods = test.createAccrualPeriods(ACCRUAL_SCHEDULE, ACCRUAL_SCHEDULE, REF_DATA);
     assertEquals(periods, ImmutableList.of(rap1, rap2, rap3));
@@ -210,37 +259,47 @@ public class InflationRateCalculationTest {
         .index(GB_HICP)
         .lag(Period.ofMonths(3))
         .interpolated(false)
+        .firstIndexValue(START_INDEX)
         .build();
     InflationEndMonthRateObservation obs1 = InflationEndMonthRateObservation.of(
-        GB_HICP, START_INDEX, YearMonth.from(DATE_2015_01_06).minusMonths(3));
+        GB_HICP, START_INDEX, YearMonth.from(DATE_2015_02_05).minusMonths(3));
     InflationEndMonthRateObservation obs2 = InflationEndMonthRateObservation.of(
-        GB_HICP, START_INDEX, YearMonth.from(DATE_2016_01_07).minusMonths(3));
+        GB_HICP, START_INDEX, YearMonth.from(DATE_2015_03_07).minusMonths(3));
     InflationEndMonthRateObservation obs3 = InflationEndMonthRateObservation.of(
-        GB_HICP, START_INDEX, YearMonth.from(DATE_2017_01_05).minusMonths(3));
-    assertEquals(test.createRateObservation(DATE_2015_01_06, START_INDEX), obs1);
-    assertEquals(test.createRateObservation(DATE_2016_01_07, START_INDEX), obs2);
-    assertEquals(test.createRateObservation(DATE_2017_01_05, START_INDEX), obs3);
+        GB_HICP, START_INDEX, YearMonth.from(DATE_2015_04_05).minusMonths(3));
+    assertEquals(test.createRateObservation(DATE_2015_02_05), obs1);
+    assertEquals(test.createRateObservation(DATE_2015_03_07), obs2);
+    assertEquals(test.createRateObservation(DATE_2015_04_05), obs3);
   }
 
-  @Test
   public void test_createRateObservation_Interpolated() {
     InflationRateCalculation test = InflationRateCalculation.builder()
         .index(CH_CPI)
         .lag(Period.ofMonths(3))
         .interpolated(true)
+        .firstIndexValue(START_INDEX)
         .build();
-    double weight1 = 1.0 - 5.0 / 31.0;
+    double weight1 = 1.0 - 4.0 / 28.0;
     double weight2 = 1.0 - 6.0 / 31.0;
-    double weight3 = 1.0 - 4.0 / 31.0;
+    double weight3 = 1.0 - 4.0 / 30.0;
     InflationEndInterpolatedRateObservation obs1 = InflationEndInterpolatedRateObservation.of(
-        CH_CPI, START_INDEX, YearMonth.from(DATE_2015_01_06).minusMonths(3), weight1);
+        CH_CPI, START_INDEX, YearMonth.from(DATE_2015_02_05).minusMonths(3), weight1);
     InflationEndInterpolatedRateObservation obs2 = InflationEndInterpolatedRateObservation.of(
-        CH_CPI, START_INDEX, YearMonth.from(DATE_2016_01_07).minusMonths(3), weight2);
+        CH_CPI, START_INDEX, YearMonth.from(DATE_2015_03_07).minusMonths(3), weight2);
     InflationEndInterpolatedRateObservation obs3 = InflationEndInterpolatedRateObservation.of(
-        CH_CPI, START_INDEX, YearMonth.from(DATE_2017_01_05).minusMonths(3), weight3);
-    assertEquals(test.createRateObservation(DATE_2015_01_06, START_INDEX), obs1);
-    assertEquals(test.createRateObservation(DATE_2016_01_07, START_INDEX), obs2);
-    assertEquals(test.createRateObservation(DATE_2017_01_05, START_INDEX), obs3);
+        CH_CPI, START_INDEX, YearMonth.from(DATE_2015_04_05).minusMonths(3), weight3);
+    assertEquals(test.createRateObservation(DATE_2015_02_05), obs1);
+    assertEquals(test.createRateObservation(DATE_2015_03_07), obs2);
+    assertEquals(test.createRateObservation(DATE_2015_04_05), obs3);
+  }
+
+  public void test_createRateObservation_noFirstIndexValue() {
+    InflationRateCalculation test = InflationRateCalculation.builder()
+        .index(CH_CPI)
+        .lag(Period.ofMonths(3))
+        .interpolated(true)
+        .build();
+    assertThrows(() -> test.createRateObservation(DATE_2015_04_05), IllegalStateException.class);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Allow InflationRateCalculation to store a locked index value
For swaps, this matches the FpML initialIndexLevel field
For bonds, this allows startIndexValue to be removed