### PR TITLE
Rename task requirements method

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/report/ReportRunnerTool.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/report/ReportRunnerTool.java
@@ -204,7 +204,7 @@ public class ReportRunnerTool implements AutoCloseable {
 
     // calculate the results
     CalculationTasks tasks = CalculationTasks.of(rules, trades, columns);
-    MarketDataRequirements reqs = tasks.getRequirements(refData);
+    MarketDataRequirements reqs = tasks.requirements(refData);
     MarketEnvironment enhancedMarketData = marketDataFactory()
         .buildMarketData(reqs, MarketDataConfig.empty(), marketSnapshot, refData);
     Results results = runner.getTaskRunner().calculateSingleScenario(tasks, enhancedMarketData, refData);

--- a/examples/src/test/java/com/opengamma/strata/examples/regression/SwapReportRegressionTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/regression/SwapReportRegressionTest.java
@@ -88,7 +88,7 @@ public class SwapReportRegressionTest {
 
     // using the direct executor means there is no need to close/shutdown the runner
     CalculationTasks tasks = CalculationTasks.of(rules, trades, columns);
-    MarketDataRequirements reqs = tasks.getRequirements(REF_DATA);
+    MarketDataRequirements reqs = tasks.requirements(REF_DATA);
     MarketEnvironment enhancedMarketData = marketDataFactory()
         .buildMarketData(reqs, MarketDataConfig.empty(), marketSnapshot, REF_DATA);
     CalculationTaskRunner runner = CalculationTaskRunner.of(MoreExecutors.newDirectExecutorService());

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketDataRequirements.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketDataRequirements.java
@@ -83,7 +83,7 @@ public final class MarketDataRequirements implements ImmutableBean {
       List<Column> columns,
       ReferenceData refData) {
 
-    return CalculationTasks.of(calculationRules, targets, columns).getRequirements(refData);
+    return CalculationTasks.of(calculationRules, targets, columns).requirements(refData);
   }
 
   /**

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationTasksTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationTasksTest.java
@@ -110,7 +110,7 @@ public class CalculationTasksTest {
 
     CalculationTasks test = CalculationTasks.of(calculationRules, targets, columns);
 
-    MarketDataRequirements requirements = test.getRequirements(REF_DATA);
+    MarketDataRequirements requirements = test.requirements(REF_DATA);
     Set<? extends MarketDataId<?>> nonObservables = requirements.getNonObservables();
     ImmutableSet<? extends ObservableId> observables = requirements.getObservables();
     ImmutableSet<ObservableId> timeSeries = requirements.getTimeSeries();

--- a/modules/function/src/test/java/com/opengamma/strata/function/calculation/swap/SwapPricingTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/calculation/swap/SwapPricingTest.java
@@ -151,7 +151,7 @@ public class SwapPricingTest {
 
     // calculate results using the runner
     CalculationTasks tasks = CalculationTasks.of(rules, trades, columns);
-    MarketDataRequirements reqs = tasks.getRequirements(REF_DATA);
+    MarketDataRequirements reqs = tasks.requirements(REF_DATA);
     MarketEnvironment enhancedMarketData = marketDataFactory()
         .buildMarketData(reqs, MarketDataConfig.empty(), suppliedData, REF_DATA);
     // using the direct executor means there is no need to close/shutdown the runner

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveEndToEndTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveEndToEndTest.java
@@ -187,7 +187,7 @@ public class CurveEndToEndTest {
 
     // using the direct executor means there is no need to close/shutdown the runner
     CalculationTasks tasks = CalculationTasks.of(calculationRules, trades, columns);
-    MarketDataRequirements reqs = tasks.getRequirements(REF_DATA);
+    MarketDataRequirements reqs = tasks.requirements(REF_DATA);
     MarketEnvironment enhancedMarketData = marketDataFactory()
         .buildMarketData(reqs, marketDataConfig, knownMarketData, REF_DATA);
     CalculationTaskRunner runner = CalculationTaskRunner.of(MoreExecutors.newDirectExecutorService());


### PR DESCRIPTION
Rename getRequirements() to requirements() as it performs an action
Remove caching, did not account for different reference data instances