### PR TITLE
Change to use PointSensitivities on trade pricers

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricer.java
@@ -14,6 +14,7 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.CompoundedRateType;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -135,7 +136,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
    * @param refData  the reference data used to calculate the settlement date
    * @return the present value sensitivity of the bond trade
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivities presentValueSensitivity(
       ResolvedCapitalIndexedBondTrade trade,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider issuerDiscountFactorsProvider,
@@ -146,7 +147,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
     PointSensitivityBuilder productSensi = productPricer.presentValueSensitivity(trade.getProduct(),
         ratesProvider, issuerDiscountFactorsProvider, settlementDate);
     return presentValueSensitivityFromProductPresentValueSensitivity(
-        trade, ratesProvider, issuerDiscountFactorsProvider, productSensi);
+        trade, ratesProvider, issuerDiscountFactorsProvider, productSensi).build();
   }
 
   /**
@@ -166,7 +167,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
    * @param periodsPerYear  the number of periods per year
    * @return the present value sensitivity of the bond trade
    */
-  public PointSensitivityBuilder presentValueSensitivityWithZSpread(
+  public PointSensitivities presentValueSensitivityWithZSpread(
       ResolvedCapitalIndexedBondTrade trade,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider issuerDiscountFactorsProvider,
@@ -180,7 +181,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
     PointSensitivityBuilder productSensi = productPricer.presentValueSensitivityWithZSpread(trade.getProduct(),
         ratesProvider, issuerDiscountFactorsProvider, settlementDate, zSpread, compoundedRateType, periodsPerYear);
     return presentValueSensitivityFromProductPresentValueSensitivity(
-        trade, ratesProvider, issuerDiscountFactorsProvider, productSensi);
+        trade, ratesProvider, issuerDiscountFactorsProvider, productSensi).build();
   }
 
   //-------------------------------------------------------------------------
@@ -317,7 +318,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
    * @param cleanRealPrice  the clean real price
    * @return the present value sensitivity of the settlement
    */
-  public PointSensitivityBuilder presentValueSensitivityFromCleanPrice(
+  public PointSensitivities presentValueSensitivityFromCleanPrice(
       ResolvedCapitalIndexedBondTrade trade,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider issuerDiscountFactorsProvider,
@@ -340,7 +341,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
                 .getAmount()));
     if (standardSettlementDate.isEqual(tradeSettlementDate)) {
       return presentValueSensitivityFromProductPresentValueSensitivity(
-          trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard);
+          trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard).build();
     }
     // check coupon payment between two settlement dates
     IssuerCurveDiscountFactors issuerDiscountFactors =
@@ -354,7 +355,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
           issuerDiscountFactors, standardSettlementDate, tradeSettlementDate));
     }
     return presentValueSensitivityFromProductPresentValueSensitivity(
-        trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard.combinedWith(pvSensiDiff));
+        trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard.combinedWith(pvSensiDiff)).build();
   }
 
   /**
@@ -374,7 +375,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
    * @param cleanRealPrice  the clean real price
    * @return the present value sensitivity of the settlement
    */
-  public PointSensitivityBuilder presentValueSensitivityFromCleanPriceWithZSpread(
+  public PointSensitivities presentValueSensitivityFromCleanPriceWithZSpread(
       ResolvedCapitalIndexedBondTrade trade,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider issuerDiscountFactorsProvider,
@@ -400,7 +401,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
                 .getAmount()));
     if (standardSettlementDate.isEqual(tradeSettlementDate)) {
       return presentValueSensitivityFromProductPresentValueSensitivity(
-          trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard);
+          trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard).build();
     }
     // check coupon payment between two settlement dates
     IssuerCurveDiscountFactors issuerDiscountFactors =
@@ -429,7 +430,7 @@ public class DiscountingCapitalIndexedBondTradePricer {
           periodsPerYear));
     }
     return presentValueSensitivityFromProductPresentValueSensitivity(
-        trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard.combinedWith(pvSensiDiff));
+        trade, ratesProvider, issuerDiscountFactorsProvider, pvSensiStandard.combinedWith(pvSensiDiff)).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondTradePricer.java
@@ -14,6 +14,7 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.CompoundedRateType;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
@@ -242,14 +243,14 @@ public class DiscountingFixedCouponBondTradePricer {
    * @param provider  the rates provider
    * @return the present value curve sensitivity of the trade
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivities presentValueSensitivity(
       ResolvedFixedCouponBondTrade trade,
       LegalEntityDiscountingProvider provider) {
 
     LocalDate settlementDate = trade.getSettlementDate();
     PointSensitivityBuilder sensiProduct = productPricer.presentValueSensitivity(
         trade.getProduct(), provider, settlementDate);
-    return presentValueSensitivityFromProductPresentValueSensitivity(trade, provider, sensiProduct);
+    return presentValueSensitivityFromProductPresentValueSensitivity(trade, provider, sensiProduct).build();
   }
 
   /**
@@ -270,7 +271,7 @@ public class DiscountingFixedCouponBondTradePricer {
    * @param periodsPerYear  the number of periods per year
    * @return the present value curve sensitivity of the trade
    */
-  public PointSensitivityBuilder presentValueSensitivityWithZSpread(
+  public PointSensitivities presentValueSensitivityWithZSpread(
       ResolvedFixedCouponBondTrade trade,
       LegalEntityDiscountingProvider provider,
       double zSpread,
@@ -280,7 +281,7 @@ public class DiscountingFixedCouponBondTradePricer {
     LocalDate settlementDate = trade.getSettlementDate();
     PointSensitivityBuilder sensiProduct = productPricer.presentValueSensitivityWithZSpread(
         trade.getProduct(), provider, zSpread, compoundedRateType, periodsPerYear, settlementDate);
-    return presentValueSensitivityFromProductPresentValueSensitivity(trade, provider, sensiProduct);
+    return presentValueSensitivityFromProductPresentValueSensitivity(trade, provider, sensiProduct).build();
   }
 
   private PointSensitivityBuilder presentValueSensitivityFromProductPresentValueSensitivity(

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/VolatilityIborCapFloorTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/VolatilityIborCapFloorTradePricer.java
@@ -9,6 +9,7 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -89,7 +90,7 @@ public class VolatilityIborCapFloorTradePricer {
    * @param volatilities  the caplet/floorlet volatilities
    * @return the present value sensitivity
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivities presentValueSensitivity(
       ResolvedIborCapFloorTrade trade,
       RatesProvider ratesProvider,
       IborCapletFloorletVolatilities volatilities) {
@@ -97,11 +98,11 @@ public class VolatilityIborCapFloorTradePricer {
     PointSensitivityBuilder pvSensiProduct =
         productPricer.presentValueSensitivity(trade.getProduct(), ratesProvider, volatilities);
     if (!trade.getPremium().isPresent()) {
-      return pvSensiProduct;
+      return pvSensiProduct.build();
     }
     PointSensitivityBuilder pvSensiPremium =
         paymentPricer.presentValueSensitivity(trade.getPremium().get(), ratesProvider);
-    return pvSensiProduct.combinedWith(pvSensiPremium);
+    return pvSensiProduct.combinedWith(pvSensiPremium).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/cms/DiscountingCmsTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/cms/DiscountingCmsTradePricer.java
@@ -9,6 +9,7 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -80,17 +81,17 @@ public class DiscountingCmsTradePricer {
    * @param ratesProvider  the rates provider
    * @return the present value sensitivity
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivities presentValueSensitivity(
       ResolvedCmsTrade trade,
       RatesProvider ratesProvider) {
 
     PointSensitivityBuilder pvSensiCms =
         productPricer.presentValueSensitivity(trade.getProduct(), ratesProvider);
     if (!trade.getPremium().isPresent()) {
-      return pvSensiCms;
+      return pvSensiCms.build();
     }
     PointSensitivityBuilder pvSensiPremium = paymentPricer.presentValueSensitivity(trade.getPremium().get(), ratesProvider);
-    return pvSensiCms.combinedWith(pvSensiPremium);
+    return pvSensiCms.combinedWith(pvSensiPremium).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsTradePricer.java
@@ -9,6 +9,7 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -80,7 +81,7 @@ public class SabrExtrapolationReplicationCmsTradePricer {
    * @param swaptionVolatilities  the swaption volatilities
    * @return the present value sensitivity
    */
-  public PointSensitivityBuilder presentValueSensitivity(
+  public PointSensitivities presentValueSensitivity(
       ResolvedCmsTrade trade,
       RatesProvider ratesProvider,
       SabrParametersSwaptionVolatilities swaptionVolatilities) {
@@ -88,10 +89,10 @@ public class SabrExtrapolationReplicationCmsTradePricer {
     PointSensitivityBuilder pvSensiCms =
         productPricer.presentValueSensitivity(trade.getProduct(), ratesProvider, swaptionVolatilities);
     if (!trade.getPremium().isPresent()) {
-      return pvSensiCms;
+      return pvSensiCms.build();
     }
     PointSensitivityBuilder pvSensiPremium = paymentPricer.presentValueSensitivity(trade.getPremium().get(), ratesProvider);
-    return pvSensiCms.combinedWith(pvSensiPremium);
+    return pvSensiCms.combinedWith(pvSensiPremium).build();
   }
 
   /**
@@ -105,12 +106,13 @@ public class SabrExtrapolationReplicationCmsTradePricer {
    * @param swaptionVolatilities  the swaption volatilities
    * @return the present value sensitivity
    */
-  public PointSensitivityBuilder presentValueSensitivitySabrParameter(
+  public PointSensitivities presentValueSensitivitySabrParameter(
       ResolvedCmsTrade trade,
       RatesProvider ratesProvider,
       SabrParametersSwaptionVolatilities swaptionVolatilities) {
 
-    return productPricer.presentValueSensitivitySabrParameter(trade.getProduct(), ratesProvider, swaptionVolatilities);
+    return productPricer.presentValueSensitivitySabrParameter(
+        trade.getProduct(), ratesProvider, swaptionVolatilities).build();
   }
 
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackFxSingleBarrierOptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackFxSingleBarrierOptionTradePricer.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -74,7 +75,7 @@ public class BlackFxSingleBarrierOptionTradePricer {
    * @param volatilityProvider  the Black volatility provider
    * @return the present value curve sensitivity of the trade
    */
-  public PointSensitivityBuilder presentValueSensitivityStickyStrike(
+  public PointSensitivities presentValueSensitivityStickyStrike(
       ResolvedFxSingleBarrierOptionTrade trade,
       RatesProvider ratesProvider,
       BlackVolatilityFxProvider volatilityProvider) {
@@ -84,7 +85,7 @@ public class BlackFxSingleBarrierOptionTradePricer {
         PRICER_PRODUCT.presentValueSensitivityStickyStrike(product, ratesProvider, volatilityProvider);
     Payment premium = trade.getPremium();
     PointSensitivityBuilder pvcsPremium = PRICER_PREMIUM.presentValueSensitivity(premium, ratesProvider);
-    return pvcsProduct.combinedWith(pvcsPremium);
+    return pvcsProduct.combinedWith(pvcsPremium).build();
   }
 
   //-------------------------------------------------------------------------
@@ -98,13 +99,13 @@ public class BlackFxSingleBarrierOptionTradePricer {
    * @param volatilityProvider  the Black volatility provider
    * @return the present value sensitivity
    */
-  public PointSensitivityBuilder presentValueSensitivityBlackVolatility(
+  public PointSensitivities presentValueSensitivityBlackVolatility(
       ResolvedFxSingleBarrierOptionTrade trade,
       RatesProvider ratesProvider,
       BlackVolatilityFxProvider volatilityProvider) {
 
     ResolvedFxSingleBarrierOption product = trade.getProduct();
-    return PRICER_PRODUCT.presentValueSensitivityVolatility(product, ratesProvider, volatilityProvider);
+    return PRICER_PRODUCT.presentValueSensitivityVolatility(product, ratesProvider, volatilityProvider).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackFxVanillaOptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/BlackFxVanillaOptionTradePricer.java
@@ -11,7 +11,6 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
-import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.product.fx.FxVanillaOption;
@@ -100,13 +99,13 @@ public class BlackFxVanillaOptionTradePricer {
    * @param volatilityProvider  the Black volatility provider
    * @return the present value sensitivity
    */
-  public PointSensitivityBuilder presentValueSensitivityBlackVolatility(
+  public PointSensitivities presentValueSensitivityBlackVolatility(
       ResolvedFxVanillaOptionTrade trade,
       RatesProvider ratesProvider,
       BlackVolatilityFxProvider volatilityProvider) {
 
     ResolvedFxVanillaOption product = trade.getProduct();
-    return PRICER_PRODUCT.presentValueSensitivityBlackVolatility(product, ratesProvider, volatilityProvider);
+    return PRICER_PRODUCT.presentValueSensitivityBlackVolatility(product, ratesProvider, volatilityProvider).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricerTest.java
@@ -352,7 +352,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivityFromCleanPrice_standard() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPrice(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -364,7 +364,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPrice_early_exCoupon() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPrice(
-        TRADE_EARLY, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE).build();
+        TRADE_EARLY, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -376,7 +376,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPrice_early() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPrice(
-        TRADE_EX_COUPON_EARLY, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE).build();
+        TRADE_EX_COUPON_EARLY, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -388,7 +388,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPrice_late() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPrice(
-        TRADE_LATE, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE).build();
+        TRADE_LATE, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -400,7 +400,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPriceWithZSpread_standard() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPriceWithZSpread(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, CONTINUOUS, 0).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, CONTINUOUS, 0);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -414,7 +414,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPriceWithZSpread_early_exCoupon() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPriceWithZSpread(TRADE_EX_COUPON_EARLY,
-        RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR).build();
+        RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -429,7 +429,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPriceWithZSpread_early() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPriceWithZSpread(TRADE_EARLY,
-        RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR).build();
+        RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -443,7 +443,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPriceWithZSpread_late() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPriceWithZSpread(TRADE_LATE,
-        RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR).build();
+        RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -457,7 +457,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityFromCleanPrice_fixed() {
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPrice(
-        TRADE_ILF_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE).build();
+        TRADE_ILF_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -528,7 +528,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivity_standard() {
     PointSensitivities point =
-        PRICER.presentValueSensitivity(TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA).build();
+        PRICER.presentValueSensitivity(TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -539,7 +539,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivity_late() {
     PointSensitivities point =
-        PRICER.presentValueSensitivity(TRADE_LATE, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA).build();
+        PRICER.presentValueSensitivity(TRADE_LATE, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -551,8 +551,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityWithZSpread_standard() {
     PointSensitivities point = PRICER.presentValueSensitivityWithZSpread(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC,
-            PERIOD_PER_YEAR).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER, p -> PRICER.presentValueWithZSpread(
@@ -564,7 +563,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivityWithZSpread_late() {
     PointSensitivities point = PRICER.presentValueSensitivityWithZSpread(
-        TRADE_LATE, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR).build();
+        TRADE_LATE, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER, p -> PRICER.presentValueWithZSpread(
@@ -576,7 +575,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
 
   public void test_presentValueSensitivity_fixed() {
     PointSensitivities point =
-        PRICER.presentValueSensitivity(TRADE_ILF_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA).build();
+        PRICER.presentValueSensitivity(TRADE_ILF_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA);
     CurrencyParameterSensitivities computed = ISSUER_RATES_PROVIDER.parameterSensitivity(point)
         .combinedWith(RATES_PROVIDER.parameterSensitivity(point));
     CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATES_PROVIDER,
@@ -590,7 +589,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
     MultiCurrencyAmount computed = PRICER.currencyExposureFromCleanPrice(
         TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPrice(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE);
     MultiCurrencyAmount expected = RATES_PROVIDER.currencyExposure(point).plus(
         PRICER.presentValueFromCleanPrice(TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE));
     assertEquals(computed.getAmounts().size(), 1);
@@ -601,8 +600,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
     MultiCurrencyAmount computed = PRICER.currencyExposureFromCleanPriceWithZSpread(
         TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     PointSensitivities point = PRICER.presentValueSensitivityFromCleanPriceWithZSpread(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC,
-        PERIOD_PER_YEAR).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     MultiCurrencyAmount expected = RATES_PROVIDER.currencyExposure(point).plus(
         PRICER.presentValueFromCleanPriceWithZSpread(TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER,
             REF_DATA, TRADE_PRICE, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR));
@@ -614,7 +612,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
     MultiCurrencyAmount computed =
         PRICER.currencyExposure(TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA);
     PointSensitivities point = PRICER.presentValueSensitivity(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA);
     MultiCurrencyAmount expected = RATES_PROVIDER.currencyExposure(point).plus(
         PRICER.presentValue(TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA));
     assertEquals(computed.getAmounts().size(), 1);
@@ -625,7 +623,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
     MultiCurrencyAmount computed = PRICER.currencyExposureWithZSpread(
         TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     PointSensitivities point = PRICER.presentValueSensitivityWithZSpread(
-        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR).build();
+        TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
     MultiCurrencyAmount expected = RATES_PROVIDER.currencyExposure(point).plus(PRICER.presentValueWithZSpread(
         TRADE_STANDARD, RATES_PROVIDER, ISSUER_RATES_PROVIDER, REF_DATA, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR));
     assertEquals(computed.getAmounts().size(), 1);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondTradePricerTest.java
@@ -45,7 +45,6 @@ import com.opengamma.strata.market.interpolator.CurveInterpolator;
 import com.opengamma.strata.market.interpolator.CurveInterpolators;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
-import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountFactors;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.ZeroRateDiscountFactors;
@@ -832,52 +831,52 @@ public class DiscountingFixedCouponBondTradePricerTest {
 
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivity() {
-    PointSensitivityBuilder pointTrade = TRADE_PRICER.presentValueSensitivity(TRADE, PROVIDER);
-    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade.build());
+    PointSensitivities pointTrade = TRADE_PRICER.presentValueSensitivity(TRADE, PROVIDER);
+    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade);
     CurrencyParameterSensitivities expectedTrade = FD_CAL.sensitivity(PROVIDER,
         (p) -> TRADE_PRICER.presentValue(TRADE, (p)));
     assertTrue(computedTrade.equalWithTolerance(expectedTrade, 30d * NOTIONAL * QUANTITY * EPS));
   }
 
   public void test_presentValueSensitivityWithZSpread_continuous() {
-    PointSensitivityBuilder pointTrade =
+    PointSensitivities pointTrade =
         TRADE_PRICER.presentValueSensitivityWithZSpread(TRADE, PROVIDER, Z_SPREAD, CONTINUOUS, 0);
-    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade.build());
+    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade);
     CurrencyParameterSensitivities expectedTrade = FD_CAL.sensitivity(
         PROVIDER, (p) -> TRADE_PRICER.presentValueWithZSpread(TRADE, (p), Z_SPREAD, CONTINUOUS, 0));
     assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
   }
 
   public void test_presentValueSensitivityWithZSpread_periodic() {
-    PointSensitivityBuilder pointTrade =
+    PointSensitivities pointTrade =
         TRADE_PRICER.presentValueSensitivityWithZSpread(TRADE, PROVIDER, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
-    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade.build());
+    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade);
     CurrencyParameterSensitivities expectedTrade = FD_CAL.sensitivity(PROVIDER,
         (p) -> TRADE_PRICER.presentValueWithZSpread(TRADE, (p), Z_SPREAD, PERIODIC, PERIOD_PER_YEAR));
     assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
   }
 
   public void test_presentValueProductSensitivity_noExcoupon() {
-    PointSensitivityBuilder pointTrade = TRADE_PRICER.presentValueSensitivity(TRADE_NO_EXCOUPON, PROVIDER);
-    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade.build());
+    PointSensitivities pointTrade = TRADE_PRICER.presentValueSensitivity(TRADE_NO_EXCOUPON, PROVIDER);
+    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade);
     CurrencyParameterSensitivities expectedTrade = FD_CAL.sensitivity(
         PROVIDER, (p) -> TRADE_PRICER.presentValue(TRADE_NO_EXCOUPON, (p)));
     assertTrue(computedTrade.equalWithTolerance(expectedTrade, 30d * NOTIONAL * QUANTITY * EPS));
   }
 
   public void test_presentValueSensitivityWithZSpread_continuous_noExcoupon() {
-    PointSensitivityBuilder pointTrade =
+    PointSensitivities pointTrade =
         TRADE_PRICER.presentValueSensitivityWithZSpread(TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, CONTINUOUS, 0);
-    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade.build());
+    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade);
     CurrencyParameterSensitivities expectedTrade = FD_CAL.sensitivity(PROVIDER, (p) ->
         TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, (p), Z_SPREAD, CONTINUOUS, 0));
     assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
   }
 
   public void test_presentValueSensitivityWithZSpread_periodic_noExcoupon() {
-    PointSensitivityBuilder pointTrade = TRADE_PRICER.presentValueSensitivityWithZSpread(
+    PointSensitivities pointTrade = TRADE_PRICER.presentValueSensitivityWithZSpread(
         TRADE_NO_EXCOUPON, PROVIDER, Z_SPREAD, PERIODIC, PERIOD_PER_YEAR);
-    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade.build());
+    CurrencyParameterSensitivities computedTrade = PROVIDER.parameterSensitivity(pointTrade);
     CurrencyParameterSensitivities expectedTrade = FD_CAL.sensitivity(PROVIDER, (p) ->
         TRADE_PRICER.presentValueWithZSpread(TRADE_NO_EXCOUPON, (p), Z_SPREAD, PERIODIC, PERIOD_PER_YEAR));
     assertTrue(computedTrade.equalWithTolerance(expectedTrade, 20d * NOTIONAL * QUANTITY * EPS));
@@ -891,7 +890,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER_BEFORE).build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER_BEFORE);
     // settle before detachment date
     ResolvedFixedCouponBondTrade tradeBefore = ResolvedFixedCouponBondTrade.builder()
         .info(TRADE_INFO_BEFORE)
@@ -900,7 +899,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .price(CLEAN_PRICE)
         .build();
     PointSensitivities computedTradeBefore =
-        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER_BEFORE).build();
+        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER_BEFORE);
     FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT, SETTLE_BEFORE, SETTLEMENT);
     PointSensitivities sensiExtra = COUPON_PRICER
         .presentValueSensitivity(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR)).build();
@@ -914,7 +913,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .price(CLEAN_PRICE)
         .build();
     PointSensitivities computedTradeOnDetachment =
-        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnDetachment, PROVIDER_BEFORE).build();
+        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnDetachment, PROVIDER_BEFORE);
     assertTrue(computedTradeOnDetachment.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
     // settle between detachment date and coupon date
     ResolvedFixedCouponBondTrade tradeBtwnDetachmentCoupon = ResolvedFixedCouponBondTrade.builder()
@@ -924,7 +923,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .price(CLEAN_PRICE)
         .build();
     PointSensitivities computedTradeBtwnDetachmentCoupon =
-        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBtwnDetachmentCoupon, PROVIDER_BEFORE).build();
+        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBtwnDetachmentCoupon, PROVIDER_BEFORE);
     assertTrue(computedTradeBtwnDetachmentCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
   }
 
@@ -935,7 +934,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER).build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER);
     // settle before detachment date
     ResolvedFixedCouponBondTrade tradeBefore = ResolvedFixedCouponBondTrade.builder()
         .info(TRADE_INFO_BEFORE)
@@ -943,7 +942,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeBefore = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER).build();
+    PointSensitivities computedTradeBefore = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER);
     assertTrue(computedTradeBefore.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
     // settle on detachment date
     ResolvedFixedCouponBondTrade tradeOnDetachment = ResolvedFixedCouponBondTrade.builder()
@@ -953,7 +952,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .price(CLEAN_PRICE)
         .build();
     PointSensitivities computedTradeOnDetachment =
-        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnDetachment, PROVIDER).build();
+        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnDetachment, PROVIDER);
     assertTrue(computedTradeOnDetachment.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
     // settle between detachment date and coupon date
     ResolvedFixedCouponBondTrade tradeBtwnDetachmentCoupon = ResolvedFixedCouponBondTrade.builder()
@@ -963,7 +962,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .price(CLEAN_PRICE)
         .build();
     PointSensitivities computedTradeBtwnDetachmentCoupon =
-        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBtwnDetachmentCoupon, PROVIDER).build();
+        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBtwnDetachmentCoupon, PROVIDER);
     assertTrue(computedTradeBtwnDetachmentCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
   }
 
@@ -974,7 +973,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER_BEFORE).build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER_BEFORE);
     // settle before coupon date
     ResolvedFixedCouponBondTrade tradeBefore = ResolvedFixedCouponBondTrade.builder()
         .info(TRADE_INFO_BEFORE)
@@ -983,7 +982,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .price(CLEAN_PRICE)
         .build();
     PointSensitivities computedTradeBefore =
-        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER_BEFORE).build();
+        TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER_BEFORE);
     FixedCouponBondPaymentPeriod periodExtra = findPeriod(PRODUCT_NO_EXCOUPON, SETTLE_BEFORE, SETTLEMENT);
     PointSensitivities sensiExtra = COUPON_PRICER
         .presentValueSensitivity(periodExtra, PROVIDER_BEFORE.issuerCurveDiscountFactors(ISSUER_ID, EUR)).build();
@@ -996,8 +995,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeOnCoupon = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnCoupon, PROVIDER_BEFORE)
-        .build();
+    PointSensitivities computedTradeOnCoupon = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnCoupon, PROVIDER_BEFORE);
     assertTrue(computedTradeOnCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
   }
 
@@ -1008,7 +1006,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER).build();
+    PointSensitivities computedTradeAfter = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeAfter, PROVIDER);
     // settle before coupon date
     ResolvedFixedCouponBondTrade tradeBefore = ResolvedFixedCouponBondTrade.builder()
         .info(TRADE_INFO_BEFORE)
@@ -1016,7 +1014,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeBefore = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER).build();
+    PointSensitivities computedTradeBefore = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeBefore, PROVIDER);
     assertTrue(computedTradeBefore.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
     // settle on coupon date
     ResolvedFixedCouponBondTrade tradeOnCoupon = ResolvedFixedCouponBondTrade.builder()
@@ -1025,7 +1023,7 @@ public class DiscountingFixedCouponBondTradePricerTest {
         .quantity(QUANTITY)
         .price(CLEAN_PRICE)
         .build();
-    PointSensitivities computedTradeOnCoupon = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnCoupon, PROVIDER).build();
+    PointSensitivities computedTradeOnCoupon = TRADE_PRICER_NO_UPFRONT.presentValueSensitivity(tradeOnCoupon, PROVIDER);
     assertTrue(computedTradeOnCoupon.equalWithTolerance(computedTradeAfter, NOTIONAL * QUANTITY * TOL));
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/BlackIborCapFloorTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/BlackIborCapFloorTradePricerTest.java
@@ -25,6 +25,7 @@ import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -99,13 +100,13 @@ public class BlackIborCapFloorTradePricerTest {
   }
 
   public void test_presentValueSensitivity() {
-    PointSensitivityBuilder computedWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
-    PointSensitivityBuilder computedWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
+    PointSensitivities computedWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
+    PointSensitivities computedWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
     PointSensitivityBuilder pvOneLeg = PRICER_PRODUCT.presentValueSensitivity(CAP_ONE_LEG, RATES, VOLS);
     PointSensitivityBuilder pvTwoLegs = PRICER_PRODUCT.presentValueSensitivity(CAP_TWO_LEGS, RATES, VOLS);
     PointSensitivityBuilder pvPrem = PRICER_PREMIUM.presentValueSensitivity(PREMIUM, RATES);
-    assertEquals(computedWithPayLeg, pvTwoLegs);
-    assertEquals(computedWithPremium, pvOneLeg.combinedWith(pvPrem));
+    assertEquals(computedWithPayLeg, pvTwoLegs.build());
+    assertEquals(computedWithPremium, pvOneLeg.combinedWith(pvPrem).build());
   }
 
   public void test_currencyExposure() {
@@ -113,10 +114,10 @@ public class BlackIborCapFloorTradePricerTest {
     MultiCurrencyAmount computedWithPremium = PRICER.currencyExposure(TRADE_PREMIUM, RATES, VOLS);
     MultiCurrencyAmount pvWithPayLeg = PRICER.presentValue(TRADE_PAYLEG, RATES, VOLS);
     MultiCurrencyAmount pvWithPremium = PRICER.presentValue(TRADE_PREMIUM, RATES, VOLS);
-    PointSensitivityBuilder pointWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
-    PointSensitivityBuilder pointWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
-    MultiCurrencyAmount expectedWithPayLeg = RATES.currencyExposure(pointWithPayLeg.build()).plus(pvWithPayLeg);
-    MultiCurrencyAmount expectedWithPremium = RATES.currencyExposure(pointWithPremium.build()).plus(pvWithPremium);
+    PointSensitivities pointWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
+    PointSensitivities pointWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
+    MultiCurrencyAmount expectedWithPayLeg = RATES.currencyExposure(pointWithPayLeg).plus(pvWithPayLeg);
+    MultiCurrencyAmount expectedWithPremium = RATES.currencyExposure(pointWithPremium).plus(pvWithPremium);
     assertEquals(computedWithPayLeg.getAmount(EUR).getAmount(),
         expectedWithPayLeg.getAmount(EUR).getAmount(), NOTIONAL_VALUE * TOL);
     assertEquals(computedWithPremium.getAmount(EUR).getAmount(),

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/NormalIborCapFloorTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/NormalIborCapFloorTradePricerTest.java
@@ -24,7 +24,7 @@ import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
-import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.product.TradeInfo;
@@ -99,11 +99,11 @@ public class NormalIborCapFloorTradePricerTest {
   }
 
   public void test_presentValueSensitivity() {
-    PointSensitivityBuilder computedWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
-    PointSensitivityBuilder computedWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
-    PointSensitivityBuilder pvOneLeg = PRICER_PRODUCT.presentValueSensitivity(CAP_ONE_LEG, RATES, VOLS);
-    PointSensitivityBuilder pvTwoLegs = PRICER_PRODUCT.presentValueSensitivity(CAP_TWO_LEGS, RATES, VOLS);
-    PointSensitivityBuilder pvPrem = PRICER_PREMIUM.presentValueSensitivity(PREMIUM, RATES);
+    PointSensitivities computedWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
+    PointSensitivities computedWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
+    PointSensitivities pvOneLeg = PRICER_PRODUCT.presentValueSensitivity(CAP_ONE_LEG, RATES, VOLS).build();
+    PointSensitivities pvTwoLegs = PRICER_PRODUCT.presentValueSensitivity(CAP_TWO_LEGS, RATES, VOLS).build();
+    PointSensitivities pvPrem = PRICER_PREMIUM.presentValueSensitivity(PREMIUM, RATES).build();
     assertEquals(computedWithPayLeg, pvTwoLegs);
     assertEquals(computedWithPremium, pvOneLeg.combinedWith(pvPrem));
   }
@@ -113,10 +113,10 @@ public class NormalIborCapFloorTradePricerTest {
     MultiCurrencyAmount computedWithPremium = PRICER.currencyExposure(TRADE_PREMIUM, RATES, VOLS);
     MultiCurrencyAmount pvWithPayLeg = PRICER.presentValue(TRADE_PAYLEG, RATES, VOLS);
     MultiCurrencyAmount pvWithPremium = PRICER.presentValue(TRADE_PREMIUM, RATES, VOLS);
-    PointSensitivityBuilder pointWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
-    PointSensitivityBuilder pointWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
-    MultiCurrencyAmount expectedWithPayLeg = RATES.currencyExposure(pointWithPayLeg.build()).plus(pvWithPayLeg);
-    MultiCurrencyAmount expectedWithPremium = RATES.currencyExposure(pointWithPremium.build()).plus(pvWithPremium);
+    PointSensitivities pointWithPayLeg = PRICER.presentValueSensitivity(TRADE_PAYLEG, RATES, VOLS);
+    PointSensitivities pointWithPremium = PRICER.presentValueSensitivity(TRADE_PREMIUM, RATES, VOLS);
+    MultiCurrencyAmount expectedWithPayLeg = RATES.currencyExposure(pointWithPayLeg).plus(pvWithPayLeg);
+    MultiCurrencyAmount expectedWithPremium = RATES.currencyExposure(pointWithPremium).plus(pvWithPremium);
     assertEquals(computedWithPayLeg.getAmount(EUR).getAmount(),
         expectedWithPayLeg.getAmount(EUR).getAmount(), NOTIONAL_VALUE * TOL);
     assertEquals(computedWithPremium.getAmount(EUR).getAmount(),

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/DiscountingCmsTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/DiscountingCmsTradePricerTest.java
@@ -29,6 +29,7 @@ import com.opengamma.strata.basics.schedule.RollConventions;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
@@ -122,24 +123,24 @@ public class DiscountingCmsTradePricerTest {
   }
 
   public void test_presentValueSensitivity() {
-    PointSensitivityBuilder pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER);
-    PointSensitivityBuilder pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER);
+    PointSensitivities pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER);
+    PointSensitivities pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER);
     PointSensitivityBuilder ptProd1 = PRODUCT_PRICER.presentValueSensitivity(CMS_ONE_LEG, RATES_PROVIDER);
     PointSensitivityBuilder ptProd2 = PRODUCT_PRICER.presentValueSensitivity(CMS_TWO_LEGS, RATES_PROVIDER);
     PointSensitivityBuilder ptPrem = PREMIUM_PRICER.presentValueSensitivity(PREMIUM, RATES_PROVIDER);
-    assertEquals(pt1, ptProd1.combinedWith(ptPrem));
-    assertEquals(pt2, ptProd2);
+    assertEquals(pt1, ptProd1.combinedWith(ptPrem).build());
+    assertEquals(pt2, ptProd2.build());
   }
 
   public void test_currencyExposure() {
     MultiCurrencyAmount computed1 = TRADE_PRICER.currencyExposure(CMS_TRADE_PREMIUM, RATES_PROVIDER);
     MultiCurrencyAmount computed2 = TRADE_PRICER.currencyExposure(CMS_TRADE, RATES_PROVIDER);
     MultiCurrencyAmount pv1 = TRADE_PRICER.presentValue(CMS_TRADE_PREMIUM, RATES_PROVIDER);
-    PointSensitivityBuilder pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER);
-    MultiCurrencyAmount expected1 = RATES_PROVIDER.currencyExposure(pt1.build()).plus(pv1);
+    PointSensitivities pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER);
+    MultiCurrencyAmount expected1 = RATES_PROVIDER.currencyExposure(pt1).plus(pv1);
     MultiCurrencyAmount pv2 = TRADE_PRICER.presentValue(CMS_TRADE, RATES_PROVIDER);
-    PointSensitivityBuilder pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER);
-    MultiCurrencyAmount expected2 = RATES_PROVIDER.currencyExposure(pt2.build()).plus(pv2);
+    PointSensitivities pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER);
+    MultiCurrencyAmount expected2 = RATES_PROVIDER.currencyExposure(pt2).plus(pv2);
     assertEquals(computed1.getAmount(EUR).getAmount(), expected1.getAmount(EUR).getAmount(), NOTIONAL_VALUE * TOL);
     assertEquals(computed2.getAmount(EUR).getAmount(), expected2.getAmount(EUR).getAmount(), NOTIONAL_VALUE * TOL);
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsTradePricerTest.java
@@ -139,20 +139,20 @@ public class SabrExtrapolationReplicationCmsTradePricerTest {
   }
 
   public void test_presentValueSensitivity() {
-    PointSensitivityBuilder pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
-    PointSensitivityBuilder pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
+    PointSensitivities pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
+    PointSensitivities pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
     PointSensitivityBuilder ptProd1 = PRODUCT_PRICER.presentValueSensitivity(CMS_ONE_LEG, RATES_PROVIDER, VOLATILITIES);
     PointSensitivityBuilder ptProd2 = PRODUCT_PRICER.presentValueSensitivity(CMS_TWO_LEGS, RATES_PROVIDER, VOLATILITIES);
     PointSensitivityBuilder ptPrem = PREMIUM_PRICER.presentValueSensitivity(PREMIUM, RATES_PROVIDER);
-    assertEquals(pt1, ptProd1.combinedWith(ptPrem));
-    assertEquals(pt2, ptProd2);
+    assertEquals(pt1, ptProd1.combinedWith(ptPrem).build());
+    assertEquals(pt2, ptProd2.build());
   }
 
   public void test_presentValueSensitivitySabrParameter() {
     PointSensitivities pt1 =
-        TRADE_PRICER.presentValueSensitivitySabrParameter(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES).build();
+        TRADE_PRICER.presentValueSensitivitySabrParameter(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
     PointSensitivities pt2 =
-        TRADE_PRICER.presentValueSensitivitySabrParameter(CMS_TRADE, RATES_PROVIDER, VOLATILITIES).build();
+        TRADE_PRICER.presentValueSensitivitySabrParameter(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
     PointSensitivities ptProd1 =
         PRODUCT_PRICER.presentValueSensitivitySabrParameter(CMS_ONE_LEG, RATES_PROVIDER, VOLATILITIES).build();
     PointSensitivities ptProd2 =
@@ -174,11 +174,11 @@ public class SabrExtrapolationReplicationCmsTradePricerTest {
     MultiCurrencyAmount computed1 = TRADE_PRICER.currencyExposure(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
     MultiCurrencyAmount computed2 = TRADE_PRICER.currencyExposure(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
     MultiCurrencyAmount pv1 = TRADE_PRICER.presentValue(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
-    PointSensitivityBuilder pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
-    MultiCurrencyAmount expected1 = RATES_PROVIDER.currencyExposure(pt1.build()).plus(pv1);
+    PointSensitivities pt1 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE_PREMIUM, RATES_PROVIDER, VOLATILITIES);
+    MultiCurrencyAmount expected1 = RATES_PROVIDER.currencyExposure(pt1).plus(pv1);
     MultiCurrencyAmount pv2 = TRADE_PRICER.presentValue(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
-    PointSensitivityBuilder pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
-    MultiCurrencyAmount expected2 = RATES_PROVIDER.currencyExposure(pt2.build()).plus(pv2);
+    PointSensitivities pt2 = TRADE_PRICER.presentValueSensitivity(CMS_TRADE, RATES_PROVIDER, VOLATILITIES);
+    MultiCurrencyAmount expected2 = RATES_PROVIDER.currencyExposure(pt2).plus(pv2);
     assertEquals(computed1.getAmount(EUR).getAmount(), expected1.getAmount(EUR).getAmount(), NOTIONAL_VALUE * TOL);
     assertEquals(computed2.getAmount(EUR).getAmount(), expected2.getAmount(EUR).getAmount(), NOTIONAL_VALUE * TOL);
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/BlackFxSingleBarrierOptionTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/BlackFxSingleBarrierOptionTradePricerTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
-import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.product.TradeInfo;
@@ -87,19 +87,19 @@ public class BlackFxSingleBarrierOptionTradePricerTest {
   }
 
   public void test_presentValueSensitivity() {
-    PointSensitivityBuilder pvSensiTrade =
+    PointSensitivities pvSensiTrade =
         PRICER_TRADE.presentValueSensitivityStickyStrike(OPTION_TRADE, RATES_PROVIDER, VOL_PROVIDER);
-    PointSensitivityBuilder pvSensiProduct =
-        PRICER_PRODUCT.presentValueSensitivityStickyStrike(OPTION_PRODUCT, RATES_PROVIDER, VOL_PROVIDER);
-    PointSensitivityBuilder pvSensiPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM, RATES_PROVIDER);
+    PointSensitivities pvSensiProduct =
+        PRICER_PRODUCT.presentValueSensitivityStickyStrike(OPTION_PRODUCT, RATES_PROVIDER, VOL_PROVIDER).build();
+    PointSensitivities pvSensiPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM, RATES_PROVIDER).build();
     assertEquals(pvSensiTrade, pvSensiProduct.combinedWith(pvSensiPremium));
   }
 
   public void test_presentValueSensitivityBlackVolatility() {
-    PointSensitivityBuilder pvSensiTrade =
+    PointSensitivities pvSensiTrade =
         PRICER_TRADE.presentValueSensitivityBlackVolatility(OPTION_TRADE, RATES_PROVIDER, VOL_PROVIDER);
-    PointSensitivityBuilder pvSensiProduct =
-        PRICER_PRODUCT.presentValueSensitivityVolatility(OPTION_PRODUCT, RATES_PROVIDER, VOL_PROVIDER);
+    PointSensitivities pvSensiProduct =
+        PRICER_PRODUCT.presentValueSensitivityVolatility(OPTION_PRODUCT, RATES_PROVIDER, VOL_PROVIDER).build();
     assertEquals(pvSensiTrade, pvSensiProduct);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/BlackFxVanillaOptionTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/BlackFxVanillaOptionTradePricerTest.java
@@ -26,7 +26,6 @@ import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
-import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.DiscountingPaymentPricer;
 import com.opengamma.strata.pricer.datasets.RatesProviderDataSets;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -106,10 +105,10 @@ public class BlackFxVanillaOptionTradePricerTest {
   }
 
   public void test_presentValueSensitivityBlackVolatility() {
-    PointSensitivityBuilder pvSensiTrade =
+    PointSensitivities pvSensiTrade =
         PRICER_TRADE.presentValueSensitivityBlackVolatility(OPTION_TRADE, RATES_PROVIDER, VOL_PROVIDER);
-    PointSensitivityBuilder pvSensiProduct =
-        PRICER_PRODUCT.presentValueSensitivityBlackVolatility(OPTION_PRODUCT, RATES_PROVIDER, VOL_PROVIDER);
+    PointSensitivities pvSensiProduct =
+        PRICER_PRODUCT.presentValueSensitivityBlackVolatility(OPTION_PRODUCT, RATES_PROVIDER, VOL_PROVIDER).build();
     assertEquals(pvSensiTrade, pvSensiProduct);
   }
 


### PR DESCRIPTION
`PointSensitivityBuilder` can be used at the product level and below, but the trade level should use `PointSensitivities`.