### PR TITLE
Add ResourceLocator.ofPath

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceLocator.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceLocator.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
@@ -89,6 +90,17 @@ public final class ResourceLocator {
     // convert Windows separators to unix
     filename = (File.separatorChar == '\\' ? filename.replace('\\', '/') : filename);
     return new ResourceLocator(FILE_URL_PREFIX + filename, Files.asByteSource(file));
+  }
+
+  /**
+   * Creates a resource from a {@code Path}.
+   *
+   * @param path  path to the file to wrap
+   * @return the resource
+   */
+  public static ResourceLocator ofPath(Path path) {
+    ArgChecker.notNull(path, "path");
+    return ofFile(path.toFile());
   }
 
   /**

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
@@ -11,6 +11,8 @@ import static org.testng.Assert.assertEquals;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.testng.annotations.Test;
 
@@ -60,6 +62,16 @@ public class ResourceLocatorTest {
   public void test_ofFile() throws Exception {
     File file = new File("src/test/resources/com/opengamma/strata/config/base/TestFile.txt");
     ResourceLocator test = ResourceLocator.ofFile(file);
+    assertEquals(test.getLocator(), "file:src/test/resources/com/opengamma/strata/config/base/TestFile.txt");
+    assertEquals(test.getByteSource().read()[0], 'H');
+    assertEquals(test.getCharSource().readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.getCharSource(StandardCharsets.UTF_8).readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.toString(), "file:src/test/resources/com/opengamma/strata/config/base/TestFile.txt");
+  }
+
+  public void test_ofPath() throws Exception {
+    Path path = Paths.get("src/test/resources/com/opengamma/strata/config/base/TestFile.txt");
+    ResourceLocator test = ResourceLocator.ofPath(path);
     assertEquals(test.getLocator(), "file:src/test/resources/com/opengamma/strata/config/base/TestFile.txt");
     assertEquals(test.getByteSource().read()[0], 'H');
     assertEquals(test.getCharSource().readLines(), ImmutableList.of("HelloWorld"));


### PR DESCRIPTION
Adds an extra factory method to create a `ResourceLocator` from a `Path` instance.