### PR TITLE
Cross FX in FxRateProvider

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/MarketDataFxRateProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/MarketDataFxRateProvider.java
@@ -55,11 +55,11 @@ class MarketDataFxRateProvider implements FxRateProvider {
       return rateCounter1.get().crossRate(rateCounter2.get()).fxRate(baseCurrency, counterCurrency);
     }
     // Double triangulation
-    if(rateBase1.isPresent() && rateCounter2.isPresent()) {
+    if (rateBase1.isPresent() && rateCounter2.isPresent()) {
       Optional<FxRate> rateTriangular2 = marketData.findValue(FxRateKey.of(triangularBaseCcy, triangularCounterCcy));
-      if(rateTriangular2.isPresent()) {
+      if (rateTriangular2.isPresent()) {
         return rateBase1.get().crossRate(rateTriangular2.get()).crossRate(rateCounter2.get())
-            .fxRate(baseCurrency, counterCurrency);        
+            .fxRate(baseCurrency, counterCurrency);
       }
     }
     throw new IllegalArgumentException("No market data available for pair " + baseCurrency + "/" + counterCurrency);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/MarketDataFxRateProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/calibration/MarketDataFxRateProvider.java
@@ -40,14 +40,29 @@ class MarketDataFxRateProvider implements FxRateProvider {
     if (rate.isPresent()) {
       return rate.get().fxRate(baseCurrency, counterCurrency);
     }
-    // Try triangulation on first currency
-    Currency triangularCcy = baseCurrency.getTriangulationCurrency();
-    Optional<FxRate> rate1 = marketData.findValue(FxRateKey.of(baseCurrency, triangularCcy));
-    Optional<FxRate> rate2 = marketData.findValue(FxRateKey.of(triangularCcy, counterCurrency));
-    if(rate1.isPresent() && rate2.isPresent()) {
-      return rate1.get().crossRate(rate2.get()).fxRate(baseCurrency, counterCurrency);
+    // Try triangulation on base currency
+    Currency triangularBaseCcy = baseCurrency.getTriangulationCurrency();
+    Optional<FxRate> rateBase1 = marketData.findValue(FxRateKey.of(baseCurrency, triangularBaseCcy));
+    Optional<FxRate> rateBase2 = marketData.findValue(FxRateKey.of(triangularBaseCcy, counterCurrency));
+    if (rateBase1.isPresent() && rateBase2.isPresent()) {
+      return rateBase1.get().crossRate(rateBase2.get()).fxRate(baseCurrency, counterCurrency);
+    }
+    // Try triangulation on counter currency
+    Currency triangularCounterCcy = counterCurrency.getTriangulationCurrency();
+    Optional<FxRate> rateCounter1 = marketData.findValue(FxRateKey.of(baseCurrency, triangularCounterCcy));
+    Optional<FxRate> rateCounter2 = marketData.findValue(FxRateKey.of(triangularCounterCcy, counterCurrency));
+    if (rateCounter1.isPresent() && rateCounter2.isPresent()) {
+      return rateCounter1.get().crossRate(rateCounter2.get()).fxRate(baseCurrency, counterCurrency);
+    }
+    // Double triangulation
+    if(rateBase1.isPresent() && rateCounter2.isPresent()) {
+      Optional<FxRate> rateTriangular2 = marketData.findValue(FxRateKey.of(triangularBaseCcy, triangularCounterCcy));
+      if(rateTriangular2.isPresent()) {
+        return rateBase1.get().crossRate(rateTriangular2.get()).crossRate(rateCounter2.get())
+            .fxRate(baseCurrency, counterCurrency);        
+      }
     }
     throw new IllegalArgumentException("No market data available for pair " + baseCurrency + "/" + counterCurrency);
   }
-  
+
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/MarketDataFxRateProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/calibration/MarketDataFxRateProviderTest.java
@@ -29,6 +29,8 @@ public class MarketDataFxRateProviderTest {
   private static final LocalDate VAL_DATE = date(2015, 6, 30);
   private static final double EUR_USD = 1.10; 
   private static final double GBP_USD = 1.50; 
+  private static final Currency BEF = Currency.of("BEF");
+  private static final double EUR_BEF = 40.3399; 
 
   public void fxRate() {
     double eurUsdRate = provider().fxRate(Currency.EUR, Currency.USD);
@@ -51,7 +53,7 @@ public class MarketDataFxRateProviderTest {
     assertThrowsIllegalArg(() -> provider().fxRate(Currency.EUR, Currency.GBP));
   }
 
-  public void cross() {
+  public void cross_base() {
     Map<FxRateKey, FxRate> marketDataMap =
         ImmutableMap.of(FxRateKey.of(Currency.EUR, Currency.USD), FxRate.of(Currency.EUR, Currency.USD, EUR_USD),
             FxRateKey.of(Currency.GBP, Currency.USD), FxRate.of(Currency.GBP, Currency.USD, GBP_USD));
@@ -59,6 +61,27 @@ public class MarketDataFxRateProviderTest {
     FxRateProvider fx =  new MarketDataFxRateProvider(marketData);
     assertEquals(fx.fxRate(Currency.GBP, Currency.EUR), GBP_USD / EUR_USD, 1.0E-10);
     assertEquals(fx.fxRate(Currency.EUR, Currency.GBP), EUR_USD / GBP_USD, 1.0E-10);
+  }
+
+  public void cross_counter() {
+    Map<FxRateKey, FxRate> marketDataMap =
+        ImmutableMap.of(FxRateKey.of(Currency.EUR, Currency.USD), FxRate.of(Currency.EUR, Currency.USD, EUR_USD),
+            FxRateKey.of(Currency.EUR, BEF), FxRate.of(Currency.EUR, BEF, EUR_BEF));
+    MarketData marketData = ImmutableMarketData.of(VAL_DATE, marketDataMap);
+    FxRateProvider fx =  new MarketDataFxRateProvider(marketData);
+    assertEquals(fx.fxRate(Currency.USD, BEF), EUR_BEF / EUR_USD, 1.0E-10);
+    assertEquals(fx.fxRate(BEF, Currency.USD), EUR_USD / EUR_BEF, 1.0E-10);
+  }
+
+  public void cross_double_triangle() {
+    Map<FxRateKey, FxRate> marketDataMap =
+        ImmutableMap.of(FxRateKey.of(Currency.EUR, Currency.USD), FxRate.of(Currency.EUR, Currency.USD, EUR_USD),
+            FxRateKey.of(Currency.EUR, BEF), FxRate.of(Currency.EUR, BEF, EUR_BEF),
+            FxRateKey.of(Currency.GBP, Currency.USD), FxRate.of(Currency.GBP, Currency.USD, GBP_USD));
+    MarketData marketData = ImmutableMarketData.of(VAL_DATE, marketDataMap);
+    FxRateProvider fx =  new MarketDataFxRateProvider(marketData);
+    assertEquals(fx.fxRate(Currency.GBP, BEF), GBP_USD * EUR_BEF / EUR_USD, 1.0E-10);
+    assertEquals(fx.fxRate(BEF, Currency.GBP), EUR_USD / EUR_BEF / GBP_USD, 1.0E-10);
   }
 
 }


### PR DESCRIPTION
Add the flexibility for the MarketDataFxRateProvider to compute rates from triangulation.