### PR TITLE
Clean SABR implementation for rho~1.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/smile/fitting/SabrModelFitter.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/smile/fitting/SabrModelFitter.java
@@ -27,12 +27,14 @@ import com.opengamma.strata.pricer.impl.volatility.smile.function.VolatilityFunc
  */
 public final class SabrModelFitter extends SmileModelFitter<SabrFormulaData> {
 
+  private static final double RHO_LIMIT = 0.999;
+  // Allowing for rho to be equal to 1 or -1 does not make sense from a financial point of view and creates numerical instability
   private static final ParameterLimitsTransform[] DEFAULT_TRANSFORMS;
   static {
     DEFAULT_TRANSFORMS = new ParameterLimitsTransform[4];
     DEFAULT_TRANSFORMS[0] = new SingleRangeLimitTransform(0, LimitType.GREATER_THAN); // alpha > 0
     DEFAULT_TRANSFORMS[1] = new DoubleRangeLimitTransform(0, 1.0); // 0 <= beta <= 1
-    DEFAULT_TRANSFORMS[2] = new DoubleRangeLimitTransform(-1.0, 1.0); // -1 <= rho <= 1
+    DEFAULT_TRANSFORMS[2] = new DoubleRangeLimitTransform(-RHO_LIMIT, RHO_LIMIT); // -RHO_LIMIT <= rho <= RHO_LIMIT
     DEFAULT_TRANSFORMS[3] = new SingleRangeLimitTransform(0, LimitType.GREATER_THAN); // nu > 0
   }
 


### PR DESCRIPTION
Return error message when the limit diverge. This is the case when rho -> 0 and z>1.
Change calibration to avoid rho~1. Allowing for rho to be equal to 1 or -1 does not make sense from a financial point of view and creates numerical instability. The bounds for the rho in the calibration are set to RHO_LIMIT = 0.999.