### PR TITLE
Use reporting currency to avoid conversion

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/ReportingCurrency.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/ReportingCurrency.java
@@ -52,6 +52,13 @@ public final class ReportingCurrency
    * from {@link CalculationFunction#naturalCurrency(CalculationTarget, ReferenceData)}.
    */
   public static final ReportingCurrency NATURAL = new ReportingCurrency(ReportingCurrencyType.NATURAL, null);
+  /**
+   * An instance requesting no currency conversion.
+   * <p>
+   * Calculation results are normally converted to a single currency.
+   * If this reporting currency is used, then no currency conversion will be performed.
+   */
+  public static final ReportingCurrency NONE = new ReportingCurrency(ReportingCurrencyType.NONE, null);
 
   /**
    * The type of reporting currency.
@@ -82,6 +89,18 @@ public final class ReportingCurrency
 
   //-------------------------------------------------------------------------
   /**
+   * Checks if the type is 'Specific'.
+   * <p>
+   * When converting calculation results, conversion will occur to the specific currency
+   * returned by {@link #getCurrency()}.
+   * 
+   * @return true if the type is 'Specific'
+   */
+  public boolean isSpecific() {
+    return (type == ReportingCurrencyType.SPECIFIC);
+  }
+
+  /**
    * Checks if the type is 'Natural'.
    * <p>
    * When converting calculation results, conversion will occur to the "natural" currency of the target.
@@ -95,15 +114,15 @@ public final class ReportingCurrency
   }
 
   /**
-   * Checks if the type is 'Specific'.
+   * Checks if the type is 'None'.
    * <p>
-   * When converting calculation results, conversion will occur to the specific currency
-   * returned by {@link #getCurrency()}.
+   * Calculation results are normally converted to a single currency.
+   * If this returns true than no currency conversion will be performed.
    * 
-   * @return true if the type is 'Specific'
+   * @return true if the type is 'None'
    */
-  public boolean isSpecific() {
-    return (type == ReportingCurrencyType.SPECIFIC);
+  public boolean isNone() {
+    return (type == ReportingCurrencyType.NONE);
   }
 
   /**

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/ReportingCurrencyType.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/ReportingCurrencyType.java
@@ -15,7 +15,7 @@ import com.opengamma.strata.collect.ArgChecker;
 /**
  * The available types of reporting currency.
  * <p>
- * There are two options - 'Natural' and 'Specific'.
+ * There are three options - 'Specific', 'Natural' and 'None'.
  */
 public enum ReportingCurrencyType {
 
@@ -28,7 +28,12 @@ public enum ReportingCurrencyType {
    * The "natural" reporting currency.
    * See {@link ReportingCurrency#NATURAL}.
    */
-  NATURAL;
+  NATURAL,
+  /**
+   * No currency conversion is to be performed.
+   * See {@link ReportingCurrency#NONE}.
+   */
+  NONE;
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
@@ -163,7 +163,7 @@ public final class CalculationTask implements ImmutableBean {
 
     // add requirements for the FX rates needed to convert the output values into the reporting currency
     for (CalculationTaskCell cell : cells) {
-      if (cell.getMeasure().isCurrencyConvertible()) {
+      if (cell.getMeasure().isCurrencyConvertible() && !cell.getReportingCurrency().isNone()) {
         Currency reportingCurrency = cell.reportingCurrency(this, refData);
         List<MarketDataId<FxRate>> fxRateIds = functionRequirements.getOutputCurrencies().stream()
             .filter(outputCurrency -> !outputCurrency.equals(reportingCurrency))

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTaskCell.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTaskCell.java
@@ -138,7 +138,11 @@ public final class CalculationTaskCell implements ImmutableBean {
       ReferenceData refData) {
 
     // the result is only converted if it is a success and both the measure and value are convertible
-    if (measure.isCurrencyConvertible() && result.isSuccess() && result.getValue() instanceof ScenarioFxConvertible) {
+    if (measure.isCurrencyConvertible() &&
+        !reportingCurrency.isNone() &&
+        result.isSuccess() &&
+        result.getValue() instanceof ScenarioFxConvertible) {
+
       ScenarioFxConvertible<?> convertible = (ScenarioFxConvertible<?>) result.getValue();
       return convertCurrency(task, convertible, fxProvider, refData);
     }

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/ReportingCurrencyTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/ReportingCurrencyTest.java
@@ -24,17 +24,29 @@ public class ReportingCurrencyTest {
   public void test_NATURAL() {
     ReportingCurrency test = ReportingCurrency.NATURAL;
     assertEquals(test.getType(), ReportingCurrencyType.NATURAL);
-    assertEquals(test.isNatural(), true);
     assertEquals(test.isSpecific(), false);
+    assertEquals(test.isNatural(), true);
+    assertEquals(test.isNone(), false);
     assertEquals(test.toString(), "Natural");
+    assertThrows(() -> test.getCurrency(), IllegalStateException.class);
+  }
+
+  public void test_NONE() {
+    ReportingCurrency test = ReportingCurrency.NONE;
+    assertEquals(test.getType(), ReportingCurrencyType.NONE);
+    assertEquals(test.isSpecific(), false);
+    assertEquals(test.isNatural(), false);
+    assertEquals(test.isNone(), true);
+    assertEquals(test.toString(), "None");
     assertThrows(() -> test.getCurrency(), IllegalStateException.class);
   }
 
   public void test_of_specific() {
     ReportingCurrency test = ReportingCurrency.of(USD);
     assertEquals(test.getType(), ReportingCurrencyType.SPECIFIC);
-    assertEquals(test.isNatural(), false);
     assertEquals(test.isSpecific(), true);
+    assertEquals(test.isNatural(), false);
+    assertEquals(test.isNone(), false);
     assertEquals(test.getCurrency(), USD);
     assertEquals(test.toString(), "Specific:USD");
   }
@@ -42,6 +54,7 @@ public class ReportingCurrencyTest {
   public void test_type() {
     assertEquals(ReportingCurrencyType.of("Specific").toString(), "Specific");
     assertEquals(ReportingCurrencyType.of("Natural").toString(), "Natural");
+    assertEquals(ReportingCurrencyType.of("None").toString(), "None");
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/Measures.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/Measures.java
@@ -24,13 +24,6 @@ public final class Measures {
    */
   public static final Measure PRESENT_VALUE = Measure.of(StandardMeasures.PRESENT_VALUE.getName());
   /**
-   * Measure representing the present value of the calculation target.
-   * <p>
-   * Calculated values are not converted to the reporting currency and may contain values in multiple currencies
-   * if the target contains multiple currencies.
-   */
-  public static final Measure PRESENT_VALUE_MULTI_CCY = Measure.of(StandardMeasures.PRESENT_VALUE_MULTI_CURRENCY.getName());
-  /**
    * Measure representing a break-down of the present value calculation on the target.
    * <p>
    * No currency conversion is performed on the monetary amounts.

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/credit/CdsTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/credit/CdsTradeCalculationFunction.java
@@ -18,7 +18,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.MarketDataId;
@@ -43,7 +42,6 @@ import com.opengamma.strata.product.credit.SingleNameReferenceInformation;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#IR01_PARALLEL_ZERO Scalar IR01, based on zero rates}
  *   <li>{@linkplain Measures#IR01_BUCKETED_ZERO Vector curve node IR01, based on zero rates}
  *   <li>{@linkplain Measures#IR01_PARALLEL_PAR Scalar IR01, based on par interest rates}
@@ -81,10 +79,7 @@ public class CdsTradeCalculationFunction
           .put(Measures.PAR_RATE, CdsMeasureCalculations::parRate)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -169,8 +164,6 @@ public class CdsTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, scenarioMarketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/deposit/TermDepositTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/deposit/TermDepositTradeCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -36,7 +35,6 @@ import com.opengamma.strata.product.deposit.TermDepositTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -66,10 +64,7 @@ public class TermDepositTradeCalculationFunction
           .put(Measures.CURRENT_CASH, TermDepositMeasureCalculations.DEFAULT::currentCash)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -131,8 +126,6 @@ public class TermDepositTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunction.java
@@ -18,7 +18,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.FieldName;
@@ -40,7 +39,6 @@ import com.opengamma.strata.product.dsf.ResolvedDsfTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -66,10 +64,7 @@ public class DsfTradeCalculationFunction
           .put(Measures.CURRENCY_EXPOSURE, DsfMeasureCalculations.DEFAULT::currencyExposure)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -138,8 +133,6 @@ public class DsfTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/fra/FraTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/fra/FraTradeCalculationFunction.java
@@ -19,7 +19,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -39,7 +38,6 @@ import com.opengamma.strata.product.fra.ResolvedFraTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#EXPLAIN_PRESENT_VALUE Explain present value}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
@@ -75,10 +73,7 @@ public class FraTradeCalculationFunction
           .put(AdvancedMeasures.PV01_SEMI_PARALLEL_GAMMA_BUCKETED, FraMeasureCalculations.DEFAULT::pv01SemiParallelGammaBucketed)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -143,8 +138,6 @@ public class FraTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/fx/FxNdfTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/fx/FxNdfTradeCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -36,7 +35,6 @@ import com.opengamma.strata.product.fx.ResolvedFxNdfTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -66,10 +64,7 @@ public class FxNdfTradeCalculationFunction
           .put(Measures.FORWARD_FX_RATE, FxNdfMeasureCalculations.DEFAULT::forwardFxRate)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -133,8 +128,6 @@ public class FxNdfTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/fx/FxSingleTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/fx/FxSingleTradeCalculationFunction.java
@@ -18,7 +18,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -37,7 +36,6 @@ import com.opengamma.strata.product.fx.ResolvedFxSingleTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -69,10 +67,7 @@ public class FxSingleTradeCalculationFunction
           .put(Measures.FORWARD_FX_RATE, FxSingleMeasureCalculations.DEFAULT::forwardFxRate)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -139,8 +134,6 @@ public class FxSingleTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/fx/FxSwapTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/fx/FxSwapTradeCalculationFunction.java
@@ -18,7 +18,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -37,7 +36,6 @@ import com.opengamma.strata.product.fx.ResolvedFxSwapTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -68,10 +66,7 @@ public class FxSwapTradeCalculationFunction
           .put(Measures.CURRENT_CASH, FxSwapMeasureCalculations.DEFAULT::currentCash)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -138,8 +133,6 @@ public class FxSwapTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/index/IborFutureTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/index/IborFutureTradeCalculationFunction.java
@@ -18,7 +18,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.FieldName;
@@ -40,7 +39,6 @@ import com.opengamma.strata.product.index.ResolvedIborFutureTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -64,10 +62,7 @@ public class IborFutureTradeCalculationFunction
           .put(Measures.PAR_SPREAD, IborFutureMeasureCalculations.DEFAULT::parSpread)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -136,8 +131,6 @@ public class IborFutureTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/payment/BulletPaymentTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/payment/BulletPaymentTradeCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -36,7 +35,6 @@ import com.opengamma.strata.product.payment.ResolvedBulletPaymentTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum}
@@ -62,10 +60,7 @@ public class BulletPaymentTradeCalculationFunction
           .put(Measures.CURRENT_CASH, BulletPaymentMeasureCalculations.DEFAULT::currentCash)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -127,8 +122,6 @@ public class BulletPaymentTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/security/GenericSecurityTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/security/GenericSecurityTradeCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -33,7 +32,6 @@ import com.opengamma.strata.product.Security;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  * </ul>
  */
 public class GenericSecurityTradeCalculationFunction
@@ -47,10 +45,7 @@ public class GenericSecurityTradeCalculationFunction
           .put(Measures.PRESENT_VALUE, SecurityMeasureCalculations::presentValue)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -104,8 +99,6 @@ public class GenericSecurityTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, scenarioMarketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/security/SecurityPositionCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/security/SecurityPositionCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -33,7 +32,6 @@ import com.opengamma.strata.product.SecurityPosition;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  * </ul>
  */
 public class SecurityPositionCalculationFunction
@@ -47,10 +45,7 @@ public class SecurityPositionCalculationFunction
           .put(Measures.PRESENT_VALUE, SecurityMeasureCalculations::presentValue)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -109,8 +104,6 @@ public class SecurityPositionCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, position, security, scenarioMarketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -33,7 +32,6 @@ import com.opengamma.strata.product.SecurityTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  * </ul>
  */
 public class SecurityTradeCalculationFunction
@@ -47,10 +45,7 @@ public class SecurityTradeCalculationFunction
           .put(Measures.PRESENT_VALUE, SecurityMeasureCalculations::presentValue)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -109,8 +104,6 @@ public class SecurityTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, trade, security, scenarioMarketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunction.java
@@ -17,7 +17,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -37,7 +36,6 @@ import com.opengamma.strata.product.swap.SwapTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#EXPLAIN_PRESENT_VALUE Explain present value}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed}
@@ -81,10 +79,7 @@ public class SwapTradeCalculationFunction
           .put(AdvancedMeasures.PV01_SEMI_PARALLEL_GAMMA_BUCKETED, SwapMeasureCalculations.DEFAULT::pv01SemiParallelGammaBucketed)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -146,8 +141,6 @@ public class SwapTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, marketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/swaption/SwaptionTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/swaption/SwaptionTradeCalculationFunction.java
@@ -18,7 +18,6 @@ import com.opengamma.strata.calc.Measure;
 import com.opengamma.strata.calc.runner.CalculationFunction;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
-import com.opengamma.strata.calc.runner.FunctionUtils;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.Result;
 import com.opengamma.strata.data.scenario.ScenarioArray;
@@ -37,7 +36,6 @@ import com.opengamma.strata.product.swaption.SwaptionTrade;
  * The supported built-in measures are:
  * <ul>
  *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
- *   <li>{@linkplain Measures#PRESENT_VALUE_MULTI_CCY Present value with no currency conversion}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_SUM PV01 calibrated sum on rate curves}
  *   <li>{@linkplain Measures#PV01_CALIBRATED_BUCKETED PV01 calibrated bucketed on rate curves}
  *   <li>{@linkplain Measures#PV01_MARKET_QUOTE_SUM PV01 market quote sum on rate curves}
@@ -65,10 +63,7 @@ public class SwaptionTradeCalculationFunction
           .put(Measures.CURRENT_CASH, SwaptionMeasureCalculations.DEFAULT::currentCash)
           .build();
 
-  private static final ImmutableSet<Measure> MEASURES = ImmutableSet.<Measure>builder()
-      .addAll(CALCULATORS.keySet())
-      .add(Measures.PRESENT_VALUE_MULTI_CCY)
-      .build();
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
   /**
    * Creates an instance.
@@ -134,8 +129,6 @@ public class SwaptionTradeCalculationFunction
     for (Measure measure : measures) {
       results.put(measure, calculate(measure, resolved, ratesMarketData, swaptionMarketData));
     }
-    // The calculated value is the same for these two measures but they are handled differently WRT FX conversion
-    FunctionUtils.duplicateResult(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY, results);
     return results;
   }
 

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/MeasuresTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/MeasuresTest.java
@@ -18,7 +18,6 @@ public class MeasuresTest {
 
   public void test_standard() {
     assertEquals(Measures.PRESENT_VALUE.isCurrencyConvertible(), true);
-    assertEquals(Measures.PRESENT_VALUE_MULTI_CCY.isCurrencyConvertible(), false);
     assertEquals(Measures.EXPLAIN_PRESENT_VALUE.isCurrencyConvertible(), false);
     assertEquals(Measures.PV01_CALIBRATED_SUM.isCurrencyConvertible(), true);
     assertEquals(Measures.PV01_CALIBRATED_BUCKETED.isCurrencyConvertible(), true);

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/deposit/TermDepositTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/deposit/TermDepositTradeCalculationFunctionTest.java
@@ -105,7 +105,6 @@ public class TermDepositTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.PAR_RATE,
         Measures.PAR_SPREAD,
         Measures.CURRENCY_EXPOSURE,
@@ -113,8 +112,6 @@ public class TermDepositTradeCalculationFunctionTest {
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_RATE, Result.success(ValuesArray.of(ImmutableList.of(expectedParRate))))
         .containsEntry(

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunctionTest.java
@@ -129,13 +129,10 @@ public class DsfTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.CURRENCY_EXPOSURE);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.CURRENCY_EXPOSURE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedCurrencyExposure))));
   }

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fra/FraTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fra/FraTradeCalculationFunctionTest.java
@@ -107,8 +107,6 @@ public class FraTradeCalculationFunctionTest {
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
             Measures.EXPLAIN_PRESENT_VALUE, Result.success(ScenarioArray.of(ImmutableList.of(expectedExplainPv))))
         .containsEntry(
             Measures.PAR_RATE, Result.success(ValuesArray.of(ImmutableList.of(expectedParRate))))

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fx/FxNdfTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fx/FxNdfTradeCalculationFunctionTest.java
@@ -104,15 +104,12 @@ public class FxNdfTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.CURRENCY_EXPOSURE,
         Measures.CURRENT_CASH,
         Measures.FORWARD_FX_RATE);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.CURRENCY_EXPOSURE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedCurrencyExp))))
         .containsEntry(

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fx/FxSingleTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fx/FxSingleTradeCalculationFunctionTest.java
@@ -92,7 +92,6 @@ public class FxSingleTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.PAR_SPREAD,
         Measures.CURRENCY_EXPOSURE,
         Measures.CURRENT_CASH,
@@ -100,8 +99,6 @@ public class FxSingleTradeCalculationFunctionTest {
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))))
         .containsEntry(

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fx/FxSwapTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fx/FxSwapTradeCalculationFunctionTest.java
@@ -100,7 +100,6 @@ public class FxSwapTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.PAR_SPREAD,
         Measures.CURRENCY_EXPOSURE,
         Measures.CURRENT_CASH,
@@ -108,8 +107,6 @@ public class FxSwapTradeCalculationFunctionTest {
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))))
         .containsEntry(

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/index/IborFutureTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/index/IborFutureTradeCalculationFunctionTest.java
@@ -91,13 +91,10 @@ public class IborFutureTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.PAR_SPREAD);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.PAR_SPREAD, Result.success(ValuesArray.of(ImmutableList.of(expectedParSpread))));
   }

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/payment/BulletPaymentTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/payment/BulletPaymentTradeCalculationFunctionTest.java
@@ -98,13 +98,10 @@ public class BulletPaymentTradeCalculationFunctionTest {
     CurrencyAmount expectedPv = pricer.presentValue(payment, provider);
 
     Set<Measure> measures = ImmutableSet.of(
-        Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY);
+        Measures.PRESENT_VALUE);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
-            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
+            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 
   public void test_pv01() {

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/security/GenericSecurityTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/security/GenericSecurityTradeCalculationFunctionTest.java
@@ -82,8 +82,6 @@ public class GenericSecurityTradeCalculationFunctionTest {
     Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/security/SecurityPositionCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/security/SecurityPositionCalculationFunctionTest.java
@@ -75,8 +75,6 @@ public class SecurityPositionCalculationFunctionTest {
     Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
     assertThat(function.calculate(POSITION, measures, PARAMS, md, REF_DATA))
         .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunctionTest.java
@@ -83,8 +83,6 @@ public class SecurityTradeCalculationFunctionTest {
     Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
             Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunctionTest.java
@@ -97,7 +97,6 @@ public class SwapTradeCalculationFunctionTest {
 
     Set<Measure> measures = ImmutableSet.of(
         Measures.PRESENT_VALUE,
-        Measures.PRESENT_VALUE_MULTI_CCY,
         Measures.EXPLAIN_PRESENT_VALUE,
         Measures.PAR_RATE,
         Measures.PAR_SPREAD,
@@ -105,8 +104,6 @@ public class SwapTradeCalculationFunctionTest {
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
             Measures.PRESENT_VALUE, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(MultiCurrencyValuesArray.of(ImmutableList.of(expectedPv))))
         .containsEntry(
             Measures.EXPLAIN_PRESENT_VALUE, Result.success(ScenarioArray.of(ImmutableList.of(expectedExplainPv))))
         .containsEntry(

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/swaption/SwaptionTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/swaption/SwaptionTradeCalculationFunctionTest.java
@@ -123,12 +123,10 @@ public class SwaptionTradeCalculationFunctionTest {
     ResolvedSwaptionTrade resolved = TRADE.resolve(REF_DATA);
     CurrencyAmount expectedPv = pricer.presentValue(resolved, provider, NORMAL_VOL_SWAPTION_PROVIDER_USD);
 
-    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE, Measures.PRESENT_VALUE_MULTI_CCY);
+    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
     assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
         .containsEntry(
-            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))))
-        .containsEntry(
-            Measures.PRESENT_VALUE_MULTI_CCY, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
+            Measures.PRESENT_VALUE, Result.success(CurrencyValuesArray.of(ImmutableList.of(expectedPv))));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Add ReportingCurrency.NONE to block currency conversion
Will scale better than lots of new measures