### PR TITLE
Make AbstractBoundCurveInterpolator public

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/AbstractBoundCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/AbstractBoundCurveInterpolator.java
@@ -13,7 +13,7 @@ import com.opengamma.strata.collect.array.DoubleArray;
 /**
  * Abstract interpolator implementation.
  */
-abstract class AbstractBoundCurveInterpolator
+public abstract class AbstractBoundCurveInterpolator
     implements BoundCurveInterpolator {
 
   /**
@@ -43,7 +43,7 @@ abstract class AbstractBoundCurveInterpolator
    * @param xValues  the x-values of the curve, must be sorted from low to high
    * @param yValues  the y-values of the curve
    */
-  AbstractBoundCurveInterpolator(DoubleArray xValues, DoubleArray yValues) {
+  protected AbstractBoundCurveInterpolator(DoubleArray xValues, DoubleArray yValues) {
     ArgChecker.notNull(xValues, "xValues");
     ArgChecker.notNull(yValues, "yValues");
     int size = xValues.size();
@@ -63,7 +63,7 @@ abstract class AbstractBoundCurveInterpolator
    * @param extrapolatorLeft  the extrapolator for x-values on the left
    * @param extrapolatorRight  the extrapolator for x-values on the right
    */
-  AbstractBoundCurveInterpolator(
+  protected AbstractBoundCurveInterpolator(
       AbstractBoundCurveInterpolator base,
       BoundCurveExtrapolator extrapolatorLeft,
       BoundCurveExtrapolator extrapolatorRight) {
@@ -77,7 +77,7 @@ abstract class AbstractBoundCurveInterpolator
 
   //-------------------------------------------------------------------------
   @Override
-  public double interpolate(double xValue) {
+  public final double interpolate(double xValue) {
     if (xValue < firstXValue) {
       return extrapolatorLeft.leftExtrapolate(xValue);
     } else if (xValue > lastXValue) {
@@ -94,10 +94,10 @@ abstract class AbstractBoundCurveInterpolator
    * @param xValue  the x-value
    * @return the interpolated y-value
    */
-  abstract double doInterpolate(double xValue);
+  protected abstract double doInterpolate(double xValue);
 
   @Override
-  public double firstDerivative(double xValue) {
+  public final double firstDerivative(double xValue) {
     if (xValue < firstXValue) {
       return extrapolatorLeft.leftExtrapolateFirstDerivative(xValue);
     } else if (xValue > lastXValue) {
@@ -112,10 +112,10 @@ abstract class AbstractBoundCurveInterpolator
    * @param xValue  the x-value
    * @return the first derivative
    */
-  abstract double doFirstDerivative(double xValue);
+  protected abstract double doFirstDerivative(double xValue);
 
   @Override
-  public DoubleArray parameterSensitivity(double xValue) {
+  public final DoubleArray parameterSensitivity(double xValue) {
     if (xValue < firstXValue) {
       return extrapolatorLeft.leftExtrapolateParameterSensitivity(xValue);
     } else if (xValue > lastXValue) {
@@ -130,10 +130,28 @@ abstract class AbstractBoundCurveInterpolator
    * @param xValue  the x-value
    * @return the parameter sensitivity
    */
-  abstract DoubleArray doParameterSensitivity(double xValue);
+  protected abstract DoubleArray doParameterSensitivity(double xValue);
 
   //-------------------------------------------------------------------------
-  static int lowerBoundIndex(double xValue, double[] xValues) {
+
+  /**
+   * Returns the index of the last value in the input array which is lower than the specified value.
+   * <p>
+   * The following conditions must be true for this method to work correctly:
+   * <ul>
+   *   <li>{@code xValues} is sorted in ascending order</li>
+   *   <li>{@code xValue} is less than the last element of {@code xValues}</li>
+   * </ul>
+   * The returned value satisfies:
+   * <pre>
+   *   0 <= value < xValues.length
+   * </pre>
+   *
+   * @param xValue  a value which is less than the last element in {@code xValues}
+   * @param xValues  an array of values sorted in ascending order
+   * @return the index of the last value in {@code xValues} which is lower than {@code xValue}
+   */
+  protected static int lowerBoundIndex(double xValue, double[] xValues) {
     int index = Arrays.binarySearch(xValues, xValue);
     // break out if find an exact match
     if (index >= 0) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/DoubleQuadraticCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/DoubleQuadraticCurveInterpolator.java
@@ -144,7 +144,7 @@ final class DoubleQuadraticCurveInterpolator
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       int higherIndex = lowerIndex + 1;
@@ -169,7 +169,7 @@ final class DoubleQuadraticCurveInterpolator
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       int higherIndex = lowerIndex + 1;
       // at start of curve, or only one interval
@@ -196,7 +196,7 @@ final class DoubleQuadraticCurveInterpolator
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       int higherIndex = lowerIndex + 1;
       int n = xValues.length;

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LinearCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LinearCurveInterpolator.java
@@ -97,7 +97,7 @@ final class LinearCurveInterpolator
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       double x1 = xValues[lowerIndex];
@@ -106,7 +106,7 @@ final class LinearCurveInterpolator
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       // check if x-value is at the last node
       if (lowerIndex == intervalCount) {
@@ -117,7 +117,7 @@ final class LinearCurveInterpolator
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       double[] result = new double[yValues.length];
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       // check if x-value is at the last node

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LogLinearCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LogLinearCurveInterpolator.java
@@ -88,7 +88,7 @@ final class LogLinearCurveInterpolator
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       double x1 = xValues[lowerIndex];
@@ -99,7 +99,7 @@ final class LogLinearCurveInterpolator
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       // check if x-value is at the last node
       if (lowerIndex == intervalCount) {
@@ -120,7 +120,7 @@ final class LogLinearCurveInterpolator
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       double[] result = new double[yValues.length];
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       // check if x-value is at the last node

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LogNaturalCubicDiscountFactorCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LogNaturalCubicDiscountFactorCurveInterpolator.java
@@ -213,13 +213,13 @@ final class LogNaturalCubicDiscountFactorCurveInterpolator implements CurveInter
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       DoubleArray resValue = evaluate(xValue, knots, coefMatrix, dimensions, nKnots);
       return Math.exp(resValue.get(0));
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       DoubleArray resValue = evaluate(xValue, knots, coefMatrix, dimensions, nKnots);
       int nCoefs = poly.getOrder();
       int numberOfIntervals = poly.getNumberOfIntervals();
@@ -229,7 +229,7 @@ final class LogNaturalCubicDiscountFactorCurveInterpolator implements CurveInter
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       int interval = FunctionUtils.getLowerBoundIndex(knots, xValue);
       if (interval == nKnots - 1) {
         interval--; // there is 1 less interval that knots

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LogNaturalCubicMonotonicityPreservingCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/LogNaturalCubicMonotonicityPreservingCurveInterpolator.java
@@ -206,13 +206,13 @@ final class LogNaturalCubicMonotonicityPreservingCurveInterpolator
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       DoubleArray resValue = evaluate(xValue, knots, coefMatrix, dimensions, nKnots);
       return Math.exp(resValue.get(0));
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       DoubleArray resValue = evaluate(xValue, knots, coefMatrix, dimensions, nKnots);
       int nCoefs = poly.getOrder();
       int numberOfIntervals = poly.getNumberOfIntervals();
@@ -223,7 +223,7 @@ final class LogNaturalCubicMonotonicityPreservingCurveInterpolator
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       int interval = FunctionUtils.getLowerBoundIndex(knots, xValue);
       if (interval == nKnots - 1) {
         interval--; // there is 1 less interval that knots

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/NaturalCubicSplineCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/NaturalCubicSplineCurveInterpolator.java
@@ -224,7 +224,7 @@ final class NaturalCubicSplineCurveInterpolator implements CurveInterpolator, Se
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int low = lowerBoundIndex(xValue, xValues);
       int high = low + 1;
@@ -243,7 +243,7 @@ final class NaturalCubicSplineCurveInterpolator implements CurveInterpolator, Se
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int low = lowerBoundIndex(xValue, xValues);
       int high = low + 1;
@@ -263,7 +263,7 @@ final class NaturalCubicSplineCurveInterpolator implements CurveInterpolator, Se
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int low = lowerBoundIndex(xValue, xValues);
       double[] result = new double[dataSize];

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/NaturalSplineCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/NaturalSplineCurveInterpolator.java
@@ -159,13 +159,13 @@ final class NaturalSplineCurveInterpolator
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       DoubleArray resValue = evaluate(xValue, knots, coefMatrix, dimensions, nKnots);
       return resValue.get(0);
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       int nCoefs = poly.getOrder();
       int numberOfIntervals = poly.getNumberOfIntervals();
       DoubleArray resValue = differentiate(xValue, knots, coefMatrix, dimensions, nKnots, nCoefs, numberOfIntervals);
@@ -173,7 +173,7 @@ final class NaturalSplineCurveInterpolator
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       int interval = FunctionUtils.getLowerBoundIndex(knots, xValue);
       if (interval == nKnots - 1) {
         interval--; // there is 1 less interval that knots

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/SquareLinearCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/SquareLinearCurveInterpolator.java
@@ -85,7 +85,7 @@ final class SquareLinearCurveInterpolator implements CurveInterpolator, Serializ
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       double x1 = xValues[lowerIndex];
@@ -103,7 +103,7 @@ final class SquareLinearCurveInterpolator implements CurveInterpolator, Serializ
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       int index;
       // check if x-value is at the last node
@@ -138,7 +138,7 @@ final class SquareLinearCurveInterpolator implements CurveInterpolator, Serializ
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       double[] result = new double[dataSize];
 
       int lowerIndex = lowerBoundIndex(xValue, xValues);

--- a/modules/market/src/main/java/com/opengamma/strata/market/interpolator/TimeSquareCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/interpolator/TimeSquareCurveInterpolator.java
@@ -88,7 +88,7 @@ final class TimeSquareCurveInterpolator implements CurveInterpolator, Serializab
 
     //-------------------------------------------------------------------------
     @Override
-    double doInterpolate(double xValue) {
+    protected double doInterpolate(double xValue) {
       ArgChecker.isTrue(xValue > 0, "Value should be stricly positive");
       // x-value is less than the x-value of the last node (lowerIndex < intervalCount)
       int lowerIndex = lowerBoundIndex(xValue, xValues);
@@ -109,7 +109,7 @@ final class TimeSquareCurveInterpolator implements CurveInterpolator, Serializab
     }
 
     @Override
-    double doFirstDerivative(double xValue) {
+    protected double doFirstDerivative(double xValue) {
       ArgChecker.isTrue(xValue > 0, "Value should be stricly positive");
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       int index;
@@ -137,7 +137,7 @@ final class TimeSquareCurveInterpolator implements CurveInterpolator, Serializab
     }
 
     @Override
-    DoubleArray doParameterSensitivity(double xValue) {
+    protected DoubleArray doParameterSensitivity(double xValue) {
       double[] resultSensitivity = new double[dataSize];
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       double x1 = xValues[lowerIndex];


### PR DESCRIPTION
This PR makes `AbstractBoundCurveInterpolator` public and its abstract methods protected. This enables it to be used by interpolator implementations in other projects.