### PR TITLE
Created new methods with adjusted forward rate for CMS periods.

### DIFF
--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/integration/RungeKuttaIntegrator1D.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/integration/RungeKuttaIntegrator1D.java
@@ -23,6 +23,16 @@ public class RungeKuttaIntegrator1D extends Integrator1D<Double, Double> {
   private final double _absTol, _relTol;
   private final int _minSteps;
 
+  /**
+   * Constructor from absolute and relative tolerance and minimal number of steps.
+   * <p>
+   * The adaptable integration process stops when the difference between 2 steps is below the absolute tolerance
+   * plus the relative tolerance multiplied by the value.
+   *  
+   * @param absTol  the absolute tolerance
+   * @param relTol  the relative tolerance
+   * @param minSteps  the minimal number of steps
+   */
   public RungeKuttaIntegrator1D(double absTol, double relTol, int minSteps) {
     if (absTol < 0.0 || Double.isNaN(absTol) || Double.isInfinite(absTol)) {
       throw new IllegalArgumentException("Absolute Tolerance must be greater than zero");
@@ -41,7 +51,6 @@ public class RungeKuttaIntegrator1D extends Integrator1D<Double, Double> {
   public RungeKuttaIntegrator1D(double tol, int minSteps) {
     this(tol, tol, minSteps);
   }
-
   public RungeKuttaIntegrator1D(double atol, double rtol) {
     this(atol, rtol, DEF_MIN_STEPS);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
@@ -315,7 +315,6 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
         .relativeYearFraction(cmsPeriod.getPaymentDate(), swap.getStartDate());
     CmsDeltaIntegrantProvider intProv = new CmsDeltaIntegrantProvider(
         cmsPeriod, swap, swaptionVolatilities, forward, strikeCpn, expiryTime, tenor, cutOffStrike, eta);
-//    double factor = dfPayment / intProv.h(forward) * intProv.g(forward);
     RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(ABS_TOL, REL_TOL, NUM_ITER);
     double[] bs = intProv.bsbsp(strikeCpn);
     double[] n = intProv.getNnp();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
@@ -248,11 +248,11 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
   }
 
   /**
-   * Computes the adjusted forward rate for a CMS coupon.
+   * Computes the adjustment to the forward rate for a CMS coupon.
    * <p>
-   * The adjusted forward rate, is the number such that, multiplied by the notional, the year fraction and the payment
-   * date discount factor, it produces the present value. In other terms, it is the number which used in the same
-   * formula used for Ibor coupon pricing will provide the correct present value.
+   * The adjustment to the forward rate, is the quantity that need to be added to the forward rate to obtain the 
+   * adjusted forward rate. The adjusted forward rate is the number which used in the same formula used for 
+   * Ibor coupon pricing (forward * notional * accrual factor * discount factor) will provide the correct present value.
    * 
    * @param cmsPeriod  the CMS period, which should be of the type {@link CmsPeriodType#COUPON}
    * @param provider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
@@ -66,10 +66,12 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
    * The minimal number of iterations for the numerical integration.
    */
   private static final int NUM_ITER = 10;
-  /**
-   * The relative tolerance for the numerical integration in PV computation.
-   */
-  private static final double REL_TOL = 1e-10;
+  /** The relative tolerance for the numerical integration in PV computation. */
+  private static final double REL_TOL = 1.0e-10;
+  /** The absolute tolerance for the numerical integration in PV computation. 
+   * The numerical integration stops when the difference between two steps is below the absolute tolerance
+   * plus the relative tolerance multiplied by the value.*/
+  private static final double ABS_TOL = 1.0e-8;
   /**
    * The relative tolerance for the numerical integration in sensitivity computation.
    */
@@ -197,8 +199,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
         cmsPeriod, swap, swaptionVolatilities, forward, strikeCpn, expiryTime, tenor, cutOffStrike, eta);
     double factor = dfPayment / intProv.h(forward) * intProv.g(forward);
     double strikePart = factor * intProv.k(strikeCpn) * intProv.bs(strikeCpn);
-    double absoluteTolerance = 1d / (factor * Math.abs(cmsPeriod.getNotional()) * cmsPeriod.getYearFraction());
-    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(absoluteTolerance, REL_TOL, NUM_ITER);
+    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(ABS_TOL, REL_TOL, NUM_ITER);
     double integralPart = 0d;
     Function<Double, Double> integrant = intProv.integrant();
     try {
@@ -217,6 +218,57 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
     }
     priceCMS *= cmsPeriod.getNotional() * cmsPeriod.getYearFraction();
     return CurrencyAmount.of(ccy, priceCMS);
+  }
+
+  /**
+   * Computes the adjusted forward rate for a CMS coupon.
+   * <p>
+   * The adjusted forward rate, is the number such that, multiplied by the notional, the year fraction and the payment
+   * date discount factor, it produces the present value. In other terms, it is the number which used in the same
+   * formula used for Ibor coupon pricing will provide the correct present value.
+   * <p>
+   * For period already fixed, this number will be equal to the swap index fixing.
+   * 
+   * @param cmsPeriod  the CMS period, which should be of the type {@link CmsPeriodType#COUPON}
+   * @param provider  the rates provider
+   * @param swaptionVolatilities  the swaption volatilities
+   * @return the adjusted forward rate
+   */
+  public double adjustedForwardRate(
+      CmsPeriod cmsPeriod,
+      RatesProvider provider,
+      SabrParametersSwaptionVolatilities swaptionVolatilities) {
+    
+    ArgChecker.isTrue(cmsPeriod.getCmsPeriodType().equals(CmsPeriodType.COUPON),
+        "Adjusted forward rate available only for CMS coupons");
+    Currency ccy = cmsPeriod.getCurrency();
+    double dfPayment = provider.discountFactor(ccy, cmsPeriod.getPaymentDate());
+    double pv = presentValue(cmsPeriod, provider, swaptionVolatilities).getAmount();
+    return pv / (cmsPeriod.getNotional() * cmsPeriod.getYearFraction() * dfPayment);
+  }
+
+  /**
+   * Computes the adjusted forward rate for a CMS coupon.
+   * <p>
+   * The adjusted forward rate, is the number such that, multiplied by the notional, the year fraction and the payment
+   * date discount factor, it produces the present value. In other terms, it is the number which used in the same
+   * formula used for Ibor coupon pricing will provide the correct present value.
+   * 
+   * @param cmsPeriod  the CMS period, which should be of the type {@link CmsPeriodType#COUPON}
+   * @param provider  the rates provider
+   * @param swaptionVolatilities  the swaption volatilities
+   * @return the adjusted forward rate
+   */
+  public double adjustmentToForwardRate(
+      CmsPeriod cmsPeriod,
+      RatesProvider provider,
+      SabrParametersSwaptionVolatilities swaptionVolatilities) {
+    
+    ArgChecker.isTrue(cmsPeriod.getFixingDate().isAfter(provider.getValuationDate()), 
+        "Adjustment computed only for coupon with fixing (strictly) after the valuation date");
+    double adjustedForwardRate = adjustedForwardRate(cmsPeriod, provider, swaptionVolatilities);
+    double forward = swapPricer.parRate(cmsPeriod.getUnderlyingSwap(), provider);
+    return adjustedForwardRate - forward;
   }
 
   //-------------------------------------------------------------------------
@@ -263,9 +315,8 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
         .relativeYearFraction(cmsPeriod.getPaymentDate(), swap.getStartDate());
     CmsDeltaIntegrantProvider intProv = new CmsDeltaIntegrantProvider(
         cmsPeriod, swap, swaptionVolatilities, forward, strikeCpn, expiryTime, tenor, cutOffStrike, eta);
-    double factor = dfPayment / intProv.h(forward) * intProv.g(forward);
-    double absoluteTolerance = 1d / (factor * Math.abs(cmsPeriod.getNotional()) * cmsPeriod.getYearFraction());
-    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(absoluteTolerance, REL_TOL, NUM_ITER);
+//    double factor = dfPayment / intProv.h(forward) * intProv.g(forward);
+    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(ABS_TOL, REL_TOL, NUM_ITER);
     double[] bs = intProv.bsbsp(strikeCpn);
     double[] n = intProv.getNnp();
     double strikePartPrice = intProv.k(strikeCpn) * n[0] * bs[0];
@@ -347,8 +398,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
     double[] strikePartPrice = intProv.getSabrExtrapolation()
         .priceAdjointSabr(Math.max(0d, strikeCpn + shift), intProv.getPutCall()) // handle tiny but negative number
         .getDerivatives().multipliedBy(factor2).toArray();
-    double absoluteTolerance = 1d / (factor * Math.abs(cmsPeriod.getNotional()) * cmsPeriod.getYearFraction());
-    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(absoluteTolerance, REL_TOL_VEGA, NUM_ITER);
+    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(ABS_TOL, REL_TOL_VEGA, NUM_ITER);
     double[] totalSensi = new double[4];
     for (int loopparameter = 0; loopparameter < 4; loopparameter++) {
       double integralPart = 0d;
@@ -425,8 +475,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
     CmsIntegrantProvider intProv = new CmsIntegrantProvider(
         cmsPeriod, swap, swaptionVolatilities, forward, strike, expiryTime, tenor, cutOffStrike, eta);
     double factor = dfPayment * intProv.g(forward) / intProv.h(forward);
-    double absoluteTolerance = 1.0E-9;
-    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(absoluteTolerance, REL_TOL_STRIKE, NUM_ITER);
+    RungeKuttaIntegrator1D integrator = new RungeKuttaIntegrator1D(ABS_TOL, REL_TOL_STRIKE, NUM_ITER);
     double[] kpkpp = intProv.kpkpp(strike);
     double firstPart;
     double thirdPart;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
@@ -414,6 +414,33 @@ public class SabrExtrapolationReplicationCmsPeriodPricerTest {
     assertEquals(sensiCap, sensiExpected);
     assertEquals(sensiFloor, sensiExpected);
   }
+  
+  public void test_adjusted_forward_rate() {
+    CmsPeriod coupon1 = COUPON.toBuilder().notional(1.0).yearFraction(1.0).build();
+    CurrencyAmount pvBuy = PRICER.presentValue(coupon1, RATES_PROVIDER, VOLATILITIES);
+    double df = RATES_PROVIDER.discountFactor(EUR, PAYMENT);
+    double adjustedForwardRateExpected = pvBuy.getAmount() / df;
+    double adjustedForwardRateComputed = PRICER.adjustedForwardRate(COUPON, RATES_PROVIDER, VOLATILITIES);
+    assertEquals(adjustedForwardRateComputed, adjustedForwardRateExpected, TOL);
+  }
+  
+  public void test_adjustment_forward_rate() {
+    double adjustedForwardRateComputed = PRICER.adjustedForwardRate(COUPON, RATES_PROVIDER, VOLATILITIES);
+    double forward = PRICER_SWAP.parRate(COUPON.getUnderlyingSwap(), RATES_PROVIDER);
+    double adjustmentComputed = PRICER.adjustmentToForwardRate(COUPON, RATES_PROVIDER, VOLATILITIES);
+    assertEquals(adjustmentComputed, adjustedForwardRateComputed - forward, TOL);
+  }
+  
+  public void test_adjusted_forward_rate_afterFix() {
+    double adjustedForward = PRICER.adjustedForwardRate(COUPON, RATES_PROVIDER_AFTER_FIX, VOLATILITIES_AFTER_FIX);
+    assertEquals(adjustedForward, OBS_INDEX , TOL);    
+  }
+
+  public void test_adjusted_rate_error() {
+    assertThrowsIllegalArg(() -> PRICER.adjustedForwardRate(CAPLET, RATES_PROVIDER, VOLATILITIES));
+    assertThrowsIllegalArg(() -> PRICER.adjustedForwardRate(CAPLET, RATES_PROVIDER_AFTER_FIX, VOLATILITIES_AFTER_FIX));
+    assertThrowsIllegalArg(() -> PRICER.adjustmentToForwardRate(COUPON, RATES_PROVIDER_AFTER_FIX, VOLATILITIES_AFTER_FIX));
+  }
 
   //-------------------------------------------------------------------------
   private static final CmsPeriod CAPLET_UP = createCmsCaplet(true, STRIKE + EPS);


### PR DESCRIPTION
Created new methods for CMS coupon with adjusted forward rate and adjustment. The adjusted forward is the number to be 'plugged' in the standard formula pv=fwd*df*notional to obtain the correct present value.
Modified the CMS pricer to have a fixed tolerance in the numerical integration. This is to make the pricing linear in the notional, i.e. multiplying the notional by 10  should multiply the PV by 10 also. Due to the variable tolerance, it was not the case before the modification.
Added documentation to the 'RungeKuttaIntegrator1D' to clarify the meaning of the absolute and relative tolerance in the code.