### PR TITLE
ON/Ibor swap convention

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightIborSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightIborSwapConvention.java
@@ -1,0 +1,570 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableValidator;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.opengamma.strata.basics.BuySell;
+import com.opengamma.strata.basics.PayReceive;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.swap.Swap;
+import com.opengamma.strata.product.swap.SwapLeg;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * A market convention for Fixed-Overnight swap trades.
+ * <p>
+ * This defines the market convention for a Fixed-Overnight single currency swap.
+ * This is often known as an <i>OIS swap</i>, although <i>Fed Fund swaps</i> are also covered.
+ * The convention is formed by combining two swap leg conventions in the same currency.
+ * <p>
+ * The convention is defined by four key dates.
+ * <ul>
+ * <li>Trade date, the date that the trade is agreed
+ * <li>Spot date, the base for date calculations, typically 2 business days after the trade date
+ * <li>Start date, the date on which the interest calculation starts, often the same as the spot date
+ * <li>End date, the date on which the interest calculation ends, typically a number of years after the start date
+ * </ul>
+ */
+@BeanDefinition
+public final class ImmutableOvernightIborSwapConvention
+    implements OvernightIborSwapConvention, ImmutableBean, Serializable {
+
+  /**
+   * The convention name, such as 'USD-FED-FUND-AA-LIBOR-3M'.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final String name;
+  /**
+   * The market convention of the floating leg.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final OvernightRateSwapLegConvention onLeg;
+  /**
+   * The market convention of the floating leg.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final IborRateSwapLegConvention iborLeg;
+  /**
+   * The offset of the spot value date from the trade date.
+   * <p>
+   * The offset is applied to the trade date to find the start date.
+   * A typical value is "plus 2 business days".
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final DaysAdjustment spotDateOffset;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains a convention based on the specified name and leg conventions.
+   * <p>
+   * The two leg conventions must be in the same currency.
+   * 
+   * @param name  the unique name of the convention 
+   * @param onLeg  the market convention for the overnight leg
+   * @param iborLeg  the market convention for the ibor leg
+   * @param spotDateOffset  the offset of the spot value date from the trade date
+   * @return the convention
+   */
+  public static ImmutableOvernightIborSwapConvention of(
+      String name,
+      OvernightRateSwapLegConvention onLeg,
+      IborRateSwapLegConvention iborLeg,
+      DaysAdjustment spotDateOffset) {
+
+    return new ImmutableOvernightIborSwapConvention(name, onLeg, iborLeg, spotDateOffset);
+  }
+
+  //-------------------------------------------------------------------------
+  @ImmutableValidator
+  private void validate() {
+    ArgChecker.isTrue(onLeg.getCurrency().equals(iborLeg.getCurrency()), "Conventions must have same currency");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public SwapTrade toTrade(
+      TradeInfo tradeInfo,
+      LocalDate startDate,
+      LocalDate endDate,
+      BuySell buySell,
+      double notional,
+      double spread) {
+
+    Optional<LocalDate> tradeDate = tradeInfo.getTradeDate();
+    if (tradeDate.isPresent()) {
+      ArgChecker.inOrderOrEqual(tradeDate.get(), startDate, "tradeDate", "startDate");
+    }
+    SwapLeg leg1 = onLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isBuy()), notional, spread);
+    SwapLeg leg2 = iborLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isSell()), notional);
+    return SwapTrade.builder()
+        .info(tradeInfo)
+        .product(Swap.of(leg1, leg2))
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code ImmutableOvernightIborSwapConvention}.
+   * @return the meta-bean, not null
+   */
+  public static ImmutableOvernightIborSwapConvention.Meta meta() {
+    return ImmutableOvernightIborSwapConvention.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(ImmutableOvernightIborSwapConvention.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static ImmutableOvernightIborSwapConvention.Builder builder() {
+    return new ImmutableOvernightIborSwapConvention.Builder();
+  }
+
+  private ImmutableOvernightIborSwapConvention(
+      String name,
+      OvernightRateSwapLegConvention onLeg,
+      IborRateSwapLegConvention iborLeg,
+      DaysAdjustment spotDateOffset) {
+    JodaBeanUtils.notNull(name, "name");
+    JodaBeanUtils.notNull(onLeg, "onLeg");
+    JodaBeanUtils.notNull(iborLeg, "iborLeg");
+    JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
+    this.name = name;
+    this.onLeg = onLeg;
+    this.iborLeg = iborLeg;
+    this.spotDateOffset = spotDateOffset;
+    validate();
+  }
+
+  @Override
+  public ImmutableOvernightIborSwapConvention.Meta metaBean() {
+    return ImmutableOvernightIborSwapConvention.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the convention name, such as 'USD-FED-FUND-AA-LIBOR-3M'.
+   * @return the value of the property, not null
+   */
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the floating leg.
+   * @return the value of the property, not null
+   */
+  @Override
+  public OvernightRateSwapLegConvention getOnLeg() {
+    return onLeg;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the floating leg.
+   * @return the value of the property, not null
+   */
+  @Override
+  public IborRateSwapLegConvention getIborLeg() {
+    return iborLeg;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the offset of the spot value date from the trade date.
+   * <p>
+   * The offset is applied to the trade date to find the start date.
+   * A typical value is "plus 2 business days".
+   * @return the value of the property, not null
+   */
+  @Override
+  public DaysAdjustment getSpotDateOffset() {
+    return spotDateOffset;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      ImmutableOvernightIborSwapConvention other = (ImmutableOvernightIborSwapConvention) obj;
+      return JodaBeanUtils.equal(name, other.name) &&
+          JodaBeanUtils.equal(onLeg, other.onLeg) &&
+          JodaBeanUtils.equal(iborLeg, other.iborLeg) &&
+          JodaBeanUtils.equal(spotDateOffset, other.spotDateOffset);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(name);
+    hash = hash * 31 + JodaBeanUtils.hashCode(onLeg);
+    hash = hash * 31 + JodaBeanUtils.hashCode(iborLeg);
+    hash = hash * 31 + JodaBeanUtils.hashCode(spotDateOffset);
+    return hash;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code ImmutableOvernightIborSwapConvention}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code name} property.
+     */
+    private final MetaProperty<String> name = DirectMetaProperty.ofImmutable(
+        this, "name", ImmutableOvernightIborSwapConvention.class, String.class);
+    /**
+     * The meta-property for the {@code onLeg} property.
+     */
+    private final MetaProperty<OvernightRateSwapLegConvention> onLeg = DirectMetaProperty.ofImmutable(
+        this, "onLeg", ImmutableOvernightIborSwapConvention.class, OvernightRateSwapLegConvention.class);
+    /**
+     * The meta-property for the {@code iborLeg} property.
+     */
+    private final MetaProperty<IborRateSwapLegConvention> iborLeg = DirectMetaProperty.ofImmutable(
+        this, "iborLeg", ImmutableOvernightIborSwapConvention.class, IborRateSwapLegConvention.class);
+    /**
+     * The meta-property for the {@code spotDateOffset} property.
+     */
+    private final MetaProperty<DaysAdjustment> spotDateOffset = DirectMetaProperty.ofImmutable(
+        this, "spotDateOffset", ImmutableOvernightIborSwapConvention.class, DaysAdjustment.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "name",
+        "onLeg",
+        "iborLeg",
+        "spotDateOffset");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          return name;
+        case 105864111:  // onLeg
+          return onLeg;
+        case 1610246066:  // iborLeg
+          return iborLeg;
+        case 746995843:  // spotDateOffset
+          return spotDateOffset;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public ImmutableOvernightIborSwapConvention.Builder builder() {
+      return new ImmutableOvernightIborSwapConvention.Builder();
+    }
+
+    @Override
+    public Class<? extends ImmutableOvernightIborSwapConvention> beanType() {
+      return ImmutableOvernightIborSwapConvention.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code name} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<String> name() {
+      return name;
+    }
+
+    /**
+     * The meta-property for the {@code onLeg} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<OvernightRateSwapLegConvention> onLeg() {
+      return onLeg;
+    }
+
+    /**
+     * The meta-property for the {@code iborLeg} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<IborRateSwapLegConvention> iborLeg() {
+      return iborLeg;
+    }
+
+    /**
+     * The meta-property for the {@code spotDateOffset} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<DaysAdjustment> spotDateOffset() {
+      return spotDateOffset;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          return ((ImmutableOvernightIborSwapConvention) bean).getName();
+        case 105864111:  // onLeg
+          return ((ImmutableOvernightIborSwapConvention) bean).getOnLeg();
+        case 1610246066:  // iborLeg
+          return ((ImmutableOvernightIborSwapConvention) bean).getIborLeg();
+        case 746995843:  // spotDateOffset
+          return ((ImmutableOvernightIborSwapConvention) bean).getSpotDateOffset();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code ImmutableOvernightIborSwapConvention}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<ImmutableOvernightIborSwapConvention> {
+
+    private String name;
+    private OvernightRateSwapLegConvention onLeg;
+    private IborRateSwapLegConvention iborLeg;
+    private DaysAdjustment spotDateOffset;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(ImmutableOvernightIborSwapConvention beanToCopy) {
+      this.name = beanToCopy.getName();
+      this.onLeg = beanToCopy.getOnLeg();
+      this.iborLeg = beanToCopy.getIborLeg();
+      this.spotDateOffset = beanToCopy.getSpotDateOffset();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          return name;
+        case 105864111:  // onLeg
+          return onLeg;
+        case 1610246066:  // iborLeg
+          return iborLeg;
+        case 746995843:  // spotDateOffset
+          return spotDateOffset;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          this.name = (String) newValue;
+          break;
+        case 105864111:  // onLeg
+          this.onLeg = (OvernightRateSwapLegConvention) newValue;
+          break;
+        case 1610246066:  // iborLeg
+          this.iborLeg = (IborRateSwapLegConvention) newValue;
+          break;
+        case 746995843:  // spotDateOffset
+          this.spotDateOffset = (DaysAdjustment) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public ImmutableOvernightIborSwapConvention build() {
+      return new ImmutableOvernightIborSwapConvention(
+          name,
+          onLeg,
+          iborLeg,
+          spotDateOffset);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the convention name, such as 'USD-FED-FUND-AA-LIBOR-3M'.
+     * @param name  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder name(String name) {
+      JodaBeanUtils.notNull(name, "name");
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the market convention of the floating leg.
+     * @param onLeg  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder onLeg(OvernightRateSwapLegConvention onLeg) {
+      JodaBeanUtils.notNull(onLeg, "onLeg");
+      this.onLeg = onLeg;
+      return this;
+    }
+
+    /**
+     * Sets the market convention of the floating leg.
+     * @param iborLeg  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder iborLeg(IborRateSwapLegConvention iborLeg) {
+      JodaBeanUtils.notNull(iborLeg, "iborLeg");
+      this.iborLeg = iborLeg;
+      return this;
+    }
+
+    /**
+     * Sets the offset of the spot value date from the trade date.
+     * <p>
+     * The offset is applied to the trade date to find the start date.
+     * A typical value is "plus 2 business days".
+     * @param spotDateOffset  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder spotDateOffset(DaysAdjustment spotDateOffset) {
+      JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
+      this.spotDateOffset = spotDateOffset;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(160);
+      buf.append("ImmutableOvernightIborSwapConvention.Builder{");
+      buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
+      buf.append("onLeg").append('=').append(JodaBeanUtils.toString(onLeg)).append(',').append(' ');
+      buf.append("iborLeg").append('=').append(JodaBeanUtils.toString(iborLeg)).append(',').append(' ');
+      buf.append("spotDateOffset").append('=').append(JodaBeanUtils.toString(spotDateOffset));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightIborSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightIborSwapConvention.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */
@@ -62,7 +62,7 @@ public final class ImmutableOvernightIborSwapConvention
    * The market convention of the floating leg.
    */
   @PropertyDefinition(validate = "notNull", overrideGet = true)
-  private final OvernightRateSwapLegConvention onLeg;
+  private final OvernightRateSwapLegConvention overnightLeg;
   /**
    * The market convention of the floating leg.
    */
@@ -84,24 +84,24 @@ public final class ImmutableOvernightIborSwapConvention
    * The two leg conventions must be in the same currency.
    * 
    * @param name  the unique name of the convention 
-   * @param onLeg  the market convention for the overnight leg
+   * @param overnightLeg  the market convention for the overnight leg
    * @param iborLeg  the market convention for the ibor leg
    * @param spotDateOffset  the offset of the spot value date from the trade date
    * @return the convention
    */
   public static ImmutableOvernightIborSwapConvention of(
       String name,
-      OvernightRateSwapLegConvention onLeg,
+      OvernightRateSwapLegConvention overnightLeg,
       IborRateSwapLegConvention iborLeg,
       DaysAdjustment spotDateOffset) {
 
-    return new ImmutableOvernightIborSwapConvention(name, onLeg, iborLeg, spotDateOffset);
+    return new ImmutableOvernightIborSwapConvention(name, overnightLeg, iborLeg, spotDateOffset);
   }
 
   //-------------------------------------------------------------------------
   @ImmutableValidator
   private void validate() {
-    ArgChecker.isTrue(onLeg.getCurrency().equals(iborLeg.getCurrency()), "Conventions must have same currency");
+    ArgChecker.isTrue(overnightLeg.getCurrency().equals(iborLeg.getCurrency()), "Conventions must have same currency");
   }
 
   //-------------------------------------------------------------------------
@@ -118,7 +118,7 @@ public final class ImmutableOvernightIborSwapConvention
     if (tradeDate.isPresent()) {
       ArgChecker.inOrderOrEqual(tradeDate.get(), startDate, "tradeDate", "startDate");
     }
-    SwapLeg leg1 = onLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isBuy()), notional, spread);
+    SwapLeg leg1 = overnightLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isBuy()), notional, spread);
     SwapLeg leg2 = iborLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isSell()), notional);
     return SwapTrade.builder()
         .info(tradeInfo)
@@ -161,15 +161,15 @@ public final class ImmutableOvernightIborSwapConvention
 
   private ImmutableOvernightIborSwapConvention(
       String name,
-      OvernightRateSwapLegConvention onLeg,
+      OvernightRateSwapLegConvention overnightLeg,
       IborRateSwapLegConvention iborLeg,
       DaysAdjustment spotDateOffset) {
     JodaBeanUtils.notNull(name, "name");
-    JodaBeanUtils.notNull(onLeg, "onLeg");
+    JodaBeanUtils.notNull(overnightLeg, "overnightLeg");
     JodaBeanUtils.notNull(iborLeg, "iborLeg");
     JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
     this.name = name;
-    this.onLeg = onLeg;
+    this.overnightLeg = overnightLeg;
     this.iborLeg = iborLeg;
     this.spotDateOffset = spotDateOffset;
     validate();
@@ -206,8 +206,8 @@ public final class ImmutableOvernightIborSwapConvention
    * @return the value of the property, not null
    */
   @Override
-  public OvernightRateSwapLegConvention getOnLeg() {
-    return onLeg;
+  public OvernightRateSwapLegConvention getOvernightLeg() {
+    return overnightLeg;
   }
 
   //-----------------------------------------------------------------------
@@ -250,7 +250,7 @@ public final class ImmutableOvernightIborSwapConvention
     if (obj != null && obj.getClass() == this.getClass()) {
       ImmutableOvernightIborSwapConvention other = (ImmutableOvernightIborSwapConvention) obj;
       return JodaBeanUtils.equal(name, other.name) &&
-          JodaBeanUtils.equal(onLeg, other.onLeg) &&
+          JodaBeanUtils.equal(overnightLeg, other.overnightLeg) &&
           JodaBeanUtils.equal(iborLeg, other.iborLeg) &&
           JodaBeanUtils.equal(spotDateOffset, other.spotDateOffset);
     }
@@ -261,7 +261,7 @@ public final class ImmutableOvernightIborSwapConvention
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(name);
-    hash = hash * 31 + JodaBeanUtils.hashCode(onLeg);
+    hash = hash * 31 + JodaBeanUtils.hashCode(overnightLeg);
     hash = hash * 31 + JodaBeanUtils.hashCode(iborLeg);
     hash = hash * 31 + JodaBeanUtils.hashCode(spotDateOffset);
     return hash;
@@ -283,10 +283,10 @@ public final class ImmutableOvernightIborSwapConvention
     private final MetaProperty<String> name = DirectMetaProperty.ofImmutable(
         this, "name", ImmutableOvernightIborSwapConvention.class, String.class);
     /**
-     * The meta-property for the {@code onLeg} property.
+     * The meta-property for the {@code overnightLeg} property.
      */
-    private final MetaProperty<OvernightRateSwapLegConvention> onLeg = DirectMetaProperty.ofImmutable(
-        this, "onLeg", ImmutableOvernightIborSwapConvention.class, OvernightRateSwapLegConvention.class);
+    private final MetaProperty<OvernightRateSwapLegConvention> overnightLeg = DirectMetaProperty.ofImmutable(
+        this, "overnightLeg", ImmutableOvernightIborSwapConvention.class, OvernightRateSwapLegConvention.class);
     /**
      * The meta-property for the {@code iborLeg} property.
      */
@@ -303,7 +303,7 @@ public final class ImmutableOvernightIborSwapConvention
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "name",
-        "onLeg",
+        "overnightLeg",
         "iborLeg",
         "spotDateOffset");
 
@@ -318,8 +318,8 @@ public final class ImmutableOvernightIborSwapConvention
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
-        case 105864111:  // onLeg
-          return onLeg;
+        case 1774606250:  // overnightLeg
+          return overnightLeg;
         case 1610246066:  // iborLeg
           return iborLeg;
         case 746995843:  // spotDateOffset
@@ -353,11 +353,11 @@ public final class ImmutableOvernightIborSwapConvention
     }
 
     /**
-     * The meta-property for the {@code onLeg} property.
+     * The meta-property for the {@code overnightLeg} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<OvernightRateSwapLegConvention> onLeg() {
-      return onLeg;
+    public MetaProperty<OvernightRateSwapLegConvention> overnightLeg() {
+      return overnightLeg;
     }
 
     /**
@@ -382,8 +382,8 @@ public final class ImmutableOvernightIborSwapConvention
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return ((ImmutableOvernightIborSwapConvention) bean).getName();
-        case 105864111:  // onLeg
-          return ((ImmutableOvernightIborSwapConvention) bean).getOnLeg();
+        case 1774606250:  // overnightLeg
+          return ((ImmutableOvernightIborSwapConvention) bean).getOvernightLeg();
         case 1610246066:  // iborLeg
           return ((ImmutableOvernightIborSwapConvention) bean).getIborLeg();
         case 746995843:  // spotDateOffset
@@ -410,7 +410,7 @@ public final class ImmutableOvernightIborSwapConvention
   public static final class Builder extends DirectFieldsBeanBuilder<ImmutableOvernightIborSwapConvention> {
 
     private String name;
-    private OvernightRateSwapLegConvention onLeg;
+    private OvernightRateSwapLegConvention overnightLeg;
     private IborRateSwapLegConvention iborLeg;
     private DaysAdjustment spotDateOffset;
 
@@ -426,7 +426,7 @@ public final class ImmutableOvernightIborSwapConvention
      */
     private Builder(ImmutableOvernightIborSwapConvention beanToCopy) {
       this.name = beanToCopy.getName();
-      this.onLeg = beanToCopy.getOnLeg();
+      this.overnightLeg = beanToCopy.getOvernightLeg();
       this.iborLeg = beanToCopy.getIborLeg();
       this.spotDateOffset = beanToCopy.getSpotDateOffset();
     }
@@ -437,8 +437,8 @@ public final class ImmutableOvernightIborSwapConvention
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
-        case 105864111:  // onLeg
-          return onLeg;
+        case 1774606250:  // overnightLeg
+          return overnightLeg;
         case 1610246066:  // iborLeg
           return iborLeg;
         case 746995843:  // spotDateOffset
@@ -454,8 +454,8 @@ public final class ImmutableOvernightIborSwapConvention
         case 3373707:  // name
           this.name = (String) newValue;
           break;
-        case 105864111:  // onLeg
-          this.onLeg = (OvernightRateSwapLegConvention) newValue;
+        case 1774606250:  // overnightLeg
+          this.overnightLeg = (OvernightRateSwapLegConvention) newValue;
           break;
         case 1610246066:  // iborLeg
           this.iborLeg = (IborRateSwapLegConvention) newValue;
@@ -497,7 +497,7 @@ public final class ImmutableOvernightIborSwapConvention
     public ImmutableOvernightIborSwapConvention build() {
       return new ImmutableOvernightIborSwapConvention(
           name,
-          onLeg,
+          overnightLeg,
           iborLeg,
           spotDateOffset);
     }
@@ -516,12 +516,12 @@ public final class ImmutableOvernightIborSwapConvention
 
     /**
      * Sets the market convention of the floating leg.
-     * @param onLeg  the new value, not null
+     * @param overnightLeg  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder onLeg(OvernightRateSwapLegConvention onLeg) {
-      JodaBeanUtils.notNull(onLeg, "onLeg");
-      this.onLeg = onLeg;
+    public Builder overnightLeg(OvernightRateSwapLegConvention overnightLeg) {
+      JodaBeanUtils.notNull(overnightLeg, "overnightLeg");
+      this.overnightLeg = overnightLeg;
       return this;
     }
 
@@ -556,7 +556,7 @@ public final class ImmutableOvernightIborSwapConvention
       StringBuilder buf = new StringBuilder(160);
       buf.append("ImmutableOvernightIborSwapConvention.Builder{");
       buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
-      buf.append("onLeg").append('=').append(JodaBeanUtils.toString(onLeg)).append(',').append(' ');
+      buf.append("overnightLeg").append('=').append(JodaBeanUtils.toString(overnightLeg)).append(',').append(' ');
       buf.append("iborLeg").append('=').append(JodaBeanUtils.toString(iborLeg)).append(',').append(' ');
       buf.append("spotDateOffset").append('=').append(JodaBeanUtils.toString(spotDateOffset));
       buf.append('}');

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConvention.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.opengamma.strata.basics.BuySell;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.basics.market.ReferenceData;
+import com.opengamma.strata.basics.market.ReferenceDataNotFoundException;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.named.ExtendedEnum;
+import com.opengamma.strata.collect.named.Named;
+import com.opengamma.strata.product.TradeConvention;
+import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * A market convention for Overnight-Ibor swap trades.
+ * <p>
+ * This defines the market convention for a Overnight-Ibor single currency swap.
+ * In USD, this is often known as an <i>Fed Fund Swap</i>.
+ * The convention is formed by combining two swap leg conventions in the same currency.
+ * <p>
+ * To manually create a convention, see {@link ImmutableOvernightIborSwapConvention}.
+ * To register a specific convention, see {@code OvernightIborSwapConvention.ini}.
+ */
+public interface OvernightIborSwapConvention
+    extends TradeConvention, Named {
+
+  /**
+   * Obtains an instance from the specified unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the convention
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static OvernightIborSwapConvention of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return extendedEnum().lookup(uniqueName);
+  }
+
+  /**
+   * Gets the extended enum helper.
+   * <p>
+   * This helper allows instances of the convention to be looked up.
+   * It also provides the complete set of available instances.
+   * 
+   * @return the extended enum helper
+   */
+  public static ExtendedEnum<OvernightIborSwapConvention> extendedEnum() {
+    return OvernightIborSwapConventions.ENUM_LOOKUP;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the overnight leg.
+   * 
+   * @return the overnight leg convention
+   */
+  public abstract OvernightRateSwapLegConvention getOnLeg();
+
+  /**
+   * Gets the market convention of the Ibor leg.
+   * 
+   * @return the Ibor leg convention
+   */
+  public abstract IborRateSwapLegConvention getIborLeg();
+
+  /**
+   * Gets the offset of the spot value date from the trade date.
+   * <p>
+   * The offset is applied to the trade date to find the start date.
+   * A typical value is "plus 2 business days".
+   * 
+   * @return the spot date offset, not null
+   */
+  public abstract DaysAdjustment getSpotDateOffset();
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates a spot-starting trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified tenor. For example, a tenor
+   * of 5 years creates a swap starting on the spot date and maturing 5 years later.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param tenor  the tenor of the swap
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  public default SwapTrade createTrade(
+      LocalDate tradeDate,
+      Tenor tenor,
+      BuySell buySell,
+      double notional,
+      double spread,
+      ReferenceData refData) {
+
+    return createTrade(tradeDate, Period.ZERO, tenor, buySell, notional, spread, refData);
+  }
+
+  /**
+   * Creates a forward-starting trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified period and tenor. For example, a period of
+   * 3 months and a tenor of 5 years creates a swap starting three months after the spot date
+   * and maturing 5 years later.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param periodToStart  the period between the spot date and the start date
+   * @param tenor  the tenor of the swap
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  public default SwapTrade createTrade(
+      LocalDate tradeDate,
+      Period periodToStart,
+      Tenor tenor,
+      BuySell buySell,
+      double notional,
+      double spread,
+      ReferenceData refData) {
+
+    LocalDate spotValue = calculateSpotDateFromTradeDate(tradeDate, refData);
+    LocalDate startDate = spotValue.plus(periodToStart);
+    LocalDate endDate = startDate.plus(tenor.getPeriod());
+    return toTrade(tradeDate, startDate, endDate, buySell, notional, spread);
+  }
+
+  /**
+   * Creates a trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified dates.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param startDate  the start date
+   * @param endDate  the end date
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @return the trade
+   */
+  public default SwapTrade toTrade(
+      LocalDate tradeDate,
+      LocalDate startDate,
+      LocalDate endDate,
+      BuySell buySell,
+      double notional,
+      double spread) {
+
+    TradeInfo tradeInfo = TradeInfo.of(tradeDate);
+    return toTrade(tradeInfo, startDate, endDate, buySell, notional, spread);
+  }
+
+  /**
+   * Creates a trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified dates.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeInfo  additional information about the trade
+   * @param startDate  the start date
+   * @param endDate  the end date
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @return the trade
+   */
+  public abstract SwapTrade toTrade(
+      TradeInfo tradeInfo,
+      LocalDate startDate,
+      LocalDate endDate,
+      BuySell buySell,
+      double notional,
+      double spread);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the spot date from the trade date.
+   * 
+   * @param tradeDate  the trade date
+   * @param refData  the reference data, used to resolve the date
+   * @return the spot date
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  public default LocalDate calculateSpotDateFromTradeDate(LocalDate tradeDate, ReferenceData refData) {
+    return getSpotDateOffset().adjust(tradeDate, refData);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this convention.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public abstract String getName();
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConvention.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */
@@ -67,7 +67,7 @@ public interface OvernightIborSwapConvention
    * 
    * @return the overnight leg convention
    */
-  public abstract OvernightRateSwapLegConvention getOnLeg();
+  public abstract OvernightRateSwapLegConvention getOvernightLeg();
 
   /**
    * Gets the market convention of the Ibor leg.

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventions.java
@@ -31,14 +31,14 @@ public final class OvernightIborSwapConventions {
       OvernightIborSwapConvention.of(StandardOvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M.getName());
   
   /**
-   * The 'GBP-SONIA-GBP-LIBOR-3M' swap convention.
+   * The 'GBP-SONIA-OIS-1Y-LIBOR-3M' swap convention.
    * <p>
-   * GBP Sonia compounded v LIBOR 3M .
+   * GBP Sonia compounded 1Y v LIBOR 3M .
    * Both legs use day count 'Act/365F'.
-   * The spot date offset is 0 days and payment offset is ? days.
+   * The spot date offset is 0 days and payment offset is 0 days.
    */
-  public static final OvernightIborSwapConvention GBP_SONIA_OIS_LIBOR_3M =
-      OvernightIborSwapConvention.of(StandardOvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M.getName());
+  public static final OvernightIborSwapConvention GBP_SONIA_OIS_1Y_LIBOR_3M =
+      OvernightIborSwapConvention.of(StandardOvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M.getName());
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventions.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import com.opengamma.strata.collect.named.ExtendedEnum;
+
+/**
+ * Market standard Fixed-Overnight swap conventions.
+ * <p>
+ * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
+ */
+public final class OvernightIborSwapConventions {
+
+  /**
+   * The extended enum lookup from name to instance.
+   */
+  static final ExtendedEnum<OvernightIborSwapConvention> ENUM_LOOKUP = ExtendedEnum.of(OvernightIborSwapConvention.class);
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 'USD-FED-FUND-AA-LIBOR-3M' swap convention.
+   * <p>
+   * USD Fed Fund Arithmetic Average 3M v Libor 3M swap.
+   * Both legs use day count 'Act/360'.
+   * The spot date offset is 2 days, the rate cut-off period is 2 days.
+   */
+  public static final OvernightIborSwapConvention USD_FED_FUND_AA_LIBOR_3M =
+      OvernightIborSwapConvention.of(StandardOvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M.getName());
+  
+  /**
+   * The 'GBP-SONIA-GBP-LIBOR-3M' swap convention.
+   * <p>
+   * GBP Sonia compounded v LIBOR 3M .
+   * Both legs use day count 'Act/365F'.
+   * The spot date offset is 0 days and payment offset is ? days.
+   */
+  public static final OvernightIborSwapConvention GBP_SONIA_OIS_LIBOR_3M =
+      OvernightIborSwapConvention.of(StandardOvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private OvernightIborSwapConventions() {
+  }
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.schedule.Frequency.P3M;
+import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED;
+import static com.opengamma.strata.product.swap.OvernightAccrualMethod.COMPOUNDED;
+
+
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.HolidayCalendarId;
+import com.opengamma.strata.basics.index.IborIndex;
+import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.product.swap.OvernightAccrualMethod;
+
+/**
+ * Market standard Fixed-Overnight swap conventions.
+ * <p>
+ * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
+ */
+final class StandardOvernightIborSwapConventions {
+
+  /**
+   * USD Fed Fund AA v LIBOR 3M swap .
+   * <p>
+   * Both legs use day count 'Act/360'.
+   * The spot date offset is 2 days and the cut-off period is 2 days.
+   */
+  public static final OvernightIborSwapConvention USD_FED_FUND_AA_LIBOR_3M =
+      makeConvention("USD-FED-FUND-AA-LIBOR-3M", USD_FED_FUND, USD_LIBOR_3M, ACT_360, P3M, 0, 2, AVERAGED, 2);
+
+  /**
+   * GBP Sonia compounded v LIBOR 3M .
+   * <p>
+   * Both legs use day count 'Act/365F'.
+   * The spot date offset is 0 days and payment offset is ? days.
+   */
+  public static final OvernightIborSwapConvention GBP_SONIA_OIS_LIBOR_3M =
+      makeConvention("GBP-SONIA-OIS-LIBOR-3M", GBP_SONIA, GBP_LIBOR_3M, ACT_365F, P3M, 0, 0, COMPOUNDED, 0);
+
+  //-------------------------------------------------------------------------
+  // build conventions
+  private static OvernightIborSwapConvention makeConvention(
+      String name,
+      OvernightIndex onIndex,
+      IborIndex iborIndex,
+      DayCount dayCount,
+      Frequency frequency,
+      int paymentLag,
+      int cutOffDays,
+      OvernightAccrualMethod accrual,
+      int spotLag) {
+
+    HolidayCalendarId calendarOn = onIndex.getFixingCalendar();
+    DaysAdjustment paymentDateOffset = DaysAdjustment.ofBusinessDays(paymentLag, calendarOn);
+    DaysAdjustment spotDateOffset = DaysAdjustment.ofBusinessDays(spotLag, calendarOn);
+    return ImmutableOvernightIborSwapConvention.of(
+        name,
+        OvernightRateSwapLegConvention.builder()
+            .index(onIndex)
+            .accrualMethod(accrual)
+            .accrualFrequency(frequency)
+            .paymentFrequency(frequency)
+            .paymentDateOffset(paymentDateOffset)
+            .stubConvention(StubConvention.SHORT_INITIAL)
+            .rateCutOffDays(cutOffDays)
+            .build(),
+        IborRateSwapLegConvention.of(iborIndex),
+        spotDateOffset);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private StandardOvernightIborSwapConventions() {
+  }
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
@@ -11,6 +11,7 @@ import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.schedule.Frequency.P12M;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
 import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED;
 import static com.opengamma.strata.product.swap.OvernightAccrualMethod.COMPOUNDED;
@@ -42,13 +43,13 @@ final class StandardOvernightIborSwapConventions {
       makeConvention("USD-FED-FUND-AA-LIBOR-3M", USD_FED_FUND, USD_LIBOR_3M, ACT_360, P3M, 0, 2, AVERAGED, 2);
 
   /**
-   * GBP Sonia compounded v LIBOR 3M .
+   * GBP Sonia compounded 1Y v LIBOR 3M .
    * <p>
    * Both legs use day count 'Act/365F'.
-   * The spot date offset is 0 days and payment offset is ? days.
+   * The spot date offset is 0 days and payment offset is 0 days.
    */
-  public static final OvernightIborSwapConvention GBP_SONIA_OIS_LIBOR_3M =
-      makeConvention("GBP-SONIA-OIS-LIBOR-3M", GBP_SONIA, GBP_LIBOR_3M, ACT_365F, P3M, 0, 0, COMPOUNDED, 0);
+  public static final OvernightIborSwapConvention GBP_SONIA_OIS_1Y_LIBOR_3M =
+      makeConvention("GBP-SONIA-OIS-1Y-LIBOR-3M", GBP_SONIA, GBP_LIBOR_3M, ACT_365F, P12M, 0, 0, COMPOUNDED, 0);
 
   //-------------------------------------------------------------------------
   // build conventions

--- a/modules/product/src/main/resources/com/opengamma/strata/config/base/OvernightIborSwapConvention.ini
+++ b/modules/product/src/main/resources/com/opengamma/strata/config/base/OvernightIborSwapConvention.ini
@@ -1,0 +1,15 @@
+# OvernightIborSwapConvention configuration
+
+# The providers are the classes that define the enum
+# The key is of the form 'provider.full.class.name'
+# The value is either
+#  'constants', the public static final constants from the class
+#  'lookup', the class implements NamedLookup with a no-args constructor
+#  'instance', the class has a static field named INSTANCE that is of type NamedLookup
+[providers]
+com.opengamma.strata.product.swap.type.StandardOvernightIborSwapConventions = constants
+
+# The set of alternate names
+# The key is the alternate name
+# The value is the standard name (loaded by a provider)
+[alternates]

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */
@@ -47,8 +47,6 @@ public class OvernightIborSwapConventionTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
   private static final double NOTIONAL_2M = 2_000_000d;
-  //  private static final BusinessDayAdjustment BDA_FOLLOW = BusinessDayAdjustment.of(FOLLOWING, GBLO);
-  //  private static final BusinessDayAdjustment BDA_MOD_FOLLOW = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO);
   private static final DaysAdjustment PLUS_ONE_DAY = DaysAdjustment.ofBusinessDays(1, GBLO);
   private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
 
@@ -74,7 +72,7 @@ public class OvernightIborSwapConventionTest {
     ImmutableOvernightIborSwapConvention test =
         ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
     assertEquals(test.getName(), NAME);
-    assertEquals(test.getOnLeg(), FFUND_LEG);
+    assertEquals(test.getOvernightLeg(), FFUND_LEG);
     assertEquals(test.getIborLeg(), USD_LIBOR_3M_LEG);
     assertEquals(test.getSpotDateOffset(), PLUS_TWO_DAYS);
   }
@@ -82,12 +80,12 @@ public class OvernightIborSwapConventionTest {
   public void test_builder() {
     ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.builder()
         .name(NAME)
-        .onLeg(FFUND_LEG)
+        .overnightLeg(FFUND_LEG)
         .iborLeg(USD_LIBOR_3M_LEG)
         .spotDateOffset(PLUS_ONE_DAY)
         .build();
     assertEquals(test.getName(), NAME);
-    assertEquals(test.getOnLeg(), FFUND_LEG);
+    assertEquals(test.getOvernightLeg(), FFUND_LEG);
     assertEquals(test.getIborLeg(), USD_LIBOR_3M_LEG);
     assertEquals(test.getSpotDateOffset(), PLUS_ONE_DAY);
   }

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.basics.BuySell.BUY;
+import static com.opengamma.strata.basics.PayReceive.PAY;
+import static com.opengamma.strata.basics.PayReceive.RECEIVE;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
+import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
+import static com.opengamma.strata.basics.schedule.Frequency.P12M;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Optional;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.BuySell;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.market.ReferenceData;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.product.swap.Swap;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * Test {@link OvernightIborSwapConvention}.
+ */
+@Test
+public class OvernightIborSwapConventionTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final double NOTIONAL_2M = 2_000_000d;
+  //  private static final BusinessDayAdjustment BDA_FOLLOW = BusinessDayAdjustment.of(FOLLOWING, GBLO);
+  //  private static final BusinessDayAdjustment BDA_MOD_FOLLOW = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO);
+  private static final DaysAdjustment PLUS_ONE_DAY = DaysAdjustment.ofBusinessDays(1, GBLO);
+  private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
+
+  private static final String NAME = "USD-FF";
+  private static final OvernightRateSwapLegConvention FFUND_LEG =
+      OvernightRateSwapLegConvention.builder()
+          .index(USD_FED_FUND)
+          .accrualMethod(AVERAGED)
+          .accrualFrequency(Frequency.P3M)
+          .paymentFrequency(Frequency.P3M)
+          .stubConvention(StubConvention.SHORT_INITIAL)
+          .rateCutOffDays(2)
+          .build();
+  private static final OvernightRateSwapLegConvention FFUND_LEG2 =
+      OvernightRateSwapLegConvention.of(USD_FED_FUND, P12M, 3);
+  private static final OvernightRateSwapLegConvention FLOATING_LEG2 =
+      OvernightRateSwapLegConvention.of(GBP_SONIA, P12M, 0);
+  private static final IborRateSwapLegConvention USD_LIBOR_3M_LEG = IborRateSwapLegConvention.of(USD_LIBOR_3M);
+  private static final IborRateSwapLegConvention GBP_LIBOR_3M_LEG = IborRateSwapLegConvention.of(GBP_LIBOR_3M);
+
+  //-------------------------------------------------------------------------
+  public void test_of() {
+    ImmutableOvernightIborSwapConvention test =
+        ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    assertEquals(test.getName(), NAME);
+    assertEquals(test.getOnLeg(), FFUND_LEG);
+    assertEquals(test.getIborLeg(), USD_LIBOR_3M_LEG);
+    assertEquals(test.getSpotDateOffset(), PLUS_TWO_DAYS);
+  }
+
+  public void test_builder() {
+    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.builder()
+        .name(NAME)
+        .onLeg(FFUND_LEG)
+        .iborLeg(USD_LIBOR_3M_LEG)
+        .spotDateOffset(PLUS_ONE_DAY)
+        .build();
+    assertEquals(test.getName(), NAME);
+    assertEquals(test.getOnLeg(), FFUND_LEG);
+    assertEquals(test.getIborLeg(), USD_LIBOR_3M_LEG);
+    assertEquals(test.getSpotDateOffset(), PLUS_ONE_DAY);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_toTrade_tenor() {
+    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 5, 7);
+    LocalDate endDate = date(2025, 5, 7);
+    SwapTrade test = base.createTrade(tradeDate, TENOR_10Y, BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    Swap expected = Swap.of(
+        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
+  }
+
+  public void test_toTrade_periodTenor() {
+    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 8, 7);
+    LocalDate endDate = date(2025, 8, 7);
+    SwapTrade test = base.createTrade(tradeDate, Period.ofMonths(3), TENOR_10Y, BuySell.SELL, NOTIONAL_2M, 0.25d, REF_DATA);
+    Swap expected = Swap.of(
+        FFUND_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M, 0.25d),
+        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M));
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
+  }
+
+  public void test_toTrade_dates() {
+    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 8, 5);
+    LocalDate endDate = date(2015, 11, 5);
+    SwapTrade test = base.toTrade(tradeDate, startDate, endDate, BUY, NOTIONAL_2M, 0.25d);
+    Swap expected = Swap.of(
+        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "name")
+  static Object[][] data_name() {
+    return new Object[][] {
+      {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, "USD-FED-FUND-AA-LIBOR-3M" },
+    };
+  }
+
+  @Test(dataProvider = "name")
+  public void test_name(OvernightIborSwapConvention convention, String name) {
+    assertEquals(convention.getName(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_toString(OvernightIborSwapConvention convention, String name) {
+    assertEquals(convention.toString(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_of_lookup(OvernightIborSwapConvention convention, String name) {
+    assertEquals(OvernightIborSwapConvention.of(name), convention);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_extendedEnum(OvernightIborSwapConvention convention, String name) {
+    OvernightIborSwapConvention.of(name);  // ensures map is populated
+    ImmutableMap<String, OvernightIborSwapConvention> map = OvernightIborSwapConvention.extendedEnum().lookupAll();
+    assertEquals(map.get(name), convention);
+  }
+
+  public void test_of_lookup_notFound() {
+    assertThrowsIllegalArg(() -> OvernightIborSwapConvention.of("Rubbish"));
+  }
+
+  public void test_of_lookup_null() {
+    assertThrowsIllegalArg(() -> OvernightIborSwapConvention.of((String) null));
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.of(
+        NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    coverImmutableBean(test);
+    ImmutableOvernightIborSwapConvention test2 = ImmutableOvernightIborSwapConvention.of(
+        "GBP-Swap", FLOATING_LEG2, GBP_LIBOR_3M_LEG, PLUS_ONE_DAY);
+    coverBeanEquals(test, test2);
+    ImmutableOvernightIborSwapConvention test3 = ImmutableOvernightIborSwapConvention.of(
+        "USD-Swap2", FFUND_LEG2, USD_LIBOR_3M_LEG, PLUS_ONE_DAY);
+    coverBeanEquals(test, test3);
+  }
+
+  public void test_serialization() {
+    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.of(
+        NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    assertSerialization(test);
+  }
+
+}

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.time.LocalDate;
+import java.time.Period;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -21,6 +22,8 @@ import com.opengamma.strata.basics.date.BusinessDayConventions;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DayCounts;
 import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.basics.index.IborIndex;
+import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.index.OvernightIndices;
 import com.opengamma.strata.basics.market.ReferenceData;
@@ -40,7 +43,7 @@ public class OvernightIborSwapConventionsTest {
   static Object[][] data_spot_lag() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, 2},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, 0},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, 0},
     };
   }
 
@@ -50,23 +53,40 @@ public class OvernightIborSwapConventionsTest {
   }
 
   //-------------------------------------------------------------------------
-  @DataProvider(name = "period")
-  static Object[][] data_period() {
+  @DataProvider(name = "periodOn")
+  static Object[][] data_period_on() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, Frequency.P3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P12M},
     };
   }
 
-  @Test(dataProvider = "period")
-  public void test_accrualPeriod(OvernightIborSwapConvention convention, Frequency frequency) {
+  @Test(dataProvider = "periodOn")
+  public void test_accrualPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
     assertEquals(convention.getOnLeg().getAccrualFrequency(), frequency);
+  }
+
+  @Test(dataProvider = "periodOn")
+  public void test_paymentPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertEquals(convention.getOnLeg().getPaymentFrequency(), frequency);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "periodIbor")
+  static Object[][] data_period_ibor() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P3M},
+    };
+  }
+
+  @Test(dataProvider = "periodIbor")
+  public void test_accrualPeriod_ibor(OvernightIborSwapConvention convention, Frequency frequency) {
     assertEquals(convention.getIborLeg().getAccrualFrequency(), frequency);
   }
 
-  @Test(dataProvider = "period")
-  public void test_paymentPeriod(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertEquals(convention.getOnLeg().getPaymentFrequency(), frequency);
+  @Test(dataProvider = "periodIbor")
+  public void test_paymentPeriod_ibor(OvernightIborSwapConvention convention, Frequency frequency) {
     assertEquals(convention.getIborLeg().getPaymentFrequency(), frequency);
   }
 
@@ -75,7 +95,7 @@ public class OvernightIborSwapConventionsTest {
   static Object[][] data_day_count() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, DayCounts.ACT_360},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, DayCounts.ACT_365F},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, DayCounts.ACT_365F},
     };
   }
 
@@ -86,17 +106,31 @@ public class OvernightIborSwapConventionsTest {
   }
 
   //-------------------------------------------------------------------------
-  @DataProvider(name = "floatLeg")
+  @DataProvider(name = "onLeg")
   static Object[][] data_float_leg() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, OvernightIndices.USD_FED_FUND},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, OvernightIndices.GBP_SONIA},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, OvernightIndices.GBP_SONIA},
     };
   }
 
-  @Test(dataProvider = "floatLeg")
+  @Test(dataProvider = "onLeg")
   public void test_float_leg(OvernightIborSwapConvention convention, OvernightIndex floatLeg) {
     assertEquals(convention.getOnLeg().getIndex(), floatLeg);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "iborLeg")
+  static Object[][] data_ibor_leg() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, IborIndices.USD_LIBOR_3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, IborIndices.GBP_LIBOR_3M},
+    };
+  }
+
+  @Test(dataProvider = "iborLeg")
+  public void test_ibor_leg(OvernightIborSwapConvention convention, IborIndex iborLeg) {
+    assertEquals(convention.getIborLeg().getIndex(), iborLeg);
   }
 
   //-------------------------------------------------------------------------
@@ -104,7 +138,7 @@ public class OvernightIborSwapConventionsTest {
   static Object[][] data_day_convention() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
     };
   }
 
@@ -118,7 +152,7 @@ public class OvernightIborSwapConventionsTest {
   static Object[][] data_stub_on() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Tenor.of(Period.ofMonths(13))},
     };
   }
   

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.BuySell;
+import com.opengamma.strata.basics.PayReceive;
+import com.opengamma.strata.basics.date.BusinessDayConvention;
+import com.opengamma.strata.basics.date.BusinessDayConventions;
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.basics.index.OvernightIndices;
+import com.opengamma.strata.basics.market.ReferenceData;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.product.swap.ResolvedSwap;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * Test {@link OvernightIborSwapConventions}.
+ */
+@Test
+public class OvernightIborSwapConventionsTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+
+  @DataProvider(name = "spotLag")
+  static Object[][] data_spot_lag() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, 2},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, 0},
+    };
+  }
+
+  @Test(dataProvider = "spotLag")
+  public void test_spot_lag(ImmutableOvernightIborSwapConvention convention, int lag) {
+    assertEquals(convention.getSpotDateOffset().getDays(), lag);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "period")
+  static Object[][] data_period() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, Frequency.P3M},
+    };
+  }
+
+  @Test(dataProvider = "period")
+  public void test_accrualPeriod(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertEquals(convention.getOnLeg().getAccrualFrequency(), frequency);
+    assertEquals(convention.getIborLeg().getAccrualFrequency(), frequency);
+  }
+
+  @Test(dataProvider = "period")
+  public void test_paymentPeriod(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertEquals(convention.getOnLeg().getPaymentFrequency(), frequency);
+    assertEquals(convention.getIborLeg().getPaymentFrequency(), frequency);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "dayCount")
+  static Object[][] data_day_count() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, DayCounts.ACT_360},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, DayCounts.ACT_365F},
+    };
+  }
+
+  @Test(dataProvider = "dayCount")
+  public void test_day_count(OvernightIborSwapConvention convention, DayCount dayCount) {
+    assertEquals(convention.getOnLeg().getDayCount(), dayCount);
+    assertEquals(convention.getIborLeg().getDayCount(), dayCount);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "floatLeg")
+  static Object[][] data_float_leg() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, OvernightIndices.USD_FED_FUND},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, OvernightIndices.GBP_SONIA},
+    };
+  }
+
+  @Test(dataProvider = "floatLeg")
+  public void test_float_leg(OvernightIborSwapConvention convention, OvernightIndex floatLeg) {
+    assertEquals(convention.getOnLeg().getIndex(), floatLeg);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "dayConvention")
+  static Object[][] data_day_convention() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
+    };
+  }
+
+  @Test(dataProvider = "dayConvention")
+  public void test_day_convention(OvernightIborSwapConvention convention, BusinessDayConvention dayConvention) {
+    assertEquals(convention.getOnLeg().getAccrualBusinessDayAdjustment().getConvention(), dayConvention);
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "stubOn")
+  static Object[][] data_stub_on() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
+    };
+  }
+  
+  @Test(dataProvider = "stubOn")
+  public void test_stub_overnight(OvernightIborSwapConvention convention, Tenor tenor) {
+    LocalDate tradeDate = LocalDate.of(2015, 10, 20);
+    SwapTrade swap = convention.createTrade(tradeDate, tenor, BuySell.BUY, 1, 0.01, REF_DATA);
+    ResolvedSwap swapResolved = swap.getProduct().resolve(REF_DATA);
+    LocalDate endDate = swapResolved.getLeg(PayReceive.PAY).get().getEndDate();
+    assertTrue(endDate.isAfter(tradeDate.plus(tenor).minusDays(7)));
+    assertTrue(endDate.isBefore(tradeDate.plus(tenor).plusDays(7)));
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverPrivateConstructor(OvernightIborSwapConventions.class);
+    coverPrivateConstructor(StandardOvernightIborSwapConventions.class);
+  }
+
+}

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */
@@ -63,12 +63,12 @@ public class OvernightIborSwapConventionsTest {
 
   @Test(dataProvider = "periodOn")
   public void test_accrualPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertEquals(convention.getOnLeg().getAccrualFrequency(), frequency);
+    assertEquals(convention.getOvernightLeg().getAccrualFrequency(), frequency);
   }
 
   @Test(dataProvider = "periodOn")
   public void test_paymentPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertEquals(convention.getOnLeg().getPaymentFrequency(), frequency);
+    assertEquals(convention.getOvernightLeg().getPaymentFrequency(), frequency);
   }
 
   //-------------------------------------------------------------------------
@@ -101,7 +101,7 @@ public class OvernightIborSwapConventionsTest {
 
   @Test(dataProvider = "dayCount")
   public void test_day_count(OvernightIborSwapConvention convention, DayCount dayCount) {
-    assertEquals(convention.getOnLeg().getDayCount(), dayCount);
+    assertEquals(convention.getOvernightLeg().getDayCount(), dayCount);
     assertEquals(convention.getIborLeg().getDayCount(), dayCount);
   }
 
@@ -116,7 +116,7 @@ public class OvernightIborSwapConventionsTest {
 
   @Test(dataProvider = "onLeg")
   public void test_float_leg(OvernightIborSwapConvention convention, OvernightIndex floatLeg) {
-    assertEquals(convention.getOnLeg().getIndex(), floatLeg);
+    assertEquals(convention.getOvernightLeg().getIndex(), floatLeg);
   }
 
   //-------------------------------------------------------------------------
@@ -144,7 +144,7 @@ public class OvernightIborSwapConventionsTest {
 
   @Test(dataProvider = "dayConvention")
   public void test_day_convention(OvernightIborSwapConvention convention, BusinessDayConvention dayConvention) {
-    assertEquals(convention.getOnLeg().getAccrualBusinessDayAdjustment().getConvention(), dayConvention);
+    assertEquals(convention.getOvernightLeg().getAccrualBusinessDayAdjustment().getConvention(), dayConvention);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Created a new type of convention: overnight v Ibor swaps.
Created standard conventions: 
- USD - Fed Fund arithmetic average v Libor 3M
- GBP - Sonia compounded 1Y v Libor 3M