### PR TITLE
Corrected inflation swap convention: spot offset, payment offset.

### DIFF
--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swap/DiscountingSwapLegPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swap/DiscountingSwapLegPricerTest.java
@@ -106,6 +106,7 @@ import com.opengamma.strata.product.swap.RatePaymentPeriod;
 import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.SwapLeg;
+import com.opengamma.strata.product.swap.SwapLegType;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.FixedInflationSwapConvention;
 import com.opengamma.strata.product.swap.type.FixedInflationSwapConventions;
@@ -805,10 +806,10 @@ public class DiscountingSwapLegPricerTest {
     LocalDate endDate = VAL_DATE_INFLATION.plusYears(nbYears);
     SwapTrade swap = US_CPI.toTrade(VAL_DATE_INFLATION, VAL_DATE_INFLATION, endDate, BuySell.BUY, NOTIONAL, rate);
     ResolvedSwap resolved = swap.getProduct().resolve(REF_DATA);
-    DiscountingSwapProductPricer pricer = DiscountingSwapProductPricer.DEFAULT;
+    DiscountingSwapLegPricer pricer = DiscountingSwapLegPricer.DEFAULT;
     RatesProvider providerEndDate = new MockRatesProvider(endDate);
-    MultiCurrencyAmount c = pricer.currentCash(resolved, providerEndDate);
-    assertEquals(c.getAmount(USD).getAmount(), -(Math.pow(1 + rate, nbYears) - 1.0) * NOTIONAL, NOTIONAL * EPS);
+    CurrencyAmount c = pricer.currentCash(resolved.getLegs(SwapLegType.FIXED).get(0), providerEndDate);
+    assertEquals(c.getAmount(), -(Math.pow(1 + rate, nbYears) - 1.0) * NOTIONAL, NOTIONAL * EPS);
   }
 
   private static final int NB_PERIODS = 10;

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConvention.java
@@ -13,7 +13,6 @@ import org.joda.convert.ToString;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
-import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.ArgChecker;
@@ -84,14 +83,7 @@ public interface FixedInflationSwapConvention
    * 
    * @return the spot date offset, not null
    */
-  public abstract BusinessDayAdjustment getSpotDateOffset();
-
-  /**
-   * Gets the offset of the payment date.
-   * 
-   * @return the spot date offset, not null
-   */
-  public abstract DaysAdjustment getPaymentDateOffset();
+  public abstract DaysAdjustment getSpotDateOffset();
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapTemplate.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapTemplate.java
@@ -82,7 +82,6 @@ public final class FixedInflationSwapTemplate
    * If selling the swap, the floating rate is paid to the counterparty, with the fixed rate being received.
    * 
    * @param tradeDate  the date of the trade
-   * @param tenor  the tenor of the trade
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount, in the payment currency of the template
    * @param fixedRate  the fixed rate, typically derived from the market
@@ -92,7 +91,6 @@ public final class FixedInflationSwapTemplate
    */
   public SwapTrade createTrade(
       LocalDate tradeDate,
-      Tenor tenor,
       BuySell buySell,
       double notional,
       double fixedRate,

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableFixedInflationSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableFixedInflationSwapConvention.java
@@ -25,7 +25,6 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
-import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Messages;
@@ -76,12 +75,7 @@ public final class ImmutableFixedInflationSwapConvention
    * A typical value is "plus 2 business days".
    */
   @PropertyDefinition(validate = "notNull", overrideGet = true)
-  private final BusinessDayAdjustment spotDateOffset;
-  /**
-   * An adjustment that alters the payment date by adding a period of days.
-   */
-  @PropertyDefinition(validate = "notNull", overrideGet = true)
-  private final DaysAdjustment paymentDateOffset;
+  private final DaysAdjustment spotDateOffset;
 
   //-------------------------------------------------------------------------
 
@@ -94,17 +88,15 @@ public final class ImmutableFixedInflationSwapConvention
    * @param fixedLeg  the market convention for the fixed leg
    * @param floatingLeg  the market convention for the floating leg
    * @param spotDateOffset  the offset of the spot value date from the trade date
-   * @param paymentDateOffset an adjustment that alters the payment date by adding a period of days
    * @return the convention
    */
   public static ImmutableFixedInflationSwapConvention of(
       String name,
       FixedRateSwapLegConvention fixedLeg,
       InflationRateSwapLegConvention floatingLeg,
-      BusinessDayAdjustment spotDateOffset,
-      DaysAdjustment paymentDateOffset) {
+      DaysAdjustment spotDateOffset) {
 
-    return new ImmutableFixedInflationSwapConvention(name, fixedLeg, floatingLeg, spotDateOffset, paymentDateOffset);
+    return new ImmutableFixedInflationSwapConvention(name, fixedLeg, floatingLeg, spotDateOffset);
   }
 
   //-------------------------------------------------------------------------
@@ -139,8 +131,6 @@ public final class ImmutableFixedInflationSwapConvention
         startDate,
         endDate,
         PayReceive.ofPay(buySell.isSell()),
-        spotDateOffset,
-        paymentDateOffset,
         notional);
     return SwapTrade.builder()
         .info(tradeInfo)
@@ -185,18 +175,15 @@ public final class ImmutableFixedInflationSwapConvention
       String name,
       FixedRateSwapLegConvention fixedLeg,
       InflationRateSwapLegConvention floatingLeg,
-      BusinessDayAdjustment spotDateOffset,
-      DaysAdjustment paymentDateOffset) {
+      DaysAdjustment spotDateOffset) {
     JodaBeanUtils.notNull(name, "name");
     JodaBeanUtils.notNull(fixedLeg, "fixedLeg");
     JodaBeanUtils.notNull(floatingLeg, "floatingLeg");
     JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
-    JodaBeanUtils.notNull(paymentDateOffset, "paymentDateOffset");
     this.name = name;
     this.fixedLeg = fixedLeg;
     this.floatingLeg = floatingLeg;
     this.spotDateOffset = spotDateOffset;
-    this.paymentDateOffset = paymentDateOffset;
     validate();
   }
 
@@ -254,18 +241,8 @@ public final class ImmutableFixedInflationSwapConvention
    * @return the value of the property, not null
    */
   @Override
-  public BusinessDayAdjustment getSpotDateOffset() {
+  public DaysAdjustment getSpotDateOffset() {
     return spotDateOffset;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets an adjustment that alters the payment date by adding a period of days.
-   * @return the value of the property, not null
-   */
-  @Override
-  public DaysAdjustment getPaymentDateOffset() {
-    return paymentDateOffset;
   }
 
   //-----------------------------------------------------------------------
@@ -287,8 +264,7 @@ public final class ImmutableFixedInflationSwapConvention
       return JodaBeanUtils.equal(name, other.name) &&
           JodaBeanUtils.equal(fixedLeg, other.fixedLeg) &&
           JodaBeanUtils.equal(floatingLeg, other.floatingLeg) &&
-          JodaBeanUtils.equal(spotDateOffset, other.spotDateOffset) &&
-          JodaBeanUtils.equal(paymentDateOffset, other.paymentDateOffset);
+          JodaBeanUtils.equal(spotDateOffset, other.spotDateOffset);
     }
     return false;
   }
@@ -300,7 +276,6 @@ public final class ImmutableFixedInflationSwapConvention
     hash = hash * 31 + JodaBeanUtils.hashCode(fixedLeg);
     hash = hash * 31 + JodaBeanUtils.hashCode(floatingLeg);
     hash = hash * 31 + JodaBeanUtils.hashCode(spotDateOffset);
-    hash = hash * 31 + JodaBeanUtils.hashCode(paymentDateOffset);
     return hash;
   }
 
@@ -332,13 +307,8 @@ public final class ImmutableFixedInflationSwapConvention
     /**
      * The meta-property for the {@code spotDateOffset} property.
      */
-    private final MetaProperty<BusinessDayAdjustment> spotDateOffset = DirectMetaProperty.ofImmutable(
-        this, "spotDateOffset", ImmutableFixedInflationSwapConvention.class, BusinessDayAdjustment.class);
-    /**
-     * The meta-property for the {@code paymentDateOffset} property.
-     */
-    private final MetaProperty<DaysAdjustment> paymentDateOffset = DirectMetaProperty.ofImmutable(
-        this, "paymentDateOffset", ImmutableFixedInflationSwapConvention.class, DaysAdjustment.class);
+    private final MetaProperty<DaysAdjustment> spotDateOffset = DirectMetaProperty.ofImmutable(
+        this, "spotDateOffset", ImmutableFixedInflationSwapConvention.class, DaysAdjustment.class);
     /**
      * The meta-properties.
      */
@@ -347,8 +317,7 @@ public final class ImmutableFixedInflationSwapConvention
         "name",
         "fixedLeg",
         "floatingLeg",
-        "spotDateOffset",
-        "paymentDateOffset");
+        "spotDateOffset");
 
     /**
      * Restricted constructor.
@@ -367,8 +336,6 @@ public final class ImmutableFixedInflationSwapConvention
           return floatingLeg;
         case 746995843:  // spotDateOffset
           return spotDateOffset;
-        case -716438393:  // paymentDateOffset
-          return paymentDateOffset;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -417,16 +384,8 @@ public final class ImmutableFixedInflationSwapConvention
      * The meta-property for the {@code spotDateOffset} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<BusinessDayAdjustment> spotDateOffset() {
+    public MetaProperty<DaysAdjustment> spotDateOffset() {
       return spotDateOffset;
-    }
-
-    /**
-     * The meta-property for the {@code paymentDateOffset} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<DaysAdjustment> paymentDateOffset() {
-      return paymentDateOffset;
     }
 
     //-----------------------------------------------------------------------
@@ -441,8 +400,6 @@ public final class ImmutableFixedInflationSwapConvention
           return ((ImmutableFixedInflationSwapConvention) bean).getFloatingLeg();
         case 746995843:  // spotDateOffset
           return ((ImmutableFixedInflationSwapConvention) bean).getSpotDateOffset();
-        case -716438393:  // paymentDateOffset
-          return ((ImmutableFixedInflationSwapConvention) bean).getPaymentDateOffset();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -467,8 +424,7 @@ public final class ImmutableFixedInflationSwapConvention
     private String name;
     private FixedRateSwapLegConvention fixedLeg;
     private InflationRateSwapLegConvention floatingLeg;
-    private BusinessDayAdjustment spotDateOffset;
-    private DaysAdjustment paymentDateOffset;
+    private DaysAdjustment spotDateOffset;
 
     /**
      * Restricted constructor.
@@ -485,7 +441,6 @@ public final class ImmutableFixedInflationSwapConvention
       this.fixedLeg = beanToCopy.getFixedLeg();
       this.floatingLeg = beanToCopy.getFloatingLeg();
       this.spotDateOffset = beanToCopy.getSpotDateOffset();
-      this.paymentDateOffset = beanToCopy.getPaymentDateOffset();
     }
 
     //-----------------------------------------------------------------------
@@ -500,8 +455,6 @@ public final class ImmutableFixedInflationSwapConvention
           return floatingLeg;
         case 746995843:  // spotDateOffset
           return spotDateOffset;
-        case -716438393:  // paymentDateOffset
-          return paymentDateOffset;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -520,10 +473,7 @@ public final class ImmutableFixedInflationSwapConvention
           this.floatingLeg = (InflationRateSwapLegConvention) newValue;
           break;
         case 746995843:  // spotDateOffset
-          this.spotDateOffset = (BusinessDayAdjustment) newValue;
-          break;
-        case -716438393:  // paymentDateOffset
-          this.paymentDateOffset = (DaysAdjustment) newValue;
+          this.spotDateOffset = (DaysAdjustment) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -561,8 +511,7 @@ public final class ImmutableFixedInflationSwapConvention
           name,
           fixedLeg,
           floatingLeg,
-          spotDateOffset,
-          paymentDateOffset);
+          spotDateOffset);
     }
 
     //-----------------------------------------------------------------------
@@ -607,33 +556,21 @@ public final class ImmutableFixedInflationSwapConvention
      * @param spotDateOffset  the new value, not null
      * @return this, for chaining, not null
      */
-    public Builder spotDateOffset(BusinessDayAdjustment spotDateOffset) {
+    public Builder spotDateOffset(DaysAdjustment spotDateOffset) {
       JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
       this.spotDateOffset = spotDateOffset;
-      return this;
-    }
-
-    /**
-     * Sets an adjustment that alters the payment date by adding a period of days.
-     * @param paymentDateOffset  the new value, not null
-     * @return this, for chaining, not null
-     */
-    public Builder paymentDateOffset(DaysAdjustment paymentDateOffset) {
-      JodaBeanUtils.notNull(paymentDateOffset, "paymentDateOffset");
-      this.paymentDateOffset = paymentDateOffset;
       return this;
     }
 
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(192);
+      StringBuilder buf = new StringBuilder(160);
       buf.append("ImmutableFixedInflationSwapConvention.Builder{");
       buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
       buf.append("fixedLeg").append('=').append(JodaBeanUtils.toString(fixedLeg)).append(',').append(' ');
       buf.append("floatingLeg").append('=').append(JodaBeanUtils.toString(floatingLeg)).append(',').append(' ');
-      buf.append("spotDateOffset").append('=').append(JodaBeanUtils.toString(spotDateOffset)).append(',').append(' ');
-      buf.append("paymentDateOffset").append('=').append(JodaBeanUtils.toString(paymentDateOffset));
+      buf.append("spotDateOffset").append('=').append(JodaBeanUtils.toString(spotDateOffset));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardFixedInflationSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardFixedInflationSwapConventions.java
@@ -47,8 +47,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "GBP-FIXED-ZC-GB-HCIP",
           fixedLegZcConvention(GBP, GBLO),
-          InflationRateSwapLegConvention.of(PriceIndices.GB_HICP, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO),
+          InflationRateSwapLegConvention.of(PriceIndices.GB_HICP, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO)),
           DaysAdjustment.ofBusinessDays(2, GBLO));
 
   /**
@@ -59,8 +58,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "GBP-FIXED-ZC-GB-RPI",
           fixedLegZcConvention(GBP, GBLO),
-          InflationRateSwapLegConvention.of(PriceIndices.GB_RPI, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO),
+          InflationRateSwapLegConvention.of(PriceIndices.GB_RPI, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO)),
           DaysAdjustment.ofBusinessDays(2, GBLO));
 
   /**
@@ -71,8 +69,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "GBP-FIXED-ZC-GB-RPIX",
           fixedLegZcConvention(GBP, GBLO),
-          InflationRateSwapLegConvention.of(PriceIndices.GB_RPIX, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO),
+          InflationRateSwapLegConvention.of(PriceIndices.GB_RPIX, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO)),
           DaysAdjustment.ofBusinessDays(2, GBLO));
 
   /**
@@ -83,8 +80,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "CHF-FIXED-ZC-CH-CPI",
           fixedLegZcConvention(CHF, CHZU),
-          InflationRateSwapLegConvention.of(PriceIndices.CH_CPI, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, CHZU),
+          InflationRateSwapLegConvention.of(PriceIndices.CH_CPI, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, CHZU)),
           DaysAdjustment.ofBusinessDays(2, CHZU));
 
   /**
@@ -95,8 +91,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "EUR-FIXED-ZC-EU-AI-CPI",
           fixedLegZcConvention(EUR, EUTA),
-          InflationRateSwapLegConvention.of(PriceIndices.EU_AI_CPI, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA),
+          InflationRateSwapLegConvention.of(PriceIndices.EU_AI_CPI, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA)),
           DaysAdjustment.ofBusinessDays(2, EUTA));
 
   /**
@@ -107,8 +102,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "EUR-FIXED-ZC-EU-EXT-CPI",
           fixedLegZcConvention(EUR, EUTA),
-          InflationRateSwapLegConvention.of(PriceIndices.EU_EXT_CPI, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA),
+          InflationRateSwapLegConvention.of(PriceIndices.EU_EXT_CPI, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA)),
           DaysAdjustment.ofBusinessDays(2, EUTA));
 
   /**
@@ -119,8 +113,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "JPY-FIXED-ZC-JP-CPI",
           fixedLegZcConvention(JPY, JPTO),
-          InflationRateSwapLegConvention.of(PriceIndices.JP_CPI_EXF, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, JPTO),
+          InflationRateSwapLegConvention.of(PriceIndices.JP_CPI_EXF, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, JPTO)),
           DaysAdjustment.ofBusinessDays(2, JPTO));
 
   /**
@@ -131,8 +124,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "USD-FIXED-ZC-US-CPI",
           fixedLegZcConvention(USD, USNY),
-          InflationRateSwapLegConvention.of(PriceIndices.US_CPI_U, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, USNY),
+          InflationRateSwapLegConvention.of(PriceIndices.US_CPI_U, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, USNY)),
           DaysAdjustment.ofBusinessDays(2, USNY));
 
   /**
@@ -143,8 +135,7 @@ final class StandardFixedInflationSwapConventions {
       ImmutableFixedInflationSwapConvention.of(
           "EUR-FIXED-ZC-FR-CPI",
           fixedLegZcConvention(EUR, EUTA),
-          InflationRateSwapLegConvention.of(PriceIndices.FR_EXT_CPI, LAG_3M),
-          BusinessDayAdjustment.of(MODIFIED_FOLLOWING, FRPA),
+          InflationRateSwapLegConvention.of(PriceIndices.FR_EXT_CPI, LAG_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, FRPA)),
           DaysAdjustment.ofBusinessDays(2, EUTA));
 
   // Create a zero-coupon fixed leg convention

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionTest.java
@@ -6,7 +6,6 @@
 package com.opengamma.strata.product.swap.type;
 
 import static com.opengamma.strata.basics.currency.Currency.GBP;
-import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.date.DayCounts.ONE_ONE;
@@ -50,7 +49,6 @@ public class FixedInflationSwapConventionTest {
 
   private static final Period LAG_3M = Period.ofMonths(3);
   private static final double NOTIONAL_2M = 2_000_000d;
-  private static final BusinessDayAdjustment BDA_FOLLOW = BusinessDayAdjustment.of(FOLLOWING, GBLO);
   private static final BusinessDayAdjustment BDA_MOD_FOLLOW = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO);
   private static final DaysAdjustment PLUS_ONE_DAY = DaysAdjustment.ofBusinessDays(1, GBLO);
 
@@ -58,9 +56,9 @@ public class FixedInflationSwapConventionTest {
   private static final FixedRateSwapLegConvention FIXED = fixedLegZcConvention(GBP, GBLO);
   private static final FixedRateSwapLegConvention FIXED2 =
       FixedRateSwapLegConvention.of(GBP, ACT_365F, P3M, BDA_MOD_FOLLOW);
-  private static final InflationRateSwapLegConvention INFL = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M);
-  private static final InflationRateSwapLegConvention INFL2 = InflationRateSwapLegConvention.of(GB_RPI, LAG_3M);
-  private static final InflationRateSwapLegConvention INFL3 = InflationRateSwapLegConvention.of(GB_RPIX, LAG_3M);
+  private static final InflationRateSwapLegConvention INFL = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M, BDA_MOD_FOLLOW);
+  private static final InflationRateSwapLegConvention INFL2 = InflationRateSwapLegConvention.of(GB_RPI, LAG_3M, BDA_MOD_FOLLOW);
+  private static final InflationRateSwapLegConvention INFL3 = InflationRateSwapLegConvention.of(GB_RPIX, LAG_3M, BDA_MOD_FOLLOW);
 
   //-------------------------------------------------------------------------
   public void test_of() {
@@ -68,13 +66,11 @@ public class FixedInflationSwapConventionTest {
         NAME, 
         FIXED, 
         INFL, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     assertEquals(test.getName(), NAME);
     assertEquals(test.getFixedLeg(), FIXED);
     assertEquals(test.getFloatingLeg(), INFL);
-    assertEquals(test.getSpotDateOffset(), BDA_FOLLOW);
-    assertEquals(test.getPaymentDateOffset(), PLUS_ONE_DAY);
+    assertEquals(test.getSpotDateOffset(), PLUS_ONE_DAY);
   }
 
   public void test_of_spotDateOffset() {
@@ -82,12 +78,11 @@ public class FixedInflationSwapConventionTest {
         NAME, 
         FIXED, 
         INFL, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     assertEquals(test.getName(), NAME);
     assertEquals(test.getFixedLeg(), FIXED);
     assertEquals(test.getFloatingLeg(), INFL);
-    assertEquals(test.getSpotDateOffset(), BDA_FOLLOW);
+    assertEquals(test.getSpotDateOffset(), PLUS_ONE_DAY);
   }
 
   public void test_builder() {
@@ -95,13 +90,12 @@ public class FixedInflationSwapConventionTest {
         .name(NAME)
         .fixedLeg(FIXED)
         .floatingLeg(INFL)
-        .spotDateOffset(BDA_FOLLOW)
-        .paymentDateOffset(PLUS_ONE_DAY)
+        .spotDateOffset(PLUS_ONE_DAY)
         .build();
     assertEquals(test.getName(), NAME);
     assertEquals(test.getFixedLeg(), FIXED);
     assertEquals(test.getFloatingLeg(), INFL);
-    assertEquals(test.getSpotDateOffset(), BDA_FOLLOW);
+    assertEquals(test.getSpotDateOffset(), PLUS_ONE_DAY);
   }
 
   //-------------------------------------------------------------------------
@@ -110,7 +104,6 @@ public class FixedInflationSwapConventionTest {
         NAME, 
         FIXED, 
         INFL, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     LocalDate tradeDate = LocalDate.of(2015, 5, 5);
     LocalDate startDate = date(2015, 8, 5);
@@ -118,7 +111,7 @@ public class FixedInflationSwapConventionTest {
     SwapTrade test = base.toTrade(tradeDate, startDate, endDate, BUY, NOTIONAL_2M, 0.25d);
     Swap expected = Swap.of(
         FIXED.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
-        INFL.toLeg(startDate, endDate, RECEIVE, BDA_FOLLOW, PLUS_ONE_DAY, NOTIONAL_2M));
+        INFL.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
     assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
     assertEquals(test.getProduct(), expected);
   }
@@ -168,21 +161,18 @@ public class FixedInflationSwapConventionTest {
         NAME, 
         FIXED, 
         INFL, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     coverImmutableBean(test);
     ImmutableFixedInflationSwapConvention test2 = ImmutableFixedInflationSwapConvention.of(
         NAME, 
         FIXED2, 
         INFL2, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     coverBeanEquals(test, test2);
     ImmutableFixedInflationSwapConvention test3 = ImmutableFixedInflationSwapConvention.of(
         NAME, 
         FIXED, 
         INFL3, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     coverBeanEquals(test, test3);
   }
@@ -192,7 +182,6 @@ public class FixedInflationSwapConventionTest {
         NAME, 
         FIXED, 
         INFL, 
-        BDA_FOLLOW, 
         PLUS_ONE_DAY);
     assertSerialization(test);
   }

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapTemplateTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapTemplateTest.java
@@ -58,19 +58,17 @@ public class FixedInflationSwapTemplateTest {
       FixedRateSwapLegConvention.of(GBP, ACT_360, P6M, BDA_FOLLOW);
   private static final FixedRateSwapLegConvention FIXED2 =
       FixedRateSwapLegConvention.of(USD, ACT_365F, P3M, BDA_MOD_FOLLOW);
-  private static final InflationRateSwapLegConvention INFL = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M);
-  private static final InflationRateSwapLegConvention INFL2 = InflationRateSwapLegConvention.of(US_CPI_U, LAG_3M);
+  private static final InflationRateSwapLegConvention INFL = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M, BDA_MOD_FOLLOW);
+  private static final InflationRateSwapLegConvention INFL2 = InflationRateSwapLegConvention.of(US_CPI_U, LAG_3M, BDA_MOD_FOLLOW);
   private static final FixedInflationSwapConvention CONV = ImmutableFixedInflationSwapConvention.of(
       NAME,
       FIXED,
       INFL,
-      BDA_FOLLOW,
       PLUS_ONE_DAY);
   private static final FixedInflationSwapConvention CONV2 = ImmutableFixedInflationSwapConvention.of(
       NAME2,
       FIXED2,
       INFL2,
-      BDA_FOLLOW,
       PLUS_ONE_DAY);
 
   //-------------------------------------------------------------------------
@@ -96,13 +94,15 @@ public class FixedInflationSwapTemplateTest {
   public void test_createTrade() {
     FixedInflationSwapTemplate base = FixedInflationSwapTemplate.of(TENOR_10Y, CONV);
     LocalDate tradeDate = LocalDate.of(2015, 5, 5);
-    LocalDate startDate = date(2015, 5, 5);
-    LocalDate endDate = date(2025, 5, 5);
-    SwapTrade test = base.createTrade(tradeDate, TENOR_10Y, BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    LocalDate startDate = date(2015, 5, 6); // T+1
+    LocalDate endDate = date(2025, 5, 6);
+    SwapTrade test = base.createTrade(tradeDate, BUY, NOTIONAL_2M, 0.25d, REF_DATA);
     Swap expected = Swap.of(
         FIXED.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
-        INFL.toLeg(startDate, endDate, RECEIVE, BDA_FOLLOW, PLUS_ONE_DAY, NOTIONAL_2M));
+        INFL.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
     assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct().getLegs().get(0), expected.getLegs().get(0));
+    assertEquals(test.getProduct().getLegs().get(1), expected.getLegs().get(1));
     assertEquals(test.getProduct(), expected);
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/InflationRateSwapLegConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/InflationRateSwapLegConventionTest.java
@@ -44,7 +44,7 @@ public class InflationRateSwapLegConventionTest {
 
   //-------------------------------------------------------------------------
   public void test_of() {
-    InflationRateSwapLegConvention test = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M);
+    InflationRateSwapLegConvention test = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M, BDA_MOD_FOLLOW);
     assertEquals(test.getIndex(), GB_HICP);
     assertEquals(test.getLag(), LAG_3M);
     assertEquals(test.getIndexCalculationMethod(), PriceIndexCalculationMethod.MONTHLY);
@@ -85,15 +85,14 @@ public class InflationRateSwapLegConventionTest {
 
   //-------------------------------------------------------------------------
   public void test_toLeg() {
-    InflationRateSwapLegConvention base = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M);
+    InflationRateSwapLegConvention base = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M, BDA_MOD_FOLLOW);
     LocalDate startDate = LocalDate.of(2015, 5, 5);
     LocalDate endDate = LocalDate.of(2020, 5, 5);
     RateCalculationSwapLeg test = base.toLeg(
         startDate,
         endDate,
-        PAY,
-        BDA_MOD_FOLLOW,
-        DaysAdjustment.NONE, NOTIONAL_2M);
+        PAY, 
+        NOTIONAL_2M);
 
     RateCalculationSwapLeg expected = RateCalculationSwapLeg.builder()
         .payReceive(PAY)
@@ -130,7 +129,7 @@ public class InflationRateSwapLegConventionTest {
   }
 
   public void test_serialization() {
-    InflationRateSwapLegConvention test = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M);
+    InflationRateSwapLegConvention test = InflationRateSwapLegConvention.of(GB_HICP, LAG_3M, BDA_MOD_FOLLOW);
     assertSerialization(test);
   }
 


### PR DESCRIPTION
Inflation conventions had a couple of incorrect fields.