### PR TITLE
Add rateIgnoringFixings to Overnight

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/view/DiscountIborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/DiscountIborIndexRates.java
@@ -127,7 +127,7 @@ public final class DiscountIborIndexRates
     if (!observation.getFixingDate().isAfter(getValuationDate())) {
       return historicRate(observation);
     }
-    return rateIgnoringTimeSeries(observation);
+    return rateIgnoringFixings(observation);
   }
 
   // historic rate
@@ -143,12 +143,12 @@ public final class DiscountIborIndexRates
       }
       throw new IllegalArgumentException(Messages.format("Unable to get fixing for {} on date {}", index, fixingDate));
     } else {
-      return rateIgnoringTimeSeries(observation);
+      return rateIgnoringFixings(observation);
     }
   }
 
   @Override
-  public double rateIgnoringTimeSeries(IborIndexObservation observation) {
+  public double rateIgnoringFixings(IborIndexObservation observation) {
     LocalDate fixingStartDate = observation.getEffectiveDate();
     LocalDate fixingEndDate = observation.getMaturityDate();
     double accrualFactor = observation.getYearFraction();
@@ -171,7 +171,7 @@ public final class DiscountIborIndexRates
   }
 
   @Override
-  public PointSensitivityBuilder rateIgnoringTimeSeriesPointSensitivity(IborIndexObservation observation) {
+  public PointSensitivityBuilder rateIgnoringFixingsPointSensitivity(IborIndexObservation observation) {
     return IborRateSensitivity.of(observation, 1d);
   }
 

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/IborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/IborIndexRates.java
@@ -129,8 +129,9 @@ public interface IborIndexRates
   public abstract double rate(IborIndexObservation observation);
 
   /**
-   * Ignores the time-series to get the forward rate at the specified fixing date, used in rare and special cases.
-   * In most cases callers should use {@link #rate(IborIndexObservation) rate(IborIndexObservation)}.
+   * Ignores the time-series of fixings to get the forward rate at the specified
+   * fixing date, used in rare and special cases. In most cases callers should use
+   * {@link #rate(IborIndexObservation) rate(IborIndexObservation)}.
    * <p>
    * An instance of {@code IborIndexRates} is typically based on a forward curve and a historic time-series.
    * The {@code rate(LocalDate)} method uses either the curve or time-series, depending on whether the
@@ -140,7 +141,7 @@ public interface IborIndexRates
    * @param observation  the rate observation, including the fixing date
    * @return the rate of the index as given by the forward curve
    */
-  public abstract double rateIgnoringTimeSeries(IborIndexObservation observation);
+  public abstract double rateIgnoringFixings(IborIndexObservation observation);
 
   /**
    * Calculates the point sensitivity of the historic or forward rate at the specified fixing date.
@@ -156,8 +157,8 @@ public interface IborIndexRates
   public abstract PointSensitivityBuilder ratePointSensitivity(IborIndexObservation observation);
 
   /**
-   * Ignores the time-series to get the forward rate point sensitivity at the specified fixing date,
-   * used in rare and special cases. In most cases callers should use
+   * Ignores the time-series of fixings to get the forward rate point sensitivity at the
+   * specified fixing date, used in rare and special cases. In most cases callers should use
    * {@link #ratePointSensitivity(IborIndexObservation) ratePointSensitivity(IborIndexObservation)}.
    * <p>
    * An instance of {@code IborIndexRates} is typically based on a forward curve and a historic time-series.
@@ -168,7 +169,7 @@ public interface IborIndexRates
    * @param observation  the rate observation, including the fixing date
    * @return the point sensitivity of the rate to the forward curve
    */
-  public abstract PointSensitivityBuilder rateIgnoringTimeSeriesPointSensitivity(IborIndexObservation observation);
+  public abstract PointSensitivityBuilder rateIgnoringFixingsPointSensitivity(IborIndexObservation observation);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/OvernightIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/OvernightIndexRates.java
@@ -128,6 +128,21 @@ public interface OvernightIndexRates
   public abstract double rate(OvernightIndexObservation observation);
 
   /**
+   * Ignores the time-series of fixings to get the forward rate at the specified
+   * fixing date, used in rare and special cases. In most cases callers should use
+   * {@link #rate(OvernightIndexObservation) rate(OvernightIndexObservation)}.
+   * <p>
+   * An instance of {@code OvernightIndexRates} is typically based on a forward curve and a historic time-series.
+   * The {@code rate(LocalDate)} method uses either the curve or time-series, depending on whether the
+   * fixing date is before or after the valuation date. This method only queries the forward curve,
+   * totally ignoring the time-series, which is needed for rare and special cases only.
+   * 
+   * @param observation  the rate observation, including the fixing date
+   * @return the rate of the index as given by the forward curve
+   */
+  public abstract double rateIgnoringFixings(OvernightIndexObservation observation);
+
+  /**
    * Calculates the point sensitivity of the historic or forward rate at the specified fixing date.
    * <p>
    * This returns a sensitivity instance referring to the curve used to determine the forward rate.
@@ -140,6 +155,21 @@ public interface OvernightIndexRates
    * @throws RuntimeException if the result cannot be calculated
    */
   public abstract PointSensitivityBuilder ratePointSensitivity(OvernightIndexObservation observation);
+
+  /**
+   * Ignores the time-series of fixings to get the forward rate point sensitivity at the
+   * specified fixing date, used in rare and special cases. In most cases callers should use
+   * {@link #ratePointSensitivity(OvernightIndexObservation) ratePointSensitivity(OvernightIndexObservation)}.
+   * <p>
+   * An instance of {@code OvernightIndexRates} is typically based on a forward curve and a historic time-series.
+   * The {@code ratePointSensitivity(LocalDate)} method uses either the curve or time-series, depending on whether the
+   * fixing date is before or after the valuation date. This method only queries the forward curve,
+   * totally ignoring the time-series, which is needed for rare and special cases only.
+   * 
+   * @param observation  the rate observation, including the fixing date
+   * @return the point sensitivity of the rate to the forward curve
+   */
+  public abstract PointSensitivityBuilder rateIgnoringFixingsPointSensitivity(OvernightIndexObservation observation);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/market/src/main/java/com/opengamma/strata/market/view/SimpleIborIndexRates.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/view/SimpleIborIndexRates.java
@@ -164,7 +164,7 @@ public final class SimpleIborIndexRates
     if (!observation.getFixingDate().isAfter(getValuationDate())) {
       return historicRate(observation);
     }
-    return rateIgnoringTimeSeries(observation);
+    return rateIgnoringFixings(observation);
   }
 
   // historic rate
@@ -180,12 +180,12 @@ public final class SimpleIborIndexRates
       }
       throw new IllegalArgumentException(Messages.format("Unable to get fixing for {} on date {}", index, fixingDate));
     } else {
-      return rateIgnoringTimeSeries(observation);
+      return rateIgnoringFixings(observation);
     }
   }
 
   @Override
-  public double rateIgnoringTimeSeries(IborIndexObservation observation) {
+  public double rateIgnoringFixings(IborIndexObservation observation) {
     double relativeYearFraction = relativeYearFraction(observation.getMaturityDate());
     return curve.yValue(relativeYearFraction);
   }
@@ -203,7 +203,7 @@ public final class SimpleIborIndexRates
   }
 
   @Override
-  public PointSensitivityBuilder rateIgnoringTimeSeriesPointSensitivity(IborIndexObservation observation) {
+  public PointSensitivityBuilder rateIgnoringFixingsPointSensitivity(IborIndexObservation observation) {
     return IborRateSensitivity.of(observation, 1d);
   }
 

--- a/modules/market/src/test/java/com/opengamma/strata/market/view/DiscountIborIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/view/DiscountIborIndexRatesTest.java
@@ -139,13 +139,13 @@ public class DiscountIborIndexRatesTest {
     assertEquals(test.rate(GBP_LIBOR_3M_VAL), RATE_VAL);
   }
 
-  public void test_rateIgnoringTimeSeries_onValuation_fixing() {
+  public void test_rateIgnoringFixings_onValuation_fixing() {
     DiscountIborIndexRates test = DiscountIborIndexRates.of(GBP_LIBOR_3M, DFCURVE, SERIES);
     LocalDate startDate = GBP_LIBOR_3M_VAL.getEffectiveDate();
     LocalDate endDate = GBP_LIBOR_3M_VAL.getMaturityDate();
     double accrualFactor = GBP_LIBOR_3M_VAL.getYearFraction();
     double expected = (DFCURVE.discountFactor(startDate) / DFCURVE.discountFactor(endDate) - 1) / accrualFactor;
-    assertEquals(test.rateIgnoringTimeSeries(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringFixings(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
   }
 
   public void test_rate_onValuation_noFixing() {
@@ -155,7 +155,7 @@ public class DiscountIborIndexRatesTest {
     double accrualFactor = GBP_LIBOR_3M_VAL.getYearFraction();
     double expected = (DFCURVE.discountFactor(startDate) / DFCURVE.discountFactor(endDate) - 1) / accrualFactor;
     assertEquals(test.rate(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
-    assertEquals(test.rateIgnoringTimeSeries(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringFixings(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
   }
 
   public void test_rate_afterValuation() {
@@ -174,17 +174,17 @@ public class DiscountIborIndexRatesTest {
     assertEquals(test.ratePointSensitivity(GBP_LIBOR_3M_VAL), PointSensitivityBuilder.none());
   }
   
-  public void test_rateIgnoringTimeSeriesPointSensitivity_onValuation() {
+  public void test_rateIgnoringFixingsPointSensitivity_onValuation() {
     DiscountIborIndexRates test = DiscountIborIndexRates.of(GBP_LIBOR_3M, DFCURVE, SERIES);
     IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M_VAL, 1d);
-    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(GBP_LIBOR_3M_VAL), expected);
+    assertEquals(test.rateIgnoringFixingsPointSensitivity(GBP_LIBOR_3M_VAL), expected);
   }
 
   public void test_ratePointSensitivity_onValuation_noFixing() {
     DiscountIborIndexRates test = DiscountIborIndexRates.of(GBP_LIBOR_3M, DFCURVE, SERIES_EMPTY);
     IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M_VAL, 1d);
     assertEquals(test.ratePointSensitivity(GBP_LIBOR_3M_VAL), expected);
-    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(GBP_LIBOR_3M_VAL), expected);
+    assertEquals(test.rateIgnoringFixingsPointSensitivity(GBP_LIBOR_3M_VAL), expected);
   }
 
   public void test_ratePointSensitivity_afterValuation() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/view/DiscountOvernightIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/view/DiscountOvernightIndexRatesTest.java
@@ -141,6 +141,15 @@ public class DiscountOvernightIndexRatesTest {
     assertEquals(test.rate(GBP_SONIA_VAL), RATE_VAL);
   }
 
+  public void test_rateIgnoringFixings_onValuation_fixing() {
+    DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, DFCURVE, SERIES);
+    LocalDate startDate = GBP_SONIA_VAL.getEffectiveDate();
+    LocalDate endDate = GBP_SONIA_VAL.getMaturityDate();
+    double accrualFactor = GBP_SONIA_VAL.getYearFraction();
+    double expected = (DFCURVE.discountFactor(startDate) / DFCURVE.discountFactor(endDate) - 1) / accrualFactor;
+    assertEquals(test.rateIgnoringFixings(GBP_SONIA_VAL), expected, 1e-8);
+  }
+
   public void test_rate_onPublication_noFixing() {
     DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, DFCURVE, SERIES_EMPTY);
     LocalDate startDate = GBP_SONIA_VAL.getEffectiveDate();
@@ -164,6 +173,12 @@ public class DiscountOvernightIndexRatesTest {
     DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, DFCURVE, SERIES);
     assertEquals(test.ratePointSensitivity(GBP_SONIA_BEFORE), PointSensitivityBuilder.none());
     assertEquals(test.ratePointSensitivity(GBP_SONIA_VAL), PointSensitivityBuilder.none());
+  }
+
+  public void test_rateIgnoringFixingsPointSensitivity_onValuation() {
+    DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, DFCURVE, SERIES);
+    OvernightRateSensitivity expected = OvernightRateSensitivity.of(GBP_SONIA_VAL, 1d);
+    assertEquals(test.rateIgnoringFixingsPointSensitivity(GBP_SONIA_VAL), expected);
   }
 
   public void test_ratePointSensitivity_onPublication_noFixing() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/view/SimpleIborIndexRatesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/view/SimpleIborIndexRatesTest.java
@@ -143,11 +143,11 @@ public class SimpleIborIndexRatesTest {
     assertEquals(test.rate(GBP_LIBOR_3M_VAL), RATE_VAL);
   }
 
-  public void test_rateIgnoringTimeSeries_onValuation_fixing() {
+  public void test_rateIgnoringFixings_onValuation_fixing() {
     SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
     double time = CURVE_DAY_COUNT.yearFraction(DATE_VAL, GBP_LIBOR_3M_VAL.getMaturityDate());
     double expected = CURVE.yValue(time);
-    assertEquals(test.rateIgnoringTimeSeries(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringFixings(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
   }
 
   public void test_rate_onValuation_noFixing() {
@@ -155,7 +155,7 @@ public class SimpleIborIndexRatesTest {
     double time = CURVE_DAY_COUNT.yearFraction(DATE_VAL, GBP_LIBOR_3M_VAL.getMaturityDate());
     double expected = CURVE.yValue(time);
     assertEquals(test.rate(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
-    assertEquals(test.rateIgnoringTimeSeries(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
+    assertEquals(test.rateIgnoringFixings(GBP_LIBOR_3M_VAL), expected, TOLERANCE_RATE);
   }
 
   public void test_rate_afterValuation() {
@@ -172,17 +172,17 @@ public class SimpleIborIndexRatesTest {
     assertEquals(test.ratePointSensitivity(GBP_LIBOR_3M_VAL), PointSensitivityBuilder.none());
   }
   
-  public void test_rateIgnoringTimeSeriesPointSensitivity_onValuation() {
+  public void test_rateIgnoringFixingsPointSensitivity_onValuation() {
     SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES);
     IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M_VAL, 1d);
-    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(GBP_LIBOR_3M_VAL), expected);
+    assertEquals(test.rateIgnoringFixingsPointSensitivity(GBP_LIBOR_3M_VAL), expected);
   }
 
   public void test_ratePointSensitivity_onValuation_noFixing() {
     SimpleIborIndexRates test = SimpleIborIndexRates.of(GBP_LIBOR_3M, DATE_VAL, CURVE, SERIES_EMPTY);
     IborRateSensitivity expected = IborRateSensitivity.of(GBP_LIBOR_3M_VAL, 1d);
     assertEquals(test.ratePointSensitivity(GBP_LIBOR_3M_VAL), expected);
-    assertEquals(test.rateIgnoringTimeSeriesPointSensitivity(GBP_LIBOR_3M_VAL), expected);
+    assertEquals(test.rateIgnoringFixingsPointSensitivity(GBP_LIBOR_3M_VAL), expected);
   }
 
   public void test_ratePointSensitivity_afterValuation() {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/deposit/DiscountingIborFixingDepositProductPricer.java
@@ -131,13 +131,13 @@ public class DiscountingIborFixingDepositProductPricer {
     IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
     // The IborFixingDeposit are fictitious instruments to anchor the beginning of the IborIndex forward curve. 
     // By using the 'rateIgnoringTimeSeries' method (instead of 'rate') we ensure that only the forward curve is involved.
-    return rates.rateIgnoringTimeSeries(product.getFloatingRate().getObservation());
+    return rates.rateIgnoringFixings(product.getFloatingRate().getObservation());
   }
 
   // query the forward rate sensitivity
   private PointSensitivityBuilder forwardRateSensitivity(ResolvedIborFixingDeposit product, RatesProvider provider) {
     IborIndexRates rates = provider.iborIndexRates(product.getFloatingRate().getIndex());
-    return rates.rateIgnoringTimeSeriesPointSensitivity(product.getFloatingRate().getObservation());
+    return rates.rateIgnoringFixingsPointSensitivity(product.getFloatingRate().getObservation());
   }
 
 }


### PR DESCRIPTION
Match method on IborIndexRates
Rename from time-series to fixings for consistency