### PR TITLE
Add getIds to MarketData and ScenarioMarketData

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CdsScenarioExample.java
@@ -38,6 +38,7 @@ import com.opengamma.strata.collect.array.DoubleMatrix;
 import com.opengamma.strata.collect.io.ResourceLocator;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.ImmutableMarketDataBuilder;
+import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.scenario.CurrencyValuesArray;
 import com.opengamma.strata.data.scenario.MarketDataBox;
 import com.opengamma.strata.data.scenario.ScenarioMarketData;
@@ -85,7 +86,7 @@ public class CdsScenarioExample {
     }
   }
 
-  // calculates P&Ls by loading a set of base market data and defining shifts to apply to this for each scenario
+  // loads the trade and market data, and performs the calculations
   private static void calculate(CalculationRunner runner) {
     // the trade to price
     CdsTrade cds = createSingleNameCds();
@@ -95,9 +96,9 @@ public class CdsScenarioExample {
     List<Column> columns = ImmutableList.of(
         Column.of(Measures.PRESENT_VALUE));
 
-    // build the set of market data for base scenario on the valuation date
+    // build the set of market data for the base scenario on the valuation date
     // this is the snapshot which will be perturbed in the scenarios
-    ImmutableMarketData baseMarketData = buildBaseMarketData();
+    MarketData baseMarketData = buildBaseMarketData();
 
     // build scenarios containing credit curve shifts
     ScenarioDefinition scenarios = buildScenarios(baseMarketData);
@@ -134,7 +135,7 @@ public class CdsScenarioExample {
 
   //-------------------------------------------------------------------------
   // builds the set of market data representing the base scenario
-  private static ImmutableMarketData buildBaseMarketData() {
+  private static MarketData buildBaseMarketData() {
 
     // initialise the market data builder for the valuation date
     LocalDate valuationDate = LocalDate.of(2014, 10, 16);
@@ -194,12 +195,12 @@ public class CdsScenarioExample {
 
   //-----------------------------------------------------------------------
   // build the scenarios to use to perturb the base market data
-  private static ScenarioDefinition buildScenarios(ImmutableMarketData baseMarketData) {
+  private static ScenarioDefinition buildScenarios(MarketData baseMarketData) {
 
     // build perturbations for each single name credit curve in the base market data set
     // here we are only interested in one credit curve, but this shows how we might deal with a larger set
     // each perturbation mapping represents the shifts to apply to one item of market data (here, a curve) in all scenarios
-    List<PerturbationMapping<?>> perturbations = baseMarketData.getValues().keySet().stream()
+    List<PerturbationMapping<?>> perturbations = baseMarketData.getIds().stream()
         .filter(id -> id instanceof IsdaSingleNameCreditCurveInputsId)
         .map(IsdaSingleNameCreditCurveInputsId.class::cast)
         .map(id -> PerturbationMapping.of(

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/BuiltMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/BuiltMarketData.java
@@ -77,6 +77,11 @@ public final class BuiltMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return underlying.getIds();
+  }
+
+  @Override
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     return underlying.findIds(name);
   }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/BuiltScenarioMarketData.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/BuiltScenarioMarketData.java
@@ -152,6 +152,11 @@ public final class BuiltScenarioMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return underlying.getIds();
+  }
+
+  @Override
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     return underlying.findIds(name);
   }

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/BuiltMarketDataTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/BuiltMarketDataTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.collect.result.FailureException;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
@@ -40,6 +41,7 @@ public class BuiltMarketDataTest {
 
     assertEquals(test.getValuationDate(), VAL_DATE);
     assertEquals(test.containsValue(ID), false);
+    assertEquals(test.getIds(), ImmutableSet.of());
     assertEquals(test.findValue(ID), Optional.empty());
     assertThrows(() -> test.getValue(ID), FailureException.class, failureMessage);
   }
@@ -51,6 +53,7 @@ public class BuiltMarketDataTest {
 
     assertEquals(test.getValuationDate(), VAL_DATE);
     assertEquals(test.containsValue(ID), false);
+    assertEquals(test.getIds(), ImmutableSet.of());
     assertEquals(test.findValue(ID), Optional.empty());
     assertThrows(() -> test.getValue(ID), MarketDataNotFoundException.class);
   }

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/BuiltScenarioMarketDataTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/BuiltScenarioMarketDataTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.collect.result.FailureException;
 import com.opengamma.strata.collect.result.FailureReason;
@@ -50,6 +51,7 @@ public class BuiltScenarioMarketDataTest {
 
     assertEquals(test.getValuationDate(), MarketDataBox.ofSingleValue(VAL_DATE));
     assertEquals(test.containsValue(ID), false);
+    assertEquals(test.getIds(), ImmutableSet.of());
     assertEquals(test.findValue(ID), Optional.empty());
     assertThrows(() -> test.getValue(ID), FailureException.class, failureMessage);
   }
@@ -60,6 +62,7 @@ public class BuiltScenarioMarketDataTest {
 
     assertEquals(test.getValuationDate(), MarketDataBox.ofSingleValue(VAL_DATE));
     assertEquals(test.containsValue(ID), false);
+    assertEquals(test.getIds(), ImmutableSet.of());
     assertEquals(test.findValue(ID), Optional.empty());
     assertThrows(() -> test.getValue(ID), MarketDataNotFoundException.class);
   }

--- a/modules/data/src/main/java/com/opengamma/strata/data/CombinedMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/CombinedMarketData.java
@@ -76,6 +76,14 @@ final class CombinedMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return ImmutableSet.<MarketDataId<?>>builder()
+        .addAll(underlying1.getIds())
+        .addAll(underlying2.getIds())
+        .build();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     return ImmutableSet.<MarketDataId<T>>builder()

--- a/modules/data/src/main/java/com/opengamma/strata/data/ExtendedMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/ExtendedMarketData.java
@@ -95,6 +95,14 @@ final class ExtendedMarketData<T>
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return ImmutableSet.<MarketDataId<?>>builder()
+        .addAll(underlying.getIds())
+        .add(id)
+        .build();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <R> Set<MarketDataId<R>> findIds(MarketDataName<R> name) {
     Set<MarketDataId<R>> ids = underlying.findIds(name);

--- a/modules/data/src/main/java/com/opengamma/strata/data/ImmutableMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/ImmutableMarketData.java
@@ -145,6 +145,11 @@ public final class ImmutableMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return values.keySet();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     // no type check against id.getMarketDataType() as checked in factory

--- a/modules/data/src/main/java/com/opengamma/strata/data/MarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/MarketData.java
@@ -121,6 +121,13 @@ public interface MarketData {
 
   //-------------------------------------------------------------------------
   /**
+   * Gets the market data identifiers.
+   *
+   * @return the set of market data identifiers
+   */
+  public abstract Set<MarketDataId<?>> getIds();
+
+  /**
    * Finds the market data identifiers associated with the specified name.
    * <p>
    * This returns the unique identifiers that refer to the specified name.

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketData.java
@@ -19,6 +19,7 @@ import org.joda.beans.PropertyDefinition;
 import org.joda.beans.impl.light.LightMetaBean;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.MarketDataId;
@@ -102,6 +103,14 @@ final class CombinedScenarioMarketData
   public <T> Optional<MarketDataBox<T>> findValue(MarketDataId<T> id) {
     Optional<MarketDataBox<T>> value1 = underlying1.findValue(id);
     return value1.isPresent() ? value1 : underlying2.findValue(id);
+  }
+
+  @Override
+  public Set<MarketDataId<?>> getIds() {
+    return ImmutableSet.<MarketDataId<?>>builder()
+        .addAll(underlying1.getIds())
+        .addAll(underlying2.getIds())
+        .build();
   }
 
   @Override

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketData.java
@@ -119,6 +119,14 @@ final class ExtendedScenarioMarketData<T>
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return ImmutableSet.<MarketDataId<?>>builder()
+        .addAll(underlying.getIds())
+        .add(id)
+        .build();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <R> Set<MarketDataId<R>> findIds(MarketDataName<R> name) {
     Set<MarketDataId<R>> ids = underlying.findIds(name);

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/ImmutableScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/ImmutableScenarioMarketData.java
@@ -201,6 +201,11 @@ public final class ImmutableScenarioMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return values.keySet();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     // no type check against id.getMarketDataType() as checked in factory

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/RepeatedScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/RepeatedScenarioMarketData.java
@@ -107,6 +107,11 @@ final class RepeatedScenarioMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return underlying.getIds();
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     return underlying.findIds(name);

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/ScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/ScenarioMarketData.java
@@ -198,6 +198,13 @@ public interface ScenarioMarketData {
 
   //-------------------------------------------------------------------------
   /**
+   * Gets the market data identifiers.
+   *
+   * @return the set of market data identifiers
+   */
+  public abstract Set<MarketDataId<?>> getIds();
+
+  /**
    * Finds the market data identifiers associated with the specified name.
    * <p>
    * This returns the unique identifiers that refer to the specified name.

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/SingleScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/SingleScenarioMarketData.java
@@ -91,6 +91,11 @@ final class SingleScenarioMarketData
   }
 
   @Override
+  public Set<MarketDataId<?>> getIds() {
+    return marketData.getIds();
+  }
+
+  @Override
   public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
     return marketData.findIds(name);
   }

--- a/modules/data/src/test/java/com/opengamma/strata/data/CombinedMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/CombinedMarketDataTest.java
@@ -61,6 +61,7 @@ public class CombinedMarketDataTest {
     assertEquals(test.findValue(ID2), Optional.of(VAL2));
     assertEquals(test.findValue(ID3), Optional.of(VAL3));
     assertEquals(test.findValue(ID5), Optional.empty());
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2, ID3));
     assertEquals(test.findIds(ID1.getMarketDataName()), ImmutableSet.of(ID1));
     assertEquals(test.findIds(ID3.getMarketDataName()), ImmutableSet.of(ID3));
     assertEquals(test.findIds(ID4.getMarketDataName()), ImmutableSet.of());

--- a/modules/data/src/test/java/com/opengamma/strata/data/ExtendedMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/ExtendedMarketDataTest.java
@@ -60,6 +60,7 @@ public class ExtendedMarketDataTest {
     assertEquals(test.findValue(ID2), Optional.of(VAL2));
     assertEquals(test.findValue(ID3), Optional.of(VAL3));
     assertEquals(test.findValue(ID4), Optional.empty());
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2, ID3));
     assertEquals(test.findIds(ID1.getMarketDataName()), ImmutableSet.of(ID1));
     assertEquals(test.findIds(ID3.getMarketDataName()), ImmutableSet.of(ID3));
     assertEquals(test.getTimeSeries(ID4), TIME_SERIES);
@@ -79,6 +80,7 @@ public class ExtendedMarketDataTest {
     assertEquals(test.findValue(ID1), Optional.of(VAL3));
     assertEquals(test.findValue(ID2), Optional.of(VAL2));
     assertEquals(test.findValue(ID3), Optional.empty());
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2));
     assertEquals(test.getTimeSeries(ID4), TIME_SERIES);
   }
 

--- a/modules/data/src/test/java/com/opengamma/strata/data/MarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/MarketDataTest.java
@@ -62,6 +62,8 @@ public class MarketDataTest {
     assertThrows(() -> test.getValue(ID3), MarketDataNotFoundException.class);
     assertEquals(test.findValue(ID3), Optional.empty());
 
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2));
+
     assertEquals(test.findIds(ID1.getMarketDataName()), ImmutableSet.of(ID1));
     assertEquals(test.findIds(new TestingName("Foo")), ImmutableSet.of());
 
@@ -82,6 +84,8 @@ public class MarketDataTest {
     assertThrows(() -> test.getValue(ID2), MarketDataNotFoundException.class);
     assertEquals(test.findValue(ID2), Optional.empty());
 
+    assertEquals(test.getIds(), ImmutableSet.of(ID1));
+
     assertEquals(test.getTimeSeries(ID4), LocalDateDoubleTimeSeries.empty());
     assertEquals(test.getTimeSeries(ID5), TIME_SERIES);
   }
@@ -90,6 +94,7 @@ public class MarketDataTest {
     MarketData test = MarketData.empty(VAL_DATE);
 
     assertEquals(test.containsValue(ID1), false);
+    assertEquals(test.getIds(), ImmutableSet.of());
     assertEquals(test.getTimeSeries(ID4), LocalDateDoubleTimeSeries.empty());
   }
 
@@ -103,6 +108,7 @@ public class MarketDataTest {
         .build();
     assertEquals(test.getValuationDate(), VAL_DATE);
     assertEquals(test.getValues().get(ID1), "123");
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID3));
     assertEquals(test.getTimeSeries().get(ID4), TIME_SERIES);
   }
 
@@ -138,6 +144,11 @@ public class MarketDataTest {
       }
 
       @Override
+      public Set<MarketDataId<?>> getIds() {
+        return ImmutableSet.of();
+      }
+
+      @Override
       public <T> Set<MarketDataId<T>> findIds(MarketDataName<T> name) {
         return ImmutableSet.of();
       }
@@ -161,6 +172,7 @@ public class MarketDataTest {
     MarketData test = test1.combinedWith(test2);
     assertEquals(test.getValue(ID1), VAL1);
     assertEquals(test.getValue(ID2), VAL2);
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2));
   }
 
   public void test_combinedWith_noClashSame() {
@@ -172,6 +184,7 @@ public class MarketDataTest {
     MarketData test = test1.combinedWith(test2);
     assertEquals(test.getValue(ID1), VAL1);
     assertEquals(test.getValue(ID2), VAL2);
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2));
   }
 
   public void test_combinedWith_clash() {
@@ -181,6 +194,7 @@ public class MarketDataTest {
     MarketData test2 = MarketData.of(VAL_DATE, dataMap2);
     MarketData combined = test1.combinedWith(test2);
     assertEquals(combined.getValue(ID1), VAL1);
+    assertEquals(combined.getIds(), ImmutableSet.of(ID1));
   }
 
   public void test_combinedWith_dateMismatch() {

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketDataTest.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.data.ObservableSource;
@@ -76,6 +77,7 @@ public class CombinedScenarioMarketDataTest {
 
     ScenarioMarketData combined = marketData1.combinedWith(marketData2);
     assertThat(combined).isEqualTo(expected);
+    assertThat(combined.getIds()).isEqualTo(ImmutableSet.of(TEST_ID1, TEST_ID2, TEST_ID3));
   }
 
   public void test_combinedWithIncompatibleScenarioCount() {
@@ -104,7 +106,9 @@ public class CombinedScenarioMarketDataTest {
         .addBox(TEST_ID2, MarketDataBox.ofScenarioValues(1.0, 1.1))
         .build();
 
-    assertThat(marketData1.combinedWith(marketData2)).isEqualTo(expected);
+    ScenarioMarketData combined = marketData1.combinedWith(marketData2);
+    assertThat(combined).isEqualTo(expected);
+    assertThat(combined.getIds()).isEqualTo(ImmutableSet.of(TEST_ID1, TEST_ID2));
   }
 
   public void test_combinedWithOtherHasOneScenario() {
@@ -121,7 +125,9 @@ public class CombinedScenarioMarketDataTest {
         .addBox(TEST_ID2, MarketDataBox.ofScenarioValues(1.0, 1.1))
         .build();
 
-    assertThat(marketData1.combinedWith(marketData2)).isEqualTo(expected);
+    ScenarioMarketData combined = marketData1.combinedWith(marketData2);
+    assertThat(combined).isEqualTo(expected);
+    assertThat(combined.getIds()).isEqualTo(ImmutableSet.of(TEST_ID1, TEST_ID2));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ExtendedScenarioMarketDataTest.java
@@ -64,6 +64,7 @@ public class ExtendedScenarioMarketDataTest {
     assertEquals(test.findValue(ID2), Optional.of(VAL2));
     assertEquals(test.findValue(ID3), Optional.of(VAL3));
     assertEquals(test.findValue(ID4), Optional.empty());
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2, ID3));
     assertEquals(test.findIds(ID1.getMarketDataName()), ImmutableSet.of(ID1));
     assertEquals(test.findIds(ID3.getMarketDataName()), ImmutableSet.of(ID3));
     assertEquals(test.getTimeSeries(ID4), TIME_SERIES);
@@ -80,6 +81,7 @@ public class ExtendedScenarioMarketDataTest {
     assertEquals(test.getValue(ID1), VAL3);
     assertEquals(test.getValue(ID2), VAL2);
     assertThrows(() -> test.getValue(ID3), MarketDataNotFoundException.class);
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2));
     assertEquals(test.findValue(ID1), Optional.of(VAL3));
     assertEquals(test.findValue(ID2), Optional.of(VAL2));
     assertEquals(test.findValue(ID3), Optional.empty());

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ImmutableScenarioMarketDataBuilderTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ImmutableScenarioMarketDataBuilderTest.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -57,6 +58,7 @@ public class ImmutableScenarioMarketDataBuilderTest {
         .addScenarioValue(eurUsdId, ImmutableList.of(eurUsdRate1, eurUsdRate2))
         .build();
     assertEquals(marketData.getScenarioCount(), 2);
+    assertEquals(marketData.getIds(), ImmutableSet.of(eurGbpId, eurUsdId));
     assertEquals(marketData.getValue(eurGbpId), MarketDataBox.ofSingleValue(eurGbpRate));
     assertEquals(marketData.getValue(eurUsdId), MarketDataBox.ofScenarioValues(eurUsdRate1, eurUsdRate2));
   }
@@ -73,6 +75,7 @@ public class ImmutableScenarioMarketDataBuilderTest {
         .addBox(eurUsdId, MarketDataBox.ofScenarioValues(eurUsdRate1, eurUsdRate2))
         .build();
     assertEquals(marketData.getScenarioCount(), 2);
+    assertEquals(marketData.getIds(), ImmutableSet.of(eurGbpId, eurUsdId));
     assertEquals(marketData.getValue(eurGbpId), MarketDataBox.ofSingleValue(eurGbpRate));
     assertEquals(marketData.getValue(eurUsdId), MarketDataBox.ofScenarioValues(eurUsdRate1, eurUsdRate2));
   }
@@ -105,6 +108,7 @@ public class ImmutableScenarioMarketDataBuilderTest {
         .addValueMap(values)
         .build();
     assertEquals(marketData.getScenarioCount(), 1);
+    assertEquals(marketData.getIds(), ImmutableSet.of(eurGbpId, eurUsdId));
     assertEquals(marketData.getValue(eurGbpId), MarketDataBox.ofSingleValue(eurGbpRate));
     assertEquals(marketData.getValue(eurUsdId), MarketDataBox.ofSingleValue(eurUsdRate));
   }
@@ -123,6 +127,7 @@ public class ImmutableScenarioMarketDataBuilderTest {
         .addScenarioValueMap(values)
         .build();
     assertEquals(marketData.getScenarioCount(), 3);
+    assertEquals(marketData.getIds(), ImmutableSet.of(eurGbpId, eurUsdId));
     assertEquals(marketData.getValue(eurGbpId), MarketDataBox.ofScenarioValue(eurGbpRates));
     assertEquals(marketData.getValue(eurUsdId), MarketDataBox.ofScenarioValue(eurUsdRates));
   }

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/RepeatedScenarioMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/RepeatedScenarioMarketDataTest.java
@@ -60,6 +60,7 @@ public class RepeatedScenarioMarketDataTest {
     assertEquals(test.findValue(ID1), Optional.of(MarketDataBox.ofSingleValue(VAL1)));
     assertEquals(test.findValue(ID2), Optional.of(MarketDataBox.ofSingleValue(VAL2)));
     assertEquals(test.findValue(ID3), Optional.empty());
+    assertEquals(test.getIds(), ImmutableSet.of(ID1, ID2));
     assertEquals(test.findIds(ID1.getMarketDataName()), ImmutableSet.of(ID1));
     assertEquals(test.getTimeSeries(ID4), TIME_SERIES);
   }

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ScenarioMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ScenarioMarketDataTest.java
@@ -63,6 +63,7 @@ public class ScenarioMarketDataTest {
     assertThrows(() -> test.getValue(ID2), MarketDataNotFoundException.class);
     assertThat(test.findValue(ID1)).hasValue(BOX1);
     assertThat(test.findValue(ID2)).isEmpty();
+    assertThat(test.getIds()).isEqualTo(ImmutableSet.of(ID1));
     assertThat(test.getTimeSeries(ID1)).isEqualTo(TIME_SERIES);
     assertThat(test.getTimeSeries(ID2)).isEqualTo(LocalDateDoubleTimeSeries.empty());
   }
@@ -77,6 +78,7 @@ public class ScenarioMarketDataTest {
     assertThrows(() -> test.getValue(ID2), MarketDataNotFoundException.class);
     assertThat(test.findValue(ID1)).hasValue(MarketDataBox.empty());
     assertThat(test.findValue(ID2)).isEmpty();
+    assertThat(test.getIds()).isEqualTo(ImmutableSet.of(ID1));
     assertThat(test.getTimeSeries(ID1)).isEqualTo(LocalDateDoubleTimeSeries.empty());
     assertThat(test.getTimeSeries(ID2)).isEqualTo(LocalDateDoubleTimeSeries.empty());
   }
@@ -96,6 +98,7 @@ public class ScenarioMarketDataTest {
     assertThrows(() -> test.getValue(ID2), MarketDataNotFoundException.class);
     assertThat(test.findValue(ID1)).isEmpty();
     assertThat(test.findValue(ID2)).isEmpty();
+    assertThat(test.getIds()).isEqualTo(ImmutableSet.of());
     assertThat(test.getTimeSeries(ID1)).isEqualTo(LocalDateDoubleTimeSeries.empty());
     assertThat(test.getTimeSeries(ID2)).isEqualTo(LocalDateDoubleTimeSeries.empty());
   }
@@ -142,6 +145,11 @@ public class ScenarioMarketDataTest {
       @SuppressWarnings("unchecked")
       public <T> Optional<MarketDataBox<T>> findValue(MarketDataId<T> id) {
         return id.equals(ID1) ? Optional.of((MarketDataBox<T>) BOX1) : Optional.empty();
+      }
+
+      @Override
+      public Set<MarketDataId<?>> getIds() {
+        return ImmutableSet.of();
       }
 
       @Override
@@ -310,6 +318,11 @@ public class ScenarioMarketDataTest {
     @Override
     public <T> Optional<MarketDataBox<T>> findValue(MarketDataId<T> id) {
       throw new UnsupportedOperationException("findValue not implemented");
+    }
+
+    @Override
+    public Set<MarketDataId<?>> getIds() {
+      return ImmutableSet.of();
     }
 
     @Override

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/curve/TestMarketDataMap.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/curve/TestMarketDataMap.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.MarketDataId;
 import com.opengamma.strata.data.MarketDataName;
@@ -72,6 +73,11 @@ public final class TestMarketDataMap implements ScenarioMarketData {
     @SuppressWarnings("unchecked")
     T value = (T) valueMap.get(id);
     return value == null ? Optional.empty() : Optional.of(MarketDataBox.ofSingleValue(value));
+  }
+
+  @Override
+  public Set<MarketDataId<?>> getIds() {
+    return ImmutableSet.copyOf(valueMap.keySet());
   }
 
   @Override


### PR DESCRIPTION
Allows the `CdsScenarioExample` to be simplified as shown.