### PR TITLE
Rename IborRateAveragingMethod to IborRateResetMethod Fixes #1083

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/SwapFpmlParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/SwapFpmlParserPlugin.java
@@ -38,8 +38,8 @@ import com.opengamma.strata.product.swap.CompoundingMethod;
 import com.opengamma.strata.product.swap.FixedRateCalculation;
 import com.opengamma.strata.product.swap.FixedRateStubCalculation;
 import com.opengamma.strata.product.swap.FixingRelativeTo;
-import com.opengamma.strata.product.swap.IborRateAveragingMethod;
 import com.opengamma.strata.product.swap.IborRateCalculation;
+import com.opengamma.strata.product.swap.IborRateResetMethod;
 import com.opengamma.strata.product.swap.IborRateStubCalculation;
 import com.opengamma.strata.product.swap.InflationRateCalculation;
 import com.opengamma.strata.product.swap.KnownAmountSwapLeg;
@@ -450,7 +450,7 @@ final class SwapFpmlParserPlugin
         ResetSchedule.Builder resetScheduleBuilder = ResetSchedule.builder();
         resetScheduleBuilder.resetFrequency(resetFreq);
         floatingEl.findChild("averagingMethod").ifPresent(el -> {
-          resetScheduleBuilder.averagingMethod(parseAveragingMethod(el));
+          resetScheduleBuilder.resetMethod(parseAveragingMethod(el));
         });
         resetScheduleBuilder.businessDayAdjustment(
             document.parseBusinessDayAdjustments(resetDatesEl.getChild("resetDatesAdjustments")));
@@ -705,14 +705,14 @@ final class SwapFpmlParserPlugin
     }
   }
 
-  // Converts an FpML 'AveragingMethodEnum' to a {@code IborRateAveragingMethod}.
-  private IborRateAveragingMethod parseAveragingMethod(XmlElement baseEl) {
+  // Converts an FpML 'AveragingMethodEnum' to a {@code IborRateResetMethod}.
+  private IborRateResetMethod parseAveragingMethod(XmlElement baseEl) {
     if (baseEl.getContent().equals("Unweighted")) {
-      return IborRateAveragingMethod.UNWEIGHTED;
+      return IborRateResetMethod.UNWEIGHTED;
     } else if (baseEl.getContent().equals("Weighted")) {
-      return IborRateAveragingMethod.WEIGHTED;
+      return IborRateResetMethod.WEIGHTED;
     } else {
-      throw new FpmlParseException(Messages.format("Unknown 'averagingMethod': {}", baseEl.getContent()));
+      throw new FpmlParseException(Messages.format("Unknown 'resetMethod': {}", baseEl.getContent()));
     }
   }
 

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlDocumentParserTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlDocumentParserTest.java
@@ -101,8 +101,8 @@ import com.opengamma.strata.product.rate.IborInterpolatedRateComputation;
 import com.opengamma.strata.product.rate.IborRateComputation;
 import com.opengamma.strata.product.swap.CompoundingMethod;
 import com.opengamma.strata.product.swap.FixedRateCalculation;
-import com.opengamma.strata.product.swap.IborRateAveragingMethod;
 import com.opengamma.strata.product.swap.IborRateCalculation;
+import com.opengamma.strata.product.swap.IborRateResetMethod;
 import com.opengamma.strata.product.swap.InflationRateCalculation;
 import com.opengamma.strata.product.swap.NotionalSchedule;
 import com.opengamma.strata.product.swap.OvernightRateCalculation;
@@ -932,7 +932,7 @@ public class FpmlDocumentParserTest {
             .index(USD_LIBOR_6M)
             .resetPeriods(ResetSchedule.builder()
                 .resetFrequency(Frequency.P1M)
-                .averagingMethod(IborRateAveragingMethod.UNWEIGHTED)
+                .resetMethod(IborRateResetMethod.UNWEIGHTED)
                 .businessDayAdjustment(BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO))
                 .build())
             .dayCount(ACT_360)

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateCalculation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateCalculation.java
@@ -8,7 +8,7 @@ package com.opengamma.strata.product.swap;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.opengamma.strata.basics.value.ValueSchedule.ALWAYS_0;
 import static com.opengamma.strata.basics.value.ValueSchedule.ALWAYS_1;
-import static com.opengamma.strata.product.swap.IborRateAveragingMethod.UNWEIGHTED;
+import static com.opengamma.strata.product.swap.IborRateResetMethod.UNWEIGHTED;
 
 import java.io.Serializable;
 import java.time.LocalDate;
@@ -358,7 +358,7 @@ public final class IborRateCalculation
       fixings.add(IborAveragedFixing.builder()
           .observation(iborObservationFn.apply(fixingDate))
           .fixedRate(firstRegular && i == 0 ? firstRegularRate : null)
-          .weight(resetPeriods.getAveragingMethod() == UNWEIGHTED ? 1 : resetPeriod.lengthInDays())
+          .weight(resetPeriods.getResetMethod() == UNWEIGHTED ? 1 : resetPeriod.lengthInDays())
           .build());
     }
     return IborAveragedRateComputation.of(fixings);

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateResetMethod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateResetMethod.java
@@ -12,15 +12,15 @@ import com.google.common.base.CaseFormat;
 import com.opengamma.strata.collect.ArgChecker;
 
 /**
- * A convention defining how to average floating rates.
+ * A convention defining how to process a floating rate reset schedule.
  * <p>
- * When calculating interest, it may be necessary to average a number of different rates.
- * This method defines how to perform the averaging.
+ * When calculating interest, there may be multiple reset dates for a given accrual period.
+ * This typically involves an average of a number of different rate fixings.
  */
 public enum IborRateResetMethod {
 
   /**
-   * The unweighted method.
+   * The unweighted average method.
    * <p>
    * The result is a simple average of the applicable rates.
    * <p>
@@ -28,7 +28,7 @@ public enum IborRateResetMethod {
    */
   UNWEIGHTED,
   /**
-   * The weighted method.
+   * The weighted average method.
    * <p>
    * The result is a weighted average of the applicable rates based on the
    * number of days each rate is applicable.

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateResetMethod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateResetMethod.java
@@ -17,7 +17,7 @@ import com.opengamma.strata.collect.ArgChecker;
  * When calculating interest, it may be necessary to average a number of different rates.
  * This method defines how to perform the averaging.
  */
-public enum IborRateAveragingMethod {
+public enum IborRateResetMethod {
 
   /**
    * The unweighted method.
@@ -46,7 +46,7 @@ public enum IborRateAveragingMethod {
    * @throws IllegalArgumentException if the name is not known
    */
   @FromString
-  public static IborRateAveragingMethod of(String uniqueName) {
+  public static IborRateResetMethod of(String uniqueName) {
     ArgChecker.notNull(uniqueName, "uniqueName");
     return valueOf(CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, uniqueName));
   }

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/ResetSchedule.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/ResetSchedule.java
@@ -74,7 +74,7 @@ public final class ResetSchedule
   @PropertyDefinition(validate = "notNull")
   private final BusinessDayAdjustment businessDayAdjustment;
   /**
-   * The rate averaging method, defaulted to 'Unweighted'.
+   * The rate reset method, defaulted to 'Unweighted'.
    * <p>
    * This is used when more than one fixing contributes to the accrual period.
    * <p>
@@ -84,12 +84,12 @@ public final class ResetSchedule
    * Defined by the 2006 ISDA definitions article 6.2a.
    */
   @PropertyDefinition(validate = "notNull")
-  private final IborRateAveragingMethod averagingMethod;
+  private final IborRateResetMethod resetMethod;
 
   //-------------------------------------------------------------------------
   @ImmutableDefaults
   private static void applyDefaults(Builder builder) {
-    builder.averagingMethod(IborRateAveragingMethod.UNWEIGHTED);
+    builder.resetMethod(IborRateResetMethod.UNWEIGHTED);
   }
 
   //-------------------------------------------------------------------------
@@ -146,13 +146,13 @@ public final class ResetSchedule
   private ResetSchedule(
       Frequency resetFrequency,
       BusinessDayAdjustment businessDayAdjustment,
-      IborRateAveragingMethod averagingMethod) {
+      IborRateResetMethod resetMethod) {
     JodaBeanUtils.notNull(resetFrequency, "resetFrequency");
     JodaBeanUtils.notNull(businessDayAdjustment, "businessDayAdjustment");
-    JodaBeanUtils.notNull(averagingMethod, "averagingMethod");
+    JodaBeanUtils.notNull(resetMethod, "resetMethod");
     this.resetFrequency = resetFrequency;
     this.businessDayAdjustment = businessDayAdjustment;
-    this.averagingMethod = averagingMethod;
+    this.resetMethod = resetMethod;
   }
 
   @Override
@@ -200,7 +200,7 @@ public final class ResetSchedule
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the rate averaging method, defaulted to 'Unweighted'.
+   * Gets the rate reset method, defaulted to 'Unweighted'.
    * <p>
    * This is used when more than one fixing contributes to the accrual period.
    * <p>
@@ -210,8 +210,8 @@ public final class ResetSchedule
    * Defined by the 2006 ISDA definitions article 6.2a.
    * @return the value of the property, not null
    */
-  public IborRateAveragingMethod getAveragingMethod() {
-    return averagingMethod;
+  public IborRateResetMethod getResetMethod() {
+    return resetMethod;
   }
 
   //-----------------------------------------------------------------------
@@ -232,7 +232,7 @@ public final class ResetSchedule
       ResetSchedule other = (ResetSchedule) obj;
       return JodaBeanUtils.equal(resetFrequency, other.resetFrequency) &&
           JodaBeanUtils.equal(businessDayAdjustment, other.businessDayAdjustment) &&
-          JodaBeanUtils.equal(averagingMethod, other.averagingMethod);
+          JodaBeanUtils.equal(resetMethod, other.resetMethod);
     }
     return false;
   }
@@ -242,7 +242,7 @@ public final class ResetSchedule
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(resetFrequency);
     hash = hash * 31 + JodaBeanUtils.hashCode(businessDayAdjustment);
-    hash = hash * 31 + JodaBeanUtils.hashCode(averagingMethod);
+    hash = hash * 31 + JodaBeanUtils.hashCode(resetMethod);
     return hash;
   }
 
@@ -252,7 +252,7 @@ public final class ResetSchedule
     buf.append("ResetSchedule{");
     buf.append("resetFrequency").append('=').append(resetFrequency).append(',').append(' ');
     buf.append("businessDayAdjustment").append('=').append(businessDayAdjustment).append(',').append(' ');
-    buf.append("averagingMethod").append('=').append(JodaBeanUtils.toString(averagingMethod));
+    buf.append("resetMethod").append('=').append(JodaBeanUtils.toString(resetMethod));
     buf.append('}');
     return buf.toString();
   }
@@ -278,10 +278,10 @@ public final class ResetSchedule
     private final MetaProperty<BusinessDayAdjustment> businessDayAdjustment = DirectMetaProperty.ofImmutable(
         this, "businessDayAdjustment", ResetSchedule.class, BusinessDayAdjustment.class);
     /**
-     * The meta-property for the {@code averagingMethod} property.
+     * The meta-property for the {@code resetMethod} property.
      */
-    private final MetaProperty<IborRateAveragingMethod> averagingMethod = DirectMetaProperty.ofImmutable(
-        this, "averagingMethod", ResetSchedule.class, IborRateAveragingMethod.class);
+    private final MetaProperty<IborRateResetMethod> resetMethod = DirectMetaProperty.ofImmutable(
+        this, "resetMethod", ResetSchedule.class, IborRateResetMethod.class);
     /**
      * The meta-properties.
      */
@@ -289,7 +289,7 @@ public final class ResetSchedule
         this, null,
         "resetFrequency",
         "businessDayAdjustment",
-        "averagingMethod");
+        "resetMethod");
 
     /**
      * Restricted constructor.
@@ -304,8 +304,8 @@ public final class ResetSchedule
           return resetFrequency;
         case -1065319863:  // businessDayAdjustment
           return businessDayAdjustment;
-        case -1476458213:  // averagingMethod
-          return averagingMethod;
+        case -958176496:  // resetMethod
+          return resetMethod;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -343,11 +343,11 @@ public final class ResetSchedule
     }
 
     /**
-     * The meta-property for the {@code averagingMethod} property.
+     * The meta-property for the {@code resetMethod} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<IborRateAveragingMethod> averagingMethod() {
-      return averagingMethod;
+    public MetaProperty<IborRateResetMethod> resetMethod() {
+      return resetMethod;
     }
 
     //-----------------------------------------------------------------------
@@ -358,8 +358,8 @@ public final class ResetSchedule
           return ((ResetSchedule) bean).getResetFrequency();
         case -1065319863:  // businessDayAdjustment
           return ((ResetSchedule) bean).getBusinessDayAdjustment();
-        case -1476458213:  // averagingMethod
-          return ((ResetSchedule) bean).getAveragingMethod();
+        case -958176496:  // resetMethod
+          return ((ResetSchedule) bean).getResetMethod();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -383,7 +383,7 @@ public final class ResetSchedule
 
     private Frequency resetFrequency;
     private BusinessDayAdjustment businessDayAdjustment;
-    private IborRateAveragingMethod averagingMethod;
+    private IborRateResetMethod resetMethod;
 
     /**
      * Restricted constructor.
@@ -399,7 +399,7 @@ public final class ResetSchedule
     private Builder(ResetSchedule beanToCopy) {
       this.resetFrequency = beanToCopy.getResetFrequency();
       this.businessDayAdjustment = beanToCopy.getBusinessDayAdjustment();
-      this.averagingMethod = beanToCopy.getAveragingMethod();
+      this.resetMethod = beanToCopy.getResetMethod();
     }
 
     //-----------------------------------------------------------------------
@@ -410,8 +410,8 @@ public final class ResetSchedule
           return resetFrequency;
         case -1065319863:  // businessDayAdjustment
           return businessDayAdjustment;
-        case -1476458213:  // averagingMethod
-          return averagingMethod;
+        case -958176496:  // resetMethod
+          return resetMethod;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -426,8 +426,8 @@ public final class ResetSchedule
         case -1065319863:  // businessDayAdjustment
           this.businessDayAdjustment = (BusinessDayAdjustment) newValue;
           break;
-        case -1476458213:  // averagingMethod
-          this.averagingMethod = (IborRateAveragingMethod) newValue;
+        case -958176496:  // resetMethod
+          this.resetMethod = (IborRateResetMethod) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -464,7 +464,7 @@ public final class ResetSchedule
       return new ResetSchedule(
           resetFrequency,
           businessDayAdjustment,
-          averagingMethod);
+          resetMethod);
     }
 
     //-----------------------------------------------------------------------
@@ -501,7 +501,7 @@ public final class ResetSchedule
     }
 
     /**
-     * Sets the rate averaging method, defaulted to 'Unweighted'.
+     * Sets the rate reset method, defaulted to 'Unweighted'.
      * <p>
      * This is used when more than one fixing contributes to the accrual period.
      * <p>
@@ -509,12 +509,12 @@ public final class ResetSchedule
      * The number of days is based on the reset period, not the period between two fixing dates.
      * <p>
      * Defined by the 2006 ISDA definitions article 6.2a.
-     * @param averagingMethod  the new value, not null
+     * @param resetMethod  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder averagingMethod(IborRateAveragingMethod averagingMethod) {
-      JodaBeanUtils.notNull(averagingMethod, "averagingMethod");
-      this.averagingMethod = averagingMethod;
+    public Builder resetMethod(IborRateResetMethod resetMethod) {
+      JodaBeanUtils.notNull(resetMethod, "resetMethod");
+      this.resetMethod = resetMethod;
       return this;
     }
 
@@ -525,7 +525,7 @@ public final class ResetSchedule
       buf.append("ResetSchedule.Builder{");
       buf.append("resetFrequency").append('=').append(JodaBeanUtils.toString(resetFrequency)).append(',').append(' ');
       buf.append("businessDayAdjustment").append('=').append(JodaBeanUtils.toString(businessDayAdjustment)).append(',').append(' ');
-      buf.append("averagingMethod").append('=').append(JodaBeanUtils.toString(averagingMethod));
+      buf.append("resetMethod").append('=').append(JodaBeanUtils.toString(resetMethod));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateAveragingMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateAveragingMethodTest.java
@@ -24,40 +24,40 @@ public class IborRateAveragingMethodTest {
   @DataProvider(name = "name")
   static Object[][] data_name() {
     return new Object[][] {
-        {IborRateAveragingMethod.WEIGHTED, "Weighted"},
-        {IborRateAveragingMethod.UNWEIGHTED, "Unweighted"},
+        {IborRateResetMethod.WEIGHTED, "Weighted"},
+        {IborRateResetMethod.UNWEIGHTED, "Unweighted"},
     };
   }
 
   @Test(dataProvider = "name")
-  public void test_toString(IborRateAveragingMethod convention, String name) {
+  public void test_toString(IborRateResetMethod convention, String name) {
     assertEquals(convention.toString(), name);
   }
 
   @Test(dataProvider = "name")
-  public void test_of_lookup(IborRateAveragingMethod convention, String name) {
-    assertEquals(IborRateAveragingMethod.of(name), convention);
+  public void test_of_lookup(IborRateResetMethod convention, String name) {
+    assertEquals(IborRateResetMethod.of(name), convention);
   }
 
   public void test_of_lookup_notFound() {
-    assertThrows(() -> IborRateAveragingMethod.of("Rubbish"), IllegalArgumentException.class);
+    assertThrows(() -> IborRateResetMethod.of("Rubbish"), IllegalArgumentException.class);
   }
 
   public void test_of_lookup_null() {
-    assertThrows(() -> IborRateAveragingMethod.of(null), IllegalArgumentException.class);
+    assertThrows(() -> IborRateResetMethod.of(null), IllegalArgumentException.class);
   }
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    coverEnum(IborRateAveragingMethod.class);
+    coverEnum(IborRateResetMethod.class);
   }
 
   public void test_serialization() {
-    assertSerialization(IborRateAveragingMethod.WEIGHTED);
+    assertSerialization(IborRateResetMethod.WEIGHTED);
   }
 
   public void test_jodaConvert() {
-    assertJodaConvert(IborRateAveragingMethod.class, IborRateAveragingMethod.WEIGHTED);
+    assertJodaConvert(IborRateResetMethod.class, IborRateResetMethod.WEIGHTED);
   }
 
 }

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateCalculationTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateCalculationTest.java
@@ -23,8 +23,8 @@ import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.product.swap.FixingRelativeTo.PERIOD_END;
 import static com.opengamma.strata.product.swap.FixingRelativeTo.PERIOD_START;
-import static com.opengamma.strata.product.swap.IborRateAveragingMethod.UNWEIGHTED;
-import static com.opengamma.strata.product.swap.IborRateAveragingMethod.WEIGHTED;
+import static com.opengamma.strata.product.swap.IborRateResetMethod.UNWEIGHTED;
+import static com.opengamma.strata.product.swap.IborRateResetMethod.WEIGHTED;
 import static com.opengamma.strata.product.swap.NegativeRateMethod.ALLOW_NEGATIVE;
 import static com.opengamma.strata.product.swap.NegativeRateMethod.NOT_NEGATIVE;
 import static org.testng.Assert.assertEquals;
@@ -427,7 +427,7 @@ public class IborRateCalculationTest {
         .resetPeriods(ResetSchedule.builder()
             .resetFrequency(P1M)
             .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
-            .averagingMethod(WEIGHTED)
+            .resetMethod(WEIGHTED)
             .build())
         .build();
 
@@ -474,7 +474,7 @@ public class IborRateCalculationTest {
         .resetPeriods(ResetSchedule.builder()
             .resetFrequency(P1M)
             .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
-            .averagingMethod(WEIGHTED)
+            .resetMethod(WEIGHTED)
             .build())
         .firstRegularRate(0.028d)
         .build();
@@ -522,7 +522,7 @@ public class IborRateCalculationTest {
         .resetPeriods(ResetSchedule.builder()
             .resetFrequency(P1M)
             .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
-            .averagingMethod(UNWEIGHTED)
+            .resetMethod(UNWEIGHTED)
             .build())
         .build();
 
@@ -569,7 +569,7 @@ public class IborRateCalculationTest {
         .resetPeriods(ResetSchedule.builder()
             .resetFrequency(P1M)
             .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, GBLO))
-            .averagingMethod(WEIGHTED)
+            .resetMethod(WEIGHTED)
             .build())
         .firstRegularRate(0.028d)
         .initialStub(IborRateStubCalculation.ofFixedRate(0.030d))
@@ -648,7 +648,7 @@ public class IborRateCalculationTest {
         .index(GBP_LIBOR_6M)
         .resetPeriods(ResetSchedule.builder()
             .resetFrequency(P3M)
-            .averagingMethod(IborRateAveragingMethod.UNWEIGHTED)
+            .resetMethod(IborRateResetMethod.UNWEIGHTED)
             .businessDayAdjustment(BusinessDayAdjustment.NONE)
             .build())
         .fixingDateOffset(MINUS_THREE_DAYS)

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateResetMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateResetMethodTest.java
@@ -15,10 +15,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Test.
+ * Test {@link IborRateResetMethod}.
  */
 @Test
-public class IborRateAveragingMethodTest {
+public class IborRateResetMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/ResetScheduleTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/ResetScheduleTest.java
@@ -15,8 +15,8 @@ import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
-import static com.opengamma.strata.product.swap.IborRateAveragingMethod.UNWEIGHTED;
-import static com.opengamma.strata.product.swap.IborRateAveragingMethod.WEIGHTED;
+import static com.opengamma.strata.product.swap.IborRateResetMethod.UNWEIGHTED;
+import static com.opengamma.strata.product.swap.IborRateResetMethod.WEIGHTED;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -50,7 +50,7 @@ public class ResetScheduleTest {
         .build();
     assertEquals(test.getResetFrequency(), P1M);
     assertEquals(test.getBusinessDayAdjustment(), BusinessDayAdjustment.of(FOLLOWING, GBLO));
-    assertEquals(test.getAveragingMethod(), UNWEIGHTED);
+    assertEquals(test.getResetMethod(), UNWEIGHTED);
   }
 
   //-------------------------------------------------------------------------
@@ -82,7 +82,7 @@ public class ResetScheduleTest {
     ResetSchedule test2 = ResetSchedule.builder()
         .resetFrequency(P3M)
         .businessDayAdjustment(BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO))
-        .averagingMethod(WEIGHTED)
+        .resetMethod(WEIGHTED)
         .build();
     coverBeanEquals(test, test2);
   }


### PR DESCRIPTION
This allows for additional, non averaging, reset types to be added.