### PR TITLE
Revert remove standard identifier from observables

### DIFF
--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/DefaultMarketDataFactoryTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/DefaultMarketDataFactoryTest.java
@@ -24,6 +24,7 @@ import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.MarketDataId;
@@ -889,10 +890,7 @@ public class DefaultMarketDataFactoryTest {
     }
 
     private Result<Double> buildResult(ObservableId id) {
-      if (id instanceof TestIdA) {
-        return Result.success(Double.parseDouble(((TestIdA) id).id.getValue()));
-      }
-      return Result.success(Double.parseDouble(((TestObservableId) id).getStandardId().getValue()));
+      return Result.success(Double.parseDouble(id.getStandardId().getValue()));
     }
   }
 
@@ -906,6 +904,16 @@ public class DefaultMarketDataFactoryTest {
 
     TestIdA(String id) {
       this.id = StandardId.of("test", id);
+    }
+
+    @Override
+    public StandardId getStandardId() {
+      return id;
+    }
+
+    @Override
+    public FieldName getFieldName() {
+      return FieldName.MARKET_VALUE;
     }
 
     @Override

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketDataNodeTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/MarketDataNodeTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.MarketDataId;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.data.ObservableSource;
@@ -283,6 +284,16 @@ public class MarketDataNodeTest {
 
     TestIdA(String id) {
       this.id = StandardId.of("test", id);
+    }
+
+    @Override
+    public StandardId getStandardId() {
+      return id;
+    }
+
+    @Override
+    public FieldName getFieldName() {
+      return FieldName.MARKET_VALUE;
     }
 
     @Override

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/TestObservableId.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/marketdata/TestObservableId.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.data.ObservableSource;
 
@@ -49,8 +50,14 @@ public class TestObservableId
     this.id = id;
   }
 
+  @Override
   public StandardId getStandardId() {
     return id;
+  }
+
+  @Override
+  public FieldName getFieldName() {
+    return FieldName.MARKET_VALUE;
   }
 
   @Override

--- a/modules/data/src/main/java/com/opengamma/strata/data/ObservableId.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/ObservableId.java
@@ -5,11 +5,27 @@
  */
 package com.opengamma.strata.data;
 
+import com.opengamma.strata.basics.StandardId;
+
 /**
  * A market data identifier that identifies observable data.
  * <p>
  * Observable data can be requested from an external data provider, for example Bloomberg or Reuters.
- * The data provider is represented by {@link ObservableSource}.
+ * <p>
+ * An observable ID contains three pieces of information:
+ * <ul>
+ *   <li>A {@link StandardId} identifying the market data. This ID can come from any system. It might be
+ *   an OpenGamma ID, for example {@code OpenGammaIndex~GBP_LIBOR_3M}, or it can be an ID from a market
+ *   data source, for example {@code BloombergTicker~AAPL US Equity}.</li>
+ *
+ *   <li>A {@link FieldName} indicating the field in the market data record containing the data. See
+ *   the {@code FieldName} documentation for more details.</li>
+ *
+ *   <li>A {@link ObservableSource} indicating where the data should come from.
+ *   It is important to note that the standard ID is not necessarily related to the source.
+ *   There is typically a mapping step in the market data system that maps the standard ID
+ *   into an ID that can be used to look up the data in the source.</li>
+ * </ul>
  * <p>
  * Observable data is always represented by a {@code double}.
  */
@@ -25,6 +41,27 @@ public interface ObservableId
   public default Class<Double> getMarketDataType() {
     return Double.class;
   }
+
+  /**
+   * Gets the standard identifier identifying the data.
+   * <p>
+   * The identifier may be the identifier used to identify the item in an underlying data provider,
+   * for example a Bloomberg ticker. It also may be any arbitrary unique identifier that can be resolved
+   * to one or more data provider identifiers which are used to request the data from the provider.
+   *
+   * @return a standard identifier, such as a ticker, to identify the desired data
+   */
+  public abstract StandardId getStandardId();
+
+  /**
+   * Gets the field name in the market data record that contains the market data item.
+   * <p>
+   * Each ticker typically exposes many different fields. The field name specifies the desired field.
+   * For example, the {@linkplain FieldName#MARKET_VALUE market value}.
+   *
+   * @return the field name in the market data record that contains the market data item
+   */
+  public abstract FieldName getFieldName();
 
   /**
    * Gets the source of market data from which the market data should be retrieved.

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketData.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketData.java
@@ -19,7 +19,6 @@ import org.joda.beans.PropertyDefinition;
 import org.joda.beans.impl.light.LightMetaBean;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.MarketDataId;

--- a/modules/data/src/test/java/com/opengamma/strata/data/TestingObservableId.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/TestingObservableId.java
@@ -8,6 +8,8 @@ package com.opengamma.strata.data;
 import java.io.Serializable;
 import java.util.Objects;
 
+import com.opengamma.strata.basics.StandardId;
+
 /**
  * MarketDataId implementation used in tests.
  */
@@ -29,6 +31,16 @@ public class TestingObservableId
   @Override
   public Class<Double> getMarketDataType() {
     return Double.class;
+  }
+
+  @Override
+  public StandardId getStandardId() {
+    return StandardId.of("Test", id);
+  }
+
+  @Override
+  public FieldName getFieldName() {
+    return FieldName.MARKET_VALUE;
   }
 
   @Override

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketDataTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/CombinedScenarioMarketDataTest.java
@@ -15,7 +15,9 @@ import java.util.Objects;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.data.ObservableSource;
 
@@ -137,6 +139,16 @@ public class CombinedScenarioMarketDataTest {
 
     private TestId(String id) {
       this.id = id;
+    }
+
+    @Override
+    public StandardId getStandardId() {
+      throw new UnsupportedOperationException("getStandardId not implemented");
+    }
+
+    @Override
+    public FieldName getFieldName() {
+      throw new UnsupportedOperationException("getFieldName not implemented");
     }
 
     @Override

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ImmutableScenarioMarketDataBuilderTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ImmutableScenarioMarketDataBuilderTest.java
@@ -19,10 +19,12 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
+import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.FxRateId;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.data.ObservableSource;
@@ -238,6 +240,16 @@ public class ImmutableScenarioMarketDataBuilderTest {
 
     private TestId(String id) {
       this.id = id;
+    }
+
+    @Override
+    public StandardId getStandardId() {
+      throw new UnsupportedOperationException("getStandardId not implemented");
+    }
+
+    @Override
+    public FieldName getFieldName() {
+      throw new UnsupportedOperationException("getFieldName not implemented");
     }
 
     @Override

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/TestObservableId.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/TestObservableId.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.data.ObservableSource;
 
@@ -47,6 +48,16 @@ class TestObservableId
   TestObservableId(StandardId id, ObservableSource obsSource) {
     this.observableSource = obsSource;
     this.id = id;
+  }
+
+  @Override
+  public StandardId getStandardId() {
+    return id;
+  }
+
+  @Override
+  public FieldName getFieldName() {
+    return FieldName.MARKET_VALUE;
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/observable/IndexQuoteId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/observable/IndexQuoteId.java
@@ -23,6 +23,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.ObservableId;
@@ -45,7 +46,7 @@ public final class IndexQuoteId implements ObservableId, ImmutableBean, Serializ
    * The field name in the market data record that contains the market data item.
    * The most common field name is {@linkplain FieldName#MARKET_VALUE market value}.
    */
-  @PropertyDefinition(validate = "notNull")
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final FieldName fieldName;
   /**
    * The source of observable market data.
@@ -94,6 +95,19 @@ public final class IndexQuoteId implements ObservableId, ImmutableBean, Serializ
   }
 
   //-------------------------------------------------------------------------
+  /**
+   * Gets the identifier of the data.
+   * <p>
+   * This returns an artificial identifier with a scheme of 'OG-Future' and
+   * a value of the index name.
+   * 
+   * @return the standard identifier
+   */
+  @Override
+  public StandardId getStandardId() {
+    return StandardId.of("OG-Index", index.getName());
+  }
+
   @Override
   public IndexQuoteId withObservableSource(ObservableSource obsSource) {
     return new IndexQuoteId(index, fieldName, obsSource);
@@ -160,6 +174,7 @@ public final class IndexQuoteId implements ObservableId, ImmutableBean, Serializ
    * The most common field name is {@linkplain FieldName#MARKET_VALUE market value}.
    * @return the value of the property, not null
    */
+  @Override
   public FieldName getFieldName() {
     return fieldName;
   }

--- a/modules/market/src/main/java/com/opengamma/strata/market/observable/QuoteId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/observable/QuoteId.java
@@ -63,13 +63,13 @@ public final class QuoteId implements ObservableId, ImmutableBean, Serializable 
    * The identifier of the data.
    * This is typically an identifier from an external data provider.
    */
-  @PropertyDefinition(validate = "notNull")
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final StandardId standardId;
   /**
    * The field name in the market data record that contains the market data item.
    * The most common field name is {@linkplain FieldName#MARKET_VALUE market value}.
    */
-  @PropertyDefinition(validate = "notNull")
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final FieldName fieldName;
   /**
    * The source of observable market data.
@@ -175,6 +175,7 @@ public final class QuoteId implements ObservableId, ImmutableBean, Serializable 
    * This is typically an identifier from an external data provider.
    * @return the value of the property, not null
    */
+  @Override
   public StandardId getStandardId() {
     return standardId;
   }
@@ -185,6 +186,7 @@ public final class QuoteId implements ObservableId, ImmutableBean, Serializable 
    * The most common field name is {@linkplain FieldName#MARKET_VALUE market value}.
    * @return the value of the property, not null
    */
+  @Override
   public FieldName getFieldName() {
     return fieldName;
   }

--- a/modules/market/src/test/java/com/opengamma/strata/market/observable/IndexQuoteIdTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/observable/IndexQuoteIdTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.data.FieldName;
 import com.opengamma.strata.data.ObservableSource;
 
@@ -32,6 +33,7 @@ public class IndexQuoteIdTest {
     assertEquals(test.getIndex(), GBP_SONIA);
     assertEquals(test.getFieldName(), FieldName.MARKET_VALUE);
     assertEquals(test.getObservableSource(), ObservableSource.NONE);
+    assertEquals(test.getStandardId(), StandardId.of("OG-Index", GBP_SONIA.getName()));
     assertEquals(test.getMarketDataType(), Double.class);
   }
 
@@ -40,6 +42,7 @@ public class IndexQuoteIdTest {
     assertEquals(test.getIndex(), GBP_SONIA);
     assertEquals(test.getFieldName(), FIELD);
     assertEquals(test.getObservableSource(), ObservableSource.NONE);
+    assertEquals(test.getStandardId(), StandardId.of("OG-Index", GBP_SONIA.getName()));
     assertEquals(test.getMarketDataType(), Double.class);
   }
 
@@ -48,6 +51,7 @@ public class IndexQuoteIdTest {
     assertEquals(test.getIndex(), GBP_SONIA);
     assertEquals(test.getFieldName(), FIELD);
     assertEquals(test.getObservableSource(), OBS_SOURCE);
+    assertEquals(test.getStandardId(), StandardId.of("OG-Index", GBP_SONIA.getName()));
     assertEquals(test.getMarketDataType(), Double.class);
   }
 


### PR DESCRIPTION
Code is clearer when operating with securities