### PR TITLE
Add methods to MarketEnvironmentBuilder for adding values in bulk

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationCheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationCheckExample.java
@@ -173,7 +173,7 @@ public class CalibrationCheckExample {
 
     // create the market data used for calculations
     MarketEnvironment marketSnapshot = MarketEnvironment.builder(VAL_DATE)
-        .addValues(quotes)
+        .addSingleValues(quotes)
         .build();
 
     // create the market data used for building trades

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationEur3CheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationEur3CheckExample.java
@@ -175,7 +175,7 @@ public class CalibrationEur3CheckExample {
 
     // create the market data used for calculations
     MarketEnvironment marketSnapshot = MarketEnvironment.builder(VAL_DATE)
-        .addValues(quotes)
+        .addSingleValues(quotes)
         .build();
 
     // create the market data used for building trades

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationSimpleForwardCheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationSimpleForwardCheckExample.java
@@ -174,7 +174,7 @@ public class CalibrationSimpleForwardCheckExample {
 
     // create the market data used for calculations
     MarketEnvironment marketSnapshot = MarketEnvironment.builder(VAL_DATE)
-        .addValues(quotes)
+        .addSingleValues(quotes)
         .build();
 
     // create the market data used for building trades

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationXCcyCheckExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CalibrationXCcyCheckExample.java
@@ -185,8 +185,8 @@ public class CalibrationXCcyCheckExample {
 
     // create the market data used for calculations
     MarketEnvironment marketSnapshot = MarketEnvironment.builder(VAL_DATE)
-        .addValues(quotes)
-        .addValues(fxRates)
+        .addSingleValues(quotes)
+        .addSingleValues(fxRates)
         .build();
 
     // create the market data used for building trades

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SwapPricingWithCalibrationExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SwapPricingWithCalibrationExample.java
@@ -129,7 +129,7 @@ public class SwapPricingWithCalibrationExample {
 
     // create the market data used for calculations
     MarketEnvironment marketSnapshot = MarketEnvironment.builder(VAL_DATE)
-        .addValues(quotes)
+        .addSingleValues(quotes)
         .addTimeSeries(fixings)
         .build();
 

--- a/examples/src/main/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilder.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilder.java
@@ -318,7 +318,7 @@ public abstract class ExampleMarketDataBuilder {
 
     try {
       Map<QuoteId, Double> quotes = QuotesCsvLoader.load(marketDataDate, quotesResource);
-      builder.addValues(quotes);
+      builder.addSingleValues(quotes);
 
     } catch (Exception ex) {
       log.error("Error loading quotes", ex);

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentBuilder.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentBuilder.java
@@ -185,17 +185,65 @@ public final class MarketEnvironmentBuilder {
   //-------------------------------------------------------------------------
   /**
    * Adds multiple items of market data, replacing any existing values with the same IDs.
+   * <p>
+   * Each value in the map is a single item of market data used in all scenarios.
    *
    * @param values  the items of market data, keyed by ID
    * @return this builder
    */
-  public MarketEnvironmentBuilder addValues(Map<? extends MarketDataId<?>, ?> values) {
+  public <T> MarketEnvironmentBuilder addSingleValues(Map<? extends MarketDataId<T>, T> values) {
     ArgChecker.notNull(values, "values");
     values.forEach((id, value) -> checkValueType(id, value));
     // extra <Object> for Eclipse
     Map<? extends MarketDataId<?>, MarketDataBox<Object>> boxedValues =
         MapStream.of(values).mapValues(value -> MarketDataBox.<Object>ofSingleValue(value)).toMap();
 
+    this.values.putAll(boxedValues);
+    return this;
+  }
+
+  /**
+   * Adds multiple items of market data, replacing any existing values with the same IDs.
+   * <p>
+   * Each value in the map contains multiple market data items, one for each scenario.
+   *
+   * @param values  the items of market data, keyed by ID
+   * @param <T>  the type of the market data value used in each scenario
+   * @return this builder
+   */
+  public <T> MarketEnvironmentBuilder addScenarioValues(
+      Map<? extends MarketDataId<T>, ? extends ScenarioMarketDataValue<T>> values) {
+
+    ArgChecker.notNull(values, "values");
+    Map<? extends MarketDataId<T>, MarketDataBox<T>> boxedValues =
+        MapStream.of(values).mapValues(value -> MarketDataBox.ofScenarioValue(value)).toMap();
+
+    boxedValues.forEach((id, value) -> {
+      checkBoxType(id, value);
+      updateScenarioCount(value);
+    });
+    this.values.putAll(boxedValues);
+    return this;
+  }
+
+  /**
+   * Adds multiple items of market data, replacing any existing values with the same IDs.
+   * <p>
+   * Each value in the map is a list of market data items, one for each scenario.
+   *
+   * @param values  the items of market data, keyed by ID
+   * @param <T>  the type of the market data value used in each scenario
+   * @return this builder
+   */
+  public <T> MarketEnvironmentBuilder addScenarioValueLists(Map<? extends MarketDataId<T>, ? extends List<T>> values) {
+    ArgChecker.notNull(values, "values");
+    Map<? extends MarketDataId<T>, MarketDataBox<T>> boxedValues =
+        MapStream.of(values).mapValues(value -> MarketDataBox.ofScenarioValues(value)).toMap();
+
+    boxedValues.forEach((id, value) -> {
+      checkBoxType(id, value);
+      updateScenarioCount(value);
+    });
     this.values.putAll(boxedValues);
     return this;
   }

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentBuilderTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketEnvironmentBuilderTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.calc.marketdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.FxRate;
+import com.opengamma.strata.basics.currency.FxRatesArray;
+import com.opengamma.strata.basics.market.FxRateId;
+import com.opengamma.strata.basics.market.MarketDataBox;
+import com.opengamma.strata.collect.array.DoubleArray;
+
+@Test
+public class MarketEnvironmentBuilderTest {
+
+  private static final LocalDate VAL_DATE = LocalDate.of(2011, 3, 8);
+
+  public void addSingleValues() {
+    FxRateId eurGbpId = FxRateId.of(Currency.EUR, Currency.GBP);
+    FxRateId eurUsdId = FxRateId.of(Currency.EUR, Currency.USD);
+    FxRate eurGbpRate = FxRate.of(Currency.EUR, Currency.GBP, 0.8);
+    FxRate eurUsdRate = FxRate.of(Currency.EUR, Currency.USD, 1.1);
+
+    Map<FxRateId, FxRate> values = ImmutableMap.of(
+        eurGbpId, eurGbpRate,
+        eurUsdId, eurUsdRate);
+    MarketEnvironment marketData = MarketEnvironment.builder(VAL_DATE).addSingleValues(values).build();
+
+    assertThat(marketData.getScenarioCount()).isEqualTo(1);
+    assertThat(marketData.getValue(eurGbpId)).isEqualTo(MarketDataBox.ofSingleValue(eurGbpRate));
+    assertThat(marketData.getValue(eurUsdId)).isEqualTo(MarketDataBox.ofSingleValue(eurUsdRate));
+  }
+
+  public void addScenarioValues() {
+    FxRateId eurGbpId = FxRateId.of(Currency.EUR, Currency.GBP);
+    FxRateId eurUsdId = FxRateId.of(Currency.EUR, Currency.USD);
+    FxRatesArray eurGbpRates = FxRatesArray.of(Currency.EUR, Currency.GBP, DoubleArray.of(0.79, 0.8, 0.81));
+    FxRatesArray eurUsdRates = FxRatesArray.of(Currency.EUR, Currency.USD, DoubleArray.of(1.09, 1.1, 1.11));
+
+    Map<FxRateId, FxRatesArray> values = ImmutableMap.of(
+        eurGbpId, eurGbpRates,
+        eurUsdId, eurUsdRates);
+    MarketEnvironment marketData = MarketEnvironment.builder(VAL_DATE).addScenarioValues(values).build();
+
+    assertThat(marketData.getScenarioCount()).isEqualTo(3);
+    assertThat(marketData.getValue(eurGbpId)).isEqualTo(MarketDataBox.ofScenarioValue(eurGbpRates));
+    assertThat(marketData.getValue(eurUsdId)).isEqualTo(MarketDataBox.ofScenarioValue(eurUsdRates));
+  }
+
+  public void addScenarioValueLists() {
+    FxRateId eurGbpId = FxRateId.of(Currency.EUR, Currency.GBP);
+    FxRateId eurUsdId = FxRateId.of(Currency.EUR, Currency.USD);
+    List<FxRate> eurGbpRates = ImmutableList.of(
+        FxRate.of(Currency.EUR, Currency.GBP, 0.79),
+        FxRate.of(Currency.EUR, Currency.GBP, 0.8),
+        FxRate.of(Currency.EUR, Currency.GBP, 0.81));
+    List<FxRate> eurUsdRates = ImmutableList.of(
+        FxRate.of(Currency.EUR, Currency.USD, 1.09),
+        FxRate.of(Currency.EUR, Currency.USD, 1.1),
+        FxRate.of(Currency.EUR, Currency.USD, 1.11));
+
+    Map<FxRateId, List<FxRate>> values = ImmutableMap.of(
+        eurGbpId, eurGbpRates,
+        eurUsdId, eurUsdRates);
+    MarketEnvironment marketData = MarketEnvironment.builder(VAL_DATE).addScenarioValueLists(values).build();
+
+    assertThat(marketData.getScenarioCount()).isEqualTo(3);
+    assertThat(marketData.getValue(eurGbpId)).isEqualTo(MarketDataBox.ofScenarioValues(eurGbpRates));
+    assertThat(marketData.getValue(eurUsdId)).isEqualTo(MarketDataBox.ofScenarioValues(eurUsdRates));
+  }
+}

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveEndToEndTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveEndToEndTest.java
@@ -81,9 +81,9 @@ import com.opengamma.strata.market.key.IndexRateKey;
 import com.opengamma.strata.market.key.MarketDataKeys;
 import com.opengamma.strata.pricer.fra.DiscountingFraProductPricer;
 import com.opengamma.strata.pricer.rate.MarketDataRatesProvider;
-import com.opengamma.strata.product.fra.ResolvedFra;
 import com.opengamma.strata.product.fra.Fra;
 import com.opengamma.strata.product.fra.FraTrade;
+import com.opengamma.strata.product.fra.ResolvedFra;
 import com.opengamma.strata.product.swap.SwapTrade;
 
 /**
@@ -182,7 +182,7 @@ public class CurveEndToEndTest {
 
     List<Column> columns = ImmutableList.of(Column.of(Measures.PRESENT_VALUE));
     MarketEnvironment knownMarketData = MarketEnvironment.builder(date(2011, 3, 8))
-        .addValues(parRateData)
+        .addSingleValues(parRateData)
         .build();
 
     // using the direct executor means there is no need to close/shutdown the runner


### PR DESCRIPTION
Previously `MarketEnvironmentBuilder` had a single method `addValues` for adding values in bulk.  It took a map as an argument whose values were single market data items which were used in every scenario.

This PR adds similar methods for adding scenario values in bulk. It also renames `addValues` to `addSingleValues` to make it clear how the map values are used.