### PR TITLE
CMS and SABR marginal improvements

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
@@ -81,6 +81,8 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
    * The maximum iteration count.
    */
   private static final int MAX_COUNT = 10;
+  /** Shift from zero bound for floor. To avoid numerical instability of the SABR function around 0. Shift by 0.01 bps. */
+  private static final double ZERO_SHIFT =  1.0E-6;
 
   /**
    * Pricer for the underlying swap. 
@@ -204,7 +206,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
         integralPart = dfPayment *
             integrateCall(integrator, integrant, swaptionVolatilities, forward, strikeCpn, expiryTime, tenor);
       } else {
-        integralPart = - dfPayment * integrator.integrate(integrant, -shift, strikeCpn);
+        integralPart = - dfPayment * integrator.integrate(integrant, -shift + ZERO_SHIFT, strikeCpn);
       }
     } catch (Exception e) {
       throw new MathException(e);
@@ -291,7 +293,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
         integralPart = dfPayment *
             integrateCall(integrator, integrantDelta, swaptionVolatilities, forward, strikeCpn, expiryTime, tenor);
       } else {
-        integralPartPrice = - integrator.integrate(integrant, -shift, strikeCpn);
+        integralPartPrice = - integrator.integrate(integrant, -shift + ZERO_SHIFT, strikeCpn);
         integralPart = - dfPayment * integrator.integrate(integrantDelta, -shift, strikeCpn);
       }
     } catch (Exception e) {
@@ -369,7 +371,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
           integralPart = dfPayment *
               integrateCall(integrator, integrant, swaptionVolatilities, forward, strikeCpn, expiryTime, tenor);
         } else {
-          integralPart = - dfPayment * integrator.integrate(integrant, -shift, strikeCpn);
+          integralPart = - dfPayment * integrator.integrate(integrant, -shift + ZERO_SHIFT, strikeCpn);
         }
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -447,7 +449,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
       thirdPart = integrateCall(integrator, integrant, swaptionVolatilities, forward, strike, expiryTime, tenor);
     } else {
       firstPart = - kpkpp[0] * intProv.bs(strike);
-      thirdPart = - integrator.integrate(integrant, -shift, strike);
+      thirdPart = - integrator.integrate(integrant, -shift + ZERO_SHIFT, strike);
     }
     double secondPart =
         intProv.k(strike) * intProv.getSabrExtrapolation().priceDerivativeStrike(strike + shift, intProv.getPutCall());
@@ -465,8 +467,11 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
 
     double res;
     double vol = swaptionVolatilities.volatility(expiryTime, tenor, forward, forward);
-    double upper = Math.max(forward * Math.exp(6d * vol * Math.sqrt(expiryTime)),
-        Math.max(cutOffStrike, 2.0d * strike)); // To ensure that the integral covers a good part of the smile
+    double upper = 
+        Math.min(
+            Math.max(forward * Math.exp(6d * vol * Math.sqrt(expiryTime)),
+        Math.max(cutOffStrike, 2.0d * strike)),// To ensure that the integral covers a good part of the smile
+        1.00); // To ensure that we don't miss the meaningful part
     res = integrator.integrate(integrant, strike, upper);
     double reminder = integrant.apply(upper) * upper;
     double error = reminder / res;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/smile/function/SabrHaganVolatilityFunctionProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/smile/function/SabrHaganVolatilityFunctionProvider.java
@@ -51,6 +51,7 @@ public final class SabrHaganVolatilityFunctionProvider
   private static final double RHO_EPS = 1e-5;
   private static final double RHO_EPS_NEGATIVE = 1e-8;
   private static final double ATM_EPS = 1e-7;
+  private static final double MIN_VOL = 1e-6; // Minimal volatility, to avoid negative volatility for extreme parameters
 
   //-------------------------------------------------------------------------
   @Override
@@ -112,7 +113,7 @@ public final class SabrHaganVolatilityFunctionProvider
       }
     }
     //There is nothing to prevent the nu * nu * (2 - 3 * rho * rho) / 24 part taking the third term, and hence the volatility negative
-    return vol;
+     return Math.max(MIN_VOL, vol);
   }
 
   /**
@@ -204,7 +205,7 @@ public final class SabrHaganVolatilityFunctionProvider
     double sf1 = sfK * (1 + betaStar * betaStar / 24 * (lnrfK * lnrfK) + Math.pow(betaStar, 4) / 1920 * Math.pow(lnrfK, 4));
     double sf2 = (1 + (Math.pow(betaStar * alpha / sfK, 2) / 24 + (rho * beta * nu * alpha) /
         (4 * sfK) + (2 - 3 * rho * rho) * nu * nu / 24) * timeToExpiry);
-    double volatility = alpha / sf1 * rzxz * sf2;
+    double volatility = Math.max(MIN_VOL, alpha / sf1 * rzxz * sf2);
 
     // Implementation note: Backward sweep.
     double vBar = 1;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
@@ -141,13 +141,13 @@ public class SabrExtrapolationReplicationCmsPeriodPricerTest {
     CurrencyAmount pvCaplet = PRICER.presentValue(CAPLET_ZERO, RATES_PROVIDER, VOLATILITIES);
     CurrencyAmount pvFloorlet = PRICER.presentValue(FLOORLET_ZERO, RATES_PROVIDER, VOLATILITIES);
     assertEquals(pv.getAmount(), pvCaplet.getAmount(), NOTIONAL * TOL);
-    assertEquals(pvFloorlet.getAmount(), 0d, NOTIONAL * TOL);
+    assertEquals(pvFloorlet.getAmount(), 0d, 2.0d * NOTIONAL * TOL);
     CurrencyAmount pvShift = PRICER.presentValue(COUPON, RATES_PROVIDER, VOLATILITIES_SHIFT);
     CurrencyAmount pvCapletShift = PRICER.presentValue(CAPLET_SHIFT, RATES_PROVIDER, VOLATILITIES_SHIFT);
     CurrencyAmount pvFloorletShift = PRICER.presentValue(FLOORLET_SHIFT, RATES_PROVIDER, VOLATILITIES_SHIFT);
     double dfPayment = RATES_PROVIDER.discountFactor(EUR, PAYMENT);
     assertEquals(pvShift.getAmount(), pvCapletShift.getAmount() - SHIFT * dfPayment * NOTIONAL * ACC_FACTOR, NOTIONAL * TOL);
-    assertEquals(pvFloorletShift.getAmount(), 0d, NOTIONAL * TOL);
+    assertEquals(pvFloorletShift.getAmount(), 0d, 2.0d * NOTIONAL * TOL);
   }
 
   public void test_presentValue_buySell() {


### PR DESCRIPTION
Added a small shift away from 0 in CMS floor pricing to avoid numerical instability in integrals. Bounded the integral upper bound to avoid missing the relevant part in numerical integration. Added a lower bound on SabrHagan volatility function (for large nu and rho~-1, formula can produce negative volatilities).