### PR TITLE
Use market-style prices for DSF

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/DsfPricingExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/DsfPricingExample.java
@@ -115,7 +115,7 @@ public class DsfPricingExample {
             .build())
         .product(product)
         .quantity(20)
-        .price(1.0075)
+        .price(100.75)
         .build();
   }
 
@@ -142,7 +142,7 @@ public class DsfPricingExample {
             .build())
         .product(product)
         .quantity(20)
-        .price(1.0085)
+        .price(100.85)
         .build();
   }
 

--- a/examples/src/main/resources/example-portfolios/dsf-portfolio.xml
+++ b/examples/src/main/resources/example-portfolios/dsf-portfolio.xml
@@ -115,7 +115,7 @@
     </underlyingSwap>
    </product>
    <quantity>20</quantity>
-   <price>1.0075</price>
+   <price>100.75</price>
   </item>
   <item type="DsfTrade">
    <info>
@@ -231,7 +231,7 @@
     </underlyingSwap>
    </product>
    <quantity>20</quantity>
-   <price>1.0085</price>
+   <price>100.85</price>
   </item>
  </trades>
 </bean>

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfMeasureCalculations.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfMeasureCalculations.java
@@ -185,7 +185,7 @@ final class DsfMeasureCalculations {
   private double settlementPrice(ResolvedDsfTrade trade, RatesProvider ratesProvider) {
     StandardId standardId = trade.getProduct().getSecurityId().getStandardId();
     QuoteId id = QuoteId.of(standardId, FieldName.SETTLEMENT_PRICE);
-    return ratesProvider.data(id) / 100;  // convert market quote to value needed
+    return ratesProvider.data(id);
   }
 
 }

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunction.java
@@ -47,6 +47,9 @@ import com.opengamma.strata.product.dsf.ResolvedDsfTrade;
  * </ul>
  * <p>
  * The "natural" currency is the currency of the swap leg that is received.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 public class DsfTradeCalculationFunction
     implements CalculationFunction<DsfTrade> {

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfTradeCalculations.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/dsf/DsfTradeCalculations.java
@@ -27,6 +27,9 @@ import com.opengamma.strata.product.dsf.ResolvedDsfTrade;
  * typically work with {@link DsfTrade}. Call
  * {@link DsfTrade#resolve(com.opengamma.strata.basics.ReferenceData) DsfTrade::resolve(ReferenceData)}
  * to convert {@code DsfTrade} to {@code ResolvedDsfTrade}.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 public class DsfTradeCalculations {
 

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/dsf/DsfTradeCalculationFunctionTest.java
@@ -86,9 +86,8 @@ public class DsfTradeCalculationFunctionTest {
       .notional(NOTIONAL)
       .underlyingSwap(SWAP)
       .build();
-  private static final double TRADE_PRICE = 0.98 + 31.0 / 32.0 / 100.0; // price quoted in 32nd of 1%
-  public static final double REF_PRICE = 0.98 + 30.0 / 32.0 / 100.0; // price quoted in 32nd of 1%
-  private static final double MARKET_PRICE = REF_PRICE * 100;
+  private static final double TRADE_PRICE = 98 + 31d / 32d; // price quoted in 32nd of 1%
+  public static final double REF_PRICE = 98 + 30d / 32d; // price quoted in 32nd of 1%
   private static final long QUANTITY = 1234L;
   public static final DsfTrade TRADE = DsfTrade.builder()
       .product(FUTURE)
@@ -165,7 +164,7 @@ public class DsfTradeCalculationFunctionTest {
         ImmutableMap.of(
             DISCOUNT_CURVE_ID, curve,
             FORWARD_CURVE_ID, curve,
-            QUOTE_KEY, MARKET_PRICE),
+            QUOTE_KEY, REF_PRICE),
         ImmutableMap.of());
     return md;
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/AbstractDsfProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/AbstractDsfProductPricer.java
@@ -12,6 +12,9 @@ import com.opengamma.strata.product.dsf.ResolvedDsf;
  * Base pricer for Deliverable Swap Futures (DSFs).
  * <p>
  * This function provides common code used when pricing an {@link ResolvedDsf}.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 public abstract class AbstractDsfProductPricer {
 
@@ -29,11 +32,11 @@ public abstract class AbstractDsfProductPricer {
    *    {@code (marginIndex(future, C2) - marginIndex(future, C1))}.
    * 
    * @param future  the future
-   * @param price  the price of the product, in decimal form
+   * @param price  the price of the product
    * @return the index
    */
   protected double marginIndex(ResolvedDsf future, double price) {
-    return price * future.getNotional();
+    return price * future.getNotional() / 100d;
   }
 
   /**
@@ -51,7 +54,7 @@ public abstract class AbstractDsfProductPricer {
       ResolvedDsf future,
       PointSensitivities priceSensitivity) {
 
-    return priceSensitivity.multipliedBy(future.getNotional());
+    return priceSensitivity.multipliedBy(future.getNotional() / 100d);
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/AbstractDsfTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/AbstractDsfTradePricer.java
@@ -13,6 +13,9 @@ import com.opengamma.strata.product.dsf.ResolvedDsfTrade;
  * Base pricer for Deliverable Swap Futures (DSFs).
  * <p>
  * This function provides common code used when pricing an {@link ResolvedDsfTrade}.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 public abstract class AbstractDsfTradePricer {
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/DiscountingDsfProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/DiscountingDsfProductPricer.java
@@ -19,6 +19,9 @@ import com.opengamma.strata.product.swap.ResolvedSwap;
  * Pricer for for Deliverable Swap Futures (DSFs).
  * <p>
  * This function provides the ability to price a {@link ResolvedDsf}.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 public final class DiscountingDsfProductPricer extends AbstractDsfProductPricer {
 
@@ -60,14 +63,14 @@ public final class DiscountingDsfProductPricer extends AbstractDsfProductPricer 
    * 
    * @param future  the future
    * @param ratesProvider  the rates provider
-   * @return the price of the product, in decimal form
+   * @return the price of the product
    */
   public double price(ResolvedDsf future, RatesProvider ratesProvider) {
     ResolvedSwap swap = future.getUnderlyingSwap();
     Currency currency = future.getCurrency();
     CurrencyAmount pvSwap = swapPricer.presentValue(swap, currency, ratesProvider);
     double df = ratesProvider.discountFactor(currency, future.getDeliveryDate());
-    return 1d + pvSwap.getAmount() / df;
+    return (1d + pvSwap.getAmount() / df) * 100d;
   }
 
   //-------------------------------------------------------------------------
@@ -88,7 +91,7 @@ public final class DiscountingDsfProductPricer extends AbstractDsfProductPricer 
     PointSensitivityBuilder sensiSwapPv = swapPricer.presentValueSensitivity(swap, ratesProvider).multipliedBy(dfInv);
     PointSensitivityBuilder sensiDf = ratesProvider.discountFactors(currency)
         .zeroRatePointSensitivity(future.getDeliveryDate()).multipliedBy(-pvSwap * dfInv * dfInv);
-    return sensiSwapPv.combinedWith(sensiDf).build();
+    return sensiSwapPv.combinedWith(sensiDf).build().multipliedBy(100d);
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/DiscountingDsfTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/dsf/DiscountingDsfTradePricer.java
@@ -18,6 +18,9 @@ import com.opengamma.strata.product.dsf.ResolvedDsfTrade;
  * Pricer implementation for Deliverable Swap Futures (DSFs).
  * <p>
  * This function provides the ability to price a {@link ResolvedDsfTrade}.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 public class DiscountingDsfTradePricer
     extends AbstractDsfTradePricer {
@@ -57,7 +60,7 @@ public class DiscountingDsfTradePricer
    * 
    * @param trade  the trade
    * @param provider  the rates provider
-   * @return the price of the trade, in decimal form
+   * @return the price of the trade
    */
   public double price(ResolvedDsfTrade trade, RatesProvider provider) {
     return productPricer.price(trade.getProduct(), provider);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/dsf/DiscountingDsfProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/dsf/DiscountingDsfProductPricerTest.java
@@ -154,7 +154,7 @@ public class DiscountingDsfProductPricerTest {
     double pvSwap = PRICER.getSwapPricer().presentValue(RSWAP, PROVIDER).getAmount(USD).getAmount();
     double yc = ACT_ACT_ISDA.relativeYearFraction(VAL_DATE, DELIVERY);
     double df = Math.exp(-USD_DSC.yValue(yc) * yc);
-    double expected = 1d + pvSwap / df;
+    double expected = (1d + pvSwap / df) * 100;
     assertEquals(computed, expected, TOL);
   }
 
@@ -163,13 +163,13 @@ public class DiscountingDsfProductPricerTest {
     CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point);
     CurrencyParameterSensitivities expected =
         FD_CAL.sensitivity(PROVIDER, (p) -> CurrencyAmount.of(USD, PRICER.price(FUTURE, (p))));
-    assertTrue(computed.equalWithTolerance(expected, 10d * EPS));
+    assertTrue(computed.equalWithTolerance(expected, 1000d * EPS));
   }
 
   //-------------------------------------------------------------------------
   public void regression() {
     double price = PRICER.price(FUTURE, PROVIDER);
-    assertEquals(price, 1.022245377054993, TOL); // 2.x
+    assertEquals(price, 102.2245377054993, TOL); // 2.x
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/dsf/DiscountingDsfTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/dsf/DiscountingDsfTradePricerTest.java
@@ -145,7 +145,7 @@ public class DiscountingDsfTradePricerTest {
       .build()
       .resolve(REF_DATA);
   private static final TradeInfo TRADE_INFO = TradeInfo.builder().tradeDate(VAL_DATE).build();
-  private static final double TRADE_PRICE = 0.98 + 31.0 / 32.0 / 100.0; // price quoted in 32nd of 1%
+  private static final double TRADE_PRICE = 98 + 31d / 32; // price quoted in 32nd
   private static final long QUANTITY = 1234L;
   private static final ResolvedDsfTrade FUTURE_TRADE = ResolvedDsfTrade.builder()
       .info(TRADE_INFO)
@@ -153,7 +153,7 @@ public class DiscountingDsfTradePricerTest {
       .quantity(QUANTITY)
       .price(TRADE_PRICE)
       .build();
-  private static final double LASTMARG_PRICE = 0.99 + 8.0 / 32.0 / 100.0;
+  private static final double LASTMARG_PRICE = 99 + 8d / 32d;
   // calculators
   private static final double TOL = 1.0e-13;
   private static final double EPS = 1.0e-6;
@@ -172,7 +172,7 @@ public class DiscountingDsfTradePricerTest {
 
   public void test_presentValue() {
     CurrencyAmount computed = TRADE_PRICER.presentValue(FUTURE_TRADE, PROVIDER, LASTMARG_PRICE);
-    double expected = QUANTITY * NOTIONAL * (PRODUCT_PRICER.price(FUTURE, PROVIDER) - LASTMARG_PRICE);
+    double expected = QUANTITY * NOTIONAL * (PRODUCT_PRICER.price(FUTURE, PROVIDER) - LASTMARG_PRICE) / 100d;
     assertEquals(computed.getCurrency(), USD);
     assertEquals(computed.getAmount(), expected, QUANTITY * NOTIONAL * TOL);
   }

--- a/modules/product/src/main/java/com/opengamma/strata/product/dsf/DsfTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/dsf/DsfTrade.java
@@ -33,6 +33,9 @@ import com.opengamma.strata.product.TradeInfo;
  * A trade representing a futures contract based on an interest rate swap.
  * <p>
  * A trade in an underlying {@link Dsf}.
+ * <p>
+ * The price of a DSF is based on the present value (NPV) of the underlying swap on the delivery date.
+ * For example, a price of 100.1822 represents a present value of $100,182.20, if the notional is $100,000.
  */
 @BeanDefinition(constructorScope = "package")
 public final class DsfTrade
@@ -61,7 +64,7 @@ public final class DsfTrade
   @PropertyDefinition(overrideGet = true)
   private final double quantity;
   /**
-   * The price that was traded, in decimal form.
+   * The price that was traded.
    * <p>
    * This is the price agreed when the trade occurred.
    */
@@ -182,7 +185,7 @@ public final class DsfTrade
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the price that was traded, in decimal form.
+   * Gets the price that was traded.
    * <p>
    * This is the price agreed when the trade occurred.
    * @return the value of the property
@@ -514,7 +517,7 @@ public final class DsfTrade
     }
 
     /**
-     * Sets the price that was traded, in decimal form.
+     * Sets the price that was traded.
      * <p>
      * This is the price agreed when the trade occurred.
      * @param price  the new value

--- a/modules/product/src/main/java/com/opengamma/strata/product/dsf/ResolvedDsfTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/dsf/ResolvedDsfTrade.java
@@ -66,7 +66,7 @@ public final class ResolvedDsfTrade
   @PropertyDefinition
   private final double quantity;
   /**
-   * The price that was traded, in decimal form.
+   * The price that was traded.
    * <p>
    * This is the price agreed when the trade occurred.
    */
@@ -179,7 +179,7 @@ public final class ResolvedDsfTrade
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the price that was traded, in decimal form.
+   * Gets the price that was traded.
    * <p>
    * This is the price agreed when the trade occurred.
    * @return the value of the property
@@ -510,7 +510,7 @@ public final class ResolvedDsfTrade
     }
 
     /**
-     * Sets the price that was traded, in decimal form.
+     * Sets the price that was traded.
      * <p>
      * This is the price agreed when the trade occurred.
      * @param price  the new value

--- a/modules/product/src/test/java/com/opengamma/strata/product/dsf/DsfTradeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/dsf/DsfTradeTest.java
@@ -16,9 +16,6 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.product.TradeInfo;
-import com.opengamma.strata.product.dsf.Dsf;
-import com.opengamma.strata.product.dsf.DsfTrade;
-import com.opengamma.strata.product.dsf.ResolvedDsfTrade;
 
 /**
  * Test {@link DsfTrade}.
@@ -35,8 +32,8 @@ public class DsfTradeTest {
       .build();
   private static final double QUANTITY = 100L;
   private static final double QUANTITY2 = 200L;
-  private static final double PRICE = 0.99;
-  private static final double PRICE2 = 0.98;
+  private static final double PRICE = 101.23;
+  private static final double PRICE2 = 98.45;
 
   //-------------------------------------------------------------------------
   public void test_builder() {


### PR DESCRIPTION
Market conventions are clear for ETDs. Avoid decimal-style prices.