### PR TITLE
Added overnight-Ibor template and curve node.

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/product/swap/OvernightIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/product/swap/OvernightIborSwapCurveNode.java
@@ -1,0 +1,714 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.market.product.swap;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableDefaults;
+import org.joda.beans.ImmutablePreBuild;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.data.MarketData;
+import com.opengamma.strata.data.ObservableId;
+import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.curve.CurveNode;
+import com.opengamma.strata.market.curve.CurveNodeDate;
+import com.opengamma.strata.market.param.DatedParameterMetadata;
+import com.opengamma.strata.market.param.LabelDateParameterMetadata;
+import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.rate.IborRateComputation;
+import com.opengamma.strata.product.swap.PaymentPeriod;
+import com.opengamma.strata.product.swap.RateAccrualPeriod;
+import com.opengamma.strata.product.swap.RatePaymentPeriod;
+import com.opengamma.strata.product.swap.ResolvedSwapLeg;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
+import com.opengamma.strata.product.swap.SwapLeg;
+import com.opengamma.strata.product.swap.SwapLegType;
+import com.opengamma.strata.product.swap.SwapTrade;
+import com.opengamma.strata.product.swap.type.OvernightIborSwapTemplate;
+
+/**
+ * A curve node whose instrument is an Overnight-Ibor interest rate swap.
+ */
+@BeanDefinition
+public final class OvernightIborSwapCurveNode
+    implements CurveNode, ImmutableBean, Serializable {
+
+  /**
+   * The template for the swap associated with this node.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final OvernightIborSwapTemplate template;
+  /**
+   * The identifier of the market data value that provides the rate.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final ObservableId rateId;
+  /**
+   * The additional spread added to the rate.
+   */
+  @PropertyDefinition
+  private final double additionalSpread;
+  /**
+   * The label to use for the node, defaulted.
+   * <p>
+   * When building, this will default based on the tenor if not specified.
+   */
+  @PropertyDefinition(validate = "notEmpty", overrideGet = true)
+  private final String label;
+  /**
+   * The method by which the date of the node is calculated, defaulted to 'End'.
+   */
+  @PropertyDefinition
+  private final CurveNodeDate date;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains a curve node for an Overnight-Ibor interest rate swap using the
+   * specified instrument template and rate.
+   * <p>
+   * A suitable default label will be created.
+   *
+   * @param template  the template used for building the instrument for the node
+   * @param rateId  the identifier of the market rate used when building the instrument for the node
+   * @return a node whose instrument is built from the template using a market rate
+   */
+  public static OvernightIborSwapCurveNode of(OvernightIborSwapTemplate template, ObservableId rateId) {
+    return of(template, rateId, 0d);
+  }
+
+  /**
+   * Obtains a curve node for an Overnight-Ibor interest rate swap using the
+   * specified instrument template, rate key and spread.
+   * <p>
+   * A suitable default label will be created.
+   *
+   * @param template  the template defining the node instrument
+   * @param rateId  the identifier of the market data providing the rate for the node instrument
+   * @param additionalSpread  the additional spread amount added to the spread
+   * @return a node whose instrument is built from the template using a market rate
+   */
+  public static OvernightIborSwapCurveNode of(OvernightIborSwapTemplate template, ObservableId rateId, double additionalSpread) {
+    return builder()
+        .template(template)
+        .rateId(rateId)
+        .additionalSpread(additionalSpread)
+        .build();
+  }
+
+  /**
+   * Obtains a curve node for an Overnight-Ibor interest rate swap using the
+   * specified instrument template, rate key, spread and label.
+   *
+   * @param template  the template defining the node instrument
+   * @param rateId  the identifier of the market data providing the rate for the node instrument
+   * @param additionalSpread  the additional spread amount added to the spread
+   * @param label  the label to use for the node
+   * @return a node whose instrument is built from the template using a market rate
+   */
+  public static OvernightIborSwapCurveNode of(
+      OvernightIborSwapTemplate template,
+      ObservableId rateId,
+      double additionalSpread,
+      String label) {
+
+    return new OvernightIborSwapCurveNode(template, rateId, additionalSpread, label, CurveNodeDate.END);
+  }
+
+  @ImmutableDefaults
+  private static void applyDefaults(Builder builder) {
+    builder.date = CurveNodeDate.END;
+  }
+
+  @ImmutablePreBuild
+  private static void preBuild(Builder builder) {
+    if (builder.label == null && builder.template != null) {
+      builder.label = builder.template.getTenor().toString();
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<ObservableId> requirements() {
+    return ImmutableSet.of(rateId);
+  }
+
+  @Override
+  public DatedParameterMetadata metadata(LocalDate valuationDate, ReferenceData refData) {
+    LocalDate nodeDate = date.calculate(
+        () -> calculateEnd(valuationDate, refData),
+        () -> calculateLastFixingDate(valuationDate, refData));
+    if (date.isFixed()) {
+      return LabelDateParameterMetadata.of(nodeDate, label);
+    }
+    return TenorDateParameterMetadata.of(nodeDate, template.getTenor(), label);
+  }
+
+  // calculate the end date
+  private LocalDate calculateEnd(LocalDate valuationDate, ReferenceData refData) {
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.BUY, 1, 1, refData);
+    return trade.getProduct().getEndDate().adjusted(refData);
+  }
+
+  // calculate the last fixing date
+  private LocalDate calculateLastFixingDate(LocalDate valuationDate, ReferenceData refData) {
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.BUY, 1, 1, refData);
+    SwapLeg iborLeg = trade.getProduct().getLegs(SwapLegType.IBOR).get(0);
+    ResolvedSwapLeg iborLegExpanded = iborLeg.resolve(refData);
+    List<PaymentPeriod> periods = iborLegExpanded.getPaymentPeriods();
+    int nbPeriods = periods.size();
+    RatePaymentPeriod lastPeriod = (RatePaymentPeriod) periods.get(nbPeriods - 1);
+    List<RateAccrualPeriod> accruals = lastPeriod.getAccrualPeriods();
+    int nbAccruals = accruals.size();
+    IborRateComputation ibor = (IborRateComputation) accruals.get(nbAccruals - 1).getRateComputation();
+    return ibor.getFixingDate();
+  }
+
+  @Override
+  public SwapTrade trade(LocalDate valuationDate, MarketData marketData, ReferenceData refData) {
+    double fixedRate = marketData.getValue(rateId) + additionalSpread;
+    return template.createTrade(valuationDate, BuySell.BUY, 1, fixedRate, refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade resolvedTrade(LocalDate valuationDate, MarketData marketData, ReferenceData refData) {
+    return trade(valuationDate, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public double initialGuess(LocalDate valuationDate, MarketData marketData, ValueType valueType) {
+    if (ValueType.ZERO_RATE.equals(valueType) || ValueType.FORWARD_RATE.equals(valueType)) {
+      return marketData.getValue(rateId);
+    }
+    if (ValueType.DISCOUNT_FACTOR.equals(valueType)) {
+      double approximateMaturity = template.getPeriodToStart().plus(template.getTenor()).toTotalMonths() / 12.0d;
+      return Math.exp(-approximateMaturity * marketData.getValue(rateId));
+    }
+    return 0d;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns a copy of this node with the specified date.
+   * 
+   * @param date  the date to use
+   * @return the node based on this node with the specified date
+   */
+  public OvernightIborSwapCurveNode withDate(CurveNodeDate date) {
+    return new OvernightIborSwapCurveNode(template, rateId, additionalSpread, label, date);
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code OvernightIborSwapCurveNode}.
+   * @return the meta-bean, not null
+   */
+  public static OvernightIborSwapCurveNode.Meta meta() {
+    return OvernightIborSwapCurveNode.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(OvernightIborSwapCurveNode.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static OvernightIborSwapCurveNode.Builder builder() {
+    return new OvernightIborSwapCurveNode.Builder();
+  }
+
+  private OvernightIborSwapCurveNode(
+      OvernightIborSwapTemplate template,
+      ObservableId rateId,
+      double additionalSpread,
+      String label,
+      CurveNodeDate date) {
+    JodaBeanUtils.notNull(template, "template");
+    JodaBeanUtils.notNull(rateId, "rateId");
+    JodaBeanUtils.notEmpty(label, "label");
+    this.template = template;
+    this.rateId = rateId;
+    this.additionalSpread = additionalSpread;
+    this.label = label;
+    this.date = date;
+  }
+
+  @Override
+  public OvernightIborSwapCurveNode.Meta metaBean() {
+    return OvernightIborSwapCurveNode.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the template for the swap associated with this node.
+   * @return the value of the property, not null
+   */
+  public OvernightIborSwapTemplate getTemplate() {
+    return template;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the identifier of the market data value that provides the rate.
+   * @return the value of the property, not null
+   */
+  public ObservableId getRateId() {
+    return rateId;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the additional spread added to the rate.
+   * @return the value of the property
+   */
+  public double getAdditionalSpread() {
+    return additionalSpread;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the label to use for the node, defaulted.
+   * <p>
+   * When building, this will default based on the tenor if not specified.
+   * @return the value of the property, not empty
+   */
+  @Override
+  public String getLabel() {
+    return label;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the method by which the date of the node is calculated, defaulted to 'End'.
+   * @return the value of the property
+   */
+  public CurveNodeDate getDate() {
+    return date;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      OvernightIborSwapCurveNode other = (OvernightIborSwapCurveNode) obj;
+      return JodaBeanUtils.equal(template, other.template) &&
+          JodaBeanUtils.equal(rateId, other.rateId) &&
+          JodaBeanUtils.equal(additionalSpread, other.additionalSpread) &&
+          JodaBeanUtils.equal(label, other.label) &&
+          JodaBeanUtils.equal(date, other.date);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(template);
+    hash = hash * 31 + JodaBeanUtils.hashCode(rateId);
+    hash = hash * 31 + JodaBeanUtils.hashCode(additionalSpread);
+    hash = hash * 31 + JodaBeanUtils.hashCode(label);
+    hash = hash * 31 + JodaBeanUtils.hashCode(date);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(192);
+    buf.append("OvernightIborSwapCurveNode{");
+    buf.append("template").append('=').append(template).append(',').append(' ');
+    buf.append("rateId").append('=').append(rateId).append(',').append(' ');
+    buf.append("additionalSpread").append('=').append(additionalSpread).append(',').append(' ');
+    buf.append("label").append('=').append(label).append(',').append(' ');
+    buf.append("date").append('=').append(JodaBeanUtils.toString(date));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code OvernightIborSwapCurveNode}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code template} property.
+     */
+    private final MetaProperty<OvernightIborSwapTemplate> template = DirectMetaProperty.ofImmutable(
+        this, "template", OvernightIborSwapCurveNode.class, OvernightIborSwapTemplate.class);
+    /**
+     * The meta-property for the {@code rateId} property.
+     */
+    private final MetaProperty<ObservableId> rateId = DirectMetaProperty.ofImmutable(
+        this, "rateId", OvernightIborSwapCurveNode.class, ObservableId.class);
+    /**
+     * The meta-property for the {@code additionalSpread} property.
+     */
+    private final MetaProperty<Double> additionalSpread = DirectMetaProperty.ofImmutable(
+        this, "additionalSpread", OvernightIborSwapCurveNode.class, Double.TYPE);
+    /**
+     * The meta-property for the {@code label} property.
+     */
+    private final MetaProperty<String> label = DirectMetaProperty.ofImmutable(
+        this, "label", OvernightIborSwapCurveNode.class, String.class);
+    /**
+     * The meta-property for the {@code date} property.
+     */
+    private final MetaProperty<CurveNodeDate> date = DirectMetaProperty.ofImmutable(
+        this, "date", OvernightIborSwapCurveNode.class, CurveNodeDate.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "template",
+        "rateId",
+        "additionalSpread",
+        "label",
+        "date");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -1321546630:  // template
+          return template;
+        case -938107365:  // rateId
+          return rateId;
+        case 291232890:  // additionalSpread
+          return additionalSpread;
+        case 102727412:  // label
+          return label;
+        case 3076014:  // date
+          return date;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public OvernightIborSwapCurveNode.Builder builder() {
+      return new OvernightIborSwapCurveNode.Builder();
+    }
+
+    @Override
+    public Class<? extends OvernightIborSwapCurveNode> beanType() {
+      return OvernightIborSwapCurveNode.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code template} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<OvernightIborSwapTemplate> template() {
+      return template;
+    }
+
+    /**
+     * The meta-property for the {@code rateId} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ObservableId> rateId() {
+      return rateId;
+    }
+
+    /**
+     * The meta-property for the {@code additionalSpread} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Double> additionalSpread() {
+      return additionalSpread;
+    }
+
+    /**
+     * The meta-property for the {@code label} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<String> label() {
+      return label;
+    }
+
+    /**
+     * The meta-property for the {@code date} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<CurveNodeDate> date() {
+      return date;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case -1321546630:  // template
+          return ((OvernightIborSwapCurveNode) bean).getTemplate();
+        case -938107365:  // rateId
+          return ((OvernightIborSwapCurveNode) bean).getRateId();
+        case 291232890:  // additionalSpread
+          return ((OvernightIborSwapCurveNode) bean).getAdditionalSpread();
+        case 102727412:  // label
+          return ((OvernightIborSwapCurveNode) bean).getLabel();
+        case 3076014:  // date
+          return ((OvernightIborSwapCurveNode) bean).getDate();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code OvernightIborSwapCurveNode}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<OvernightIborSwapCurveNode> {
+
+    private OvernightIborSwapTemplate template;
+    private ObservableId rateId;
+    private double additionalSpread;
+    private String label;
+    private CurveNodeDate date;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+      applyDefaults(this);
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(OvernightIborSwapCurveNode beanToCopy) {
+      this.template = beanToCopy.getTemplate();
+      this.rateId = beanToCopy.getRateId();
+      this.additionalSpread = beanToCopy.getAdditionalSpread();
+      this.label = beanToCopy.getLabel();
+      this.date = beanToCopy.getDate();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -1321546630:  // template
+          return template;
+        case -938107365:  // rateId
+          return rateId;
+        case 291232890:  // additionalSpread
+          return additionalSpread;
+        case 102727412:  // label
+          return label;
+        case 3076014:  // date
+          return date;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case -1321546630:  // template
+          this.template = (OvernightIborSwapTemplate) newValue;
+          break;
+        case -938107365:  // rateId
+          this.rateId = (ObservableId) newValue;
+          break;
+        case 291232890:  // additionalSpread
+          this.additionalSpread = (Double) newValue;
+          break;
+        case 102727412:  // label
+          this.label = (String) newValue;
+          break;
+        case 3076014:  // date
+          this.date = (CurveNodeDate) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public OvernightIborSwapCurveNode build() {
+      preBuild(this);
+      return new OvernightIborSwapCurveNode(
+          template,
+          rateId,
+          additionalSpread,
+          label,
+          date);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the template for the swap associated with this node.
+     * @param template  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder template(OvernightIborSwapTemplate template) {
+      JodaBeanUtils.notNull(template, "template");
+      this.template = template;
+      return this;
+    }
+
+    /**
+     * Sets the identifier of the market data value that provides the rate.
+     * @param rateId  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder rateId(ObservableId rateId) {
+      JodaBeanUtils.notNull(rateId, "rateId");
+      this.rateId = rateId;
+      return this;
+    }
+
+    /**
+     * Sets the additional spread added to the rate.
+     * @param additionalSpread  the new value
+     * @return this, for chaining, not null
+     */
+    public Builder additionalSpread(double additionalSpread) {
+      this.additionalSpread = additionalSpread;
+      return this;
+    }
+
+    /**
+     * Sets the label to use for the node, defaulted.
+     * <p>
+     * When building, this will default based on the tenor if not specified.
+     * @param label  the new value, not empty
+     * @return this, for chaining, not null
+     */
+    public Builder label(String label) {
+      JodaBeanUtils.notEmpty(label, "label");
+      this.label = label;
+      return this;
+    }
+
+    /**
+     * Sets the method by which the date of the node is calculated, defaulted to 'End'.
+     * @param date  the new value
+     * @return this, for chaining, not null
+     */
+    public Builder date(CurveNodeDate date) {
+      this.date = date;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(192);
+      buf.append("OvernightIborSwapCurveNode.Builder{");
+      buf.append("template").append('=').append(JodaBeanUtils.toString(template)).append(',').append(' ');
+      buf.append("rateId").append('=').append(JodaBeanUtils.toString(rateId)).append(',').append(' ');
+      buf.append("additionalSpread").append('=').append(JodaBeanUtils.toString(additionalSpread)).append(',').append(' ');
+      buf.append("label").append('=').append(JodaBeanUtils.toString(label)).append(',').append(' ');
+      buf.append("date").append('=').append(JodaBeanUtils.toString(date));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/market/src/test/java/com/opengamma/strata/market/product/swap/OvernightIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/product/swap/OvernightIborSwapCurveNodeTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.market.product.swap;
+
+import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrows;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.product.common.BuySell.BUY;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.data.ImmutableMarketData;
+import com.opengamma.strata.data.MarketData;
+import com.opengamma.strata.data.MarketDataNotFoundException;
+import com.opengamma.strata.data.ObservableId;
+import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.curve.CurveNodeDate;
+import com.opengamma.strata.market.observable.QuoteId;
+import com.opengamma.strata.market.param.DatedParameterMetadata;
+import com.opengamma.strata.market.param.ParameterMetadata;
+import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.swap.SwapTrade;
+import com.opengamma.strata.product.swap.type.OvernightIborSwapConventions;
+import com.opengamma.strata.product.swap.type.OvernightIborSwapTemplate;
+
+/**
+ * Test {@link FixedIborSwapCurveNode}.
+ */
+@Test
+public class OvernightIborSwapCurveNodeTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final LocalDate VAL_DATE = date(2015, 6, 30);
+
+  private static final OvernightIborSwapTemplate TEMPLATE =
+      OvernightIborSwapTemplate.of(TENOR_10Y, OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M);
+  private static final QuoteId QUOTE_ID = QuoteId.of(StandardId.of("OG-Ticker", "Deposit1"));
+  private static final double SPREAD = 0.0015;
+  private static final String LABEL = "Label";
+  private static final String LABEL_AUTO = "10Y";
+
+  private static final double TOLERANCE_DF = 1.0E-10;
+
+  public void test_builder() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.builder()
+        .label(LABEL)
+        .template(TEMPLATE)
+        .rateId(QUOTE_ID)
+        .additionalSpread(SPREAD)
+        .build();
+    assertEquals(test.getLabel(), LABEL);
+    assertEquals(test.getRateId(), QUOTE_ID);
+    assertEquals(test.getAdditionalSpread(), SPREAD);
+    assertEquals(test.getTemplate(), TEMPLATE);
+    assertEquals(test.getDate(), CurveNodeDate.END);
+  }
+
+  public void test_of_noSpread() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID);
+    assertEquals(test.getLabel(), LABEL_AUTO);
+    assertEquals(test.getRateId(), QUOTE_ID);
+    assertEquals(test.getAdditionalSpread(), 0.0d);
+    assertEquals(test.getTemplate(), TEMPLATE);
+  }
+
+  public void test_of_withSpread() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    assertEquals(test.getLabel(), LABEL_AUTO);
+    assertEquals(test.getRateId(), QUOTE_ID);
+    assertEquals(test.getAdditionalSpread(), SPREAD);
+    assertEquals(test.getTemplate(), TEMPLATE);
+  }
+
+  public void test_of_withSpreadAndLabel() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD, LABEL);
+    assertEquals(test.getLabel(), LABEL);
+    assertEquals(test.getRateId(), QUOTE_ID);
+    assertEquals(test.getAdditionalSpread(), SPREAD);
+    assertEquals(test.getTemplate(), TEMPLATE);
+  }
+
+  public void test_requirements() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    Set<ObservableId> set = test.requirements();
+    Iterator<ObservableId> itr = set.iterator();
+    assertEquals(itr.next(), QUOTE_ID);
+    assertFalse(itr.hasNext());
+  }
+
+  public void test_trade() {
+    OvernightIborSwapCurveNode node = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate tradeDate = LocalDate.of(2015, 1, 22);
+    double rate = 0.125;
+    MarketData marketData = ImmutableMarketData.builder(tradeDate).addValue(QUOTE_ID, rate).build();
+    SwapTrade trade = node.trade(tradeDate, marketData, REF_DATA);
+    SwapTrade expected = TEMPLATE.createTrade(tradeDate, BUY, 1, rate + SPREAD, REF_DATA);
+    assertEquals(trade, expected);
+  }
+
+  public void test_trade_noMarketData() {
+    OvernightIborSwapCurveNode node = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    MarketData marketData = MarketData.empty(valuationDate);
+    assertThrows(() -> node.trade(valuationDate, marketData, REF_DATA), MarketDataNotFoundException.class);
+  }
+
+  public void test_initialGuess() {
+    OvernightIborSwapCurveNode node = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    double rate = 0.035;
+    MarketData marketData = ImmutableMarketData.builder(valuationDate).addValue(QUOTE_ID, rate).build();
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.ZERO_RATE), rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.FORWARD_RATE), rate);
+    double df = Math.exp(-TENOR_10Y.get(ChronoUnit.YEARS) * rate);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.DISCOUNT_FACTOR), df, TOLERANCE_DF);
+    assertEquals(node.initialGuess(valuationDate, marketData, ValueType.PRICE_INDEX), 0d);
+  }
+
+  public void test_metadata_end() {
+    OvernightIborSwapCurveNode node = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ParameterMetadata metadata = node.metadata(valuationDate, REF_DATA);
+    // 2015-01-22 is Thursday, start is 2015-01-26, but 2025-01-26 is Sunday, so end is 2025-01-27
+    assertEquals(((TenorDateParameterMetadata) metadata).getDate(), LocalDate.of(2025, 1, 27));
+    assertEquals(((TenorDateParameterMetadata) metadata).getTenor(), Tenor.TENOR_10Y);
+  }
+
+  public void test_metadata_fixed() {
+    OvernightIborSwapCurveNode node =
+        OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD, LABEL).withDate(CurveNodeDate.of(VAL_DATE));
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    DatedParameterMetadata metadata = node.metadata(valuationDate, REF_DATA);
+    assertEquals(metadata.getDate(), VAL_DATE);
+    assertEquals(metadata.getLabel(), node.getLabel());
+  }
+
+  public void test_metadata_last_fixing() {
+    OvernightIborSwapCurveNode node =
+        OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD, LABEL).withDate(CurveNodeDate.LAST_FIXING);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    LocalDate fixingExpected = LocalDate.of(2024, 10, 24);
+    DatedParameterMetadata metadata = node.metadata(valuationDate, REF_DATA);
+    assertEquals(metadata.getDate(), fixingExpected);
+    assertEquals(metadata.getLabel(), node.getLabel());
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    coverImmutableBean(test);
+    OvernightIborSwapCurveNode test2 = OvernightIborSwapCurveNode.of(
+        OvernightIborSwapTemplate.of(TENOR_10Y, OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M),
+        QuoteId.of(StandardId.of("OG-Ticker", "Deposit2")));
+    coverBeanEquals(test, test2);
+  }
+
+  public void test_serialization() {
+    OvernightIborSwapCurveNode test = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    assertSerialization(test);
+  }
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapTemplate.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightIborSwapTemplate.java
@@ -1,0 +1,538 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableValidator;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.ReferenceDataNotFoundException;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.product.TradeTemplate;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * A template for creating Overnight-Ibor swap trades.
+ * <p>
+ * This defines almost all the data necessary to create an Overnight-Ibor single currency {@link SwapTrade}.
+ * The trade date, notional and spread are required to complete the template and create the trade.
+ * As such, it is often possible to get a market price for a trade based on the template.
+ * The market price is typically quoted as a bid/ask on the spread rate.
+ * <p>
+ * The template references four dates.
+ * <ul>
+ * <li>Trade date, the date that the trade is agreed
+ * <li>Spot date, the base for date calculations, typically 2 business days after the trade date
+ * <li>Start date, the date on which accrual starts
+ * <li>End date, the date on which accrual ends
+ * </ul>
+ * Some of these dates are specified by the convention embedded within this template.
+ */
+@BeanDefinition
+public final class OvernightIborSwapTemplate
+    implements TradeTemplate, ImmutableBean, Serializable {
+
+  /**
+   * The period between the spot value date and the start date.
+   * <p>
+   * This is often zero, but can be greater if the swap if <i>forward starting</i>.
+   * This must not be negative.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final Period periodToStart;
+  /**
+   * The tenor of the swap.
+   * <p>
+   * This is the period from the first accrual date to the last accrual date.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final Tenor tenor;
+  /**
+   * The market convention of the swap.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final OvernightIborSwapConvention convention;
+
+  //-------------------------------------------------------------------------
+  @ImmutableValidator
+  private void validate() {
+    ArgChecker.isFalse(periodToStart.isNegative(), "Period to start must not be negative");
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains a template based on the specified tenor and convention.
+   * <p>
+   * The swap will start on the spot date.
+   * 
+   * @param tenor  the tenor of the swap
+   * @param convention  the market convention
+   * @return the template
+   */
+  public static OvernightIborSwapTemplate of(Tenor tenor, OvernightIborSwapConvention convention) {
+    return of(Period.ZERO, tenor, convention);
+  }
+
+  /**
+   * Obtains a template based on the specified period, tenor and convention.
+   * <p>
+   * The period from the spot date to the start date is specified.
+   * 
+   * @param periodToStart  the period between the spot date and the start date
+   * @param tenor  the tenor of the swap
+   * @param convention  the market convention
+   * @return the template
+   */
+  public static OvernightIborSwapTemplate of(Period periodToStart, Tenor tenor, OvernightIborSwapConvention convention) {
+    return OvernightIborSwapTemplate.builder()
+        .periodToStart(periodToStart)
+        .tenor(tenor)
+        .convention(convention)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates a trade based on this template.
+   * <p>
+   * This returns a trade based on the specified trade date.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the Overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the Overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount, in the payment currency of the template
+   * @param spread  the spread, applied to the Overnight leg
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  public SwapTrade createTrade(
+      LocalDate tradeDate,
+      BuySell buySell,
+      double notional,
+      double spread,
+      ReferenceData refData) {
+
+    return convention.createTrade(tradeDate, periodToStart, tenor, buySell, notional, spread, refData);
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code OvernightIborSwapTemplate}.
+   * @return the meta-bean, not null
+   */
+  public static OvernightIborSwapTemplate.Meta meta() {
+    return OvernightIborSwapTemplate.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(OvernightIborSwapTemplate.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static OvernightIborSwapTemplate.Builder builder() {
+    return new OvernightIborSwapTemplate.Builder();
+  }
+
+  private OvernightIborSwapTemplate(
+      Period periodToStart,
+      Tenor tenor,
+      OvernightIborSwapConvention convention) {
+    JodaBeanUtils.notNull(periodToStart, "periodToStart");
+    JodaBeanUtils.notNull(tenor, "tenor");
+    JodaBeanUtils.notNull(convention, "convention");
+    this.periodToStart = periodToStart;
+    this.tenor = tenor;
+    this.convention = convention;
+    validate();
+  }
+
+  @Override
+  public OvernightIborSwapTemplate.Meta metaBean() {
+    return OvernightIborSwapTemplate.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the period between the spot value date and the start date.
+   * <p>
+   * This is often zero, but can be greater if the swap if <i>forward starting</i>.
+   * This must not be negative.
+   * @return the value of the property, not null
+   */
+  public Period getPeriodToStart() {
+    return periodToStart;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the tenor of the swap.
+   * <p>
+   * This is the period from the first accrual date to the last accrual date.
+   * @return the value of the property, not null
+   */
+  public Tenor getTenor() {
+    return tenor;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the swap.
+   * @return the value of the property, not null
+   */
+  public OvernightIborSwapConvention getConvention() {
+    return convention;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      OvernightIborSwapTemplate other = (OvernightIborSwapTemplate) obj;
+      return JodaBeanUtils.equal(periodToStart, other.periodToStart) &&
+          JodaBeanUtils.equal(tenor, other.tenor) &&
+          JodaBeanUtils.equal(convention, other.convention);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(periodToStart);
+    hash = hash * 31 + JodaBeanUtils.hashCode(tenor);
+    hash = hash * 31 + JodaBeanUtils.hashCode(convention);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(128);
+    buf.append("OvernightIborSwapTemplate{");
+    buf.append("periodToStart").append('=').append(periodToStart).append(',').append(' ');
+    buf.append("tenor").append('=').append(tenor).append(',').append(' ');
+    buf.append("convention").append('=').append(JodaBeanUtils.toString(convention));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code OvernightIborSwapTemplate}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code periodToStart} property.
+     */
+    private final MetaProperty<Period> periodToStart = DirectMetaProperty.ofImmutable(
+        this, "periodToStart", OvernightIborSwapTemplate.class, Period.class);
+    /**
+     * The meta-property for the {@code tenor} property.
+     */
+    private final MetaProperty<Tenor> tenor = DirectMetaProperty.ofImmutable(
+        this, "tenor", OvernightIborSwapTemplate.class, Tenor.class);
+    /**
+     * The meta-property for the {@code convention} property.
+     */
+    private final MetaProperty<OvernightIborSwapConvention> convention = DirectMetaProperty.ofImmutable(
+        this, "convention", OvernightIborSwapTemplate.class, OvernightIborSwapConvention.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "periodToStart",
+        "tenor",
+        "convention");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -574688858:  // periodToStart
+          return periodToStart;
+        case 110246592:  // tenor
+          return tenor;
+        case 2039569265:  // convention
+          return convention;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public OvernightIborSwapTemplate.Builder builder() {
+      return new OvernightIborSwapTemplate.Builder();
+    }
+
+    @Override
+    public Class<? extends OvernightIborSwapTemplate> beanType() {
+      return OvernightIborSwapTemplate.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code periodToStart} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Period> periodToStart() {
+      return periodToStart;
+    }
+
+    /**
+     * The meta-property for the {@code tenor} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Tenor> tenor() {
+      return tenor;
+    }
+
+    /**
+     * The meta-property for the {@code convention} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<OvernightIborSwapConvention> convention() {
+      return convention;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case -574688858:  // periodToStart
+          return ((OvernightIborSwapTemplate) bean).getPeriodToStart();
+        case 110246592:  // tenor
+          return ((OvernightIborSwapTemplate) bean).getTenor();
+        case 2039569265:  // convention
+          return ((OvernightIborSwapTemplate) bean).getConvention();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code OvernightIborSwapTemplate}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<OvernightIborSwapTemplate> {
+
+    private Period periodToStart;
+    private Tenor tenor;
+    private OvernightIborSwapConvention convention;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(OvernightIborSwapTemplate beanToCopy) {
+      this.periodToStart = beanToCopy.getPeriodToStart();
+      this.tenor = beanToCopy.getTenor();
+      this.convention = beanToCopy.getConvention();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -574688858:  // periodToStart
+          return periodToStart;
+        case 110246592:  // tenor
+          return tenor;
+        case 2039569265:  // convention
+          return convention;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case -574688858:  // periodToStart
+          this.periodToStart = (Period) newValue;
+          break;
+        case 110246592:  // tenor
+          this.tenor = (Tenor) newValue;
+          break;
+        case 2039569265:  // convention
+          this.convention = (OvernightIborSwapConvention) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public OvernightIborSwapTemplate build() {
+      return new OvernightIborSwapTemplate(
+          periodToStart,
+          tenor,
+          convention);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the period between the spot value date and the start date.
+     * <p>
+     * This is often zero, but can be greater if the swap if <i>forward starting</i>.
+     * This must not be negative.
+     * @param periodToStart  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder periodToStart(Period periodToStart) {
+      JodaBeanUtils.notNull(periodToStart, "periodToStart");
+      this.periodToStart = periodToStart;
+      return this;
+    }
+
+    /**
+     * Sets the tenor of the swap.
+     * <p>
+     * This is the period from the first accrual date to the last accrual date.
+     * @param tenor  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder tenor(Tenor tenor) {
+      JodaBeanUtils.notNull(tenor, "tenor");
+      this.tenor = tenor;
+      return this;
+    }
+
+    /**
+     * Sets the market convention of the swap.
+     * @param convention  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder convention(OvernightIborSwapConvention convention) {
+      JodaBeanUtils.notNull(convention, "convention");
+      this.convention = convention;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(128);
+      buf.append("OvernightIborSwapTemplate.Builder{");
+      buf.append("periodToStart").append('=').append(JodaBeanUtils.toString(periodToStart)).append(',').append(' ');
+      buf.append("tenor").append('=').append(JodaBeanUtils.toString(tenor)).append(',').append(' ');
+      buf.append("convention").append('=').append(JodaBeanUtils.toString(convention));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapTemplateTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapTemplateTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.USNY;
+import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
+import static com.opengamma.strata.basics.date.Tenor.TENOR_2Y;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
+import static com.opengamma.strata.basics.schedule.Frequency.P3M;
+import static com.opengamma.strata.basics.schedule.Frequency.P6M;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.product.common.BuySell.BUY;
+import static com.opengamma.strata.product.common.PayReceive.PAY;
+import static com.opengamma.strata.product.common.PayReceive.RECEIVE;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Optional;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.product.swap.Swap;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * Test {@link OvernightIborSwapTemplate}.
+ */
+@Test
+public class OvernightIborSwapTemplateTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final double NOTIONAL_2M = 2_000_000d;
+
+  private static final OvernightRateSwapLegConvention ON_LEG =
+      OvernightRateSwapLegConvention.of(USD_FED_FUND, P6M, 2);
+  private static final OvernightRateSwapLegConvention ON_LEG_2 =
+      OvernightRateSwapLegConvention.of(GBP_SONIA, P3M, 0);
+  private static final IborRateSwapLegConvention IBOR = IborRateSwapLegConvention.of(USD_LIBOR_3M);
+  private static final IborRateSwapLegConvention IBOR2 = IborRateSwapLegConvention.of(GBP_LIBOR_3M);
+
+  private static final DaysAdjustment SPOT_DATE_ADJUSTMENT_2 = DaysAdjustment.ofBusinessDays(2, USNY);
+  private static final DaysAdjustment SPOT_DATE_ADJUSTMENT_0 = DaysAdjustment.ofBusinessDays(0, GBLO);
+
+  private static final OvernightIborSwapConvention CONV =
+      ImmutableOvernightIborSwapConvention.of("USD-Swap", ON_LEG, IBOR, SPOT_DATE_ADJUSTMENT_2);
+  private static final OvernightIborSwapConvention CONV2 =
+      ImmutableOvernightIborSwapConvention.of("GBP-Swap", ON_LEG_2, IBOR2, SPOT_DATE_ADJUSTMENT_0);
+
+  //-------------------------------------------------------------------------
+  public void test_of() {
+    OvernightIborSwapTemplate test = OvernightIborSwapTemplate.of(TENOR_10Y, CONV);
+    assertEquals(test.getPeriodToStart(), Period.ZERO);
+    assertEquals(test.getTenor(), TENOR_10Y);
+    assertEquals(test.getConvention(), CONV);
+  }
+
+  public void test_of_period() {
+    OvernightIborSwapTemplate test = OvernightIborSwapTemplate.of(Period.ofMonths(3), TENOR_10Y, CONV);
+    assertEquals(test.getPeriodToStart(), Period.ofMonths(3));
+    assertEquals(test.getTenor(), TENOR_10Y);
+    assertEquals(test.getConvention(), CONV);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_builder_notEnoughData() {
+    assertThrowsIllegalArg(() -> OvernightIborSwapTemplate.builder()
+        .tenor(TENOR_2Y)
+        .build());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_createTrade() {
+    OvernightIborSwapTemplate base = OvernightIborSwapTemplate.of(Period.ofMonths(3), TENOR_10Y, CONV);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 8, 7);
+    LocalDate endDate = date(2025, 8, 7);
+    SwapTrade test = base.createTrade(tradeDate, BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    Swap expected = Swap.of(
+        ON_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        IBOR.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    OvernightIborSwapTemplate test = OvernightIborSwapTemplate.of(Period.ofMonths(3), TENOR_10Y, CONV);
+    coverImmutableBean(test);
+    OvernightIborSwapTemplate test2 = OvernightIborSwapTemplate.of(Period.ofMonths(2), TENOR_2Y, CONV2);
+    coverBeanEquals(test, test2);
+  }
+
+  public void test_serialization() {
+    OvernightIborSwapTemplate test = OvernightIborSwapTemplate.of(Period.ofMonths(3), TENOR_10Y, CONV);
+    assertSerialization(test);
+  }
+
+}


### PR DESCRIPTION
Added Overnight/Ibor swap template and curve node.
Mainly used for USD Fed Fund swaps.
Example of curve calibration with those nodes will be provided in a subsequent PR.