### PR TITLE
SABR calibration to ATM volatilities

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionVolatilities.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.pricer.swaption;
 
+import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.param.ParameterPerturbation;
 
 /**
@@ -12,6 +13,11 @@ import com.opengamma.strata.market.param.ParameterPerturbation;
  */
 public interface BlackSwaptionVolatilities
     extends SwaptionVolatilities {
+  
+  @Override
+  public default ValueType getVolatilityType() {
+    return ValueType.BLACK_VOLATILITY;
+  }
 
   @Override
   public abstract BlackSwaptionVolatilities withParameter(int parameterIndex, double newValue);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionVolatilities.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.pricer.swaption;
 
+import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.param.ParameterPerturbation;
 
 /**
@@ -12,6 +13,11 @@ import com.opengamma.strata.market.param.ParameterPerturbation;
  */
 public interface NormalSwaptionVolatilities
     extends SwaptionVolatilities {
+  
+  @Override
+  public default ValueType getVolatilityType() {
+    return ValueType.NORMAL_VOLATILITY;
+  }
 
   @Override
   public abstract NormalSwaptionVolatilities withParameter(int parameterIndex, double newValue);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilities.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.pricer.swaption;
 
 import com.opengamma.strata.basics.value.ValueDerivatives;
+import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.param.ParameterPerturbation;
 
 /**
@@ -15,6 +16,11 @@ import com.opengamma.strata.market.param.ParameterPerturbation;
  */
 public interface SabrSwaptionVolatilities
     extends SwaptionVolatilities {
+  
+  @Override
+  public default ValueType getVolatilityType() {
+    return ValueType.BLACK_VOLATILITY; // SABR implemented with Black implied volatility
+  }
 
   @Override
   public abstract SabrSwaptionVolatilities withParameter(int parameterIndex, double newValue);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilities.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 import com.opengamma.strata.market.MarketDataView;
+import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.ParameterPerturbation;
 import com.opengamma.strata.market.param.ParameterizedData;
@@ -39,6 +40,8 @@ public interface SwaptionVolatilities
    * @return the convention
    */
   public abstract FixedIborSwapConvention getConvention();
+  
+  public abstract ValueType getVolatilityType();
 
   /**
    * Gets the valuation date.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilities.java
@@ -41,6 +41,11 @@ public interface SwaptionVolatilities
    */
   public abstract FixedIborSwapConvention getConvention();
   
+  /**
+   * Gets the type of volatility returned by the {@link SwaptionVolatilities#volatility} method.
+   * 
+   * @return the type
+   */
   public abstract ValueType getVolatilityType();
 
   /**

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeBlackCleanDataTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeBlackCleanDataTest.java
@@ -219,9 +219,9 @@ public class SabrSwaptionCalibratorCubeBlackCleanDataTest {
     List<DoubleArray> nuJacobian = calibrated.getDataSensitivityNu().get();
 
     int surfacePointIndex = 0;
-    for (int looptenor = 0; looptenor < TENORS.size(); looptenor++) {
-      double tenor = TENORS.get(looptenor).get(ChronoUnit.YEARS);
-      for (int loopexpiry = 0; loopexpiry < EXPIRIES.size(); loopexpiry++) {
+    for (int loopexpiry = 0; loopexpiry < EXPIRIES.size(); loopexpiry++) {
+      for (int looptenor = 0; looptenor < TENORS.size(); looptenor++) {
+        double tenor = TENORS.get(looptenor).get(ChronoUnit.YEARS);
         LocalDate expiry = EUR_FIXED_1Y_EURIBOR_6M.getFloatingLeg().getStartDateBusinessDayAdjustment()
             .adjust(CALIBRATION_DATE.plus(EXPIRIES.get(loopexpiry)), REF_DATA);
         ZonedDateTime expiryDateTime = expiry.atTime(11, 0).atZone(ZoneId.of("Europe/Berlin"));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalSimpleDataTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalSimpleDataTest.java
@@ -5,12 +5,17 @@
  */
 package com.opengamma.strata.pricer.swaption;
 
-import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DAY_COUNT;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_ARRAY_SPARSE;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_NORMAL_SIMPLE;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_NORMAL_ATM_SIMPLE;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.EXPIRIES_SIMPLE;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.EXPIRIES_SIMPLE_2;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.MONEYNESS;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.TENORS_SIMPLE;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.ATM_SIMPLE;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_DATE;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_TIME;
 import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -68,8 +73,8 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
 
-  private static final LocalDate CALIBRATION_DATE = LocalDate.of(2016, 2, 29);
-  private static final ZonedDateTime CALIBRATION_TIME = CALIBRATION_DATE.atTime(10, 0).atZone(ZoneId.of("Europe/Berlin"));
+  private static final LocalDate CALIBRATION_DATE = DATA_DATE;
+  private static final ZonedDateTime CALIBRATION_TIME = DATA_TIME;
 
   private static final SabrSwaptionCalibrator SABR_CALIBRATION = SabrSwaptionCalibrator.DEFAULT;
 
@@ -103,6 +108,7 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
   private static final SwaptionVolatilitiesName NAME_SABR = SwaptionVolatilitiesName.of("Calibrated-SABR");
 
   private static final double TOLERANCE_PRICE_CALIBRATION_LS = 5.0E-4; // Calibration Least Square; result not exact
+  private static final double TOLERANCE_PRICE_CALIBRATION_ROOT = 1.0E-6; // Calibration Least Square; result not exact
   private static final double TOLERANCE_PARAM_SENSITIVITY = 3.0E-2;
   private static final double TOLERANCE_PARAM_SENSITIVITY_NU = 9.0E-2;
   private static final double TOLERANCE_EXPIRY = 1.0E-6;
@@ -119,7 +125,7 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
         .withMetadata(DefaultSurfaceMetadata.builder()
             .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION).surfaceName("Shift").build());
     SabrParametersSwaptionVolatilities calibrated = SABR_CALIBRATION.calibrateWithFixedBetaAndShift(NAME_SABR,
-        EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, ACT_365F, TENORS_SIMPLE, DATA_SIMPLE,
+        EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, DAY_COUNT, TENORS_SIMPLE, DATA_SIMPLE,
         MULTICURVE, betaSurface, shiftSurface, INTERPOLATOR_2D);
 
     for (int looptenor = 0; looptenor < TENORS_SIMPLE.size(); looptenor++) {
@@ -149,6 +155,47 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
     }
   }
 
+  @SuppressWarnings("unused")
+  @Test
+  public void normal_atm() {
+    double beta = 0.50;
+    Surface betaSurface = ConstantSurface.of("Beta", beta)
+        .withMetadata(DefaultSurfaceMetadata.builder()
+            .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION)
+            .zValueType(ValueType.SABR_BETA).surfaceName("Beta").build());
+    double shift = 0.0300;
+    Surface shiftSurface = ConstantSurface.of("Shift", shift)
+        .withMetadata(DefaultSurfaceMetadata.builder()
+            .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION).surfaceName("Shift").build());
+    SabrParametersSwaptionVolatilities calibratedSmile = SABR_CALIBRATION.calibrateWithFixedBetaAndShift(NAME_SABR,
+        EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, DAY_COUNT, TENORS_SIMPLE, DATA_SIMPLE,
+        MULTICURVE, betaSurface, shiftSurface, INTERPOLATOR_2D);
+    SabrParametersSwaptionVolatilities calibratedAtm =
+        SABR_CALIBRATION.calibrateAlphaWithAtm(NAME_SABR, calibratedSmile, MULTICURVE, TENORS_SIMPLE, EXPIRIES_SIMPLE_2,
+            INTERPOLATOR_2D, ATM_SIMPLE);
+    int nbExp = EXPIRIES_SIMPLE_2.size();
+    int nbTenor = TENORS_SIMPLE.size();
+    for (int loopexpiry = 0; loopexpiry < nbExp; loopexpiry++) {
+      for (int looptenor = 0; looptenor < nbTenor; looptenor++) {
+        double tenor = TENORS_SIMPLE.get(looptenor).get(ChronoUnit.YEARS);
+        LocalDate expiry = EUR_FIXED_1Y_EURIBOR_6M.getFloatingLeg().getStartDateBusinessDayAdjustment()
+            .adjust(CALIBRATION_DATE.plus(EXPIRIES_SIMPLE_2.get(loopexpiry)), REF_DATA);
+        LocalDate effectiveDate = EUR_FIXED_1Y_EURIBOR_6M.calculateSpotDateFromTradeDate(expiry, REF_DATA);
+        LocalDate endDate = effectiveDate.plus(TENORS_SIMPLE.get(looptenor));
+        SwapTrade swap = EUR_FIXED_1Y_EURIBOR_6M
+            .toTrade(CALIBRATION_DATE, effectiveDate, endDate, BuySell.BUY, 1.0, 0.0);
+        double parRate = SWAP_PRICER.parRate(swap.resolve(REF_DATA).getProduct(), MULTICURVE);
+        ZonedDateTime expiryDateTime = expiry.atTime(11, 0).atZone(ZoneId.of("Europe/Berlin"));
+        double time = calibratedAtm.relativeTime(expiryDateTime);
+        double volBlack = calibratedAtm.volatility(expiryDateTime, tenor, parRate, parRate);
+        double priceComputed = BlackFormulaRepository.price(parRate + shift, parRate + shift, time, volBlack, true);
+        double priceNormal = NormalFormulaRepository.price(parRate, parRate, time,
+            DATA_NORMAL_ATM_SIMPLE[looptenor + loopexpiry * nbTenor], PutCall.CALL);
+        assertEquals(priceComputed, priceNormal, TOLERANCE_PRICE_CALIBRATION_ROOT);
+      }
+    }
+  }
+
   /**
    * Check that the sensitivities of parameters with respect to data is stored in the metadata.
    * Compare the sensitivities to a finite difference approximation.
@@ -166,7 +213,7 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
         .withMetadata(DefaultSurfaceMetadata.builder()
             .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION).surfaceName("Shift").build());
     SabrParametersSwaptionVolatilities calibrated = SABR_CALIBRATION.calibrateWithFixedBetaAndShift(NAME_SABR,
-        EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, ACT_365F, TENORS_SIMPLE, DATA_SIMPLE,
+        EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, DAY_COUNT, TENORS_SIMPLE, DATA_SIMPLE,
         MULTICURVE, betaSurface, shiftSurface, INTERPOLATOR_2D);
     double fdShift = 1.0E-5;
 
@@ -187,9 +234,9 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
     List<DoubleArray> nuJacobian = calibrated.getDataSensitivityNu().get();
 
     int surfacePointIndex = 0;
-    for (int looptenor = 0; looptenor < TENORS_SIMPLE.size(); looptenor++) {
-      double tenor = TENORS_SIMPLE.get(looptenor).get(ChronoUnit.YEARS);
-      for (int loopexpiry = 0; loopexpiry < EXPIRIES_SIMPLE.size(); loopexpiry++) {
+    for (int loopexpiry = 0; loopexpiry < EXPIRIES_SIMPLE.size(); loopexpiry++) {
+      for (int looptenor = 0; looptenor < TENORS_SIMPLE.size(); looptenor++) {
+        double tenor = TENORS_SIMPLE.get(looptenor).get(ChronoUnit.YEARS);
         LocalDate expiry = EUR_FIXED_1Y_EURIBOR_6M.getFloatingLeg().getStartDateBusinessDayAdjustment()
             .adjust(CALIBRATION_DATE.plus(EXPIRIES_SIMPLE.get(loopexpiry)), REF_DATA);
         ZonedDateTime expiryDateTime = expiry.atTime(11, 0).atZone(ZoneId.of("Europe/Berlin"));
@@ -228,7 +275,7 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
                         DATA_NORMAL_SIMPLE, looptenor, loopexpiry, loopmoney, (2 * loopsign - 1) * fdShift);
                 SabrParametersSwaptionVolatilities calibratedShifted = SABR_CALIBRATION.calibrateWithFixedBetaAndShift(
                     SwaptionVolatilitiesName.of("Calibrated-SABR-Shifted"),
-                    EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, ACT_365F, TENORS_SIMPLE, dataShifted,
+                    EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, DAY_COUNT, TENORS_SIMPLE, dataShifted,
                     MULTICURVE, betaSurface, shiftSurface, INTERPOLATOR_2D);
                 alphaShifted[loopsign] = calibratedShifted.getParameters().getAlphaSurface().zValue(time, tenor);
                 rhoShifted[loopsign] = calibratedShifted.getParameters().getRhoSurface().zValue(time, tenor);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalSimpleDataTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalSimpleDataTest.java
@@ -13,7 +13,7 @@ import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.EXPIRIES_SIM
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.EXPIRIES_SIMPLE_2;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.MONEYNESS;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.TENORS_SIMPLE;
-import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.ATM_SIMPLE;
+import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.ATM_NORMAL_SIMPLE;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_DATE;
 import static com.opengamma.strata.pricer.swaption.SwaptionCubeData.DATA_TIME;
 import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
@@ -108,7 +108,7 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
   private static final SwaptionVolatilitiesName NAME_SABR = SwaptionVolatilitiesName.of("Calibrated-SABR");
 
   private static final double TOLERANCE_PRICE_CALIBRATION_LS = 5.0E-4; // Calibration Least Square; result not exact
-  private static final double TOLERANCE_PRICE_CALIBRATION_ROOT = 1.0E-6; // Calibration Least Square; result not exact
+  private static final double TOLERANCE_PRICE_CALIBRATION_ROOT = 1.0E-6; // Calibration root finding
   private static final double TOLERANCE_PARAM_SENSITIVITY = 3.0E-2;
   private static final double TOLERANCE_PARAM_SENSITIVITY_NU = 9.0E-2;
   private static final double TOLERANCE_EXPIRY = 1.0E-6;
@@ -171,8 +171,8 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
         EUR_FIXED_1Y_EURIBOR_6M, CALIBRATION_TIME, DAY_COUNT, TENORS_SIMPLE, DATA_SIMPLE,
         MULTICURVE, betaSurface, shiftSurface, INTERPOLATOR_2D);
     SabrParametersSwaptionVolatilities calibratedAtm =
-        SABR_CALIBRATION.calibrateAlphaWithAtm(NAME_SABR, calibratedSmile, MULTICURVE, TENORS_SIMPLE, EXPIRIES_SIMPLE_2,
-            INTERPOLATOR_2D, ATM_SIMPLE);
+        SABR_CALIBRATION.calibrateAlphaWithAtm(NAME_SABR, calibratedSmile, MULTICURVE, ATM_NORMAL_SIMPLE, TENORS_SIMPLE,
+            EXPIRIES_SIMPLE_2, INTERPOLATOR_2D);
     int nbExp = EXPIRIES_SIMPLE_2.size();
     int nbTenor = TENORS_SIMPLE.size();
     for (int loopexpiry = 0; loopexpiry < nbExp; loopexpiry++) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorSmileTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorSmileTest.java
@@ -145,7 +145,7 @@ public class SabrSwaptionCalibratorSmileTest {
       double shift,
       double tolerance) {
     Pair<LeastSquareResultsWithTransform, DoubleArray> rComputed = SABR_CALIBRATION
-        .calibrateShiftedFromNormalVolatilities(BDA, CALIBRATION_TIME, ACT_365F, EXPIRY_PERIOD, FORWARD,
+        .calibrateLsShiftedFromNormalVolatilities(BDA, CALIBRATION_TIME, ACT_365F, EXPIRY_PERIOD, FORWARD,
             moneyness, ValueType.SIMPLE_MONEYNESS, normalVol, startParameters, fixed, shift);
     SabrFormulaData sabrComputed = SabrFormulaData.of(rComputed.getFirst().getModelParameters().toArrayUnsafe());
     for (int i = 0; i < moneyness.size(); i++) {
@@ -173,7 +173,7 @@ public class SabrSwaptionCalibratorSmileTest {
       double shift,
       double tolerance) {
     Pair<LeastSquareResultsWithTransform, DoubleArray> rComputed = SABR_CALIBRATION
-        .calibrateShiftedFromBlackVolatilities(BDA, CALIBRATION_TIME, ACT_365F, EXPIRY_PERIOD, FORWARD,
+        .calibrateLsShiftedFromBlackVolatilities(BDA, CALIBRATION_TIME, ACT_365F, EXPIRY_PERIOD, FORWARD,
             moneyness, ValueType.SIMPLE_MONEYNESS, blackVol, 0.0, startParameters, fixed, shift);
     SabrFormulaData sabrComputed = SabrFormulaData.of(rComputed.getFirst().getModelParameters().toArrayUnsafe());
     for (int i = 0; i < moneyness.size(); i++) {
@@ -208,7 +208,7 @@ public class SabrSwaptionCalibratorSmileTest {
       // Prices generated from Black implied volatilities
     }
     Pair<LeastSquareResultsWithTransform, DoubleArray> rComputed = SABR_CALIBRATION
-        .calibrateShiftedFromPrices(BDA, CALIBRATION_TIME, ACT_365F, EXPIRY_PERIOD, FORWARD,
+        .calibrateLsShiftedFromPrices(BDA, CALIBRATION_TIME, ACT_365F, EXPIRY_PERIOD, FORWARD,
             moneyness, ValueType.SIMPLE_MONEYNESS, DoubleArray.ofUnsafe(prices), startParameters, fixed, shift);
     SabrFormulaData sabrComputed = SabrFormulaData.of(rComputed.getFirst().getModelParameters().toArrayUnsafe());
     for (int i = 0; i < moneyness.size(); i++) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionRawDataSensitivityCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionRawDataSensitivityCalculatorTest.java
@@ -180,14 +180,14 @@ public class SabrSwaptionRawDataSensitivityCalculatorTest {
       List<RawOptionData> dataRaw) {
     PointSensitivities points =
         LEG_PRICER.presentValueSensitivitySabrParameter(FLOOR_LEG, MULTICURVE, sabrCalibrated).build();
-    CurrencyParameterSensitivities sabrParametersSurfaceSensitivities = sabrCalibrated.parameterSensitivity(points);    
+    CurrencyParameterSensitivities sabrParametersSurfaceSensitivities = sabrCalibrated.parameterSensitivity(points);
     CurrencyParameterSensitivity parallelSensitivitiesSurface =
-        RDSC.parallelSensitivity(sabrParametersSurfaceSensitivities, sabrCalibrated);        
+        RDSC.parallelSensitivity(sabrParametersSurfaceSensitivities, sabrCalibrated);
     DoubleArray sensitivityArray = parallelSensitivitiesSurface.getSensitivity();
-    double fdShift = 1.0E-6;    
+    double fdShift = 1.0E-6;
     int surfacePointIndex = 0;
-    for (int looptenor = 0; looptenor < TENORS.size(); looptenor++) {
-      for (int loopexpiry = 0; loopexpiry < EXPIRIES.size(); loopexpiry++) {
+    for (int loopexpiry = 0; loopexpiry < EXPIRIES.size(); loopexpiry++) {
+      for (int looptenor = 0; looptenor < TENORS.size(); looptenor++) {
         Pair<DoubleArray, DoubleArray> ds = dataRaw.get(looptenor).availableSmileAtExpiry(EXPIRIES.get(loopexpiry));
         if (!ds.getFirst().isEmpty()) {
           double[] pv = new double[2]; // pv with shift up and down

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
@@ -132,6 +132,8 @@ public class SwaptionCubeData {
   }
   public static final double[] DATA_NORMAL_ATM_SIMPLE =
       {0.00265, 0.00270, 0.00260, 0.00265, 0.00255, 0.00260, 0.00250, 0.00255};
+  public static final double[] DATA_LOGNORMAL_ATM_SIMPLE =
+    {0.265, 0.270, 0.260, 0.265, 0.255, 0.260, 0.250, 0.255};
   public static final double[] EXPIRIES_SIMPLE_2_TIME = new double[DATA_NORMAL_ATM_SIMPLE.length];
   static {
     for (int i = 0; i < EXPIRIES_SIMPLE_2.size(); i++) {
@@ -142,16 +144,25 @@ public class SwaptionCubeData {
     }
   }
   public static final double[] TENOR_TIME = {1, 2, 1, 2, 1, 2, 1, 2};
-  private static final SurfaceMetadata METADATA = DefaultSurfaceMetadata.builder().surfaceName("ATM")
+  private static final SurfaceMetadata METADATA_NORMAL = DefaultSurfaceMetadata.builder().surfaceName("ATM")
       .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION)
       .zValueType(ValueType.NORMAL_VOLATILITY).addInfo(SurfaceInfoType.SWAP_CONVENTION, EUR_FIXED_1Y_EURIBOR_6M)
+      .dayCount(DAY_COUNT).build();
+  private static final SurfaceMetadata METADATA_LOGNORMAL = DefaultSurfaceMetadata.builder().surfaceName("ATM")
+      .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION)
+      .zValueType(ValueType.BLACK_VOLATILITY).addInfo(SurfaceInfoType.SWAP_CONVENTION, EUR_FIXED_1Y_EURIBOR_6M)
       .dayCount(DAY_COUNT).build();
   private static final Interpolator1D LINEAR_FLAT = CombinedInterpolatorExtrapolator.of(
       CurveInterpolators.LINEAR.getName(), CurveExtrapolators.FLAT.getName(), CurveExtrapolators.FLAT.getName());
   private static final GridInterpolator2D INTERPOLATOR_2D = new GridInterpolator2D(LINEAR_FLAT, LINEAR_FLAT);
-  public static final InterpolatedNodalSurface ATM_SIMPLE_SURFACE = 
-      InterpolatedNodalSurface.of(METADATA, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
+  public static final InterpolatedNodalSurface ATM_NORMAL_SIMPLE_SURFACE = 
+      InterpolatedNodalSurface.of(METADATA_NORMAL, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
           DoubleArray.ofUnsafe(TENOR_TIME), DoubleArray.ofUnsafe(DATA_NORMAL_ATM_SIMPLE), INTERPOLATOR_2D);
-  public static final SwaptionVolatilities ATM_SIMPLE = 
-      NormalSwaptionExpiryTenorVolatilities.of(ATM_SIMPLE_SURFACE, DATA_TIME);
+  public static final InterpolatedNodalSurface ATM_LOGNORMAL_SIMPLE_SURFACE = 
+      InterpolatedNodalSurface.of(METADATA_LOGNORMAL, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
+          DoubleArray.ofUnsafe(TENOR_TIME), DoubleArray.ofUnsafe(DATA_LOGNORMAL_ATM_SIMPLE), INTERPOLATOR_2D);
+  public static final SwaptionVolatilities ATM_NORMAL_SIMPLE = 
+      NormalSwaptionExpiryTenorVolatilities.of(ATM_NORMAL_SIMPLE_SURFACE, DATA_TIME);
+  public static final SwaptionVolatilities ATM_LOGNORMAL_SIMPLE = 
+      BlackSwaptionExpiryTenorVolatilities.of(ATM_LOGNORMAL_SIMPLE_SURFACE, DATA_TIME);
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
@@ -5,13 +5,30 @@
  */
 package com.opengamma.strata.pricer.swaption;
 
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.date.BusinessDayAdjustment;
+import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.interpolator.CurveExtrapolators;
+import com.opengamma.strata.market.interpolator.CurveInterpolators;
+import com.opengamma.strata.market.surface.DefaultSurfaceMetadata;
+import com.opengamma.strata.market.surface.InterpolatedNodalSurface;
+import com.opengamma.strata.market.surface.SurfaceInfoType;
+import com.opengamma.strata.market.surface.SurfaceMetadata;
+import com.opengamma.strata.math.impl.interpolation.CombinedInterpolatorExtrapolator;
+import com.opengamma.strata.math.impl.interpolation.GridInterpolator2D;
+import com.opengamma.strata.math.impl.interpolation.Interpolator1D;
 import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 
@@ -22,6 +39,9 @@ public class SwaptionCubeData {
 
   /** Normal volatility for EUR - Data from 29-February-2016*/
   public static final LocalDate DATA_DATE = LocalDate.of(2016, 2, 29);
+  public static final ZonedDateTime DATA_TIME = DATA_DATE.atTime(10, 0).atZone(ZoneId.of("Europe/Berlin"));
+  public static final DayCount DAY_COUNT = ACT_365F;
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
   public static final FixedIborSwapConvention EUR_FIXED_1Y_EURIBOR_6M = FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
   public static final DoubleArray MONEYNESS =
       DoubleArray.of(-0.0200, -0.0100, -0.0050, -0.0025, 0.0000, 0.0025, 0.0050, 0.0100, 0.0200);
@@ -103,4 +123,35 @@ public class SwaptionCubeData {
           {0.00446, 0.003534, 0.002833, 0.002542, 0.002439, 0.002627, 0.002993, 0.003854, 0.005565}}
   };
 
+  public static final List<Period> EXPIRIES_SIMPLE_2 = new ArrayList<>();
+  static {
+    EXPIRIES_SIMPLE_2.add(Period.ofMonths(1));
+    EXPIRIES_SIMPLE_2.add(Period.ofMonths(3));
+    EXPIRIES_SIMPLE_2.add(Period.ofMonths(6));
+    EXPIRIES_SIMPLE_2.add(Period.ofYears(1));
+  }
+  public static final double[] DATA_NORMAL_ATM_SIMPLE =
+      {0.00265, 0.00270, 0.00260, 0.00265, 0.00255, 0.00260, 0.00250, 0.00255};
+  public static final double[] EXPIRIES_SIMPLE_2_TIME = new double[DATA_NORMAL_ATM_SIMPLE.length];
+  static {
+    for (int i = 0; i < EXPIRIES_SIMPLE_2.size(); i++) {
+      BusinessDayAdjustment bda = EUR_FIXED_1Y_EURIBOR_6M.getFloatingLeg().getStartDateBusinessDayAdjustment();
+      EXPIRIES_SIMPLE_2_TIME[2 * i] =
+          DAY_COUNT.relativeYearFraction(DATA_DATE, bda.adjust(DATA_DATE.plus(EXPIRIES_SIMPLE_2.get(i)), REF_DATA));
+      EXPIRIES_SIMPLE_2_TIME[2 * i + 1] = EXPIRIES_SIMPLE_2_TIME[2 * i];
+    }
+  }
+  public static final double[] TENOR_TIME = {1, 2, 1, 2, 1, 2, 1, 2};
+  private static final SurfaceMetadata METADATA = DefaultSurfaceMetadata.builder().surfaceName("ATM")
+      .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION)
+      .zValueType(ValueType.NORMAL_VOLATILITY).addInfo(SurfaceInfoType.SWAP_CONVENTION, EUR_FIXED_1Y_EURIBOR_6M)
+      .dayCount(DAY_COUNT).build();
+  private static final Interpolator1D LINEAR_FLAT = CombinedInterpolatorExtrapolator.of(
+      CurveInterpolators.LINEAR.getName(), CurveExtrapolators.FLAT.getName(), CurveExtrapolators.FLAT.getName());
+  private static final GridInterpolator2D INTERPOLATOR_2D = new GridInterpolator2D(LINEAR_FLAT, LINEAR_FLAT);
+  public static final InterpolatedNodalSurface ATM_SIMPLE_SURFACE = 
+      InterpolatedNodalSurface.of(METADATA, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
+          DoubleArray.ofUnsafe(TENOR_TIME), DoubleArray.ofUnsafe(DATA_NORMAL_ATM_SIMPLE), INTERPOLATOR_2D);
+  public static final SwaptionVolatilities ATM_SIMPLE = 
+      NormalSwaptionExpiryTenorVolatilities.of(ATM_SIMPLE_SURFACE, DATA_TIME);
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilitiesTest.java
@@ -131,7 +131,7 @@ public class SwaptionVolatilitiesTest {
 
     @Override
     public ValueType getVolatilityType() {
-      return null;
+      return ValueType.BLACK_VOLATILITY;
     }
 
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilitiesTest.java
@@ -13,6 +13,7 @@ import java.time.ZonedDateTime;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.ParameterPerturbation;
@@ -121,6 +122,16 @@ public class SwaptionVolatilitiesTest {
     @Override
     public double tenor(LocalDate startDate, LocalDate endDate) {
       throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LocalDate getValuationDate() {
+      return getValuationDateTime().toLocalDate();
+    }
+
+    @Override
+    public ValueType getVolatilityType() {
+      return null;
     }
 
   }


### PR DESCRIPTION
Enhanced the 'SabrSwaptionCalibrator' to allow calibration of the SABR alpha parameter to at-the-money volatilities.