### PR TITLE
Example of using scenarios with a single name CDS

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
@@ -1,0 +1,337 @@
+/**
+ * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.examples.finance;
+
+import static com.opengamma.strata.measure.StandardComponents.marketDataFactory;
+import static java.util.stream.Collectors.toList;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharSource;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.calc.CalculationRules;
+import com.opengamma.strata.calc.CalculationRunner;
+import com.opengamma.strata.calc.Column;
+import com.opengamma.strata.calc.Results;
+import com.opengamma.strata.calc.marketdata.MarketDataConfig;
+import com.opengamma.strata.calc.marketdata.MarketDataFilter;
+import com.opengamma.strata.calc.marketdata.MarketDataRequirements;
+import com.opengamma.strata.calc.marketdata.PerturbationMapping;
+import com.opengamma.strata.calc.marketdata.ScenarioDefinition;
+import com.opengamma.strata.calc.runner.CalculationFunctions;
+import com.opengamma.strata.collect.Messages;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.array.DoubleMatrix;
+import com.opengamma.strata.collect.io.ResourceLocator;
+import com.opengamma.strata.data.ImmutableMarketData;
+import com.opengamma.strata.data.ImmutableMarketDataBuilder;
+import com.opengamma.strata.data.scenario.CurrencyValuesArray;
+import com.opengamma.strata.data.scenario.MarketDataBox;
+import com.opengamma.strata.data.scenario.ScenarioMarketData;
+import com.opengamma.strata.data.scenario.ScenarioPerturbation;
+import com.opengamma.strata.examples.marketdata.credit.markit.MarkitRedCode;
+import com.opengamma.strata.examples.marketdata.credit.markit.MarkitSingleNameCreditCurveDataParser;
+import com.opengamma.strata.examples.marketdata.credit.markit.MarkitYieldCurveDataParser;
+import com.opengamma.strata.math.impl.statistics.descriptive.SampleInterpolationQuantileMethod;
+import com.opengamma.strata.measure.Measures;
+import com.opengamma.strata.measure.StandardComponents;
+import com.opengamma.strata.pricer.credit.IsdaCreditCurveInputs;
+import com.opengamma.strata.pricer.credit.IsdaSingleNameCreditCurveInputsId;
+import com.opengamma.strata.pricer.credit.IsdaYieldCurveInputs;
+import com.opengamma.strata.pricer.credit.IsdaYieldCurveInputsId;
+import com.opengamma.strata.product.Trade;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.credit.CdsTrade;
+import com.opengamma.strata.product.credit.RestructuringClause;
+import com.opengamma.strata.product.credit.SeniorityLevel;
+import com.opengamma.strata.product.credit.SingleNameReferenceInformation;
+import com.opengamma.strata.product.credit.type.CdsConventions;
+
+/**
+ * Example to illustrate using the calculation API to run a set of scenarios on a single name CDS.
+ * <p>
+ * In this example we load the interest rate curve and the credit curve required to price the CDS using the built-in
+ * curve file loaders.
+ * <p>
+ * We then define scenarios in which each point on the credit curve is randomly perturbed, illustrating a very simple
+ * Monte Carlo approach. It would be equally possible to use other sources of data, such as historical credit spreads,
+ * to generate the perturbations instead.
+ * <p>
+ * The calculation API is used to obtain the present value under each scenario, producing a vector of results.
+ * We then transform this into a vector of P&Ls, which we use to calculate VaR.
+ */
+public class CdsScenarioExample {
+
+  private static final String MARKET_DATA_RESOURCE_ROOT = "example-marketdata";
+
+  public static void main(String[] args) {
+    // set up calculation runner component, which needs life-cycle management
+    // a typical application might use dependency injection to obtain the instance
+    try (CalculationRunner runner = CalculationRunner.ofMultiThreaded()) {
+      calculate(runner);
+    }
+  }
+
+  // calculates P&Ls by loading a set of base market data and defining shifts to apply to this for each scenario
+  private static void calculate(CalculationRunner runner) {
+    // the trade to price
+    CdsTrade cds = createSingleNameCds();
+    List<Trade> trades = ImmutableList.of(cds);
+
+    // the columns, specifying the measures to be calculated
+    List<Column> columns = ImmutableList.of(
+        Column.of(Measures.PRESENT_VALUE));
+
+    // initialise the market data builder for the valuation date
+    LocalDate valuationDate = LocalDate.of(2014, 10, 16);
+    ImmutableMarketDataBuilder baseMarketDataBuilder = ImmutableMarketData.builder(valuationDate);
+
+    // add base yield curves
+    loadBaseYieldCurves(baseMarketDataBuilder);
+
+    // add base credit curves
+    loadBaseSingleNameCreditCurves(baseMarketDataBuilder);
+
+    // build a single market data snapshot for the valuation date
+    // this is the base snapshot which will be perturbed in the scenarios
+    ImmutableMarketData baseMarketData = baseMarketDataBuilder.build();
+
+    // build scenarios containing credit curve shifts
+    ScenarioDefinition scenarios = buildScenarios(baseMarketData);
+
+    // use the standard rules defining how to calculate the measures we are requesting
+    CalculationFunctions functions = StandardComponents.calculationFunctions();
+    CalculationRules rules = CalculationRules.of(functions);
+
+    // use the built-in reference data, which includes some holiday calendars
+    ReferenceData refData = ReferenceData.standard();
+
+    // now combine the base market data with the scenario definition to create the full set of scenario market data
+    MarketDataRequirements reqs = MarketDataRequirements.of(rules, trades, columns, refData);
+    ScenarioMarketData scenarioMarketData =
+        marketDataFactory().createMultiScenario(reqs, MarketDataConfig.empty(), baseMarketData, refData, scenarios);
+
+    // calculate the results
+    Results results = runner.calculateMultiScenario(rules, trades, columns, scenarioMarketData, refData);
+
+    // the results contain the one measure requested (Present Value) for each scenario
+    // the first scenario is the base
+    CurrencyValuesArray pvVector = (CurrencyValuesArray) results.get(0, 0).getValue();
+    outputCurrencyValues("PVs", pvVector);
+
+    CurrencyValuesArray pnlVector = getSortedPnls(pvVector);
+    outputCurrencyValues("Scenario PnLs", pnlVector);
+
+    double var95 = SampleInterpolationQuantileMethod.DEFAULT.quantileFromUnsorted(0.05, pnlVector.getValues());
+    System.out.println(Messages.format("95% VaR: {}", var95));
+  }
+
+  //-------------------------------------------------------------------------
+  // loads the base yield curves from a fixed resource
+  private static void loadBaseYieldCurves(ImmutableMarketDataBuilder builder) {
+    ResourceLocator resource = ResourceLocator.ofClasspath(MARKET_DATA_RESOURCE_ROOT + "/credit/2014-10-16/cds.yieldCurves.csv");
+    CharSource inputSource = resource.getCharSource();
+
+    // use the built-in markit yield curve parser
+    Map<IsdaYieldCurveInputsId, IsdaYieldCurveInputs> yieldCurves = MarkitYieldCurveDataParser.parse(inputSource);
+
+    builder.addValueMap(yieldCurves);
+  }
+
+  // loads the base single name credit curves from a fixed resource
+  private static void loadBaseSingleNameCreditCurves(ImmutableMarketDataBuilder builder) {
+    ResourceLocator curvesResource = ResourceLocator.ofClasspath(MARKET_DATA_RESOURCE_ROOT + "/credit/2014-10-16/singleName.creditCurves.csv");
+    CharSource curvesInputSource = curvesResource.getCharSource();
+
+    ResourceLocator staticDataResource = ResourceLocator.ofClasspath(MARKET_DATA_RESOURCE_ROOT + "/credit/2014-10-16/singleName.staticData.csv");
+    CharSource staticDataInputSource = staticDataResource.getCharSource();
+
+    // use the built-in markit credit curve parser
+    MarkitSingleNameCreditCurveDataParser.parse(builder, curvesInputSource, staticDataInputSource);
+  }
+
+  //-----------------------------------------------------------------------
+  // create a single name CDS with 100 bps coupon
+  private static CdsTrade createSingleNameCds() {
+    return CdsConventions.USD_NORTH_AMERICAN
+        .toTrade(
+            LocalDate.of(2014, 9, 22),
+            LocalDate.of(2019, 12, 20),
+            BuySell.BUY,
+            100_000_000d,
+            0.0100,
+            SingleNameReferenceInformation.of(
+                MarkitRedCode.id("COMP01"),
+                SeniorityLevel.SENIOR_UNSECURED_FOREIGN,
+                Currency.USD,
+                RestructuringClause.NO_RESTRUCTURING_2014),
+            3_694_117.72d,
+            LocalDate.of(2014, 10, 21));
+  }
+
+  //-----------------------------------------------------------------------
+  // build the scenarios to use to perturb the base market data
+  private static ScenarioDefinition buildScenarios(ImmutableMarketData baseMarketData) {
+
+    // build perturbations for each single name credit curve in the base market data set
+    // here we are only interested in one credit curve, but this shows how we might deal with a larger set
+    // each perturbation mapping represents the shifts to apply to one item of market data (here, a curve) in all scenarios
+    List<PerturbationMapping<?>> perturbations = baseMarketData.getValues().keySet().stream()
+        .filter(id -> id instanceof IsdaSingleNameCreditCurveInputsId)
+        .map(IsdaSingleNameCreditCurveInputsId.class::cast)
+        .map(id -> PerturbationMapping.of(
+            IsdaCreditCurveInputs.class,
+            IsdaCreditCurveFilter.of(id),
+            buildScenarioShifts(baseMarketData.getValue(id))))
+        .collect(toList());
+
+    // we could add perturbations to other pieces of market data by continuing to add to the perturbations list
+    // each perturbation mapping must contain shifts for the same number of scenarios
+
+    // together the perturbations to the items of market data define a scenario
+    return ScenarioDefinition.ofMappings(perturbations);
+  }
+
+  // build the shifts to apply to a given curve in each scenario
+  private static IsdaCreditCurveShifts buildScenarioShifts(IsdaCreditCurveInputs baseCurve) {
+
+    // create a shift matrix - one row per scenario, each column representing a nodal point on the curve
+    int scenarioCount = 100;
+    int curveNodes = baseCurve.getNumberOfPoints();
+    double[][] relativeShifts = new double[scenarioCount + 1][curveNodes];
+
+    // include a base scenario with no shifts (i.e. multiply by 1)
+    for (int nodeIndex = 0; nodeIndex < curveNodes; nodeIndex++) {
+      relativeShifts[0][nodeIndex] = 1;
+    }
+
+    // for the remaining scenarios, create random relative shifts between 0.95 and 1.05 for illustration
+    // here we could instead calculate the shifts from historical data, perhaps applying a weighting such as EWMA
+    Random r = new Random();
+    for (int scenarioIndex = 1; scenarioIndex <= scenarioCount; scenarioIndex++) {
+      for (int nodeIndex = 0; nodeIndex < curveNodes; nodeIndex++) {
+        relativeShifts[scenarioIndex][nodeIndex] =  1 + ((r.nextDouble() - 0.5) * 0.1);
+      }
+    }
+
+    // return the shifts object which will be applied to the base market data
+    DoubleMatrix shiftMatrix = DoubleMatrix.copyOf(relativeShifts);
+    return new IsdaCreditCurveShifts(shiftMatrix);
+  }
+
+  //-------------------------------------------------------------------------
+  private static CurrencyValuesArray getSortedPnls(CurrencyValuesArray pvVector) {
+    double[] scenarioPnls = new double[pvVector.getScenarioCount() - 1];
+
+    // the base PV was calculated in the first scenario where no shifts were applied
+    double basePv = pvVector.getValues().get(0);
+
+    // for the remaining scenarios, work out the scenario P&L by subtracting the base PV
+    for (int i = 1; i < pvVector.getScenarioCount(); i++) {
+      double scenarioPv = pvVector.getValues().get(i);
+      double pnl = scenarioPv - basePv;
+      scenarioPnls[i - 1] = pnl;
+    }
+
+    // sort the P&Ls, so we have the highest loss to the highest profit
+    Arrays.sort(scenarioPnls);
+
+    return CurrencyValuesArray.of(pvVector.getCurrency(), DoubleArray.ofUnsafe(scenarioPnls));
+  }
+
+  //-------------------------------------------------------------------------
+  private static void outputCurrencyValues(String title, CurrencyValuesArray currencyValues) {
+    NumberFormat numberFormat = new DecimalFormat("0.00", new DecimalFormatSymbols(Locale.ENGLISH));
+    System.out.println(Messages.format("{} ({}):", title, currencyValues.getCurrency()));
+    for (int i = 0; i < currencyValues.getScenarioCount(); i++) {
+      double scenarioValue = currencyValues.getValues().get(i);
+      System.out.println(numberFormat.format(scenarioValue));
+    }
+    System.out.println();
+  }
+
+  //-------------------------------------------------------------------------
+  // implements shifts to a credit curve across all scenarios
+  // this custom implementation of ScenarioPerturbation is necessary for CDS where non-standard market data types are used
+  // for other asset clases, the built-in CurvePointShifts may be used
+  private static class IsdaCreditCurveShifts implements ScenarioPerturbation<IsdaCreditCurveInputs> {
+
+    private final DoubleMatrix shifts;
+
+    public IsdaCreditCurveShifts(DoubleMatrix shifts){
+      this.shifts = shifts;
+    }
+
+    @Override
+    public MarketDataBox<IsdaCreditCurveInputs> applyTo(MarketDataBox<IsdaCreditCurveInputs> marketData, ReferenceData refData) {
+      return marketData.mapWithIndex(shifts.rowCount(), (curve, scenarioIndex) -> applyShifts(scenarioIndex, curve));
+    }
+
+    @Override
+    public int getScenarioCount() {
+      return shifts.rowCount();
+    }
+
+    private IsdaCreditCurveInputs applyShifts(int scenarioIndex, IsdaCreditCurveInputs curve) {
+      // return the manipulated curve
+      return IsdaCreditCurveInputs.of(
+          curve.getName(),
+          curve.getCreditCurvePoints(),
+          curve.getEndDatePoints(),
+          getShiftedParRates(curve.getParRates(), shifts.rowArray(scenarioIndex)),
+          curve.getCdsConvention(),
+          curve.getScalingFactor());
+    }
+
+    private double[] getShiftedParRates(double[] parRates, double[] shifts) {
+      double[] shiftedParRates = new double[parRates.length];
+      for (int i = 0; i < shiftedParRates.length; i++) {
+        // multiply the par rates from the base curve by the relative shifts generated for this scenario
+        shiftedParRates[i] = parRates[i] * shifts[i];
+      }
+      return shiftedParRates;
+    }
+
+  }
+
+  // implements a filter which selects the credit curve to perturb based on matching a given ID
+  // this custom implementation of MarketDataFilter is necessary for CDS where non-standard market data types are used
+  // for other asset classes, the built-in CurveNameFilter or AllCurvesFilter may be used
+  private static class IsdaCreditCurveFilter implements MarketDataFilter<IsdaCreditCurveInputs, IsdaSingleNameCreditCurveInputsId> {
+
+    private final IsdaSingleNameCreditCurveInputsId id;
+
+    public static IsdaCreditCurveFilter of(IsdaSingleNameCreditCurveInputsId id) {
+      return new IsdaCreditCurveFilter(id);
+    }
+
+    private IsdaCreditCurveFilter(IsdaSingleNameCreditCurveInputsId id) {
+      this.id = id;
+    }
+
+    @Override
+    public Class<?> getMarketDataIdType() {
+      return IsdaSingleNameCreditCurveInputsId.class;
+    }
+
+    @Override
+    public boolean matches(IsdaSingleNameCreditCurveInputsId marketDataId, MarketDataBox<IsdaCreditCurveInputs> marketData, ReferenceData refData) {
+      return this.id.equals(marketDataId);
+    }
+
+  }
+
+}

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
  * 
  * Please see distribution for license.
  */
@@ -95,19 +95,9 @@ public class CdsScenarioExample {
     List<Column> columns = ImmutableList.of(
         Column.of(Measures.PRESENT_VALUE));
 
-    // initialise the market data builder for the valuation date
-    LocalDate valuationDate = LocalDate.of(2014, 10, 16);
-    ImmutableMarketDataBuilder baseMarketDataBuilder = ImmutableMarketData.builder(valuationDate);
-
-    // add base yield curves
-    loadBaseYieldCurves(baseMarketDataBuilder);
-
-    // add base credit curves
-    loadBaseSingleNameCreditCurves(baseMarketDataBuilder);
-
-    // build a single market data snapshot for the valuation date
-    // this is the base snapshot which will be perturbed in the scenarios
-    ImmutableMarketData baseMarketData = baseMarketDataBuilder.build();
+    // build the set of market data for base scenario on the valuation date
+    // this is the snapshot which will be perturbed in the scenarios
+    ImmutableMarketData baseMarketData = buildBaseMarketData();
 
     // build scenarios containing credit curve shifts
     ScenarioDefinition scenarios = buildScenarios(baseMarketData);
@@ -143,6 +133,23 @@ public class CdsScenarioExample {
   }
 
   //-------------------------------------------------------------------------
+  // builds the set of market data representing the base scenario
+  private static ImmutableMarketData buildBaseMarketData() {
+
+    // initialise the market data builder for the valuation date
+    LocalDate valuationDate = LocalDate.of(2014, 10, 16);
+    ImmutableMarketDataBuilder baseMarketDataBuilder = ImmutableMarketData.builder(valuationDate);
+
+    // add yield curves
+    loadBaseYieldCurves(baseMarketDataBuilder);
+
+    // add credit curves
+    loadBaseSingleNameCreditCurves(baseMarketDataBuilder);
+
+    // build a single market data snapshot for the valuation date
+    return baseMarketDataBuilder.build();
+  }
+
   // loads the base yield curves from a fixed resource
   private static void loadBaseYieldCurves(ImmutableMarketDataBuilder builder) {
     ResourceLocator resource = ResourceLocator.ofClasspath(MARKET_DATA_RESOURCE_ROOT + "/credit/2014-10-16/cds.yieldCurves.csv");

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
@@ -204,7 +204,7 @@ public class CdsScenarioExample {
     // we could add perturbations to other pieces of market data by continuing to add to the perturbations list
     // each perturbation mapping must contain shifts for the same number of scenarios
 
-    // together the perturbations to the items of market data define a scenario
+    // together the perturbations to the items of market data define the complete set of scenarios
     return ScenarioDefinition.ofMappings(perturbations);
   }
 

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
@@ -128,7 +128,7 @@ public class CdsScenarioExample {
 
     // use a built-in utility to calculate VaR
     // since the P&Ls are sorted starting with the greatest loss, the 95% greatest loss occurs at the 5% position
-    double var95 = SampleInterpolationQuantileMethod.DEFAULT.quantileFromUnsorted(0.05, pnlVector.getValues());
+    double var95 = SampleInterpolationQuantileMethod.DEFAULT.quantileFromSorted(0.05, pnlVector.getValues());
     System.out.println(Messages.format("95% VaR: {}", var95));
   }
 

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
@@ -132,9 +132,12 @@ public class CdsScenarioExample {
     CurrencyValuesArray pvVector = (CurrencyValuesArray) results.get(0, 0).getValue();
     outputCurrencyValues("PVs", pvVector);
 
+    // transform the present values into P&Ls, sorted from greatest loss to greatest profit
     CurrencyValuesArray pnlVector = getSortedPnls(pvVector);
     outputCurrencyValues("Scenario PnLs", pnlVector);
 
+    // use a built-in utility to calculate VaR
+    // since the P&Ls are sorted starting with the greatest loss, the 95% greatest loss occurs at the 5% position
     double var95 = SampleInterpolationQuantileMethod.DEFAULT.quantileFromUnsorted(0.05, pnlVector.getValues());
     System.out.println(Messages.format("95% VaR: {}", var95));
   }


### PR DESCRIPTION
Avoids using `ExampleMarketDataBuilder` in favour of the clarity of where the base market data is coming from. I would suggest we look to do this more generally.

Example output:

```
PVs (USD):
-0.01
-33661.47
-71308.83
410.14
21320.49
21421.20
-50075.48
-51138.52
27526.84
26787.14
47476.01
-43587.56
46244.38
20382.37
-43325.40
17068.74
46714.07
-10337.88
-33393.30
34371.55
62713.55
7770.51
56347.69
70663.44
-743.81
-61523.12
50833.92
18030.41
23266.93
-240.58
34116.45
-26766.97
8904.71
42270.97
-56239.81
-65027.22
48402.92
29905.80
-57605.63
34048.10
648.15
-22557.18
6682.99
-22313.87
21532.19
14853.45
70604.12
-3277.30
-26465.24
35798.77
1522.63
44601.29
18135.09
11068.70
-61838.51
30311.39
-64201.57
-652.29
36876.12
-64082.32
-49677.47
56600.00
-18867.31
56430.89
6324.80
-6068.56
37410.93
26609.04
31608.69
-57124.17
-8137.47
-50392.20
44883.62
-45902.63
65192.33
35182.06
45236.68
9625.27
-45680.71
70066.53
8263.90
-53933.60
9093.88
-35322.55
2527.64
21278.87
61340.97
-37386.80
-19542.83
-54017.28
-8966.20
4918.03
16772.75
67865.22
-928.18
-45262.21
-60079.43
34192.88
-14981.96
47892.11
19470.77

Scenario PnLs (USD):
-71308.82
-65027.21
-64201.57
-64082.32
-61838.50
-61523.11
-60079.42
-57605.62
-57124.17
-56239.80
-54017.27
-53933.60
-51138.51
-50392.19
-50075.47
-49677.47
-45902.62
-45680.71
-45262.20
-43587.56
-43325.40
-37386.79
-35322.54
-33661.47
-33393.29
-26766.96
-26465.24
-22557.18
-22313.87
-19542.83
-18867.31
-14981.96
-10337.88
-8966.20
-8137.47
-6068.56
-3277.30
-928.18
-743.81
-652.28
-240.57
410.14
648.15
1522.64
2527.64
4918.03
6324.80
6682.99
7770.51
8263.91
8904.71
9093.89
9625.28
11068.70
14853.45
16772.76
17068.74
18030.41
18135.09
19470.77
20382.37
21278.88
21320.50
21421.21
21532.20
23266.94
26609.04
26787.15
27526.84
29905.80
30311.40
31608.70
34048.10
34116.46
34192.89
34371.56
35182.06
35798.77
36876.13
37410.94
42270.98
44601.30
44883.63
45236.68
46244.39
46714.08
47476.01
47892.12
48402.92
50833.92
56347.69
56430.90
56600.01
61340.97
62713.56
65192.34
67865.22
70066.54
70604.13
70663.44

95% VaR: -61838.50304811215
```