### PR TITLE
Rename swaption sensitivity method to avoid ambiguity. 

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/swaption/SabrSwaptionCubePvRiskExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/swaption/SabrSwaptionCubePvRiskExample.java
@@ -166,7 +166,7 @@ public class SabrSwaptionCubePvRiskExample {
     CurrencyAmount pv = SWAPTION_PRICER.presentValue(resolvedSwaption, multicurve, sabr);
     System.out.println("  |-> PV: " + pv.toString());
 
-    PointSensitivities deltaPts = SWAPTION_PRICER.presentValueSensitivity(resolvedSwaption, multicurve, sabr).build();
+    PointSensitivities deltaPts = SWAPTION_PRICER.presentValueSensitivityModel(resolvedSwaption, multicurve, sabr).build();
     CurrencyParameterSensitivities deltaBucketed = multicurve.parameterSensitivity(deltaPts);
     System.out.println("  |-> Delta bucketed: " + deltaBucketed.toString());
 

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/swaption/SabrSwaptionCubePvRiskExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/swaption/SabrSwaptionCubePvRiskExample.java
@@ -166,7 +166,7 @@ public class SabrSwaptionCubePvRiskExample {
     CurrencyAmount pv = SWAPTION_PRICER.presentValue(resolvedSwaption, multicurve, sabr);
     System.out.println("  |-> PV: " + pv.toString());
 
-    PointSensitivities deltaPts = SWAPTION_PRICER.presentValueSensitivityModel(resolvedSwaption, multicurve, sabr).build();
+    PointSensitivities deltaPts = SWAPTION_PRICER.presentValueSensitivityStickyModel(resolvedSwaption, multicurve, sabr).build();
     CurrencyParameterSensitivities deltaBucketed = multicurve.parameterSensitivity(deltaPts);
     System.out.println("  |-> Delta bucketed: " + deltaBucketed.toString());
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldTradePricer.java
@@ -120,10 +120,11 @@ public class BlackSwaptionCashParYieldTradePricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption trade.
+   * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * change of volatility due to the implicit change of forward rate or moneyness.
    * 
    * @param trade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalTradePricer.java
@@ -120,10 +120,11 @@ public class BlackSwaptionPhysicalTradePricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption trade.
+   * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * change of volatility due to the implicit change of forward rate or moneyness.
    * 
    * @param trade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldTradePricer.java
@@ -120,10 +120,11 @@ public class NormalSwaptionCashParYieldTradePricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption trade.
+   * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * change of volatility due to the implicit change of forward rate or moneyness.
    * 
    * @param trade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalTradePricer.java
@@ -120,10 +120,11 @@ public class NormalSwaptionPhysicalTradePricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption trade.
+   * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * change of volatility due to the implicit change of forward rate or moneyness.
    * 
    * @param trade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
@@ -71,7 +71,7 @@ public class SabrSwaptionCashParYieldProductPricer
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap product
    */
-  public PointSensitivityBuilder presentValueSensitivityModel(
+  public PointSensitivityBuilder presentValueSensitivityStickyModel(
       ResolvedSwaption swaption,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
@@ -60,17 +60,18 @@ public class SabrSwaptionCashParYieldProductPricer
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption product.
+   * Calculates the present value sensitivity of the swaption product to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky model parameter" style, i.e. the sensitivity to the 
+   * curve nodes with the SABR model parameters unchanged. This sensitivity does not include a potential 
+   * re-calibration of the model parameters to the raw market data.
    * 
    * @param swaption  the swaption product
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap product
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivityBuilder presentValueSensitivityModel(
       ResolvedSwaption swaption,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricer.java
@@ -128,14 +128,14 @@ public class SabrSwaptionCashParYieldTradePricer {
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap trade
    */
-  public PointSensitivityBuilder presentValueSensitivityModel(
+  public PointSensitivityBuilder presentValueSensitivityStickyModel(
       ResolvedSwaptionTrade trade,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {
 
     ResolvedSwaption product = trade.getProduct();
     PointSensitivityBuilder pvcsProduct =
-        productPricer.presentValueSensitivityModel(product, ratesProvider, swaptionVolatilities);
+        productPricer.presentValueSensitivityStickyModel(product, ratesProvider, swaptionVolatilities);
     Payment premium = trade.getPremium();
     PointSensitivityBuilder pvcsPremium = paymentPricer.presentValueSensitivity(premium, ratesProvider);
     return pvcsProduct.combinedWith(pvcsPremium);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricer.java
@@ -117,24 +117,25 @@ public class SabrSwaptionCashParYieldTradePricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption trade.
+   * Calculates the present value sensitivity of the swaption trade to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky model parameter" style, i.e. the sensitivity to the 
+   * curve nodes with the SABR model parameters unchanged. This sensitivity does not include a potential 
+   * re-calibration of the model parameters to the raw market data.
    * 
    * @param trade  the swaption trade
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap trade
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivityBuilder presentValueSensitivityModel(
       ResolvedSwaptionTrade trade,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {
 
     ResolvedSwaption product = trade.getProduct();
     PointSensitivityBuilder pvcsProduct =
-        productPricer.presentValueSensitivity(product, ratesProvider, swaptionVolatilities);
+        productPricer.presentValueSensitivityModel(product, ratesProvider, swaptionVolatilities);
     Payment premium = trade.getPremium();
     PointSensitivityBuilder pvcsPremium = paymentPricer.presentValueSensitivity(premium, ratesProvider);
     return pvcsProduct.combinedWith(pvcsPremium);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
@@ -69,7 +69,7 @@ public class SabrSwaptionPhysicalProductPricer
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap product
    */
-  public PointSensitivityBuilder presentValueSensitivityModel(
+  public PointSensitivityBuilder presentValueSensitivityStickyModel(
       ResolvedSwaption swaption,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
@@ -58,17 +58,18 @@ public class SabrSwaptionPhysicalProductPricer
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption product.
+   * Calculates the present value sensitivity of the swaption product to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky model parameter" style, i.e. the sensitivity to the 
+   * curve nodes with the SABR model parameters unchanged. This sensitivity does not include a potential 
+   * re-calibration of the model parameters to the raw market data.
    * 
    * @param swaption  the swaption product
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap product
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivityBuilder presentValueSensitivityModel(
       ResolvedSwaption swaption,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricer.java
@@ -130,14 +130,14 @@ public class SabrSwaptionPhysicalTradePricer {
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap trade
    */
-  public PointSensitivityBuilder presentValueSensitivityModel(
+  public PointSensitivityBuilder presentValueSensitivityStickyModel(
       ResolvedSwaptionTrade trade,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {
 
     ResolvedSwaption product = trade.getProduct();
     PointSensitivityBuilder pvcsProduct =
-        productPricer.presentValueSensitivityModel(product, ratesProvider, swaptionVolatilities);
+        productPricer.presentValueSensitivityStickyModel(product, ratesProvider, swaptionVolatilities);
     Payment premium = trade.getPremium();
     PointSensitivityBuilder pvcsPremium = paymentPricer.presentValueSensitivity(premium, ratesProvider);
     return pvcsProduct.combinedWith(pvcsPremium);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricer.java
@@ -119,24 +119,25 @@ public class SabrSwaptionPhysicalTradePricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption product.
+   * Calculates the present value sensitivity of the swaption trade to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky model parameter" style, i.e. the sensitivity to the 
+   * curve nodes with the SABR model parameters unchanged. This sensitivity does not include a potential 
+   * re-calibration of the model parameters to the raw market data.
    * 
    * @param trade  the swaption trade
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
    * @return the present value curve sensitivity of the swap trade
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivityBuilder presentValueSensitivityModel(
       ResolvedSwaptionTrade trade,
       RatesProvider ratesProvider,
       SabrSwaptionVolatilities swaptionVolatilities) {
 
     ResolvedSwaption product = trade.getProduct();
     PointSensitivityBuilder pvcsProduct =
-        productPricer.presentValueSensitivity(product, ratesProvider, swaptionVolatilities);
+        productPricer.presentValueSensitivityModel(product, ratesProvider, swaptionVolatilities);
     Payment premium = trade.getPremium();
     PointSensitivityBuilder pvcsPremium = paymentPricer.presentValueSensitivity(premium, ratesProvider);
     return pvcsProduct.combinedWith(pvcsPremium);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -262,10 +262,11 @@ public class VolatilitySwaptionCashParYieldProductPricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption.
+   * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * change of volatility due to the implicit change of forward rate or moneyness.
    * 
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -265,10 +265,11 @@ public class VolatilitySwaptionPhysicalProductPricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the present value sensitivity of the swaption.
+   * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity of the product is the sensitivity of the present value to
-   * the underlying curves.
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * change of volatility due to the implicit change of forward rate or moneyness.
    * 
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -331,13 +331,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), expectedRec.getAmount(EUR).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedPay.size(), 1);
@@ -350,13 +350,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), expectedRec.getAmount(EUR).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedPay.size(), 1);
@@ -440,22 +440,22 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_presentValueSensitivity() {
+  public void test_presentValueSensitivityStickyModel() {
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 200d));
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay.build());
     CurrencyParameterSensitivities expectedPay =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_PAY_SHORT, (p), VOL_PROVIDER));
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 200d));
   }
 
-  public void test_presentValueSensitivity_stickyStrike() {
+  public void test_presentValueSensitivityStickyStrike() {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), false);
     double impliedVol = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
@@ -478,43 +478,43 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 300d));
   }
 
-  public void test_presentValueSensitivity_atMaturity() {
+  public void test_presentValueSensitivityStickyModel_atMaturity() {
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
         RATE_PROVIDER_AT_MATURITY.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec = FD_CAL.sensitivity(
         RATE_PROVIDER_AT_MATURITY, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER_AT_MATURITY));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
-    PointSensitivities pointPay = PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT,
+    PointSensitivities pointPay = PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT,
         RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
   }
 
-  public void test_presentValueSensitivity_afterMaturity() {
-    PointSensitivities pointRec = PRICER.presentValueSensitivityModel(
+  public void test_presentValueSensitivityStickyModel_afterMaturity() {
+    PointSensitivities pointRec = PRICER.presentValueSensitivityStickyModel(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
-    PointSensitivities pointPay = PRICER.presentValueSensitivityModel(
+    PointSensitivities pointPay = PRICER.presentValueSensitivityStickyModel(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
   }
 
-  public void test_presentValueSensitivity_parity() {
+  public void test_presentValueSensitivityStickyModel_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     assertTrue(pvSensiRecLong.equalWithTolerance(pvSensiRecShort.multipliedBy(-1d), NOTIONAL * TOL));
     assertTrue(pvSensiPayLong.equalWithTolerance(pvSensiPayShort.multipliedBy(-1d), NOTIONAL * TOL));
 
@@ -692,7 +692,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   public void regressionCurveSensitivity() {
     double[] sensiDscExp = new double[] {0.0, 0.0, 0.0, 0.0, -1.1942174487944763E7, -1565567.6976298545};
     double[] sensiFwdExp = new double[] {0.0, 0.0, 0.0, 0.0, -2.3978768078237808E8, 4.8392987803482056E8};
-    PointSensitivityBuilder point = PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
     CurrencyParameterSensitivities sensi = RATE_PROVIDER.parameterSensitivity(point.build());
     double[] sensiDscCmp = sensi.getSensitivity(SwaptionSabrRateVolatilityDataSet.META_DSC_EUR.getCurveName(), EUR)
         .getSensitivity().toArray();

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -331,13 +331,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), expectedRec.getAmount(EUR).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedPay.size(), 1);
@@ -350,13 +350,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), expectedRec.getAmount(EUR).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedPay.size(), 1);
@@ -442,13 +442,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivity() {
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 200d));
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay.build());
     CurrencyParameterSensitivities expectedPay =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_PAY_SHORT, (p), VOL_PROVIDER));
@@ -480,13 +480,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivity_atMaturity() {
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
         RATE_PROVIDER_AT_MATURITY.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec = FD_CAL.sensitivity(
         RATE_PROVIDER_AT_MATURITY, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER_AT_MATURITY));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
-    PointSensitivities pointPay = PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT,
+    PointSensitivities pointPay = PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT,
         RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
@@ -494,12 +494,12 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   public void test_presentValueSensitivity_afterMaturity() {
-    PointSensitivities pointRec = PRICER.presentValueSensitivity(
+    PointSensitivities pointRec = PRICER.presentValueSensitivityModel(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
-    PointSensitivities pointPay = PRICER.presentValueSensitivity(
+    PointSensitivities pointPay = PRICER.presentValueSensitivityModel(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
@@ -508,13 +508,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivity_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivity(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivity(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     assertTrue(pvSensiRecLong.equalWithTolerance(pvSensiRecShort.multipliedBy(-1d), NOTIONAL * TOL));
     assertTrue(pvSensiPayLong.equalWithTolerance(pvSensiPayShort.multipliedBy(-1d), NOTIONAL * TOL));
 
@@ -692,7 +692,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   public void regressionCurveSensitivity() {
     double[] sensiDscExp = new double[] {0.0, 0.0, 0.0, 0.0, -1.1942174487944763E7, -1565567.6976298545};
     double[] sensiFwdExp = new double[] {0.0, 0.0, 0.0, 0.0, -2.3978768078237808E8, 4.8392987803482056E8};
-    PointSensitivityBuilder point = PRICER.presentValueSensitivity(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
     CurrencyParameterSensitivities sensi = RATE_PROVIDER.parameterSensitivity(point.build());
     double[] sensiDscCmp = sensi.getSensitivity(SwaptionSabrRateVolatilityDataSet.META_DSC_EUR.getCurveName(), EUR)
         .getSensitivity().toArray();

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
@@ -151,9 +151,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivityModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade =
         RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
@@ -164,9 +164,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivityModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -174,9 +174,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivityModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
@@ -151,9 +151,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivity(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivity(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade =
         RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
@@ -164,9 +164,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivity(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivity(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -174,9 +174,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivity(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivity(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -238,13 +238,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
     MultiCurrencyAmount computedRec = SWAPTION_PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), expectedRec.getAmount(USD).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedPay.size(), 1);
@@ -257,13 +257,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), expectedRec.getAmount(USD).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedPay.size(), 1);
@@ -342,13 +342,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivity() {
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
     PointSensitivityBuilder pointPay =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay.build());
     CurrencyParameterSensitivities expectedPay =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, (p), VOL_PROVIDER));
@@ -380,13 +380,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   public void test_presentValueSensitivity_atMaturity() {
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
         RATE_PROVIDER_AT_MATURITY.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec = FD_CAL.sensitivity(
         RATE_PROVIDER_AT_MATURITY, (p) -> SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER_AT_MATURITY));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
-    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT,
+    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT,
         RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
@@ -394,12 +394,12 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   public void test_presentValueSensitivity_afterMaturity() {
-    PointSensitivities pointRec = SWAPTION_PRICER.presentValueSensitivity(
+    PointSensitivities pointRec = SWAPTION_PRICER.presentValueSensitivityModel(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
-    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivity(
+    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivityModel(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
@@ -408,13 +408,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   public void test_presentValueSensitivity_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayLong = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayShort = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     assertTrue(pvSensiRecLong.equalWithTolerance(pvSensiRecShort.multipliedBy(-1d), NOTIONAL * TOL));
     assertTrue(pvSensiPayLong.equalWithTolerance(pvSensiPayShort.multipliedBy(-1d), NOTIONAL * TOL));
 
@@ -577,7 +577,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   public void regressionPvCurveSensi() {
     PointSensitivityBuilder point =
-        SWAPTION_PRICER.presentValueSensitivity(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REGRESSION);
+        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REGRESSION);
     CurrencyParameterSensitivities sensiComputed = RATE_PROVIDER.parameterSensitivity(point.build());
     final double[] deltaDsc = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 109037.92080563342, 637123.4570377409,
         -931862.187003511, -2556192.7520530378, -4233440.216336116, -5686205.439275854, -6160338.898970505,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -238,13 +238,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
     MultiCurrencyAmount computedRec = SWAPTION_PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), expectedRec.getAmount(USD).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER));
     assertEquals(computedPay.size(), 1);
@@ -257,13 +257,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), expectedRec.getAmount(USD).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
         .plus(SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
     assertEquals(computedPay.size(), 1);
@@ -340,22 +340,22 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_presentValueSensitivity() {
+  public void test_presentValueSensitivityStickyModel() {
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
     PointSensitivityBuilder pointPay =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay.build());
     CurrencyParameterSensitivities expectedPay =
         FD_CAL.sensitivity(RATE_PROVIDER, (p) -> SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, (p), VOL_PROVIDER));
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 100d));
   }
 
-  public void test_presentValueSensitivity_stickyStrike() {
+  public void test_presentValueSensitivityStickyModel_stickyStrike() {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesUsd(VAL_DATE, false);
     double impliedVol = SWAPTION_PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
@@ -378,28 +378,28 @@ public class SabrSwaptionPhysicalProductPricerTest {
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 100d));
   }
 
-  public void test_presentValueSensitivity_atMaturity() {
+  public void test_presentValueSensitivityStickyModel_atMaturity() {
     PointSensitivityBuilder pointRec =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
         RATE_PROVIDER_AT_MATURITY.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec = FD_CAL.sensitivity(
         RATE_PROVIDER_AT_MATURITY, (p) -> SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER_AT_MATURITY));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
-    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT,
+    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT,
         RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
   }
 
-  public void test_presentValueSensitivity_afterMaturity() {
-    PointSensitivities pointRec = SWAPTION_PRICER.presentValueSensitivityModel(
+  public void test_presentValueSensitivityStickyModel_afterMaturity() {
+    PointSensitivities pointRec = SWAPTION_PRICER.presentValueSensitivityStickyModel(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
-    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivityModel(
+    PointSensitivities pointPay = SWAPTION_PRICER.presentValueSensitivityStickyModel(
         SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
@@ -408,13 +408,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   public void test_presentValueSensitivity_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayLong = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
     CurrencyParameterSensitivities pvSensiPayShort = RATE_PROVIDER.parameterSensitivity(
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
     assertTrue(pvSensiRecLong.equalWithTolerance(pvSensiRecShort.multipliedBy(-1d), NOTIONAL * TOL));
     assertTrue(pvSensiPayLong.equalWithTolerance(pvSensiPayShort.multipliedBy(-1d), NOTIONAL * TOL));
 
@@ -577,7 +577,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   public void regressionPvCurveSensi() {
     PointSensitivityBuilder point =
-        SWAPTION_PRICER.presentValueSensitivityModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REGRESSION);
+        SWAPTION_PRICER.presentValueSensitivityStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REGRESSION);
     CurrencyParameterSensitivities sensiComputed = RATE_PROVIDER.parameterSensitivity(point.build());
     final double[] deltaDsc = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 109037.92080563342, 637123.4570377409,
         -931862.187003511, -2556192.7520530378, -4233440.216336116, -5686205.439275854, -6160338.898970505,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
@@ -145,9 +145,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivity(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivity(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade =
         RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
@@ -158,9 +158,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivity(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivity(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -168,9 +168,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivity(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivity(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
@@ -145,9 +145,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivityModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade =
         RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
@@ -158,9 +158,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivityModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -168,9 +168,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivityBuilder pvcsTrade = PRICER
-        .presentValueSensitivityModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade.build());
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));


### PR DESCRIPTION
Rename swaption sensitivity method to avoid ambiguity. Added 'Model" to the 'presentValueSensitivity' to indicate that the model parameters are kept unchanged. This mimics 'presentValueSensitivityStickyStrike'
Improve Javadoc on swaption sensitivity. Clarify what is kept constant in the different sensitivity computations.