### PR TITLE
Bond yield: allow 0 coupon

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
@@ -494,18 +494,28 @@ public class DiscountingFixedCouponBondProductPricer {
    * @return the accrued interest of the product 
    */
   public double accruedInterest(ResolvedFixedCouponBond bond, LocalDate settlementDate) {
+    double notional = bond.getNotional();
+    return accruedYearFraction(bond, settlementDate) * bond.getFixedRate() * notional;
+  }
+
+  /**
+   * Calculates the accrued year fraction of the fixed coupon bond with the specified settlement date.
+   * 
+   * @param bond  the product
+   * @param settlementDate  the settlement date
+   * @return the accrued year fraction of the product 
+   */
+  public double accruedYearFraction(ResolvedFixedCouponBond bond, LocalDate settlementDate) {
     if (bond.getUnadjustedStartDate().isAfter(settlementDate)) {
       return 0d;
     }
-    double notional = bond.getNotional();
     FixedCouponBondPaymentPeriod period = bond.findPeriod(settlementDate)
         .orElseThrow(() -> new IllegalArgumentException("Date outside range of bond"));
     LocalDate previousAccrualDate = period.getUnadjustedStartDate();
-    double fixedRate = bond.getFixedRate();
-    double accruedInterest = bond.yearFraction(previousAccrualDate, settlementDate) * fixedRate * notional;
+    double accruedInterest = bond.yearFraction(previousAccrualDate, settlementDate) ;
     double result = 0d;
     if (settlementDate.isAfter(period.getDetachmentDate())) {
-      result = accruedInterest - notional * fixedRate * period.getYearFraction();
+      result = accruedInterest - period.getYearFraction();
     } else {
       result = accruedInterest;
     }
@@ -794,7 +804,7 @@ public class DiscountingFixedCouponBondProductPricer {
       return 0d;
     }
     int couponIndex = couponIndex(bond.getPeriodicPayments(), settlementDate);
-    double factorSpot = accruedInterest(bond, settlementDate) / bond.getFixedRate() / bond.getNotional();
+    double factorSpot = accruedYearFraction(bond, settlementDate);
     double factorPeriod = bond.getPeriodicPayments().get(couponIndex).getYearFraction();
     return (factorPeriod - factorSpot) / factorPeriod;
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
@@ -512,12 +512,12 @@ public class DiscountingFixedCouponBondProductPricer {
     FixedCouponBondPaymentPeriod period = bond.findPeriod(settlementDate)
         .orElseThrow(() -> new IllegalArgumentException("Date outside range of bond"));
     LocalDate previousAccrualDate = period.getUnadjustedStartDate();
-    double accruedInterest = bond.yearFraction(previousAccrualDate, settlementDate) ;
+    double accruedYearFraction = bond.yearFraction(previousAccrualDate, settlementDate) ;
     double result = 0d;
     if (settlementDate.isAfter(period.getDetachmentDate())) {
-      result = accruedInterest - period.getYearFraction();
+      result = accruedYearFraction - period.getYearFraction();
     } else {
-      result = accruedInterest;
+      result = accruedYearFraction;
     }
     return result;
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricerTest.java
@@ -56,7 +56,7 @@ import com.opengamma.strata.product.bond.FixedCouponBondYieldConvention;
 import com.opengamma.strata.product.bond.ResolvedFixedCouponBond;
 
 /**
- * Test
+ * Test {@link DiscountingFixedCouponBondProductPricer}
  */
 @Test
 public class DiscountingFixedCouponBondProductPricerTest {
@@ -422,6 +422,7 @@ public class DiscountingFixedCouponBondProductPricerTest {
       .exCouponPeriod(DaysAdjustment.NONE)
       .build()
       .resolve(REF_DATA);
+  private static final ResolvedFixedCouponBond PRODUCT_US_0 = PRODUCT_US.toBuilder().fixedRate(0.0d).build();
   private static final LocalDate VALUATION_US = date(2011, 8, 18);
   private static final LocalDate SETTLEMENT_US = PRODUCT_US.getSettlementDateOffset().adjust(VALUATION_US, REF_DATA);
   private static final LocalDate VALUATION_LAST_US = date(2016, 6, 3);
@@ -432,6 +433,16 @@ public class DiscountingFixedCouponBondProductPricerTest {
     double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_US, SETTLEMENT_US, YIELD_US);
     assertEquals(dirtyPrice, 1.0417352500524246, TOL); // 2.x.
     double yield = PRICER.yieldFromDirtyPrice(PRODUCT_US, SETTLEMENT_US, dirtyPrice);
+    assertEquals(yield, YIELD_US, TOL);
+  }
+
+  // Check price from yield when coupon is 0.
+  public void dirtyPriceFromYieldUS0() {
+    double dirtyPrice0 = PRICER.dirtyPriceFromYield(PRODUCT_US_0, SETTLEMENT_US, 0.0d);
+    assertEquals(dirtyPrice0, 1.0d, TOL);
+    double dirtyPrice = PRICER.dirtyPriceFromYield(PRODUCT_US_0, SETTLEMENT_US, YIELD_US);
+    assertEquals(dirtyPrice, 0.8129655023939295, TOL); // Previous run
+    double yield = PRICER.yieldFromDirtyPrice(PRODUCT_US_0, SETTLEMENT_US, dirtyPrice);
     assertEquals(yield, YIELD_US, TOL);
   }
 


### PR DESCRIPTION
Change yield for fixed coupon bonds to allow coupons with value 0. Previously a coupon of 0 was returning an error when computing yield.