### PR TITLE
Allow ValueSchedule to vary at start

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueSchedule.java
@@ -130,9 +130,6 @@ public final class ValueSchedule
       ValueAdjustment[] expandedSteps = new ValueAdjustment[size];
       for (ValueStep step : steps) {
         int index = step.findIndex(periods);
-        if (index == 0) {
-          throw new IllegalArgumentException("ValueStep is not allowed at the start of the schedule");
-        }
         if (expandedSteps[index] != null && !expandedSteps[index].equals(step.getValue())) {
           throw new IllegalArgumentException("Two ValueStep instances resolve to the same schedule period");
         }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueScheduleTest.java
@@ -155,14 +155,14 @@ public class ValueScheduleTest {
     assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
   }
 
-  public void test_resolveValues_indexBased_indexTooBig() {
-    ValueStep step = ValueStep.of(3, ValueAdjustment.ofReplace(300d));
+  public void test_resolveValues_dateBased_indexZeroValid() {
+    ValueStep step = ValueStep.of(date(2014, 1, 1), ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
-    assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
+    assertEquals(test.resolveValues(PERIODS), ImmutableList.of(300d, 300d, 300d));
   }
 
-  public void test_resolveValues_dateBased_indexZeroInvalid() {
-    ValueStep step = ValueStep.of(date(2014, 1, 1), ValueAdjustment.ofReplace(300d));
+  public void test_resolveValues_indexBased_indexTooBig() {
+    ValueStep step = ValueStep.of(3, ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
     assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
   }


### PR DESCRIPTION
Code now allows the first step to be at the very start
in this case the initial value will not be used