### PR TITLE
Enhance swaption volatilities

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
@@ -7,8 +7,6 @@ package com.opengamma.strata.pricer.swaption;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -57,6 +55,13 @@ import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 public final class BlackSwaptionExpiryTenorVolatilities
     implements BlackSwaptionVolatilities, ImmutableBean, Serializable {
 
+  /** 
+   * The valuation date-time.
+   * <p>
+   * The volatilities are calibrated for this date-time. 
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final ZonedDateTime valuationDateTime;
   /**
    * The Black volatility surface.
    * <p>
@@ -65,13 +70,6 @@ public final class BlackSwaptionExpiryTenorVolatilities
    */
   @PropertyDefinition(validate = "notNull")
   private final Surface surface;
-  /** 
-   * The valuation date-time.
-   * <p>
-   * The volatilities are calibrated for this date-time. 
-   */
-  @PropertyDefinition(validate = "notNull", overrideGet = true)
-  private final ZonedDateTime valuationDateTime;
   /** 
    * The swap convention that the surface is calibrated against.
    */
@@ -97,54 +95,24 @@ public final class BlackSwaptionExpiryTenorVolatilities
    * Suitable surface metadata can be created using
    * {@link Surfaces#swaptionBlackExpiryTenor(String, DayCount, FixedIborSwapConvention)}.
    * 
-   * @param surface  the implied volatility surface
    * @param valuationDateTime  the valuation date-time
-   * @return the volatilities
-   */
-  public static BlackSwaptionExpiryTenorVolatilities of(
-      Surface surface,
-      ZonedDateTime valuationDateTime) {
-
-    return new BlackSwaptionExpiryTenorVolatilities(surface, valuationDateTime);
-  }
-
-  /**
-   * Obtains an instance from the implied volatility surface and the date, time and zone for which it is valid.
-   * <p>
-   * The surface is specified by an instance of {@link Surface}, such as {@link InterpolatedNodalSurface}.
-   * The surface must contain the correct metadata:
-   * <ul>
-   * <li>The x-value type must be {@link ValueType#YEAR_FRACTION}
-   * <li>The y-value type must be {@link ValueType#YEAR_FRACTION}
-   * <li>The z-value type must be {@link ValueType#BLACK_VOLATILITY}
-   * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
-   * <li>The swap convention must be set in the additional information using {@link SurfaceInfoType#SWAP_CONVENTION}
-   * </ul>
-   * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionBlackExpiryTenor(String, DayCount, FixedIborSwapConvention)}.
-   * 
    * @param surface  the implied volatility surface
-   * @param valuationDate  the valuation date
-   * @param valuationTime  the valuation time
-   * @param valuationZone  the valuation time zone
    * @return the volatilities
    */
   public static BlackSwaptionExpiryTenorVolatilities of(
-      Surface surface,
-      LocalDate valuationDate,
-      LocalTime valuationTime,
-      ZoneId valuationZone) {
+      ZonedDateTime valuationDateTime,
+      Surface surface) {
 
-    return of(surface, valuationDate.atTime(valuationTime).atZone(valuationZone));
+    return new BlackSwaptionExpiryTenorVolatilities(valuationDateTime, surface);
   }
 
   @ImmutableConstructor
   private BlackSwaptionExpiryTenorVolatilities(
-      Surface surface,
-      ZonedDateTime valuationDateTime) {
+      ZonedDateTime valuationDateTime,
+      Surface surface) {
 
-    ArgChecker.notNull(surface, "surface");
     ArgChecker.notNull(valuationDateTime, "valuationDateTime");
+    ArgChecker.notNull(surface, "surface");
     surface.getMetadata().getXValueType().checkEquals(
         ValueType.YEAR_FRACTION, "Incorrect x-value type for Black volatilities");
     surface.getMetadata().getYValueType().checkEquals(
@@ -198,12 +166,12 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
   @Override
   public BlackSwaptionExpiryTenorVolatilities withParameter(int parameterIndex, double newValue) {
-    return new BlackSwaptionExpiryTenorVolatilities(surface.withParameter(parameterIndex, newValue), valuationDateTime);
+    return new BlackSwaptionExpiryTenorVolatilities(valuationDateTime, surface.withParameter(parameterIndex, newValue));
   }
 
   @Override
   public BlackSwaptionExpiryTenorVolatilities withPerturbation(ParameterPerturbation perturbation) {
-    return new BlackSwaptionExpiryTenorVolatilities(surface.withPerturbation(perturbation), valuationDateTime);
+    return new BlackSwaptionExpiryTenorVolatilities(valuationDateTime, surface.withPerturbation(perturbation));
   }
 
   //-------------------------------------------------------------------------
@@ -310,18 +278,6 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the Black volatility surface.
-   * <p>
-   * The x-value of the surface is the expiry, as a year fraction.
-   * The y-value of the surface is the swap tenor, as a year fraction rounded to the month.
-   * @return the value of the property, not null
-   */
-  public Surface getSurface() {
-    return surface;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
    * Gets the valuation date-time.
    * <p>
    * The volatilities are calibrated for this date-time.
@@ -333,6 +289,18 @@ public final class BlackSwaptionExpiryTenorVolatilities
   }
 
   //-----------------------------------------------------------------------
+  /**
+   * Gets the Black volatility surface.
+   * <p>
+   * The x-value of the surface is the expiry, as a year fraction.
+   * The y-value of the surface is the swap tenor, as a year fraction rounded to the month.
+   * @return the value of the property, not null
+   */
+  public Surface getSurface() {
+    return surface;
+  }
+
+  //-----------------------------------------------------------------------
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
@@ -340,8 +308,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       BlackSwaptionExpiryTenorVolatilities other = (BlackSwaptionExpiryTenorVolatilities) obj;
-      return JodaBeanUtils.equal(surface, other.surface) &&
-          JodaBeanUtils.equal(valuationDateTime, other.valuationDateTime);
+      return JodaBeanUtils.equal(valuationDateTime, other.valuationDateTime) &&
+          JodaBeanUtils.equal(surface, other.surface);
     }
     return false;
   }
@@ -349,8 +317,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
-    hash = hash * 31 + JodaBeanUtils.hashCode(surface);
     hash = hash * 31 + JodaBeanUtils.hashCode(valuationDateTime);
+    hash = hash * 31 + JodaBeanUtils.hashCode(surface);
     return hash;
   }
 
@@ -358,8 +326,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
   public String toString() {
     StringBuilder buf = new StringBuilder(96);
     buf.append("BlackSwaptionExpiryTenorVolatilities{");
-    buf.append("surface").append('=').append(surface).append(',').append(' ');
-    buf.append("valuationDateTime").append('=').append(JodaBeanUtils.toString(valuationDateTime));
+    buf.append("valuationDateTime").append('=').append(valuationDateTime).append(',').append(' ');
+    buf.append("surface").append('=').append(JodaBeanUtils.toString(surface));
     buf.append('}');
     return buf.toString();
   }
@@ -375,22 +343,22 @@ public final class BlackSwaptionExpiryTenorVolatilities
     static final Meta INSTANCE = new Meta();
 
     /**
-     * The meta-property for the {@code surface} property.
-     */
-    private final MetaProperty<Surface> surface = DirectMetaProperty.ofImmutable(
-        this, "surface", BlackSwaptionExpiryTenorVolatilities.class, Surface.class);
-    /**
      * The meta-property for the {@code valuationDateTime} property.
      */
     private final MetaProperty<ZonedDateTime> valuationDateTime = DirectMetaProperty.ofImmutable(
         this, "valuationDateTime", BlackSwaptionExpiryTenorVolatilities.class, ZonedDateTime.class);
     /**
+     * The meta-property for the {@code surface} property.
+     */
+    private final MetaProperty<Surface> surface = DirectMetaProperty.ofImmutable(
+        this, "surface", BlackSwaptionExpiryTenorVolatilities.class, Surface.class);
+    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "surface",
-        "valuationDateTime");
+        "valuationDateTime",
+        "surface");
 
     /**
      * Restricted constructor.
@@ -401,10 +369,10 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
-        case -1853231955:  // surface
-          return surface;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
+        case -1853231955:  // surface
+          return surface;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -426,14 +394,6 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
     //-----------------------------------------------------------------------
     /**
-     * The meta-property for the {@code surface} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<Surface> surface() {
-      return surface;
-    }
-
-    /**
      * The meta-property for the {@code valuationDateTime} property.
      * @return the meta-property, not null
      */
@@ -441,14 +401,22 @@ public final class BlackSwaptionExpiryTenorVolatilities
       return valuationDateTime;
     }
 
+    /**
+     * The meta-property for the {@code surface} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Surface> surface() {
+      return surface;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
-        case -1853231955:  // surface
-          return ((BlackSwaptionExpiryTenorVolatilities) bean).getSurface();
         case -949589828:  // valuationDateTime
           return ((BlackSwaptionExpiryTenorVolatilities) bean).getValuationDateTime();
+        case -1853231955:  // surface
+          return ((BlackSwaptionExpiryTenorVolatilities) bean).getSurface();
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -470,8 +438,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
    */
   private static final class Builder extends DirectFieldsBeanBuilder<BlackSwaptionExpiryTenorVolatilities> {
 
-    private Surface surface;
     private ZonedDateTime valuationDateTime;
+    private Surface surface;
 
     /**
      * Restricted constructor.
@@ -483,10 +451,10 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
-        case -1853231955:  // surface
-          return surface;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
+        case -1853231955:  // surface
+          return surface;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -495,11 +463,11 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
-        case -1853231955:  // surface
-          this.surface = (Surface) newValue;
-          break;
         case -949589828:  // valuationDateTime
           this.valuationDateTime = (ZonedDateTime) newValue;
+          break;
+        case -1853231955:  // surface
+          this.surface = (Surface) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -534,8 +502,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     public BlackSwaptionExpiryTenorVolatilities build() {
       return new BlackSwaptionExpiryTenorVolatilities(
-          surface,
-          valuationDateTime);
+          valuationDateTime,
+          surface);
     }
 
     //-----------------------------------------------------------------------
@@ -543,8 +511,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     public String toString() {
       StringBuilder buf = new StringBuilder(96);
       buf.append("BlackSwaptionExpiryTenorVolatilities.Builder{");
-      buf.append("surface").append('=').append(JodaBeanUtils.toString(surface)).append(',').append(' ');
-      buf.append("valuationDateTime").append('=').append(JodaBeanUtils.toString(valuationDateTime));
+      buf.append("valuationDateTime").append('=').append(JodaBeanUtils.toString(valuationDateTime)).append(',').append(' ');
+      buf.append("surface").append('=').append(JodaBeanUtils.toString(surface));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionVolatilities.java
@@ -13,7 +13,7 @@ import com.opengamma.strata.market.param.ParameterPerturbation;
  */
 public interface NormalSwaptionVolatilities
     extends SwaptionVolatilities {
-  
+
   @Override
   public default ValueType getVolatilityType() {
     return ValueType.NORMAL_VOLATILITY;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
@@ -6,8 +6,6 @@
 package com.opengamma.strata.pricer.swaption;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +64,13 @@ public final class SabrParametersSwaptionVolatilities
   @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final SwaptionVolatilitiesName name;
   /** 
+   * The valuation date-time.
+   * <p>
+   * The volatilities are calibrated for this date-time. 
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final ZonedDateTime valuationDateTime;
+  /** 
    * The SABR model parameters.
    * <p>
    * Each model parameter of SABR model is a surface.
@@ -74,13 +79,6 @@ public final class SabrParametersSwaptionVolatilities
    */
   @PropertyDefinition(validate = "notNull")
   private final SabrInterestRateParameters parameters;
-  /** 
-   * The valuation date-time.
-   * <p>
-   * The volatilities are calibrated for this date-time. 
-   */
-  @PropertyDefinition(validate = "notNull", overrideGet = true)
-  private final ZonedDateTime valuationDateTime;
   /** 
    * The sensitivity of the Alpha parameters to the raw data used for calibration.
    * <p>
@@ -115,36 +113,16 @@ public final class SabrParametersSwaptionVolatilities
    * Obtains an instance from the SABR model parameters and the date-time for which it is valid.
    * 
    * @param name  the name
-   * @param parameters  the SABR model parameters
    * @param valuationDateTime  the valuation date-time
-   * @return the volatilities
-   */
-  public static SabrParametersSwaptionVolatilities of(
-      SwaptionVolatilitiesName name,
-      SabrInterestRateParameters parameters,
-      ZonedDateTime valuationDateTime) {
-
-    return new SabrParametersSwaptionVolatilities(name, parameters, valuationDateTime, null, null, null, null);
-  }
-
-  /**
-   * Obtains an instance from the SABR model parameters and the date, time and zone for which it is valid.
-   * 
-   * @param name  the name
    * @param parameters  the SABR model parameters
-   * @param valuationDate  the valuation date
-   * @param valuationTime  the valuation time
-   * @param valuationZone  the valuation time zone
    * @return the volatilities
    */
   public static SabrParametersSwaptionVolatilities of(
       SwaptionVolatilitiesName name,
-      SabrInterestRateParameters parameters,
-      LocalDate valuationDate,
-      LocalTime valuationTime,
-      ZoneId valuationZone) {
+      ZonedDateTime valuationDateTime,
+      SabrInterestRateParameters parameters) {
 
-    return of(name, parameters, valuationDate.atTime(valuationTime).atZone(valuationZone));
+    return new SabrParametersSwaptionVolatilities(name, valuationDateTime, parameters, null, null, null, null);
   }
 
   //-------------------------------------------------------------------------
@@ -202,8 +180,8 @@ public final class SabrParametersSwaptionVolatilities
     SabrInterestRateParameters updated = parameters.withParameter(parameterIndex, newValue);
     return new SabrParametersSwaptionVolatilities(
         name,
-        updated,
         valuationDateTime,
+        updated,
         dataSensitivityAlpha,
         dataSensitivityBeta,
         dataSensitivityRho,
@@ -215,8 +193,8 @@ public final class SabrParametersSwaptionVolatilities
     SabrInterestRateParameters updated = parameters.withPerturbation(perturbation);
     return new SabrParametersSwaptionVolatilities(
         name,
-        updated,
         valuationDateTime,
+        updated,
         dataSensitivityAlpha,
         dataSensitivityBeta,
         dataSensitivityRho,
@@ -349,18 +327,18 @@ public final class SabrParametersSwaptionVolatilities
 
   private SabrParametersSwaptionVolatilities(
       SwaptionVolatilitiesName name,
-      SabrInterestRateParameters parameters,
       ZonedDateTime valuationDateTime,
+      SabrInterestRateParameters parameters,
       List<DoubleArray> dataSensitivityAlpha,
       List<DoubleArray> dataSensitivityBeta,
       List<DoubleArray> dataSensitivityRho,
       List<DoubleArray> dataSensitivityNu) {
     JodaBeanUtils.notNull(name, "name");
-    JodaBeanUtils.notNull(parameters, "parameters");
     JodaBeanUtils.notNull(valuationDateTime, "valuationDateTime");
+    JodaBeanUtils.notNull(parameters, "parameters");
     this.name = name;
-    this.parameters = parameters;
     this.valuationDateTime = valuationDateTime;
+    this.parameters = parameters;
     this.dataSensitivityAlpha = (dataSensitivityAlpha != null ? ImmutableList.copyOf(dataSensitivityAlpha) : null);
     this.dataSensitivityBeta = (dataSensitivityBeta != null ? ImmutableList.copyOf(dataSensitivityBeta) : null);
     this.dataSensitivityRho = (dataSensitivityRho != null ? ImmutableList.copyOf(dataSensitivityRho) : null);
@@ -394,6 +372,18 @@ public final class SabrParametersSwaptionVolatilities
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the valuation date-time.
+   * <p>
+   * The volatilities are calibrated for this date-time.
+   * @return the value of the property, not null
+   */
+  @Override
+  public ZonedDateTime getValuationDateTime() {
+    return valuationDateTime;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Gets the SABR model parameters.
    * <p>
    * Each model parameter of SABR model is a surface.
@@ -403,18 +393,6 @@ public final class SabrParametersSwaptionVolatilities
    */
   public SabrInterestRateParameters getParameters() {
     return parameters;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets the valuation date-time.
-   * <p>
-   * The volatilities are calibrated for this date-time.
-   * @return the value of the property, not null
-   */
-  @Override
-  public ZonedDateTime getValuationDateTime() {
-    return valuationDateTime;
   }
 
   //-----------------------------------------------------------------------
@@ -478,8 +456,8 @@ public final class SabrParametersSwaptionVolatilities
     if (obj != null && obj.getClass() == this.getClass()) {
       SabrParametersSwaptionVolatilities other = (SabrParametersSwaptionVolatilities) obj;
       return JodaBeanUtils.equal(name, other.name) &&
-          JodaBeanUtils.equal(parameters, other.parameters) &&
           JodaBeanUtils.equal(valuationDateTime, other.valuationDateTime) &&
+          JodaBeanUtils.equal(parameters, other.parameters) &&
           JodaBeanUtils.equal(dataSensitivityAlpha, other.dataSensitivityAlpha) &&
           JodaBeanUtils.equal(dataSensitivityBeta, other.dataSensitivityBeta) &&
           JodaBeanUtils.equal(dataSensitivityRho, other.dataSensitivityRho) &&
@@ -492,8 +470,8 @@ public final class SabrParametersSwaptionVolatilities
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(name);
-    hash = hash * 31 + JodaBeanUtils.hashCode(parameters);
     hash = hash * 31 + JodaBeanUtils.hashCode(valuationDateTime);
+    hash = hash * 31 + JodaBeanUtils.hashCode(parameters);
     hash = hash * 31 + JodaBeanUtils.hashCode(dataSensitivityAlpha);
     hash = hash * 31 + JodaBeanUtils.hashCode(dataSensitivityBeta);
     hash = hash * 31 + JodaBeanUtils.hashCode(dataSensitivityRho);
@@ -506,8 +484,8 @@ public final class SabrParametersSwaptionVolatilities
     StringBuilder buf = new StringBuilder(256);
     buf.append("SabrParametersSwaptionVolatilities{");
     buf.append("name").append('=').append(name).append(',').append(' ');
-    buf.append("parameters").append('=').append(parameters).append(',').append(' ');
     buf.append("valuationDateTime").append('=').append(valuationDateTime).append(',').append(' ');
+    buf.append("parameters").append('=').append(parameters).append(',').append(' ');
     buf.append("dataSensitivityAlpha").append('=').append(dataSensitivityAlpha).append(',').append(' ');
     buf.append("dataSensitivityBeta").append('=').append(dataSensitivityBeta).append(',').append(' ');
     buf.append("dataSensitivityRho").append('=').append(dataSensitivityRho).append(',').append(' ');
@@ -532,15 +510,15 @@ public final class SabrParametersSwaptionVolatilities
     private final MetaProperty<SwaptionVolatilitiesName> name = DirectMetaProperty.ofImmutable(
         this, "name", SabrParametersSwaptionVolatilities.class, SwaptionVolatilitiesName.class);
     /**
-     * The meta-property for the {@code parameters} property.
-     */
-    private final MetaProperty<SabrInterestRateParameters> parameters = DirectMetaProperty.ofImmutable(
-        this, "parameters", SabrParametersSwaptionVolatilities.class, SabrInterestRateParameters.class);
-    /**
      * The meta-property for the {@code valuationDateTime} property.
      */
     private final MetaProperty<ZonedDateTime> valuationDateTime = DirectMetaProperty.ofImmutable(
         this, "valuationDateTime", SabrParametersSwaptionVolatilities.class, ZonedDateTime.class);
+    /**
+     * The meta-property for the {@code parameters} property.
+     */
+    private final MetaProperty<SabrInterestRateParameters> parameters = DirectMetaProperty.ofImmutable(
+        this, "parameters", SabrParametersSwaptionVolatilities.class, SabrInterestRateParameters.class);
     /**
      * The meta-property for the {@code dataSensitivityAlpha} property.
      */
@@ -571,8 +549,8 @@ public final class SabrParametersSwaptionVolatilities
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "name",
-        "parameters",
         "valuationDateTime",
+        "parameters",
         "dataSensitivityAlpha",
         "dataSensitivityBeta",
         "dataSensitivityRho",
@@ -589,10 +567,10 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
-        case 458736106:  // parameters
-          return parameters;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
+        case 458736106:  // parameters
+          return parameters;
         case 1650101705:  // dataSensitivityAlpha
           return dataSensitivityAlpha;
         case -85295067:  // dataSensitivityBeta
@@ -630,19 +608,19 @@ public final class SabrParametersSwaptionVolatilities
     }
 
     /**
-     * The meta-property for the {@code parameters} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<SabrInterestRateParameters> parameters() {
-      return parameters;
-    }
-
-    /**
      * The meta-property for the {@code valuationDateTime} property.
      * @return the meta-property, not null
      */
     public MetaProperty<ZonedDateTime> valuationDateTime() {
       return valuationDateTime;
+    }
+
+    /**
+     * The meta-property for the {@code parameters} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<SabrInterestRateParameters> parameters() {
+      return parameters;
     }
 
     /**
@@ -683,10 +661,10 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return ((SabrParametersSwaptionVolatilities) bean).getName();
-        case 458736106:  // parameters
-          return ((SabrParametersSwaptionVolatilities) bean).getParameters();
         case -949589828:  // valuationDateTime
           return ((SabrParametersSwaptionVolatilities) bean).getValuationDateTime();
+        case 458736106:  // parameters
+          return ((SabrParametersSwaptionVolatilities) bean).getParameters();
         case 1650101705:  // dataSensitivityAlpha
           return ((SabrParametersSwaptionVolatilities) bean).dataSensitivityAlpha;
         case -85295067:  // dataSensitivityBeta
@@ -717,8 +695,8 @@ public final class SabrParametersSwaptionVolatilities
   public static final class Builder extends DirectFieldsBeanBuilder<SabrParametersSwaptionVolatilities> {
 
     private SwaptionVolatilitiesName name;
-    private SabrInterestRateParameters parameters;
     private ZonedDateTime valuationDateTime;
+    private SabrInterestRateParameters parameters;
     private List<DoubleArray> dataSensitivityAlpha;
     private List<DoubleArray> dataSensitivityBeta;
     private List<DoubleArray> dataSensitivityRho;
@@ -736,8 +714,8 @@ public final class SabrParametersSwaptionVolatilities
      */
     private Builder(SabrParametersSwaptionVolatilities beanToCopy) {
       this.name = beanToCopy.getName();
-      this.parameters = beanToCopy.getParameters();
       this.valuationDateTime = beanToCopy.getValuationDateTime();
+      this.parameters = beanToCopy.getParameters();
       this.dataSensitivityAlpha = beanToCopy.dataSensitivityAlpha;
       this.dataSensitivityBeta = beanToCopy.dataSensitivityBeta;
       this.dataSensitivityRho = beanToCopy.dataSensitivityRho;
@@ -750,10 +728,10 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
-        case 458736106:  // parameters
-          return parameters;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
+        case 458736106:  // parameters
+          return parameters;
         case 1650101705:  // dataSensitivityAlpha
           return dataSensitivityAlpha;
         case -85295067:  // dataSensitivityBeta
@@ -774,11 +752,11 @@ public final class SabrParametersSwaptionVolatilities
         case 3373707:  // name
           this.name = (SwaptionVolatilitiesName) newValue;
           break;
-        case 458736106:  // parameters
-          this.parameters = (SabrInterestRateParameters) newValue;
-          break;
         case -949589828:  // valuationDateTime
           this.valuationDateTime = (ZonedDateTime) newValue;
+          break;
+        case 458736106:  // parameters
+          this.parameters = (SabrInterestRateParameters) newValue;
           break;
         case 1650101705:  // dataSensitivityAlpha
           this.dataSensitivityAlpha = (List<DoubleArray>) newValue;
@@ -826,8 +804,8 @@ public final class SabrParametersSwaptionVolatilities
     public SabrParametersSwaptionVolatilities build() {
       return new SabrParametersSwaptionVolatilities(
           name,
-          parameters,
           valuationDateTime,
+          parameters,
           dataSensitivityAlpha,
           dataSensitivityBeta,
           dataSensitivityRho,
@@ -847,6 +825,19 @@ public final class SabrParametersSwaptionVolatilities
     }
 
     /**
+     * Sets the valuation date-time.
+     * <p>
+     * The volatilities are calibrated for this date-time.
+     * @param valuationDateTime  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder valuationDateTime(ZonedDateTime valuationDateTime) {
+      JodaBeanUtils.notNull(valuationDateTime, "valuationDateTime");
+      this.valuationDateTime = valuationDateTime;
+      return this;
+    }
+
+    /**
      * Sets the SABR model parameters.
      * <p>
      * Each model parameter of SABR model is a surface.
@@ -858,19 +849,6 @@ public final class SabrParametersSwaptionVolatilities
     public Builder parameters(SabrInterestRateParameters parameters) {
       JodaBeanUtils.notNull(parameters, "parameters");
       this.parameters = parameters;
-      return this;
-    }
-
-    /**
-     * Sets the valuation date-time.
-     * <p>
-     * The volatilities are calibrated for this date-time.
-     * @param valuationDateTime  the new value, not null
-     * @return this, for chaining, not null
-     */
-    public Builder valuationDateTime(ZonedDateTime valuationDateTime) {
-      JodaBeanUtils.notNull(valuationDateTime, "valuationDateTime");
-      this.valuationDateTime = valuationDateTime;
       return this;
     }
 
@@ -968,8 +946,8 @@ public final class SabrParametersSwaptionVolatilities
       StringBuilder buf = new StringBuilder(256);
       buf.append("SabrParametersSwaptionVolatilities.Builder{");
       buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
-      buf.append("parameters").append('=').append(JodaBeanUtils.toString(parameters)).append(',').append(' ');
       buf.append("valuationDateTime").append('=').append(JodaBeanUtils.toString(valuationDateTime)).append(',').append(' ');
+      buf.append("parameters").append('=').append(JodaBeanUtils.toString(parameters)).append(',').append(' ');
       buf.append("dataSensitivityAlpha").append('=').append(JodaBeanUtils.toString(dataSensitivityAlpha)).append(',').append(' ');
       buf.append("dataSensitivityBeta").append('=').append(JodaBeanUtils.toString(dataSensitivityBeta)).append(',').append(' ');
       buf.append("dataSensitivityRho").append('=').append(JodaBeanUtils.toString(dataSensitivityRho)).append(',').append(' ');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibrator.java
@@ -322,8 +322,8 @@ public class SabrSwaptionCalibrator {
         alphaSurface, betaSurface, rhoSurface, nuSurface, shiftSurface, sabrVolatilityFormula);
     return SabrParametersSwaptionVolatilities.builder()
         .name(name)
-        .parameters(params)
         .valuationDateTime(calibrationDateTime)
+        .parameters(params)
         .dataSensitivityAlpha(dataSensitivityAlpha)
         .dataSensitivityRho(dataSensitivityRho)
         .dataSensitivityNu(dataSensitivityNu).build();
@@ -478,8 +478,8 @@ public class SabrSwaptionCalibrator {
         sabr.getParameters().getNuSurface(), sabr.getParameters().getShiftSurface(), sabrVolatilityFormula);
     return SabrParametersSwaptionVolatilities.builder()
         .name(name)
-        .parameters(params)
         .valuationDateTime(sabr.getValuationDateTime())
+        .parameters(params)
         .dataSensitivityAlpha(dataSensitivityAlpha).build();
   }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionVolatilities.java
@@ -40,7 +40,7 @@ public interface SwaptionVolatilities
    * @return the convention
    */
   public abstract FixedIborSwapConvention getConvention();
-  
+
   /**
    * Gets the type of volatility returned by the {@link SwaptionVolatilities#volatility} method.
    * 
@@ -51,7 +51,7 @@ public interface SwaptionVolatilities
   /**
    * Gets the valuation date.
    * <p>
-   * The raw data in this provider is calibrated for this date.
+   * The volatilities are calibrated for this date.
    * 
    * @return the valuation date
    */
@@ -63,7 +63,7 @@ public interface SwaptionVolatilities
   /**
    * Gets the valuation date-time.
    * <p>
-   * The raw data in this provider is calibrated for this date-time.
+   * The volatilities are calibrated for this date-time.
    * 
    * @return the valuation date-time
    */
@@ -77,7 +77,7 @@ public interface SwaptionVolatilities
 
   //-------------------------------------------------------------------------
   /**
-   * Calculates the volatility at the specified date-time.
+   * Calculates the volatility at the specified expiry.
    * <p>
    * This relies on tenor supplied by {@link #tenor(LocalDate, LocalDate)}.
    * 
@@ -93,7 +93,7 @@ public interface SwaptionVolatilities
   }
 
   /**
-   * Calculates the volatility at the specified date-time.
+   * Calculates the volatility at the specified expiry.
    * <p>
    * This relies on expiry supplied by {@link #relativeTime(ZonedDateTime)}.
    * This relies on tenor supplied by {@link #tenor(LocalDate, LocalDate)}.
@@ -267,10 +267,10 @@ public interface SwaptionVolatilities
    * <p>
    * When the date is after the valuation date (and potentially time), the returned number is negative.
    * 
-   * @param date  the date/time to find the relative year fraction of
+   * @param dateTime  the date-time to find the relative year fraction of
    * @return the relative year fraction
    */
-  public abstract double relativeTime(ZonedDateTime date);
+  public abstract double relativeTime(ZonedDateTime dateTime);
 
   /**
    * Calculates the tenor of the swap based on its start date and end date.

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
@@ -646,7 +646,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricerTest {
       SabrInterestRateParameters sabrParams,
       SabrParametersSwaptionVolatilities orgVols) {
     return SabrParametersSwaptionVolatilities.of(
-        SwaptionVolatilitiesName.of("Test-SABR"), sabrParams, orgVols.getValuationDateTime());
+        SwaptionVolatilitiesName.of("Test-SABR"), orgVols.getValuationDateTime(), sabrParams);
   }
 
   private void testSensitivityValue(

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
@@ -115,7 +115,7 @@ public class BlackSwaptionCashParYieldProductPricerTest {
       Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_ACT_ISDA, SWAP_CONVENTION);
   private static final Surface SURFACE = InterpolatedNodalSurface.of(METADATA, EXPIRY, TENOR, VOL, INTERPOLATOR_2D);
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER =
-      BlackSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE.atStartOfDay(ZoneOffset.UTC));
+      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
   // underlying swap and swaption
   private static final HolidayCalendarId CALENDAR = HolidayCalendarIds.SAT_SUN;
   private static final BusinessDayAdjustment BDA_MF = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, CALENDAR);
@@ -239,9 +239,9 @@ public class BlackSwaptionCashParYieldProductPricerTest {
           .iborIndexCurve(EUR_EURIBOR_6M, FWD6_CURVE)
           .build();
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER_AT_MATURITY =
-      BlackSwaptionExpiryTenorVolatilities.of(SURFACE, MATURITY.atStartOfDay(ZoneOffset.UTC));
+      BlackSwaptionExpiryTenorVolatilities.of(MATURITY.atStartOfDay(ZoneOffset.UTC), SURFACE);
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER_AFTER_MATURITY =
-      BlackSwaptionExpiryTenorVolatilities.of(SURFACE, MATURITY.plusDays(1).atStartOfDay(ZoneOffset.UTC));
+      BlackSwaptionExpiryTenorVolatilities.of(MATURITY.plusDays(1).atStartOfDay(ZoneOffset.UTC), SURFACE);
   // test parameters
   private static final double TOL = 1.0e-12;
   private static final double FD_EPS = 1.0e-7;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
@@ -69,7 +69,7 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
   private static final BlackSwaptionExpiryTenorVolatilities PROVIDER =
-      BlackSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE, VAL_TIME, LONDON_ZONE);
+      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
       dateUtc(2015, 2, 17), dateUtc(2015, 5, 17), dateUtc(2015, 6, 17), dateUtc(2017, 2, 17)};
@@ -137,8 +137,8 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataUp, INTERPOLATOR_2D);
         InterpolatedNodalSurface paramDw =
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataDw, INTERPOLATOR_2D);
-        BlackSwaptionExpiryTenorVolatilities provUp = BlackSwaptionExpiryTenorVolatilities.of(paramUp, VAL_DATE_TIME);
-        BlackSwaptionExpiryTenorVolatilities provDw = BlackSwaptionExpiryTenorVolatilities.of(paramDw, VAL_DATE_TIME);
+        BlackSwaptionExpiryTenorVolatilities provUp = BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramUp);
+        BlackSwaptionExpiryTenorVolatilities provDw = BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramDw);
         double volUp = provUp.volatility(
             TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
         double volDw = provDw.volatility(
@@ -151,10 +151,10 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    BlackSwaptionExpiryTenorVolatilities test1 = BlackSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE_TIME);
+    BlackSwaptionExpiryTenorVolatilities test1 = BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
     coverImmutableBean(test1);
     BlackSwaptionExpiryTenorVolatilities test2 =
-        BlackSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE.atStartOfDay(ZoneOffset.UTC));
+        BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
     coverBeanEquals(test1, test2);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
@@ -438,9 +438,9 @@ public class BlackSwaptionPhysicalProductPricerTest {
     Surface surfaceDw = ConstantSurface.of(
         SwaptionBlackVolatilityDataSets.META_DATA, SwaptionBlackVolatilityDataSets.VOLATILITY - shiftVol);
     CurrencyAmount pvP = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
-        BlackSwaptionExpiryTenorVolatilities.of(surfaceUp, VAL_DATE.atStartOfDay(ZoneOffset.UTC)));
+        BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceUp));
     CurrencyAmount pvM = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
-        BlackSwaptionExpiryTenorVolatilities.of(surfaceDw, VAL_DATE.atStartOfDay(ZoneOffset.UTC)));
+        BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceDw));
     double pvnvsFd = (pvP.getAmount() - pvM.getAmount()) / (2 * shiftVol);
     SwaptionSensitivity pvnvsAd = PRICER_SWAPTION_BLACK
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_CST_SWAPTION_PROVIDER_USD);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.pricer.swaption;
 
 import static com.opengamma.strata.basics.currency.Currency.USD;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.product.common.BuySell.BUY;
@@ -466,27 +467,24 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    double impliedLongRecComputed =
-        PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_REC_LONG, RATE_PROVIDER,
-            VOL_PROVIDER.getDayCount(), pvLongRec.getAmount());
+    double impliedLongRecComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
+        SWAPTION_REC_LONG, RATE_PROVIDER, ACT_365F, pvLongRec.getAmount());
     double impliedLongRecInterpolated =
         PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
     assertEquals(impliedLongRecComputed, impliedLongRecInterpolated, TOL);
 
     CurrencyAmount pvLongPay =
         PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    double impliedLongPayComputed =
-        PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_PAY_LONG, RATE_PROVIDER,
-            VOL_PROVIDER.getDayCount(), pvLongPay.getAmount());
+    double impliedLongPayComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
+        SWAPTION_PAY_LONG, RATE_PROVIDER, ACT_365F, pvLongPay.getAmount());
     double impliedLongPayInterpolated =
         PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
     assertEquals(impliedLongPayComputed, impliedLongPayInterpolated, TOL);
 
     CurrencyAmount pvShortRec =
         PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
-    double impliedShortRecComputed =
-        PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_REC_SHORT, RATE_PROVIDER,
-            VOL_PROVIDER.getDayCount(), pvShortRec.getAmount());
+    double impliedShortRecComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
+        SWAPTION_REC_SHORT, RATE_PROVIDER, ACT_365F, pvShortRec.getAmount());
     double impliedShortRecInterpolated =
         PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
     assertEquals(impliedShortRecComputed, impliedShortRecInterpolated, TOL);
@@ -495,8 +493,8 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   public void implied_volatility_wrong_sign() {
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatilityFromPresentValue(SWAPTION_REC_LONG, RATE_PROVIDER,
-        VOL_PROVIDER.getDayCount(), -pvLongRec.getAmount()));
+    assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatilityFromPresentValue(
+        SWAPTION_REC_LONG, RATE_PROVIDER, ACT_365F, -pvLongRec.getAmount()));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
@@ -75,7 +75,7 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
   private static final NormalSwaptionExpiryTenorVolatilities PROVIDER =
-      NormalSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE, VAL_TIME, LONDON_ZONE);
+      NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
       dateUtc(2015, 2, 17), dateUtc(2015, 5, 17), dateUtc(2015, 6, 17), dateUtc(2017, 2, 17)};
@@ -145,8 +145,8 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataUp, INTERPOLATOR_2D);
         InterpolatedNodalSurface paramDw =
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataDw, INTERPOLATOR_2D);
-        NormalSwaptionExpiryTenorVolatilities provUp = NormalSwaptionExpiryTenorVolatilities.of(paramUp, VAL_DATE_TIME);
-        NormalSwaptionExpiryTenorVolatilities provDw = NormalSwaptionExpiryTenorVolatilities.of(paramDw, VAL_DATE_TIME);
+        NormalSwaptionExpiryTenorVolatilities provUp = NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramUp);
+        NormalSwaptionExpiryTenorVolatilities provDw = NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramDw);
         double volUp = provUp.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
         double volDw = provDw.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
         double fd = 0.5 * (volUp - volDw) / eps;
@@ -165,10 +165,10 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    NormalSwaptionExpiryTenorVolatilities test1 = NormalSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE_TIME);
+    NormalSwaptionExpiryTenorVolatilities test1 = NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
     coverImmutableBean(test1);
     NormalSwaptionExpiryTenorVolatilities test2 =
-        NormalSwaptionExpiryTenorVolatilities.of(SURFACE, VAL_DATE.atStartOfDay(ZoneOffset.UTC));
+        NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
     coverBeanEquals(test1, test2);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.pricer.swaption;
 
 import static com.opengamma.strata.basics.currency.Currency.USD;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.product.common.BuySell.BUY;
@@ -188,27 +189,24 @@ public class NormalSwaptionPhysicalProductPricerTest {
   public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
-    double impliedLongRecComputed =
-        PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_LONG_REC, MULTI_USD,
-            NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), pvLongRec.getAmount());
+    double impliedLongRecComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
+        SWAPTION_LONG_REC, MULTI_USD, ACT_365F, pvLongRec.getAmount());
     double impliedLongRecInterpolated =
         PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
     assertEquals(impliedLongRecComputed, impliedLongRecInterpolated, TOLERANCE_RATE);
 
     CurrencyAmount pvShortRec =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
-    double impliedShortRecComputed =
-        PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_SHORT_REC, MULTI_USD,
-            NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), pvShortRec.getAmount());
+    double impliedShortRecComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
+        SWAPTION_SHORT_REC, MULTI_USD, ACT_365F, pvShortRec.getAmount());
     double impliedShortRecInterpolated =
         PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
     assertEquals(impliedShortRecComputed, impliedShortRecInterpolated, TOLERANCE_RATE);
 
     CurrencyAmount pvLongPay =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
-    double impliedLongPayComputed =
-        PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_LONG_PAY, MULTI_USD,
-            NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), pvLongPay.getAmount());
+    double impliedLongPayComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
+        SWAPTION_LONG_PAY, MULTI_USD, ACT_365F, pvLongPay.getAmount());
     double impliedLongPayInterpolated =
         PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
     assertEquals(impliedLongPayComputed, impliedLongPayInterpolated, TOLERANCE_RATE);
@@ -217,8 +215,8 @@ public class NormalSwaptionPhysicalProductPricerTest {
   public void implied_volatility_wrong_sign() {
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
-    assertThrowsIllegalArg(() -> PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(SWAPTION_LONG_REC, MULTI_USD,
-        NORMAL_VOL_SWAPTION_PROVIDER_USD.getDayCount(), -pvLongRec.getAmount()));
+    assertThrowsIllegalArg(() -> PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
+        SWAPTION_LONG_REC, MULTI_USD, ACT_365F, -pvLongRec.getAmount()));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -448,7 +448,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     SurfaceMetadata blackMeta =
         Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount(), VOL_PROVIDER.getConvention());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
-        ConstantSurface.of(blackMeta, impliedVol), VOL_PROVIDER.getValuationDateTime());
+        VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity
     PointSensitivityBuilder pointRec =
         PRICER.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -348,7 +348,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
     SurfaceMetadata blackMeta =
         Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount(), VOL_PROVIDER.getConvention());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
-        ConstantSurface.of(blackMeta, impliedVol), VOL_PROVIDER.getValuationDateTime());
+        VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity
     PointSensitivityBuilder pointRec =
         SWAPTION_PRICER.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilitiesTest.java
@@ -60,25 +60,15 @@ public class SabrSwaptionVolatilitiesTest {
   private static final double TOLERANCE_VOL = 1.0E-10;
 
   public void test_of() {
-    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     assertEquals(test.getConvention(), CONV);
     assertEquals(test.getDayCount(), ACT_ACT_ISDA);
     assertEquals(test.getParameters(), PARAM);
     assertEquals(test.getValuationDateTime(), DATE_TIME);
   }
 
-  public void test_of_dateTimeZone() {
-    SabrParametersSwaptionVolatilities test1 = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE, TIME, ZONE);
-    assertEquals(test1.getConvention(), CONV);
-    assertEquals(test1.getDayCount(), ACT_ACT_ISDA);
-    assertEquals(test1.getParameters(), PARAM);
-    assertEquals(test1.getValuationDateTime(), DATE.atTime(TIME).atZone(ZONE));
-    SabrParametersSwaptionVolatilities test2 = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
-    assertEquals(test1, test2);
-  }
-
   public void test_findData() {
-    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     assertEquals(test.findData(PARAM.getAlphaSurface().getName()), Optional.of(PARAM.getAlphaSurface()));
     assertEquals(test.findData(PARAM.getBetaSurface().getName()), Optional.of(PARAM.getBetaSurface()));
     assertEquals(test.findData(PARAM.getRhoSurface().getName()), Optional.of(PARAM.getRhoSurface()));
@@ -88,7 +78,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_tenor() {
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     double test1 = prov.tenor(DATE, DATE);
     assertEquals(test1, 0d);
     double test2 = prov.tenor(DATE, DATE.plusYears(2));
@@ -101,7 +91,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_relativeTime() {
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     double test1 = prov.relativeTime(DATE_TIME);
     assertEquals(test1, 0d);
     double test2 = prov.relativeTime(DATE_TIME.plusYears(2));
@@ -110,7 +100,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_volatility() {
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     for (int i = 0; i < NB_TEST; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
         double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
@@ -123,7 +113,7 @@ public class SabrSwaptionVolatilitiesTest {
 
   public void test_parameterSensitivity() {
     double alphaSensi = 2.24, betaSensi = 3.45, rhoSensi = -2.12, nuSensi = -0.56;
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     for (int i = 0; i < NB_TEST; i++) {
       double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
       PointSensitivities point = PointSensitivities.of(
@@ -175,7 +165,7 @@ public class SabrSwaptionVolatilitiesTest {
     double[] points1 = new double[] {2.24, 3.45, -2.12, -0.56};
     double[] points2 = new double[] {-0.145, 1.01, -5.0, -11.0};
     double[] points3 = new double[] {1.3, -4.32, 2.1, -7.18};
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     for (int i = 0; i < NB_TEST; i++) {
       PointSensitivities sensi1 = PointSensitivities.of(
           SwaptionSabrSensitivity.of(CONV, TEST_OPTION_EXPIRY[0], TEST_TENOR[i], ALPHA, USD, points1[0]),
@@ -217,10 +207,10 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void coverage() {
-    SabrParametersSwaptionVolatilities test1 = SabrParametersSwaptionVolatilities.of(NAME, PARAM, DATE_TIME);
+    SabrParametersSwaptionVolatilities test1 = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
     coverImmutableBean(test1);
     SabrParametersSwaptionVolatilities test2 = SabrParametersSwaptionVolatilities.of(
-        NAME2, SwaptionSabrRateVolatilityDataSet.SABR_PARAM_USD, DATE_TIME.plusDays(1));
+        NAME2, DATE_TIME.plusDays(1), SwaptionSabrRateVolatilityDataSet.SABR_PARAM_USD);
     coverBeanEquals(test1, test2);
   }
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
@@ -69,7 +69,7 @@ public class SwaptionBlackVolatilityDataSets {
   private static final ZoneId VAL_ZONE_STD = ZoneId.of("Europe/London");
   /** Black volatility provider */
   public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_SWAPTION_PROVIDER_USD_STD =
-      BlackSwaptionExpiryTenorVolatilities.of(SURFACE_STD, VAL_DATE_STD, VAL_TIME_STD, VAL_ZONE_STD);
+      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
 
   /** constant volatility */
   public static final double VOLATILITY = 0.20;
@@ -79,6 +79,6 @@ public class SwaptionBlackVolatilityDataSets {
   private static final Surface CST_SURFACE = ConstantSurface.of(META_DATA, VOLATILITY);
   /** flat Black volatility provider */
   public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_CST_SWAPTION_PROVIDER_USD =
-      BlackSwaptionExpiryTenorVolatilities.of(CST_SURFACE, VAL_DATE_STD, VAL_TIME_STD, VAL_ZONE_STD);
+      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), CST_SURFACE);
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
@@ -158,7 +158,7 @@ public class SwaptionCubeData {
       InterpolatedNodalSurface.of(METADATA_LOGNORMAL, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
           DoubleArray.ofUnsafe(TENOR_TIME), DoubleArray.ofUnsafe(DATA_LOGNORMAL_ATM_SIMPLE), INTERPOLATOR_2D);
   public static final SwaptionVolatilities ATM_NORMAL_SIMPLE = 
-      NormalSwaptionExpiryTenorVolatilities.of(ATM_NORMAL_SIMPLE_SURFACE, DATA_TIME);
+      NormalSwaptionExpiryTenorVolatilities.of(DATA_TIME, ATM_NORMAL_SIMPLE_SURFACE);
   public static final SwaptionVolatilities ATM_LOGNORMAL_SIMPLE = 
-      BlackSwaptionExpiryTenorVolatilities.of(ATM_LOGNORMAL_SIMPLE_SURFACE, DATA_TIME);
+      BlackSwaptionExpiryTenorVolatilities.of(DATA_TIME, ATM_LOGNORMAL_SIMPLE_SURFACE);
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
@@ -71,7 +71,7 @@ public class SwaptionNormalVolatilityDataSets {
   private static final ZoneId VAL_ZONE_STD = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME_STD = VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD);
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_STD =
-      NormalSwaptionExpiryTenorVolatilities.of(SURFACE_STD, VAL_DATE_TIME_STD);
+      NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME_STD, SURFACE_STD);
 
   /**
    * Returns the swaption normal volatility surface shifted by a given amount. The shift is parallel.
@@ -80,11 +80,11 @@ public class SwaptionNormalVolatilityDataSets {
    */
   public static NormalSwaptionExpiryTenorVolatilities normalVolSwaptionProviderUsdStsShifted(double shift) {
     DoubleArray volShifted = NORMAL_VOL.map(v -> v + shift);
-    return NormalSwaptionExpiryTenorVolatilities.of(SURFACE_STD.withZValues(volShifted), VAL_DATE_TIME_STD);
+    return NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME_STD, SURFACE_STD.withZValues(volShifted));
   }
 
   public static NormalSwaptionExpiryTenorVolatilities normalVolSwaptionProviderUsdStd(LocalDate valuationDate) {
-    return NormalSwaptionExpiryTenorVolatilities.of(SURFACE_STD, valuationDate, VAL_TIME_STD, VAL_ZONE_STD);
+    return NormalSwaptionExpiryTenorVolatilities.of(valuationDate.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
   }
 
   //     =====     Flat volatilities for testing     =====
@@ -96,7 +96,7 @@ public class SwaptionNormalVolatilityDataSets {
       InterpolatedNodalSurface.of(METADATA, TIMES_FLAT, TENOR_FLAT, NORMAL_VOL_FLAT, INTERPOLATOR_2D);
 
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT =
-      NormalSwaptionExpiryTenorVolatilities.of(SURFACE_FLAT, VAL_DATE_STD, VAL_TIME_STD, VAL_ZONE_STD);
+      NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME_STD, SURFACE_FLAT);
 
   //     =====     Market data as of 2014-03-20     =====
 
@@ -131,6 +131,6 @@ public class SwaptionNormalVolatilityDataSets {
 
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_20150320 =
       NormalSwaptionExpiryTenorVolatilities.of(
-          SURFACE_20150320, VAL_DATE_20150320, VAL_TIME_20150320, VAL_ZONE_20150320);
+          VAL_DATE_20150320.atTime(VAL_TIME_20150320).atZone(VAL_ZONE_20150320), SURFACE_20150320);
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrRateVolatilityDataSet.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrRateVolatilityDataSet.java
@@ -172,8 +172,8 @@ public class SwaptionSabrRateVolatilityDataSet {
    */
   public static SabrParametersSwaptionVolatilities getVolatilitiesUsd(LocalDate valuationDate, boolean shift) {
     ZonedDateTime dateTime = valuationDate.atStartOfDay(ZoneOffset.UTC);
-    return shift ? SabrParametersSwaptionVolatilities.of(NAME, SABR_PARAM_SHIFT_USD, dateTime)
-        : SabrParametersSwaptionVolatilities.of(NAME, SABR_PARAM_USD, dateTime);
+    return shift ? SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_SHIFT_USD)
+        : SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_USD);
   }
 
   /*
@@ -300,7 +300,7 @@ public class SwaptionSabrRateVolatilityDataSet {
    */
   public static SabrParametersSwaptionVolatilities getVolatilitiesEur(LocalDate valuationDate, boolean shift) {
     ZonedDateTime dateTime = valuationDate.atStartOfDay(ZoneOffset.UTC);
-    return shift ? SabrParametersSwaptionVolatilities.of(NAME, SABR_PARAM_SHIFT_EUR, dateTime)
-        : SabrParametersSwaptionVolatilities.of(NAME, SABR_PARAM_EUR, dateTime);
+    return shift ? SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_SHIFT_EUR)
+        : SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_EUR);
   }
 }


### PR DESCRIPTION
Parameter order should be name-key-datetime-underlying to match `DiscountFactors` and other views.

This PR simply swaps the parameter order and order of properties.