### PR TITLE
Created curve sensitivity re-bucketing util.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.sensitivity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivity;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveParameterMetadata;
+import com.opengamma.strata.market.curve.DatedCurveParameterMetadata;
+import com.opengamma.strata.market.curve.DefaultCurveMetadata;
+import com.opengamma.strata.market.curve.meta.SimpleCurveNodeMetadata;
+
+/**
+ * Utilities to transform sensitivities.
+ */
+public class CurveSensitivityUtils {
+
+  /**
+   * Re-buckets a {@link CurveCurrencyParameterSensitivities} to a given set of dates. 
+   * <p>
+   * The list of dates must be sorted in chronological order. All sensitivities are re-bucketed to the same date list.
+   * The re-bucketing is done by linear weighting on the number of days, i.e. the sensitivities for dates outside the 
+   * extremes are fully bucketed to the extremes and for date between two re-bucketing dates, the weight on the start 
+   * date is the number days between end date and the date re-bucketed divided by the number of days between the 
+   * start and the end.
+   * The input sensitivity should have a {@link DatedCurveParameterMetadata} for each sensitivity. 
+   * 
+   * @param sensitivities  the input sensitivities
+   * @param targetDates  the list of dates for the re-bucketing
+   * @return the sensitivity after the re-bucketing
+   */
+  public static CurveCurrencyParameterSensitivities linearRebucketing(
+      CurveCurrencyParameterSensitivities sensitivities,
+      List<LocalDate> targetDates) {
+    int nbBuckets = targetDates.size();
+    List<CurveParameterMetadata> pmdTarget = new ArrayList<>();
+    for(int i = 0; i<nbBuckets; i++) {
+      pmdTarget.add(SimpleCurveNodeMetadata.of(targetDates.get(i), targetDates.get(i).toString()));
+    }
+    ImmutableList<CurveCurrencyParameterSensitivity> listSensi = sensitivities.getSensitivities();
+    List<CurveCurrencyParameterSensitivity> sensitivityTarget = new ArrayList<>();
+    for (CurveCurrencyParameterSensitivity s : listSensi) {
+      double[] rebucketedSensitivityAmounts = new double[nbBuckets];
+      CurveMetadata m = s.getMetadata();
+      DoubleArray sa = s.getSensitivity();
+      ArgChecker.isTrue(m.getParameterMetadata().isPresent(), "parameter metadata must be present");
+      List<CurveParameterMetadata> lm = m.getParameterMetadata().get();
+      for (int loopnode = 0; loopnode < sa.size(); loopnode++) {
+        ArgChecker.isTrue(lm.get(loopnode) instanceof DatedCurveParameterMetadata, "re-bucketing require sensitivity date");
+        DatedCurveParameterMetadata dpm = (DatedCurveParameterMetadata) lm.get(loopnode);
+        if (!dpm.getDate().isAfter(targetDates.get(0))) {
+          rebucketedSensitivityAmounts[0] += sa.get(loopnode);
+        } else if (!dpm.getDate().isBefore(targetDates.get(nbBuckets - 1))) {
+          rebucketedSensitivityAmounts[nbBuckets - 1] += sa.get(loopnode);
+        } else {
+          int k = 0;
+          while (dpm.getDate().isAfter(targetDates.get(k))) {
+            k++;
+          } // k contains the index of the node after "dpm" date 
+          long intervalLength = targetDates.get(k).toEpochDay() - targetDates.get(k - 1).toEpochDay();
+          double weight = ((double) (targetDates.get(k).toEpochDay() - dpm.getDate().toEpochDay())) / intervalLength;
+          rebucketedSensitivityAmounts[k - 1] += weight * sa.get(loopnode);
+          rebucketedSensitivityAmounts[k] += (1.0d - weight) * sa.get(loopnode);
+        }
+      }
+      CurveCurrencyParameterSensitivity rebucketedSensitivity =
+          CurveCurrencyParameterSensitivity.of(
+              DefaultCurveMetadata.builder().curveName(s.getCurveName()).parameterMetadata(pmdTarget).build(),
+              s.getCurrency(), DoubleArray.ofUnsafe(rebucketedSensitivityAmounts));
+      sensitivityTarget.add(rebucketedSensitivity);
+    }
+    return CurveCurrencyParameterSensitivities.of(sensitivityTarget);
+  }
+
+}

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
@@ -58,11 +58,12 @@ public class CurveSensitivityUtils {
       List<CurveParameterMetadata> parameterMetadataList = metadataCurve.getParameterMetadata()
           .orElseThrow(() -> new IllegalArgumentException("parameter metadata must be present"));
       for (int loopnode = 0; loopnode < sensitivityAmounts.size(); loopnode++) {
-        ArgChecker.isTrue(parameterMetadataList.get(loopnode) instanceof DatedCurveParameterMetadata,
+        CurveParameterMetadata nodeMetadata = parameterMetadataList.get(loopnode);
+        ArgChecker.isTrue(nodeMetadata instanceof DatedCurveParameterMetadata,
             "re-bucketing requires sensitivity date for node {} which is of type {} while 'DatedCurveParameterMetadata' is expected", 
-            parameterMetadataList.get(loopnode).getLabel(), parameterMetadataList.get(loopnode).getClass());
-        DatedCurveParameterMetadata dpm = (DatedCurveParameterMetadata) parameterMetadataList.get(loopnode);
-        LocalDate nodeDate = dpm.getDate();
+            nodeMetadata.getLabel(), nodeMetadata.getClass().getName());
+        DatedCurveParameterMetadata datedParameterMetadata = (DatedCurveParameterMetadata) nodeMetadata;
+        LocalDate nodeDate = datedParameterMetadata.getDate();
         rebucketingArray(targetDates, rebucketedSensitivityAmounts, sensitivityAmounts.get(loopnode), nodeDate);
       }
       CurveCurrencyParameterSensitivity rebucketedSensitivity =
@@ -108,17 +109,18 @@ public class CurveSensitivityUtils {
       List<CurveParameterMetadata> parameterMetadataList = metadataCurve.getParameterMetadata()
           .orElseThrow(() -> new IllegalArgumentException("parameter metadata must be present"));
       for (int loopnode = 0; loopnode < sensitivityAmounts.size(); loopnode++) {
-        ArgChecker.isTrue((parameterMetadataList.get(loopnode) instanceof DatedCurveParameterMetadata) ||
-            (parameterMetadataList.get(loopnode) instanceof TenorCurveNodeMetadata), 
+        CurveParameterMetadata nodeMetadata = parameterMetadataList.get(loopnode);
+        ArgChecker.isTrue((nodeMetadata instanceof DatedCurveParameterMetadata) ||
+            (nodeMetadata instanceof TenorCurveNodeMetadata), 
             "re-bucketing requires sensitivity date or node for node {} which is of type {}", 
-            parameterMetadataList.get(loopnode).getLabel(), parameterMetadataList.get(loopnode).getClass());
+            nodeMetadata.getLabel(), nodeMetadata.getClass().getName());
         LocalDate nodeDate;
-        if (parameterMetadataList.get(loopnode) instanceof DatedCurveParameterMetadata) {
-          DatedCurveParameterMetadata dpm = (DatedCurveParameterMetadata) parameterMetadataList.get(loopnode);
-          nodeDate = dpm.getDate();
+        if (nodeMetadata instanceof DatedCurveParameterMetadata) {
+          DatedCurveParameterMetadata datedParameterMetadata = (DatedCurveParameterMetadata) nodeMetadata;
+          nodeDate = datedParameterMetadata.getDate();
         } else {
-          TenorCurveNodeMetadata tpm = (TenorCurveNodeMetadata) parameterMetadataList.get(loopnode);
-          nodeDate = sensitivityDate.plus(tpm.getTenor());
+          TenorCurveNodeMetadata tenorParameterMetadata = (TenorCurveNodeMetadata) nodeMetadata;
+          nodeDate = sensitivityDate.plus(tenorParameterMetadata.getTenor());
         }
         rebucketingArray(targetDates, rebucketedSensitivityAmounts, sensitivityAmounts.get(loopnode), nodeDate);
       }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
@@ -5,10 +5,11 @@
  */
 package com.opengamma.strata.pricer.sensitivity;
 
+import static java.util.stream.Collectors.toList;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.opengamma.strata.collect.ArgChecker;
@@ -48,7 +49,7 @@ public class CurveSensitivityUtils {
     int nbBuckets = targetDates.size();    
     List<CurveParameterMetadata> pmdTarget = targetDates.stream()
         .map(date -> SimpleCurveNodeMetadata.of(date, date.toString()))
-        .collect(Collectors.toList());
+        .collect(toList());
     ImmutableList<CurveCurrencyParameterSensitivity> sensitivitiesList = sensitivities.getSensitivities();
     List<CurveCurrencyParameterSensitivity> sensitivityTarget = new ArrayList<>();
     for (CurveCurrencyParameterSensitivity sensitivity : sensitivitiesList) {
@@ -99,7 +100,7 @@ public class CurveSensitivityUtils {
     int nbBuckets = targetDates.size(); 
     List<CurveParameterMetadata> pmdTarget = targetDates.stream()
         .map(date -> SimpleCurveNodeMetadata.of(date, date.toString()))
-        .collect(Collectors.toList());
+        .collect(toList());
     ImmutableList<CurveCurrencyParameterSensitivity> sensitivitiesList = sensitivities.getSensitivities();
     List<CurveCurrencyParameterSensitivity> sensitivityTarget = new ArrayList<>();
     for (CurveCurrencyParameterSensitivity sensitivity : sensitivitiesList) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtils.java
@@ -19,6 +19,7 @@ import com.opengamma.strata.market.curve.CurveParameterMetadata;
 import com.opengamma.strata.market.curve.DatedCurveParameterMetadata;
 import com.opengamma.strata.market.curve.DefaultCurveMetadata;
 import com.opengamma.strata.market.curve.meta.SimpleCurveNodeMetadata;
+import com.opengamma.strata.market.curve.meta.TenorCurveNodeMetadata;
 
 /**
  * Utilities to transform sensitivities.
@@ -44,7 +45,7 @@ public class CurveSensitivityUtils {
       List<LocalDate> targetDates) {
     int nbBuckets = targetDates.size();
     List<CurveParameterMetadata> pmdTarget = new ArrayList<>();
-    for(int i = 0; i<nbBuckets; i++) {
+    for (int i = 0; i < nbBuckets; i++) {
       pmdTarget.add(SimpleCurveNodeMetadata.of(targetDates.get(i), targetDates.get(i).toString()));
     }
     ImmutableList<CurveCurrencyParameterSensitivity> listSensi = sensitivities.getSensitivities();
@@ -56,22 +57,11 @@ public class CurveSensitivityUtils {
       ArgChecker.isTrue(m.getParameterMetadata().isPresent(), "parameter metadata must be present");
       List<CurveParameterMetadata> lm = m.getParameterMetadata().get();
       for (int loopnode = 0; loopnode < sa.size(); loopnode++) {
-        ArgChecker.isTrue(lm.get(loopnode) instanceof DatedCurveParameterMetadata, "re-bucketing require sensitivity date");
+        ArgChecker.isTrue(lm.get(loopnode) instanceof DatedCurveParameterMetadata,
+            "re-bucketing require sensitivity date");
         DatedCurveParameterMetadata dpm = (DatedCurveParameterMetadata) lm.get(loopnode);
-        if (!dpm.getDate().isAfter(targetDates.get(0))) {
-          rebucketedSensitivityAmounts[0] += sa.get(loopnode);
-        } else if (!dpm.getDate().isBefore(targetDates.get(nbBuckets - 1))) {
-          rebucketedSensitivityAmounts[nbBuckets - 1] += sa.get(loopnode);
-        } else {
-          int k = 0;
-          while (dpm.getDate().isAfter(targetDates.get(k))) {
-            k++;
-          } // k contains the index of the node after "dpm" date 
-          long intervalLength = targetDates.get(k).toEpochDay() - targetDates.get(k - 1).toEpochDay();
-          double weight = ((double) (targetDates.get(k).toEpochDay() - dpm.getDate().toEpochDay())) / intervalLength;
-          rebucketedSensitivityAmounts[k - 1] += weight * sa.get(loopnode);
-          rebucketedSensitivityAmounts[k] += (1.0d - weight) * sa.get(loopnode);
-        }
+        LocalDate nodeDate = dpm.getDate();
+        rebucketingArray(targetDates, nbBuckets, rebucketedSensitivityAmounts, sa.get(loopnode), nodeDate);
       }
       CurveCurrencyParameterSensitivity rebucketedSensitivity =
           CurveCurrencyParameterSensitivity.of(
@@ -80,6 +70,91 @@ public class CurveSensitivityUtils {
       sensitivityTarget.add(rebucketedSensitivity);
     }
     return CurveCurrencyParameterSensitivities.of(sensitivityTarget);
+  }
+
+
+  /**
+   * Re-buckets a {@link CurveCurrencyParameterSensitivities} to a given set of dates. 
+   * <p>
+   * The list of dates must be sorted in chronological order. All sensitivities are re-bucketed to the same date list.
+   * The re-bucketing is done by linear weighting on the number of days, i.e. the sensitivities for dates outside the 
+   * extremes are fully bucketed to the extremes and for date between two re-bucketing dates, the weight on the start 
+   * date is the number days between end date and the date re-bucketed divided by the number of days between the 
+   * start and the end.
+   * The input sensitivity should have a {@link DatedCurveParameterMetadata} for each sensitivity. 
+   * 
+   * @param sensitivities  the input sensitivities
+   * @param targetDates  the list of dates for the re-bucketing
+   * @param sensitivityDate  the date for which the sensitivities are valid
+   * @return the sensitivity after the re-bucketing
+   */
+  public static CurveCurrencyParameterSensitivities linearRebucketing(
+      CurveCurrencyParameterSensitivities sensitivities,
+      List<LocalDate> targetDates,
+      LocalDate sensitivityDate) {
+    int nbBuckets = targetDates.size();
+    List<CurveParameterMetadata> pmdTarget = new ArrayList<>();
+    for (int i = 0; i < nbBuckets; i++) {
+      pmdTarget.add(SimpleCurveNodeMetadata.of(targetDates.get(i), targetDates.get(i).toString()));
+    }
+    ImmutableList<CurveCurrencyParameterSensitivity> listSensi = sensitivities.getSensitivities();
+    List<CurveCurrencyParameterSensitivity> sensitivityTarget = new ArrayList<>();
+    for (CurveCurrencyParameterSensitivity s : listSensi) {
+      double[] rebucketedSensitivityAmounts = new double[nbBuckets];
+      CurveMetadata m = s.getMetadata();
+      DoubleArray sa = s.getSensitivity();
+      ArgChecker.isTrue(m.getParameterMetadata().isPresent(), "parameter metadata must be present");
+      List<CurveParameterMetadata> lm = m.getParameterMetadata().get();
+      for (int loopnode = 0; loopnode < sa.size(); loopnode++) {
+        ArgChecker.isTrue((lm.get(loopnode) instanceof DatedCurveParameterMetadata) ||
+            (lm.get(loopnode) instanceof TenorCurveNodeMetadata), "re-bucketing require sensitivity date");
+        LocalDate nodeDate;
+        if (lm.get(loopnode) instanceof DatedCurveParameterMetadata) {
+          DatedCurveParameterMetadata dpm = (DatedCurveParameterMetadata) lm.get(loopnode);
+          nodeDate = dpm.getDate();
+        } else {
+          TenorCurveNodeMetadata tpm = (TenorCurveNodeMetadata) lm.get(loopnode);
+          nodeDate = sensitivityDate.plus(tpm.getTenor());
+        }
+        rebucketingArray(targetDates, nbBuckets, rebucketedSensitivityAmounts, sa.get(loopnode), nodeDate);
+      }
+      CurveCurrencyParameterSensitivity rebucketedSensitivity =
+          CurveCurrencyParameterSensitivity.of(
+              DefaultCurveMetadata.builder().curveName(s.getCurveName()).parameterMetadata(pmdTarget).build(),
+              s.getCurrency(), DoubleArray.ofUnsafe(rebucketedSensitivityAmounts));
+      sensitivityTarget.add(rebucketedSensitivity);
+    }
+    return CurveCurrencyParameterSensitivities.of(sensitivityTarget);
+  }
+
+  /**
+   * 
+   * @param targetDates
+   * @param nbBuckets
+   * @param rebucketedSensitivityAmounts  the array of sensitivities; the array is modified by the method
+   * @param sa
+   * @param nodeDate  the date associated to the node re-bucketed
+   */
+  private static void rebucketingArray(
+      List<LocalDate> targetDates, 
+      int nbBuckets, 
+      double[] rebucketedSensitivityAmounts, 
+      double sa, 
+      LocalDate nodeDate) {
+    if (!nodeDate.isAfter(targetDates.get(0))) {
+      rebucketedSensitivityAmounts[0] += sa;
+    } else if (!nodeDate.isBefore(targetDates.get(nbBuckets - 1))) {
+      rebucketedSensitivityAmounts[nbBuckets - 1] += sa;
+    } else {
+      int k = 0;
+      while (nodeDate.isAfter(targetDates.get(k))) {
+        k++;
+      } // k contains the index of the node after "dpm" date 
+      long intervalLength = targetDates.get(k).toEpochDay() - targetDates.get(k - 1).toEpochDay();
+      double weight = ((double) (targetDates.get(k).toEpochDay() - nodeDate.toEpochDay())) / intervalLength;
+      rebucketedSensitivityAmounts[k - 1] += weight * sa;
+      rebucketedSensitivityAmounts[k] += (1.0d - weight) * sa;
+    }
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtilsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtilsTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.sensitivity;
+
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivities;
+import com.opengamma.strata.market.curve.CurveCurrencyParameterSensitivity;
+import com.opengamma.strata.market.curve.CurveMetadata;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.CurveParameterMetadata;
+import com.opengamma.strata.market.curve.DefaultCurveMetadata;
+import com.opengamma.strata.market.curve.meta.SimpleCurveNodeMetadata;
+import com.opengamma.strata.market.curve.meta.TenorCurveNodeMetadata;
+
+/**
+ * Tests {@link CurveSensitivityUtils}.
+ */
+@Test
+public class CurveSensitivityUtilsTest {
+  
+  private static final CurveName NAME_1 = CurveName.of("CURVE 1");
+  private static final Currency CCY_1 = Currency.EUR;
+  private static final CurveName NAME_2 = CurveName.of("CURVE 2");
+  private static final Currency CCY_2 = Currency.USD;
+  private static final List<LocalDate> TARGET_DATES = new ArrayList<>();
+  static {
+    TARGET_DATES.add(LocalDate.of(2016, 8, 18));
+    TARGET_DATES.add(LocalDate.of(2020, 1, 5));
+    TARGET_DATES.add(LocalDate.of(2025, 12, 20));
+    TARGET_DATES.add(LocalDate.of(2045, 7, 4));
+  }
+  private static final List<LocalDate> SENSITIVITY_DATES = new ArrayList<>();
+  static {
+    SENSITIVITY_DATES.add(LocalDate.of(2016, 8, 17));
+    SENSITIVITY_DATES.add(LocalDate.of(2016, 8, 18));
+    SENSITIVITY_DATES.add(LocalDate.of(2016, 8, 19));
+    SENSITIVITY_DATES.add(LocalDate.of(2019, 1, 5));
+    SENSITIVITY_DATES.add(LocalDate.of(2020, 1, 5));
+    SENSITIVITY_DATES.add(LocalDate.of(2021, 1, 5));
+    SENSITIVITY_DATES.add(LocalDate.of(2024, 12, 25));
+    SENSITIVITY_DATES.add(LocalDate.of(2025, 12, 20));
+    SENSITIVITY_DATES.add(LocalDate.of(2026, 12, 15));
+    SENSITIVITY_DATES.add(LocalDate.of(2045, 7, 4));
+    SENSITIVITY_DATES.add(LocalDate.of(2055, 7, 4));
+  }
+  private static final double SENSITIVITY_AMOUNT = 123.45;
+  private static final double[] WEIGHTS_HC = 
+    {1.0, 1.0, 0.999190283, 0.295546559, 0.0, 0.831801471, 0.165441176, 1.0, 0.94955157, 0.0, 0.0 };
+  // weights externally provided and hard-coded here
+  private static final int[] WEIGHTS_START = {0, 0, 0, 0, 0, 1, 1, 2, 2, 2, 2 };
+  private static final double TOLERANCE_SENSI = 1.0E-5;
+
+  public void hard_coded_value_one_curve_one_date() {
+    for (int loopdate = 0; loopdate < SENSITIVITY_DATES.size(); loopdate++) {
+      List<CurveParameterMetadata> pmdInput = new ArrayList<>();
+      pmdInput.add(SimpleCurveNodeMetadata.of(SENSITIVITY_DATES.get(loopdate), "test"));
+      CurveMetadata cmd = DefaultCurveMetadata.builder().curveName(NAME_1).parameterMetadata(pmdInput).build();
+      CurveCurrencyParameterSensitivity s =
+          CurveCurrencyParameterSensitivity.of(cmd, CCY_1, DoubleArray.of(SENSITIVITY_AMOUNT));
+      CurveCurrencyParameterSensitivities s2 = CurveCurrencyParameterSensitivities.of(s);
+      CurveCurrencyParameterSensitivities sTarget = CurveSensitivityUtils.linearRebucketing(s2, TARGET_DATES);
+      assertTrue(sTarget.getSensitivities().size() == 1);
+      CurveCurrencyParameterSensitivity sTarget1 = sTarget.getSensitivities().get(0);
+      assertTrue(sTarget1.getCurveName().equals(NAME_1));
+      assertTrue(sTarget1.getCurrency().equals(CCY_1));
+      assertTrue(sTarget1.getSensitivity().size() == TARGET_DATES.size());
+      assertEquals(sTarget1.getSensitivity().get(WEIGHTS_START[loopdate]),
+          WEIGHTS_HC[loopdate] * SENSITIVITY_AMOUNT, TOLERANCE_SENSI);
+      assertEquals(sTarget1.getSensitivity().get(WEIGHTS_START[loopdate] + 1), 
+          (1.0d - WEIGHTS_HC[loopdate]) * SENSITIVITY_AMOUNT, TOLERANCE_SENSI);
+    }
+  }
+
+  public void hard_coded_value_one_curve_all_dates() {
+    List<CurveParameterMetadata> pmdInput = new ArrayList<>();
+    double[] sensiExpected = new double[TARGET_DATES.size()];
+    for (int loopdate = 0; loopdate < SENSITIVITY_DATES.size(); loopdate++) {
+      pmdInput.add(SimpleCurveNodeMetadata.of(SENSITIVITY_DATES.get(loopdate), "test"));
+      sensiExpected[WEIGHTS_START[loopdate]] += WEIGHTS_HC[loopdate] * SENSITIVITY_AMOUNT;
+      sensiExpected[WEIGHTS_START[loopdate] + 1] += (1.0d - WEIGHTS_HC[loopdate]) * SENSITIVITY_AMOUNT;
+    }
+    CurveMetadata cmd = DefaultCurveMetadata.builder().curveName(NAME_1).parameterMetadata(pmdInput).build();
+    CurveCurrencyParameterSensitivity s =
+        CurveCurrencyParameterSensitivity.of(cmd, CCY_1, DoubleArray.of(SENSITIVITY_DATES.size(), (d) -> SENSITIVITY_AMOUNT));
+    CurveCurrencyParameterSensitivities s2 = CurveCurrencyParameterSensitivities.of(s);
+    CurveCurrencyParameterSensitivities sTarget = CurveSensitivityUtils.linearRebucketing(s2, TARGET_DATES);
+    assertTrue(sTarget.getSensitivities().size() == 1);
+    CurveCurrencyParameterSensitivity sTarget1 = sTarget.getSensitivities().get(0);
+    assertTrue(sTarget1.getCurveName().equals(NAME_1));
+    assertTrue(sTarget1.getCurrency().equals(CCY_1));
+    assertTrue(sTarget1.getSensitivity().size() == TARGET_DATES.size());
+    for (int looptarget = 0; looptarget < TARGET_DATES.size(); looptarget++) {
+      assertEquals(sTarget1.getSensitivity().get(looptarget), sensiExpected[looptarget], TOLERANCE_SENSI);
+    }
+  }
+
+  public void hard_coded_value_two_curves_one_date() {
+    for (int loopdate = 0; loopdate < SENSITIVITY_DATES.size() - 1; loopdate++) {
+      List<CurveParameterMetadata> pmdInput1 = new ArrayList<>();
+      pmdInput1.add(SimpleCurveNodeMetadata.of(SENSITIVITY_DATES.get(loopdate), "test"));
+      CurveMetadata cmd1 = DefaultCurveMetadata.builder().curveName(NAME_1).parameterMetadata(pmdInput1).build();
+      CurveCurrencyParameterSensitivity s1 =
+          CurveCurrencyParameterSensitivity.of(cmd1, CCY_1, DoubleArray.of(SENSITIVITY_AMOUNT));
+      List<CurveParameterMetadata> pmdInput2 = new ArrayList<>();
+      pmdInput2.add(SimpleCurveNodeMetadata.of(SENSITIVITY_DATES.get(loopdate + 1), "test"));
+      CurveMetadata cmd2 = DefaultCurveMetadata.builder().curveName(NAME_2).parameterMetadata(pmdInput2).build();
+      CurveCurrencyParameterSensitivity s2 =
+          CurveCurrencyParameterSensitivity.of(cmd2, CCY_2, DoubleArray.of(SENSITIVITY_AMOUNT));
+      CurveCurrencyParameterSensitivities sList = CurveCurrencyParameterSensitivities.of(s1, s2);
+      CurveCurrencyParameterSensitivities sTarget = CurveSensitivityUtils.linearRebucketing(sList, TARGET_DATES);
+      assertTrue(sTarget.getSensitivities().size() == 2);
+      CurveCurrencyParameterSensitivity sTarget1 = sTarget.getSensitivities().get(0);
+      assertTrue(sTarget1.getCurveName().equals(NAME_1));
+      assertTrue(sTarget1.getCurrency().equals(CCY_1));
+      assertTrue(sTarget1.getSensitivity().size() == TARGET_DATES.size());
+      assertEquals(sTarget1.getSensitivity().get(WEIGHTS_START[loopdate]),
+          WEIGHTS_HC[loopdate] * SENSITIVITY_AMOUNT, TOLERANCE_SENSI);
+      assertEquals(sTarget1.getSensitivity().get(WEIGHTS_START[loopdate] + 1),
+          (1.0d - WEIGHTS_HC[loopdate]) * SENSITIVITY_AMOUNT, TOLERANCE_SENSI);
+      CurveCurrencyParameterSensitivity sTarget2 = sTarget.getSensitivities().get(1);
+      assertTrue(sTarget2.getCurveName().equals(NAME_2));
+      assertTrue(sTarget2.getCurrency().equals(CCY_2));
+      assertTrue(sTarget2.getSensitivity().size() == TARGET_DATES.size());
+      assertEquals(sTarget2.getSensitivity().get(WEIGHTS_START[loopdate + 1]),
+          WEIGHTS_HC[loopdate + 1] * SENSITIVITY_AMOUNT, TOLERANCE_SENSI);
+      assertEquals(sTarget2.getSensitivity().get(WEIGHTS_START[loopdate + 1] + 1),
+          (1.0d - WEIGHTS_HC[loopdate + 1]) * SENSITIVITY_AMOUNT, TOLERANCE_SENSI);
+    }
+  }
+
+  public void missing_metadata() {
+    CurveCurrencyParameterSensitivity s1 =
+        CurveCurrencyParameterSensitivity.of(DefaultCurveMetadata.of(NAME_1), CCY_1, DoubleArray.of(SENSITIVITY_AMOUNT));
+    CurveCurrencyParameterSensitivities s2 = CurveCurrencyParameterSensitivities.of(s1);
+    assertThrowsIllegalArg(() -> CurveSensitivityUtils.linearRebucketing(s2, TARGET_DATES));
+  }
+
+  public void wrong_metadata() {
+    List<CurveParameterMetadata> pmdInput = new ArrayList<>();
+    pmdInput.add(TenorCurveNodeMetadata.of(Tenor.TENOR_10M));
+    CurveCurrencyParameterSensitivity s1 =
+        CurveCurrencyParameterSensitivity.of(
+            DefaultCurveMetadata.builder().curveName(NAME_1).parameterMetadata(pmdInput).build(), 
+            CCY_1, DoubleArray.of(SENSITIVITY_AMOUNT));
+    CurveCurrencyParameterSensitivities s2 = CurveCurrencyParameterSensitivities.of(s1);
+    assertThrowsIllegalArg(() -> CurveSensitivityUtils.linearRebucketing(s2, TARGET_DATES));
+  }
+
+}


### PR DESCRIPTION
Allows to reassign the sensitivity to a a different set of nodes described by dates or tenors. The re-bucketing is done by linear interpolation of the sensitivity based on the number of days between nodes.
This utility is useful for reducing or standardizing the sensitivity nodes in curve sensitivity.