### PR TITLE
Query rates provider contents

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.measure.rate;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableSet;
+
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
@@ -19,6 +21,7 @@ import org.joda.beans.Property;
 import org.joda.beans.PropertyDefinition;
 import org.joda.beans.impl.light.LightMetaBean;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -97,6 +100,35 @@ final class DefaultLookupRatesProvider
   @Override
   public LocalDate getValuationDate() {
     return marketData.getValuationDate();
+  }
+
+  @Override
+  public ImmutableSet<Currency> getDiscountCurrencies() {
+    return lookup.getDiscountCurrencies();
+  }
+
+  @Override
+  public ImmutableSet<IborIndex> getIborIndices() {
+    return lookup.getForwardIndices().stream()
+        .filter(IborIndex.class::isInstance)
+        .map(IborIndex.class::cast)
+        .collect(toImmutableSet());
+  }
+
+  @Override
+  public ImmutableSet<OvernightIndex> getOvernightIndices() {
+    return lookup.getForwardIndices().stream()
+        .filter(OvernightIndex.class::isInstance)
+        .map(OvernightIndex.class::cast)
+        .collect(toImmutableSet());
+  }
+
+  @Override
+  public ImmutableSet<PriceIndex> getPriceIndices() {
+    return lookup.getForwardIndices().stream()
+        .filter(PriceIndex.class::isInstance)
+        .map(PriceIndex.class::cast)
+        .collect(toImmutableSet());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/BaseProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/BaseProvider.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.pricer;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
@@ -31,6 +32,13 @@ public interface BaseProvider
    * @return the valuation date
    */
   public abstract LocalDate getValuationDate();
+
+  /**
+   * Gets the set of currencies that discount factors are provided for.
+   *
+   * @return the set of discount curve currencies
+   */
+  public abstract Set<Currency> getDiscountCurrencies();
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.pricer.rate;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableSet;
+
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Map;
@@ -29,6 +31,7 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxMatrix;
@@ -150,6 +153,36 @@ public final class ImmutableRatesProvider
         .indexCurves(indexCurves)
         .priceIndexValues(priceIndexValues)
         .timeSeries(timeSeries);
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> getDiscountCurrencies() {
+    return discountCurves.keySet();
+  }
+
+  @Override
+  public ImmutableSet<IborIndex> getIborIndices() {
+    return indexCurves.keySet().stream()
+        .filter(IborIndex.class::isInstance)
+        .map(IborIndex.class::cast)
+        .collect(toImmutableSet());
+  }
+
+  @Override
+  public ImmutableSet<OvernightIndex> getOvernightIndices() {
+    return indexCurves.keySet().stream()
+        .filter(OvernightIndex.class::isInstance)
+        .map(OvernightIndex.class::cast)
+        .collect(toImmutableSet());
+  }
+
+  @Override
+  public ImmutableSet<PriceIndex> getPriceIndices() {
+    return priceIndexValues.keySet().stream()
+        .filter(PriceIndex.class::isInstance)
+        .map(PriceIndex.class::cast)
+        .collect(toImmutableSet());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.pricer.rate;
 
 import java.util.Optional;
+import java.util.Set;
 
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
@@ -40,6 +41,28 @@ import com.opengamma.strata.pricer.fx.FxIndexSensitivity;
 public interface RatesProvider
     extends BaseProvider {
 
+  /**
+   * Gets the set of Ibor indices that are available.
+   *
+   * @return the set of Ibor indices
+   */
+  public abstract Set<IborIndex> getIborIndices();
+
+  /**
+   * Gets the set of Overnight indices that are available.
+   *
+   * @return the set of Overnight indices
+   */
+  public abstract Set<OvernightIndex> getOvernightIndices();
+
+  /**
+   * Gets the set of Price indices that are available.
+   *
+   * @return the set of Price indices
+   */
+  public abstract Set<PriceIndex> getPriceIndices();
+
+  //-------------------------------------------------------------------------
   /**
    * Gets the rates for an FX index.
    * <p>

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.pricer.impl;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.index.FxIndex;
@@ -57,6 +58,27 @@ public class MockRatesProvider
    */
   public MockRatesProvider(LocalDate valuationDate) {
     this.valuationDate = valuationDate;
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> getDiscountCurrencies() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ImmutableSet<IborIndex> getIborIndices() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ImmutableSet<OvernightIndex> getOvernightIndices() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ImmutableSet<PriceIndex> getPriceIndices() {
+    throw new UnsupportedOperationException();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimpleRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimpleRatesProvider.java
@@ -22,6 +22,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.date.DayCount;
@@ -90,6 +91,39 @@ public class SimpleRatesProvider
     this.valuationDate = valuationDate;
     this.discountFactors = discountFactors;
     this.iborRates = iborRates;
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> getDiscountCurrencies() {
+    if (discountFactors != null) {
+      return ImmutableSet.of(discountFactors.getCurrency());
+    }
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public ImmutableSet<IborIndex> getIborIndices() {
+    if (iborRates != null) {
+      return ImmutableSet.of(iborRates.getIndex());
+    }
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public ImmutableSet<OvernightIndex> getOvernightIndices() {
+    if (overnightRates != null) {
+      return ImmutableSet.of(overnightRates.getIndex());
+    }
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public ImmutableSet<PriceIndex> getPriceIndices() {
+    if (priceIndexValues != null) {
+      return ImmutableSet.of(priceIndexValues.getIndex());
+    }
+    return ImmutableSet.of();
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Allow currencies and indices to be queried.
Hiding this information isn't helpful at this point.