### PR TITLE
Market data not found exception

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketDataNotFoundException.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/market/MarketDataNotFoundException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.market;
+
+/**
+ * Exception thrown if market data cannot be found.
+ */
+public class MarketDataNotFoundException extends RuntimeException {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Creates the exception passing the exception message.
+   *
+   * @param message  the exception message, null tolerant
+   */
+  public MarketDataNotFoundException(String message) {
+    super(message);
+  }
+
+}

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/ExtendedMarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/ExtendedMarketDataTest.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.basics.market;
 
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -54,7 +54,7 @@ public class ExtendedMarketDataTest {
     assertEquals(test.getValue(KEY1), VAL1);
     assertEquals(test.getValue(KEY2), VAL2);
     assertEquals(test.getValue(KEY3), VAL3);
-    assertThrowsIllegalArg(() -> test.getValue(KEY4));
+    assertThrows(() -> test.getValue(KEY4), MarketDataNotFoundException.class);
     assertEquals(test.findValue(KEY1), Optional.of(VAL1));
     assertEquals(test.findValue(KEY2), Optional.of(VAL2));
     assertEquals(test.findValue(KEY3), Optional.of(VAL3));
@@ -72,7 +72,7 @@ public class ExtendedMarketDataTest {
     assertEquals(test.containsValue(KEY3), false);
     assertEquals(test.getValue(KEY1), VAL3);
     assertEquals(test.getValue(KEY2), VAL2);
-    assertThrowsIllegalArg(() -> test.getValue(KEY3));
+    assertThrows(() -> test.getValue(KEY3), MarketDataNotFoundException.class);
     assertEquals(test.findValue(KEY1), Optional.of(VAL3));
     assertEquals(test.findValue(KEY2), Optional.of(VAL2));
     assertEquals(test.findValue(KEY3), Optional.empty());

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/ImmutableMarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/ImmutableMarketDataTest.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.basics.market;
 
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -48,7 +48,7 @@ public class ImmutableMarketDataTest {
 
   public void of_badType() {
     Map<MarketDataKey<?>, Object> dataMap = ImmutableMap.of(KEY1, "123");
-    assertThrowsIllegalArg(() -> ImmutableMarketData.of(VAL_DATE, dataMap));
+    assertThrows(() -> ImmutableMarketData.of(VAL_DATE, dataMap), ClassCastException.class);
   }
 
   public void builder() {
@@ -73,7 +73,7 @@ public class ImmutableMarketDataTest {
 
   public void getValue() {
     assertThat(DATA.getValue(KEY1)).isEqualTo(123d);
-    assertThrowsIllegalArg(() -> DATA.getValue(KEY2));
+    assertThrows(() -> DATA.getValue(KEY2), MarketDataNotFoundException.class);
   }
 
   public void getTimeSeries() {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/market/MarketDataTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/market/MarketDataTest.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.basics.market;
 
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -53,6 +54,13 @@ public class MarketDataTest {
     assertThat(test.findValue(KEY2)).isEmpty();
     assertThat(test.getValue(KEY1)).isEqualTo(123d);
     assertThat(test.getTimeSeries(KEY2)).isEqualTo(TIME_SERIES);
+  }
+
+  public void empty() {
+    MarketData test = MarketData.empty(VAL_DATE);
+
+    assertEquals(test.containsValue(KEY1), false);
+    assertEquals(test.getTimeSeries(KEY1), LocalDateDoubleTimeSeries.empty());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/CalculationMarketData.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import com.opengamma.strata.basics.market.MarketData;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataKey;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ScenarioMarketDataKey;
 import com.opengamma.strata.basics.market.ScenarioMarketDataValue;
@@ -102,7 +103,7 @@ public interface CalculationMarketData {
    * @param <T>  the type of the market data
    * @param key  the key identifying the item of market data
    * @return the box providing access to the market data values for each scenario
-   * @throws IllegalArgumentException if no value is found
+   * @throws MarketDataNotFoundException if no value is found
    */
   public abstract <T> MarketDataBox<T> getValue(MarketDataKey<T> key);
 
@@ -144,7 +145,6 @@ public interface CalculationMarketData {
   }
 
   //-------------------------------------------------------------------------
-
   /**
    * Gets the time-series identified by the specified key, empty if not found.
    * <p>

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketEnvironment.java
@@ -31,6 +31,7 @@ import com.opengamma.strata.basics.market.FxRateId;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataId;
 import com.opengamma.strata.basics.market.MarketDataKey;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableId;
 import com.opengamma.strata.calc.runner.MissingMappingId;
 import com.opengamma.strata.calc.runner.NoMatchingRuleId;
@@ -173,7 +174,8 @@ public final class MarketEnvironment implements ImmutableBean, CalculationEnviro
       if (failure != null) {
         throw new FailureException(failure);
       }
-      throw new IllegalArgumentException("No market data available for " + id);
+      throw new MarketDataNotFoundException(Messages.format(
+          "Market data not found for identifier '{}' of type '{}'", id, id.getClass().getSimpleName()));
     }
     if (!id.getMarketDataType().isAssignableFrom(value.getMarketDataType())) {
       throw new IllegalArgumentException(

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappingsTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/mapping/DefaultMarketDataMappingsTest.java
@@ -5,7 +5,7 @@
  */
 package com.opengamma.strata.calc.marketdata.mapping;
 
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataFeed;
 import com.opengamma.strata.basics.market.MarketDataId;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.calc.marketdata.CalculationEnvironment;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.TestId;
@@ -101,9 +102,9 @@ public class DefaultMarketDataMappingsTest {
   }
 
   public void getValueNoData() {
-    assertThrowsIllegalArg(() -> mappings.getValue(testKey, CalculationEnvironment.empty()));
-    assertThrowsIllegalArg(() -> mappings.getValue(testSimpleKey, CalculationEnvironment.empty()));
-    assertThrowsIllegalArg(() -> mappings.getValue(testObservableKey, CalculationEnvironment.empty()));
+    assertThrows(() -> mappings.getValue(testKey, CalculationEnvironment.empty()), MarketDataNotFoundException.class);
+    assertThrows(() -> mappings.getValue(testSimpleKey, CalculationEnvironment.empty()), MarketDataNotFoundException.class);
+    assertThrows(() -> mappings.getValue(testObservableKey, CalculationEnvironment.empty()), MarketDataNotFoundException.class);
   }
 
   public void getTimeSeries() {

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/function/result/CurrencyValuesArrayTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/function/result/CurrencyValuesArrayTest.java
@@ -25,12 +25,16 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.basics.market.FxRateId;
 import com.opengamma.strata.basics.market.MarketDataFeed;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.calc.marketdata.CalculationEnvironment;
 import com.opengamma.strata.calc.marketdata.DefaultCalculationMarketData;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.mapping.MarketDataMappings;
 import com.opengamma.strata.collect.array.DoubleArray;
 
+/**
+ * Test {@link CurrencyValuesArray}.
+ */
 @Test
 public class CurrencyValuesArrayTest {
 
@@ -133,10 +137,7 @@ public class CurrencyValuesArrayTest {
     MarketDataMappings mappings = MarketDataMappings.of(MarketDataFeed.NONE);
     DefaultCalculationMarketData calculationMarketData = DefaultCalculationMarketData.of(marketData, mappings);
 
-    assertThrows(
-        () -> list.convertedTo(USD, calculationMarketData),
-        IllegalArgumentException.class,
-        "No market data available for .*");
+    assertThrows(() -> list.convertedTo(USD, calculationMarketData), MarketDataNotFoundException.class);
   }
 
   /**

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/function/result/DefaultScenarioResultTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/function/result/DefaultScenarioResultTest.java
@@ -23,11 +23,15 @@ import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.basics.market.FxRateId;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataFeed;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.calc.marketdata.CalculationEnvironment;
 import com.opengamma.strata.calc.marketdata.DefaultCalculationMarketData;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.mapping.MarketDataMappings;
 
+/**
+ * Test {@link DefaultScenarioResult}.
+ */
 @Test
 public class DefaultScenarioResultTest {
 
@@ -107,10 +111,7 @@ public class DefaultScenarioResultTest {
         CurrencyAmount.of(Currency.GBP, 3));
     DefaultScenarioResult<CurrencyAmount> test = DefaultScenarioResult.of(values);
 
-    assertThrows(
-        () -> test.convertedTo(Currency.USD, calculationMarketData),
-        IllegalArgumentException.class,
-        "No market data available.*");
+    assertThrows(() -> test.convertedTo(Currency.USD, calculationMarketData), MarketDataNotFoundException.class);
   }
 
   public void wrongNumberOfFxRates() {
@@ -134,6 +135,7 @@ public class DefaultScenarioResultTest {
         IllegalArgumentException.class,
         "Market data must contain same number of scenarios.*");
   }
+
   //-------------------------------------------------------------------------
   public void coverage() {
     DefaultScenarioResult<Integer> test = DefaultScenarioResult.of(1, 2, 3);

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveInputsMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/CurveInputsMarketDataFunctionTest.java
@@ -24,6 +24,7 @@ import com.opengamma.strata.basics.date.DayCounts;
 import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataFeed;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
 import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
@@ -246,8 +247,7 @@ public class CurveInputsMarketDataFunctionTest {
 
     assertThrows(
         () -> marketDataFunction.build(curveInputsId, marketDataConfig, emptyData, REF_DATA),
-        IllegalArgumentException.class,
-        "No market data available for .*");
+        MarketDataNotFoundException.class);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/DiscountCurveMarketDataFunctionTest.java
+++ b/modules/function/src/test/java/com/opengamma/strata/function/marketdata/curve/DiscountCurveMarketDataFunctionTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.market.MarketDataBox;
 import com.opengamma.strata.basics.market.MarketDataFeed;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.calc.marketdata.MarketEnvironment;
 import com.opengamma.strata.calc.marketdata.config.MarketDataConfig;
@@ -126,7 +127,7 @@ public class DiscountCurveMarketDataFunctionTest {
     DiscountCurveMarketDataFunction test = new DiscountCurveMarketDataFunction();
 
     DiscountCurveId id = DiscountCurveId.of(AUD, CURVE_GROUP_NAME, FEED);
-    assertThrows(() -> test.build(id, MarketDataConfig.empty(), marketData, REF_DATA), IllegalArgumentException.class);
+    assertThrows(() -> test.build(id, MarketDataConfig.empty(), marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_noCurveOfDesiredCurrencyInGroup() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNodeTest.java
@@ -6,10 +6,9 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.BuySell.BUY;
-
 import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -26,6 +25,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -112,13 +112,11 @@ public class FixedIborSwapCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     FixedIborSwapCurveNode node = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(valuationDate).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNodeTest.java
@@ -6,11 +6,10 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.BuySell.BUY;
-
 import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
 import static com.opengamma.strata.basics.date.Tenor.TENOR_6M;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsWithCause;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -27,6 +26,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -110,13 +110,11 @@ public class FixedOvernightSwapCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     FixedOvernightSwapCurveNode node = FixedOvernightSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(valuationDate).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FraCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FraCurveNodeTest.java
@@ -6,7 +6,6 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.currency.Currency.GBP;
-
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
@@ -14,7 +13,7 @@ import static com.opengamma.strata.basics.date.Tenor.TENOR_5M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_6M;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -33,6 +32,7 @@ import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -152,13 +152,11 @@ public class FraCurveNodeTest {
     assertEquals(trade.getInfo(), tradeInfoExpected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     FraCurveNode node = FraCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    ImmutableMarketData md = ImmutableMarketData.builder(VAL_DATE).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, md, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FxSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FxSwapCurveNodeTest.java
@@ -6,10 +6,9 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.EUTA;
-
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.USNY;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsWithCause;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -35,6 +34,7 @@ import com.opengamma.strata.basics.market.FxRateKey;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
 import com.opengamma.strata.basics.market.MarketDataKey;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.SimpleMarketDataKey;
 import com.opengamma.strata.basics.market.StandardId;
@@ -116,13 +116,11 @@ public class FxSwapCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     FxSwapCurveNode node = FxSwapCurveNode.of(TEMPLATE, QUOTE_KEY_PTS);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey quoteKey = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    ImmutableMarketData md = ImmutableMarketData.builder(valuationDate).addValue(quoteKey, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, md, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNodeTest.java
@@ -6,11 +6,10 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
-
 import static com.opengamma.strata.basics.index.IborIndices.EUR_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_6M;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -28,6 +27,7 @@ import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -129,13 +129,11 @@ public class IborFixingDepositCurveNodeTest {
     assertEquals(trade.getInfo(), tradeInfoExpected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     IborFixingDepositCurveNode node = IborFixingDepositCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFutureCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborFutureCurveNodeTest.java
@@ -6,7 +6,7 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -107,13 +108,11 @@ public class IborFutureCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     IborFutureCurveNode node = IborFutureCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
-    LocalDate date = LocalDate.of(2015, 10, 20);
-    double price = 0.99;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Unknown"));
-    MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(key, price).build();
-    assertThrowsIllegalArg(() -> node.trade(date, marketData, REF_DATA));
+    LocalDate valuationDate = LocalDate.of(2015, 10, 20);
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborIborSwapCurveNodeTest.java
@@ -6,10 +6,9 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.BuySell.BUY;
-
 import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -26,6 +25,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -112,13 +112,11 @@ public class IborIborSwapCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     IborIborSwapCurveNode node = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
@@ -6,12 +6,11 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.currency.Currency.EUR;
-
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.EUTA;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsWithCause;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -32,6 +31,7 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -151,13 +151,11 @@ public class TermDepositCurveNodeTest {
     assertEquals(trade.getInfo(), tradeInfoExpected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     TermDepositCurveNode node = TermDepositCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/ThreeLegBasisSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/ThreeLegBasisSwapCurveNodeTest.java
@@ -6,10 +6,9 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.BuySell.BUY;
-
 import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -26,6 +25,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ObservableKey;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.StandardId;
@@ -112,13 +112,11 @@ public class ThreeLegBasisSwapCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     ThreeLegBasisSwapCurveNode node = ThreeLegBasisSwapCurveNode.of(TEMPLATE, QUOTE_KEY, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/XCcyIborIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/XCcyIborIborSwapCurveNodeTest.java
@@ -6,10 +6,9 @@
 package com.opengamma.strata.market.curve.node;
 
 import static com.opengamma.strata.basics.BuySell.BUY;
-
 import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
@@ -29,6 +28,7 @@ import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.market.FxRateKey;
 import com.opengamma.strata.basics.market.ImmutableMarketData;
 import com.opengamma.strata.basics.market.MarketData;
+import com.opengamma.strata.basics.market.MarketDataNotFoundException;
 import com.opengamma.strata.basics.market.ReferenceData;
 import com.opengamma.strata.basics.market.SimpleMarketDataKey;
 import com.opengamma.strata.basics.market.StandardId;
@@ -120,13 +120,11 @@ public class XCcyIborIborSwapCurveNodeTest {
     assertEquals(trade, expected);
   }
 
-  public void test_trade_differentKey() {
+  public void test_trade_noMarketData() {
     XCcyIborIborSwapCurveNode node = XCcyIborIborSwapCurveNode.of(TEMPLATE, SPREAD_KEY, SPREAD_ADJ);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
-    double rate = 0.035;
-    QuoteKey key = QuoteKey.of(StandardId.of("OG-Ticker", "Deposit2"));
-    MarketData marketData = ImmutableMarketData.builder(VAL_DATE).addValue(key, rate).build();
-    assertThrowsIllegalArg(() -> node.trade(valuationDate, marketData, REF_DATA));
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
   }
 
   public void test_initialGuess() {


### PR DESCRIPTION
Add specific market data not found exception.
Reorder methods in `MarketData` to match `ReferenceData`.