### PR TITLE
Convention not in surface info

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/SurfaceInfoType.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/SurfaceInfoType.java
@@ -11,7 +11,6 @@ import org.joda.convert.FromString;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.collect.TypedString;
 import com.opengamma.strata.market.model.MoneynessType;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 
 /**
  * The type that provides meaning to additional surface information.
@@ -36,10 +35,6 @@ public final class SurfaceInfoType<T>
    * Key used to access information about the {@link DayCount}.
    */
   public static final SurfaceInfoType<DayCount> DAY_COUNT = SurfaceInfoType.of("DayCount");
-  /**
-   * Key used to access information about the swaption convention.
-   */
-  public static final SurfaceInfoType<FixedIborSwapConvention> SWAP_CONVENTION = SurfaceInfoType.of("SwapConvention");
   /**
    * Key used to access information about the type of moneyness.
    */

--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/Surfaces.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/Surfaces.java
@@ -8,7 +8,6 @@ package com.opengamma.strata.market.surface;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.model.MoneynessType;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 
 /**
  * Helper for creating common types of surfaces.
@@ -79,15 +78,10 @@ public final class Surfaces {
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param convention  the swap convention
    * @return the surface metadata
    */
-  public static SurfaceMetadata swaptionBlackExpiryTenor(
-      String name,
-      DayCount dayCount,
-      FixedIborSwapConvention convention) {
-
-    return swaptionBlackExpiryTenor(SurfaceName.of(name), dayCount, convention);
+  public static SurfaceMetadata swaptionBlackExpiryTenor(String name, DayCount dayCount) {
+    return swaptionBlackExpiryTenor(SurfaceName.of(name), dayCount);
   }
 
   /**
@@ -99,21 +93,15 @@ public final class Surfaces {
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param convention  the swap convention
    * @return the surface metadata
    */
-  public static SurfaceMetadata swaptionBlackExpiryTenor(
-      SurfaceName name,
-      DayCount dayCount,
-      FixedIborSwapConvention convention) {
-
+  public static SurfaceMetadata swaptionBlackExpiryTenor(SurfaceName name, DayCount dayCount) {
     return DefaultSurfaceMetadata.builder()
         .surfaceName(name)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.BLACK_VOLATILITY)
         .dayCount(dayCount)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, convention)
         .build();
   }
 
@@ -127,15 +115,10 @@ public final class Surfaces {
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param convention  the swap convention
    * @return the surface metadata
    */
-  public static SurfaceMetadata swaptionNormalExpiryTenor(
-      String name,
-      DayCount dayCount,
-      FixedIborSwapConvention convention) {
-
-    return swaptionNormalExpiryTenor(SurfaceName.of(name), dayCount, convention);
+  public static SurfaceMetadata swaptionNormalExpiryTenor(String name, DayCount dayCount) {
+    return swaptionNormalExpiryTenor(SurfaceName.of(name), dayCount);
   }
 
   /**
@@ -147,21 +130,15 @@ public final class Surfaces {
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param convention  the swap convention
    * @return the surface metadata
    */
-  public static SurfaceMetadata swaptionNormalExpiryTenor(
-      SurfaceName name,
-      DayCount dayCount,
-      FixedIborSwapConvention convention) {
-
+  public static SurfaceMetadata swaptionNormalExpiryTenor(SurfaceName name, DayCount dayCount) {
     return DefaultSurfaceMetadata.builder()
         .surfaceName(name)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.NORMAL_VOLATILITY)
         .dayCount(dayCount)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, convention)
         .build();
   }
 
@@ -174,17 +151,15 @@ public final class Surfaces {
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param convention  the swap convention
    * @param zType  the z-value type
    * @return the surface metadata
    */
   public static SurfaceMetadata swaptionSabrExpiryTenor(
       String name,
       DayCount dayCount,
-      FixedIborSwapConvention convention,
       ValueType zType) {
 
-    return swaptionSabrExpiryTenor(SurfaceName.of(name), dayCount, convention, zType);
+    return swaptionSabrExpiryTenor(SurfaceName.of(name), dayCount, zType);
   }
 
   /**
@@ -195,14 +170,12 @@ public final class Surfaces {
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param convention  the swap convention
    * @param zType  the z-value type
    * @return the surface metadata
    */
   public static SurfaceMetadata swaptionSabrExpiryTenor(
       SurfaceName name,
       DayCount dayCount,
-      FixedIborSwapConvention convention,
       ValueType zType) {
 
     if (!zType.equals(ValueType.SABR_ALPHA) && !zType.equals(ValueType.SABR_BETA) &&
@@ -215,7 +188,6 @@ public final class Surfaces {
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(zType)
         .dayCount(dayCount)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, convention)
         .build();
   }
 

--- a/modules/market/src/test/java/com/opengamma/strata/market/surface/SurfaceInfoTypeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/surface/SurfaceInfoTypeTest.java
@@ -11,7 +11,6 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.market.model.MoneynessType;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 
 /**
  * Test {@link SurfaceInfoType}.
@@ -22,11 +21,6 @@ public class SurfaceInfoTypeTest {
   public void test_DAY_COUNT() {
     SurfaceInfoType<DayCount> test = SurfaceInfoType.DAY_COUNT;
     assertEquals(test.toString(), "DayCount");
-  }
-
-  public void test_SWAP_CONVENTION() {
-    SurfaceInfoType<FixedIborSwapConvention> test = SurfaceInfoType.SWAP_CONVENTION;
-    assertEquals(test.toString(), "SwapConvention");
   }
 
   public void test_MONEYNESS_TYPE() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/surface/SurfacesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/surface/SurfacesTest.java
@@ -13,8 +13,6 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.model.MoneynessType;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 
 /**
  * Test {@link Surfaces}.
@@ -24,7 +22,6 @@ public class SurfacesTest {
 
   private static final String NAME = "Foo";
   private static final SurfaceName SURFACE_NAME = SurfaceName.of(NAME);
-  private static final FixedIborSwapConvention CONVENTION = FixedIborSwapConventions.GBP_FIXED_1Y_LIBOR_3M;
 
   //-------------------------------------------------------------------------
   public void iborFutureOptionNormalExpirySimpleMoneyness_string() {
@@ -55,81 +52,75 @@ public class SurfacesTest {
 
   //-------------------------------------------------------------------------
   public void swaptionBlackExpiryTenor_string() {
-    SurfaceMetadata test = Surfaces.swaptionBlackExpiryTenor(NAME, ACT_360, CONVENTION);
+    SurfaceMetadata test = Surfaces.swaptionBlackExpiryTenor(NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.BLACK_VOLATILITY)
         .dayCount(ACT_360)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, CONVENTION)
         .build();
     assertEquals(test, expected);
   }
 
   public void swaptionBlackExpiryTenor_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionBlackExpiryTenor(SURFACE_NAME, ACT_360, CONVENTION);
+    SurfaceMetadata test = Surfaces.swaptionBlackExpiryTenor(SURFACE_NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.BLACK_VOLATILITY)
         .dayCount(ACT_360)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, CONVENTION)
         .build();
     assertEquals(test, expected);
   }
 
   //-------------------------------------------------------------------------
   public void swaptionNormalExpiryTenor_string() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpiryTenor(NAME, ACT_360, CONVENTION);
+    SurfaceMetadata test = Surfaces.swaptionNormalExpiryTenor(NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.NORMAL_VOLATILITY)
         .dayCount(ACT_360)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, CONVENTION)
         .build();
     assertEquals(test, expected);
   }
 
   public void swaptionNormalExpiryTenor_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpiryTenor(SURFACE_NAME, ACT_360, CONVENTION);
+    SurfaceMetadata test = Surfaces.swaptionNormalExpiryTenor(SURFACE_NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.NORMAL_VOLATILITY)
         .dayCount(ACT_360)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, CONVENTION)
         .build();
     assertEquals(test, expected);
   }
 
   //-------------------------------------------------------------------------
   public void swaptionSabrExpiryTenor_string() {
-    SurfaceMetadata test = Surfaces.swaptionSabrExpiryTenor(NAME, ACT_360, CONVENTION, ValueType.SABR_BETA);
+    SurfaceMetadata test = Surfaces.swaptionSabrExpiryTenor(NAME, ACT_360, ValueType.SABR_BETA);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.SABR_BETA)
         .dayCount(ACT_360)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, CONVENTION)
         .build();
     assertEquals(test, expected);
   }
 
   public void swaptionSabrExpiryTenor_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionSabrExpiryTenor(SURFACE_NAME, ACT_360, CONVENTION, ValueType.SABR_BETA);
+    SurfaceMetadata test = Surfaces.swaptionSabrExpiryTenor(SURFACE_NAME, ACT_360, ValueType.SABR_BETA);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
         .yValueType(ValueType.YEAR_FRACTION)
         .zValueType(ValueType.SABR_BETA)
         .dayCount(ACT_360)
-        .addInfo(SurfaceInfoType.SWAP_CONVENTION, CONVENTION)
         .build();
     assertEquals(test, expected);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
@@ -56,6 +56,11 @@ public final class BlackSwaptionExpiryTenorVolatilities
     implements BlackSwaptionVolatilities, ImmutableBean, Serializable {
 
   /**
+   * The swap convention that the volatilities are to be used for.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final FixedIborSwapConvention convention;
+  /**
    * The valuation date-time.
    * <p>
    * The volatilities are calibrated for this date-time.
@@ -70,10 +75,6 @@ public final class BlackSwaptionExpiryTenorVolatilities
    */
   @PropertyDefinition(validate = "notNull")
   private final Surface surface;
-  /**
-   * The swap convention that the surface is calibrated against.
-   */
-  private final FixedIborSwapConvention convention;  // cached, not a property
   /**
    * The day count convention of the surface.
    */
@@ -90,27 +91,30 @@ public final class BlackSwaptionExpiryTenorVolatilities
    * <li>The y-value type must be {@link ValueType#YEAR_FRACTION}
    * <li>The z-value type must be {@link ValueType#BLACK_VOLATILITY}
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
-   * <li>The swap convention must be set in the additional information using {@link SurfaceInfoType#SWAP_CONVENTION}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionBlackExpiryTenor(String, DayCount, FixedIborSwapConvention)}.
+   * {@link Surfaces#swaptionBlackExpiryTenor(String, DayCount)}.
    * 
+   * @param convention  the swap convention that the volatilities are to be used for
    * @param valuationDateTime  the valuation date-time
    * @param surface  the implied volatility surface
    * @return the volatilities
    */
   public static BlackSwaptionExpiryTenorVolatilities of(
+      FixedIborSwapConvention convention,
       ZonedDateTime valuationDateTime,
       Surface surface) {
 
-    return new BlackSwaptionExpiryTenorVolatilities(valuationDateTime, surface);
+    return new BlackSwaptionExpiryTenorVolatilities(convention, valuationDateTime, surface);
   }
 
   @ImmutableConstructor
   private BlackSwaptionExpiryTenorVolatilities(
+      FixedIborSwapConvention convention,
       ZonedDateTime valuationDateTime,
       Surface surface) {
 
+    ArgChecker.notNull(convention, "convention");
     ArgChecker.notNull(valuationDateTime, "valuationDateTime");
     ArgChecker.notNull(surface, "surface");
     surface.getMetadata().getXValueType().checkEquals(
@@ -119,14 +123,12 @@ public final class BlackSwaptionExpiryTenorVolatilities
         ValueType.YEAR_FRACTION, "Incorrect y-value type for Black volatilities");
     surface.getMetadata().getZValueType().checkEquals(
         ValueType.BLACK_VOLATILITY, "Incorrect z-value type for Black volatilities");
-    FixedIborSwapConvention swapConvention = surface.getMetadata().findInfo(SurfaceInfoType.SWAP_CONVENTION)
-        .orElseThrow(() -> new IllegalArgumentException("Incorrect surface metadata, missing swap convention"));
     DayCount dayCount = surface.getMetadata().findInfo(SurfaceInfoType.DAY_COUNT)
         .orElseThrow(() -> new IllegalArgumentException("Incorrect surface metadata, missing DayCount"));
 
     this.valuationDateTime = valuationDateTime;
     this.surface = surface;
-    this.convention = swapConvention;
+    this.convention = convention;
     this.dayCount = dayCount;
   }
 
@@ -134,11 +136,6 @@ public final class BlackSwaptionExpiryTenorVolatilities
   @Override
   public SwaptionVolatilitiesName getName() {
     return SwaptionVolatilitiesName.of(surface.getName().getName());
-  }
-
-  @Override
-  public FixedIborSwapConvention getConvention() {
-    return convention;
   }
 
   @Override
@@ -166,12 +163,14 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
   @Override
   public BlackSwaptionExpiryTenorVolatilities withParameter(int parameterIndex, double newValue) {
-    return new BlackSwaptionExpiryTenorVolatilities(valuationDateTime, surface.withParameter(parameterIndex, newValue));
+    return new BlackSwaptionExpiryTenorVolatilities(
+        convention, valuationDateTime, surface.withParameter(parameterIndex, newValue));
   }
 
   @Override
   public BlackSwaptionExpiryTenorVolatilities withPerturbation(ParameterPerturbation perturbation) {
-    return new BlackSwaptionExpiryTenorVolatilities(valuationDateTime, surface.withPerturbation(perturbation));
+    return new BlackSwaptionExpiryTenorVolatilities(
+        convention, valuationDateTime, surface.withPerturbation(perturbation));
   }
 
   //-------------------------------------------------------------------------
@@ -278,6 +277,16 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the swap convention that the volatilities are to be used for.
+   * @return the value of the property, not null
+   */
+  @Override
+  public FixedIborSwapConvention getConvention() {
+    return convention;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Gets the valuation date-time.
    * <p>
    * The volatilities are calibrated for this date-time.
@@ -308,7 +317,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       BlackSwaptionExpiryTenorVolatilities other = (BlackSwaptionExpiryTenorVolatilities) obj;
-      return JodaBeanUtils.equal(valuationDateTime, other.valuationDateTime) &&
+      return JodaBeanUtils.equal(convention, other.convention) &&
+          JodaBeanUtils.equal(valuationDateTime, other.valuationDateTime) &&
           JodaBeanUtils.equal(surface, other.surface);
     }
     return false;
@@ -317,6 +327,7 @@ public final class BlackSwaptionExpiryTenorVolatilities
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(convention);
     hash = hash * 31 + JodaBeanUtils.hashCode(valuationDateTime);
     hash = hash * 31 + JodaBeanUtils.hashCode(surface);
     return hash;
@@ -324,8 +335,9 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(96);
+    StringBuilder buf = new StringBuilder(128);
     buf.append("BlackSwaptionExpiryTenorVolatilities{");
+    buf.append("convention").append('=').append(convention).append(',').append(' ');
     buf.append("valuationDateTime").append('=').append(valuationDateTime).append(',').append(' ');
     buf.append("surface").append('=').append(JodaBeanUtils.toString(surface));
     buf.append('}');
@@ -343,6 +355,11 @@ public final class BlackSwaptionExpiryTenorVolatilities
     static final Meta INSTANCE = new Meta();
 
     /**
+     * The meta-property for the {@code convention} property.
+     */
+    private final MetaProperty<FixedIborSwapConvention> convention = DirectMetaProperty.ofImmutable(
+        this, "convention", BlackSwaptionExpiryTenorVolatilities.class, FixedIborSwapConvention.class);
+    /**
      * The meta-property for the {@code valuationDateTime} property.
      */
     private final MetaProperty<ZonedDateTime> valuationDateTime = DirectMetaProperty.ofImmutable(
@@ -357,6 +374,7 @@ public final class BlackSwaptionExpiryTenorVolatilities
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
+        "convention",
         "valuationDateTime",
         "surface");
 
@@ -369,6 +387,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 2039569265:  // convention
+          return convention;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
         case -1853231955:  // surface
@@ -394,6 +414,14 @@ public final class BlackSwaptionExpiryTenorVolatilities
 
     //-----------------------------------------------------------------------
     /**
+     * The meta-property for the {@code convention} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<FixedIborSwapConvention> convention() {
+      return convention;
+    }
+
+    /**
      * The meta-property for the {@code valuationDateTime} property.
      * @return the meta-property, not null
      */
@@ -413,6 +441,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
+        case 2039569265:  // convention
+          return ((BlackSwaptionExpiryTenorVolatilities) bean).getConvention();
         case -949589828:  // valuationDateTime
           return ((BlackSwaptionExpiryTenorVolatilities) bean).getValuationDateTime();
         case -1853231955:  // surface
@@ -438,6 +468,7 @@ public final class BlackSwaptionExpiryTenorVolatilities
    */
   private static final class Builder extends DirectFieldsBeanBuilder<BlackSwaptionExpiryTenorVolatilities> {
 
+    private FixedIborSwapConvention convention;
     private ZonedDateTime valuationDateTime;
     private Surface surface;
 
@@ -451,6 +482,8 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 2039569265:  // convention
+          return convention;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
         case -1853231955:  // surface
@@ -463,6 +496,9 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
+        case 2039569265:  // convention
+          this.convention = (FixedIborSwapConvention) newValue;
+          break;
         case -949589828:  // valuationDateTime
           this.valuationDateTime = (ZonedDateTime) newValue;
           break;
@@ -502,6 +538,7 @@ public final class BlackSwaptionExpiryTenorVolatilities
     @Override
     public BlackSwaptionExpiryTenorVolatilities build() {
       return new BlackSwaptionExpiryTenorVolatilities(
+          convention,
           valuationDateTime,
           surface);
     }
@@ -509,8 +546,9 @@ public final class BlackSwaptionExpiryTenorVolatilities
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(96);
+      StringBuilder buf = new StringBuilder(128);
       buf.append("BlackSwaptionExpiryTenorVolatilities.Builder{");
+      buf.append("convention").append('=').append(JodaBeanUtils.toString(convention)).append(',').append(' ');
       buf.append("valuationDateTime").append('=').append(JodaBeanUtils.toString(valuationDateTime)).append(',').append(' ');
       buf.append("surface").append('=').append(JodaBeanUtils.toString(surface));
       buf.append('}');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
@@ -64,6 +64,11 @@ public final class SabrParametersSwaptionVolatilities
   @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final SwaptionVolatilitiesName name;
   /**
+   * The swap convention that the volatilities are to be used for.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final FixedIborSwapConvention convention;
+  /**
    * The valuation date-time.
    * <p>
    * The volatilities are calibrated for this date-time.
@@ -113,24 +118,21 @@ public final class SabrParametersSwaptionVolatilities
    * Obtains an instance from the SABR model parameters and the date-time for which it is valid.
    * 
    * @param name  the name
+   * @param convention  the swap convention that the volatilities are to be used for
    * @param valuationDateTime  the valuation date-time
    * @param parameters  the SABR model parameters
    * @return the volatilities
    */
   public static SabrParametersSwaptionVolatilities of(
       SwaptionVolatilitiesName name,
+      FixedIborSwapConvention convention,
       ZonedDateTime valuationDateTime,
       SabrInterestRateParameters parameters) {
 
-    return new SabrParametersSwaptionVolatilities(name, valuationDateTime, parameters, null, null, null, null);
+    return new SabrParametersSwaptionVolatilities(name, convention, valuationDateTime, parameters, null, null, null, null);
   }
 
   //-------------------------------------------------------------------------
-  @Override
-  public FixedIborSwapConvention getConvention() {
-    return getParameters().getConvention();
-  }
-
   /**
    * Gets the day count used to calculate the expiry year fraction.
    * 
@@ -180,6 +182,7 @@ public final class SabrParametersSwaptionVolatilities
     SabrInterestRateParameters updated = parameters.withParameter(parameterIndex, newValue);
     return new SabrParametersSwaptionVolatilities(
         name,
+        convention,
         valuationDateTime,
         updated,
         dataSensitivityAlpha,
@@ -193,6 +196,7 @@ public final class SabrParametersSwaptionVolatilities
     SabrInterestRateParameters updated = parameters.withPerturbation(perturbation);
     return new SabrParametersSwaptionVolatilities(
         name,
+        convention,
         valuationDateTime,
         updated,
         dataSensitivityAlpha,
@@ -327,6 +331,7 @@ public final class SabrParametersSwaptionVolatilities
 
   private SabrParametersSwaptionVolatilities(
       SwaptionVolatilitiesName name,
+      FixedIborSwapConvention convention,
       ZonedDateTime valuationDateTime,
       SabrInterestRateParameters parameters,
       List<DoubleArray> dataSensitivityAlpha,
@@ -334,9 +339,11 @@ public final class SabrParametersSwaptionVolatilities
       List<DoubleArray> dataSensitivityRho,
       List<DoubleArray> dataSensitivityNu) {
     JodaBeanUtils.notNull(name, "name");
+    JodaBeanUtils.notNull(convention, "convention");
     JodaBeanUtils.notNull(valuationDateTime, "valuationDateTime");
     JodaBeanUtils.notNull(parameters, "parameters");
     this.name = name;
+    this.convention = convention;
     this.valuationDateTime = valuationDateTime;
     this.parameters = parameters;
     this.dataSensitivityAlpha = (dataSensitivityAlpha != null ? ImmutableList.copyOf(dataSensitivityAlpha) : null);
@@ -368,6 +375,16 @@ public final class SabrParametersSwaptionVolatilities
   @Override
   public SwaptionVolatilitiesName getName() {
     return name;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the swap convention that the volatilities are to be used for.
+   * @return the value of the property, not null
+   */
+  @Override
+  public FixedIborSwapConvention getConvention() {
+    return convention;
   }
 
   //-----------------------------------------------------------------------
@@ -456,6 +473,7 @@ public final class SabrParametersSwaptionVolatilities
     if (obj != null && obj.getClass() == this.getClass()) {
       SabrParametersSwaptionVolatilities other = (SabrParametersSwaptionVolatilities) obj;
       return JodaBeanUtils.equal(name, other.name) &&
+          JodaBeanUtils.equal(convention, other.convention) &&
           JodaBeanUtils.equal(valuationDateTime, other.valuationDateTime) &&
           JodaBeanUtils.equal(parameters, other.parameters) &&
           JodaBeanUtils.equal(dataSensitivityAlpha, other.dataSensitivityAlpha) &&
@@ -470,6 +488,7 @@ public final class SabrParametersSwaptionVolatilities
   public int hashCode() {
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(name);
+    hash = hash * 31 + JodaBeanUtils.hashCode(convention);
     hash = hash * 31 + JodaBeanUtils.hashCode(valuationDateTime);
     hash = hash * 31 + JodaBeanUtils.hashCode(parameters);
     hash = hash * 31 + JodaBeanUtils.hashCode(dataSensitivityAlpha);
@@ -481,9 +500,10 @@ public final class SabrParametersSwaptionVolatilities
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(256);
+    StringBuilder buf = new StringBuilder(288);
     buf.append("SabrParametersSwaptionVolatilities{");
     buf.append("name").append('=').append(name).append(',').append(' ');
+    buf.append("convention").append('=').append(convention).append(',').append(' ');
     buf.append("valuationDateTime").append('=').append(valuationDateTime).append(',').append(' ');
     buf.append("parameters").append('=').append(parameters).append(',').append(' ');
     buf.append("dataSensitivityAlpha").append('=').append(dataSensitivityAlpha).append(',').append(' ');
@@ -509,6 +529,11 @@ public final class SabrParametersSwaptionVolatilities
      */
     private final MetaProperty<SwaptionVolatilitiesName> name = DirectMetaProperty.ofImmutable(
         this, "name", SabrParametersSwaptionVolatilities.class, SwaptionVolatilitiesName.class);
+    /**
+     * The meta-property for the {@code convention} property.
+     */
+    private final MetaProperty<FixedIborSwapConvention> convention = DirectMetaProperty.ofImmutable(
+        this, "convention", SabrParametersSwaptionVolatilities.class, FixedIborSwapConvention.class);
     /**
      * The meta-property for the {@code valuationDateTime} property.
      */
@@ -549,6 +574,7 @@ public final class SabrParametersSwaptionVolatilities
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "name",
+        "convention",
         "valuationDateTime",
         "parameters",
         "dataSensitivityAlpha",
@@ -567,6 +593,8 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
+        case 2039569265:  // convention
+          return convention;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
         case 458736106:  // parameters
@@ -605,6 +633,14 @@ public final class SabrParametersSwaptionVolatilities
      */
     public MetaProperty<SwaptionVolatilitiesName> name() {
       return name;
+    }
+
+    /**
+     * The meta-property for the {@code convention} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<FixedIborSwapConvention> convention() {
+      return convention;
     }
 
     /**
@@ -661,6 +697,8 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return ((SabrParametersSwaptionVolatilities) bean).getName();
+        case 2039569265:  // convention
+          return ((SabrParametersSwaptionVolatilities) bean).getConvention();
         case -949589828:  // valuationDateTime
           return ((SabrParametersSwaptionVolatilities) bean).getValuationDateTime();
         case 458736106:  // parameters
@@ -695,6 +733,7 @@ public final class SabrParametersSwaptionVolatilities
   public static final class Builder extends DirectFieldsBeanBuilder<SabrParametersSwaptionVolatilities> {
 
     private SwaptionVolatilitiesName name;
+    private FixedIborSwapConvention convention;
     private ZonedDateTime valuationDateTime;
     private SabrInterestRateParameters parameters;
     private List<DoubleArray> dataSensitivityAlpha;
@@ -714,6 +753,7 @@ public final class SabrParametersSwaptionVolatilities
      */
     private Builder(SabrParametersSwaptionVolatilities beanToCopy) {
       this.name = beanToCopy.getName();
+      this.convention = beanToCopy.getConvention();
       this.valuationDateTime = beanToCopy.getValuationDateTime();
       this.parameters = beanToCopy.getParameters();
       this.dataSensitivityAlpha = beanToCopy.dataSensitivityAlpha;
@@ -728,6 +768,8 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           return name;
+        case 2039569265:  // convention
+          return convention;
         case -949589828:  // valuationDateTime
           return valuationDateTime;
         case 458736106:  // parameters
@@ -751,6 +793,9 @@ public final class SabrParametersSwaptionVolatilities
       switch (propertyName.hashCode()) {
         case 3373707:  // name
           this.name = (SwaptionVolatilitiesName) newValue;
+          break;
+        case 2039569265:  // convention
+          this.convention = (FixedIborSwapConvention) newValue;
           break;
         case -949589828:  // valuationDateTime
           this.valuationDateTime = (ZonedDateTime) newValue;
@@ -804,6 +849,7 @@ public final class SabrParametersSwaptionVolatilities
     public SabrParametersSwaptionVolatilities build() {
       return new SabrParametersSwaptionVolatilities(
           name,
+          convention,
           valuationDateTime,
           parameters,
           dataSensitivityAlpha,
@@ -821,6 +867,17 @@ public final class SabrParametersSwaptionVolatilities
     public Builder name(SwaptionVolatilitiesName name) {
       JodaBeanUtils.notNull(name, "name");
       this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the swap convention that the volatilities are to be used for.
+     * @param convention  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder convention(FixedIborSwapConvention convention) {
+      JodaBeanUtils.notNull(convention, "convention");
+      this.convention = convention;
       return this;
     }
 
@@ -943,9 +1000,10 @@ public final class SabrParametersSwaptionVolatilities
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(256);
+      StringBuilder buf = new StringBuilder(288);
       buf.append("SabrParametersSwaptionVolatilities.Builder{");
       buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
+      buf.append("convention").append('=').append(JodaBeanUtils.toString(convention)).append(',').append(' ');
       buf.append("valuationDateTime").append('=').append(JodaBeanUtils.toString(valuationDateTime)).append(',').append(' ');
       buf.append("parameters").append('=').append(JodaBeanUtils.toString(parameters)).append(',').append(' ');
       buf.append("dataSensitivityAlpha").append('=').append(JodaBeanUtils.toString(dataSensitivityAlpha)).append(',').append(' ');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibrator.java
@@ -304,13 +304,13 @@ public class SabrSwaptionCalibrator {
       }
     }
     SurfaceMetadata metadataAlpha = Surfaces.swaptionSabrExpiryTenor(
-        name.getName() + "-Alpha", dayCount, convention, ValueType.SABR_ALPHA)
+        name.getName() + "-Alpha", dayCount, ValueType.SABR_ALPHA)
         .withParameterMetadata(parameterMetadata);
     SurfaceMetadata metadataRho = Surfaces.swaptionSabrExpiryTenor(
-        name.getName() + "-Rho", dayCount, convention, ValueType.SABR_RHO)
+        name.getName() + "-Rho", dayCount, ValueType.SABR_RHO)
         .withParameterMetadata(parameterMetadata);
     SurfaceMetadata metadataNu = Surfaces.swaptionSabrExpiryTenor(
-        name.getName() + "-Nu", dayCount, convention, ValueType.SABR_NU)
+        name.getName() + "-Nu", dayCount, ValueType.SABR_NU)
         .withParameterMetadata(parameterMetadata);
     InterpolatedNodalSurface alphaSurface = InterpolatedNodalSurface
         .of(metadataAlpha, timeToExpiryArray, timeTenorArray, alphaArray, interpolator);
@@ -322,6 +322,7 @@ public class SabrSwaptionCalibrator {
         alphaSurface, betaSurface, rhoSurface, nuSurface, shiftSurface, sabrVolatilityFormula);
     return SabrParametersSwaptionVolatilities.builder()
         .name(name)
+        .convention(convention)
         .valuationDateTime(calibrationDateTime)
         .parameters(params)
         .dataSensitivityAlpha(dataSensitivityAlpha)
@@ -469,7 +470,7 @@ public class SabrSwaptionCalibrator {
       }
     }
     SurfaceMetadata metadataAlpha = Surfaces.swaptionSabrExpiryTenor(
-        name.getName() + "-Alpha", dayCount, convention, ValueType.SABR_ALPHA)
+        name.getName() + "-Alpha", dayCount, ValueType.SABR_ALPHA)
         .withParameterMetadata(parameterMetadata);
     InterpolatedNodalSurface alphaSurface = InterpolatedNodalSurface
         .of(metadataAlpha, timeToExpiryArray, timeTenorArray, alphaArray, interpolator);
@@ -478,6 +479,7 @@ public class SabrSwaptionCalibrator {
         sabr.getParameters().getNuSurface(), sabr.getParameters().getShiftSurface(), sabrVolatilityFormula);
     return SabrParametersSwaptionVolatilities.builder()
         .name(name)
+        .convention(convention)
         .valuationDateTime(sabr.getValuationDateTime())
         .parameters(params)
         .dataSensitivityAlpha(dataSensitivityAlpha).build();

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsPeriodPricerTest.java
@@ -646,7 +646,7 @@ public class SabrExtrapolationReplicationCmsPeriodPricerTest {
       SabrInterestRateParameters sabrParams,
       SabrParametersSwaptionVolatilities orgVols) {
     return SabrParametersSwaptionVolatilities.of(
-        SwaptionVolatilitiesName.of("Test-SABR"), orgVols.getValuationDateTime(), sabrParams);
+        SwaptionVolatilitiesName.of("Test-SABR"), orgVols.getConvention(), orgVols.getValuationDateTime(), sabrParams);
   }
 
   private void testSensitivityValue(

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/model/SabrInterestRateParametersTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/model/SabrInterestRateParametersTest.java
@@ -8,7 +8,6 @@ package com.opengamma.strata.pricer.model;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_ACT_ISDA;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.market.curve.interpolator.CurveInterpolators.LINEAR;
-import static com.opengamma.strata.product.swap.type.FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M;
 import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
@@ -30,16 +29,16 @@ public class SabrInterestRateParametersTest {
 
   private static final GridSurfaceInterpolator GRID = GridSurfaceInterpolator.of(LINEAR, LINEAR);
   private static final InterpolatedNodalSurface ALPHA_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrAlpha", ACT_ACT_ISDA, USD_FIXED_6M_LIBOR_3M, ValueType.SABR_ALPHA),
+      Surfaces.swaptionSabrExpiryTenor("SabrAlpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(0.2, 0.2, 0.2, 0.2), GRID);
   private static final InterpolatedNodalSurface BETA_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrBeta", ACT_ACT_ISDA, USD_FIXED_6M_LIBOR_3M, ValueType.SABR_BETA),
+      Surfaces.swaptionSabrExpiryTenor("SabrBeta", ACT_ACT_ISDA, ValueType.SABR_BETA),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(1, 1, 1, 1), GRID);
   private static final InterpolatedNodalSurface RHO_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrRho", ACT_ACT_ISDA, USD_FIXED_6M_LIBOR_3M, ValueType.SABR_RHO),
+      Surfaces.swaptionSabrExpiryTenor("SabrRho", ACT_ACT_ISDA, ValueType.SABR_RHO),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(-0.5, -0.5, -0.5, -0.5), GRID);
   private static final InterpolatedNodalSurface NU_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrNu", ACT_ACT_ISDA, USD_FIXED_6M_LIBOR_3M, ValueType.SABR_NU),
+      Surfaces.swaptionSabrExpiryTenor("SabrNu", ACT_ACT_ISDA, ValueType.SABR_NU),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(0.5, 0.5, 0.5, 0.5), GRID);
   private static final SabrVolatilityFormula FORMULA = SabrVolatilityFormula.hagan();
   private static final SabrInterestRateParameters PARAMETERS =

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
@@ -111,11 +111,10 @@ public class BlackSwaptionCashParYieldProductPricerTest {
   private static final DoubleArray TENOR = DoubleArray.of(2, 10, 2, 10, 2, 10);
   private static final DoubleArray VOL = DoubleArray.of(0.35, 0.30, 0.34, 0.25, 0.25, 0.20);
   private static final FixedIborSwapConvention SWAP_CONVENTION = FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
-  private static final SurfaceMetadata METADATA =
-      Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_ACT_ISDA, SWAP_CONVENTION);
+  private static final SurfaceMetadata METADATA = Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_ACT_ISDA);
   private static final Surface SURFACE = InterpolatedNodalSurface.of(METADATA, EXPIRY, TENOR, VOL, INTERPOLATOR_2D);
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER =
-      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
+      BlackSwaptionExpiryTenorVolatilities.of(SWAP_CONVENTION, VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
   // underlying swap and swaption
   private static final HolidayCalendarId CALENDAR = HolidayCalendarIds.SAT_SUN;
   private static final BusinessDayAdjustment BDA_MF = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, CALENDAR);
@@ -239,9 +238,9 @@ public class BlackSwaptionCashParYieldProductPricerTest {
           .iborIndexCurve(EUR_EURIBOR_6M, FWD6_CURVE)
           .build();
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER_AT_MATURITY =
-      BlackSwaptionExpiryTenorVolatilities.of(MATURITY.atStartOfDay(ZoneOffset.UTC), SURFACE);
+      BlackSwaptionExpiryTenorVolatilities.of(SWAP_CONVENTION, MATURITY.atStartOfDay(ZoneOffset.UTC), SURFACE);
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER_AFTER_MATURITY =
-      BlackSwaptionExpiryTenorVolatilities.of(MATURITY.plusDays(1).atStartOfDay(ZoneOffset.UTC), SURFACE);
+      BlackSwaptionExpiryTenorVolatilities.of(SWAP_CONVENTION, MATURITY.plusDays(1).atStartOfDay(ZoneOffset.UTC), SURFACE);
   // test parameters
   private static final double TOL = 1.0e-12;
   private static final double FD_EPS = 1.0e-7;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
@@ -60,7 +60,7 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
           SwaptionSurfaceExpiryTenorParameterMetadata.of(TIME.get(i), TENOR.get(i));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.swaptionBlackExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F, CONVENTION).withParameterMetadata(list);
+    METADATA = Surfaces.swaptionBlackExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, TENOR, VOL, INTERPOLATOR_2D);
@@ -69,7 +69,7 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
   private static final BlackSwaptionExpiryTenorVolatilities PROVIDER =
-      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
+      BlackSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
       dateUtc(2015, 2, 17), dateUtc(2015, 5, 17), dateUtc(2015, 6, 17), dateUtc(2017, 2, 17)};
@@ -137,8 +137,10 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataUp, INTERPOLATOR_2D);
         InterpolatedNodalSurface paramDw =
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataDw, INTERPOLATOR_2D);
-        BlackSwaptionExpiryTenorVolatilities provUp = BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramUp);
-        BlackSwaptionExpiryTenorVolatilities provDw = BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramDw);
+        BlackSwaptionExpiryTenorVolatilities provUp =
+            BlackSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, paramUp);
+        BlackSwaptionExpiryTenorVolatilities provDw =
+            BlackSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, paramDw);
         double volUp = provUp.volatility(
             TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
         double volDw = provDw.volatility(
@@ -151,10 +153,11 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    BlackSwaptionExpiryTenorVolatilities test1 = BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
+    BlackSwaptionExpiryTenorVolatilities test1 =
+        BlackSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
     coverImmutableBean(test1);
     BlackSwaptionExpiryTenorVolatilities test2 =
-        BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
+        BlackSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
     coverBeanEquals(test1, test2);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
@@ -438,9 +438,11 @@ public class BlackSwaptionPhysicalProductPricerTest {
     Surface surfaceDw = ConstantSurface.of(
         SwaptionBlackVolatilityDataSets.META_DATA, SwaptionBlackVolatilityDataSets.VOLATILITY - shiftVol);
     CurrencyAmount pvP = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
-        BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceUp));
+        BlackSwaptionExpiryTenorVolatilities.of(
+            BLACK_VOL_CST_SWAPTION_PROVIDER_USD.getConvention(), VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceUp));
     CurrencyAmount pvM = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
-        BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceDw));
+        BlackSwaptionExpiryTenorVolatilities.of(
+            BLACK_VOL_CST_SWAPTION_PROVIDER_USD.getConvention(), VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceDw));
     double pvnvsFd = (pvP.getAmount() - pvM.getAmount()) / (2 * shiftVol);
     SwaptionSensitivity pvnvsAd = PRICER_SWAPTION_BLACK
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_CST_SWAPTION_PROVIDER_USD);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
@@ -66,7 +66,7 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
           SwaptionSurfaceExpiryTenorParameterMetadata.of(TIME.get(i), TENOR.get(i));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.swaptionNormalExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F, CONVENTION).withParameterMetadata(list);
+    METADATA = Surfaces.swaptionNormalExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, TENOR, VOL, INTERPOLATOR_2D);
@@ -75,7 +75,7 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
   private static final NormalSwaptionExpiryTenorVolatilities PROVIDER =
-      NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
+      NormalSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
       dateUtc(2015, 2, 17), dateUtc(2015, 5, 17), dateUtc(2015, 6, 17), dateUtc(2017, 2, 17)};
@@ -145,8 +145,10 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataUp, INTERPOLATOR_2D);
         InterpolatedNodalSurface paramDw =
             InterpolatedNodalSurface.of(METADATA, TIME, TENOR, volDataDw, INTERPOLATOR_2D);
-        NormalSwaptionExpiryTenorVolatilities provUp = NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramUp);
-        NormalSwaptionExpiryTenorVolatilities provDw = NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, paramDw);
+        NormalSwaptionExpiryTenorVolatilities provUp =
+            NormalSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, paramUp);
+        NormalSwaptionExpiryTenorVolatilities provDw =
+            NormalSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, paramDw);
         double volUp = provUp.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
         double volDw = provDw.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
         double fd = 0.5 * (volUp - volDw) / eps;
@@ -165,10 +167,11 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    NormalSwaptionExpiryTenorVolatilities test1 = NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME, SURFACE);
+    NormalSwaptionExpiryTenorVolatilities test1 =
+        NormalSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
     coverImmutableBean(test1);
     NormalSwaptionExpiryTenorVolatilities test2 =
-        NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
+        NormalSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);
     coverBeanEquals(test1, test2);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -446,9 +446,9 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), false);
     double impliedVol = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
-        Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount(), VOL_PROVIDER.getConvention());
+        Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
-        VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
+        VOL_PROVIDER.getConvention(), VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity
     PointSensitivityBuilder pointRec =
         PRICER.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -346,9 +346,9 @@ public class SabrSwaptionPhysicalProductPricerTest {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesUsd(VAL_DATE, false);
     double impliedVol = SWAPTION_PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
-        Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount(), VOL_PROVIDER.getConvention());
+        Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
-        VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
+        VOL_PROVIDER.getConvention(), VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity
     PointSensitivityBuilder pointRec =
         SWAPTION_PRICER.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilitiesTest.java
@@ -45,7 +45,7 @@ public class SabrSwaptionVolatilitiesTest {
   private static final ZoneId ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime DATE_TIME = DATE.atTime(TIME).atZone(ZONE);
   private static final SabrInterestRateParameters PARAM = SwaptionSabrRateVolatilityDataSet.SABR_PARAM_SHIFT_USD;
-  private static final FixedIborSwapConvention CONV = PARAM.getConvention();
+  private static final FixedIborSwapConvention CONV = SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_USD;
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
       dateUtc(2014, 1, 3), dateUtc(2014, 1, 3), dateUtc(2015, 1, 3), dateUtc(2017, 1, 3)};
@@ -60,7 +60,7 @@ public class SabrSwaptionVolatilitiesTest {
   private static final double TOLERANCE_VOL = 1.0E-10;
 
   public void test_of() {
-    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     assertEquals(test.getConvention(), CONV);
     assertEquals(test.getDayCount(), ACT_ACT_ISDA);
     assertEquals(test.getParameters(), PARAM);
@@ -68,7 +68,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_findData() {
-    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities test = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     assertEquals(test.findData(PARAM.getAlphaSurface().getName()), Optional.of(PARAM.getAlphaSurface()));
     assertEquals(test.findData(PARAM.getBetaSurface().getName()), Optional.of(PARAM.getBetaSurface()));
     assertEquals(test.findData(PARAM.getRhoSurface().getName()), Optional.of(PARAM.getRhoSurface()));
@@ -78,7 +78,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_tenor() {
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     double test1 = prov.tenor(DATE, DATE);
     assertEquals(test1, 0d);
     double test2 = prov.tenor(DATE, DATE.plusYears(2));
@@ -91,7 +91,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_relativeTime() {
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     double test1 = prov.relativeTime(DATE_TIME);
     assertEquals(test1, 0d);
     double test2 = prov.relativeTime(DATE_TIME.plusYears(2));
@@ -100,7 +100,7 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void test_volatility() {
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     for (int i = 0; i < NB_TEST; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
         double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
@@ -113,7 +113,7 @@ public class SabrSwaptionVolatilitiesTest {
 
   public void test_parameterSensitivity() {
     double alphaSensi = 2.24, betaSensi = 3.45, rhoSensi = -2.12, nuSensi = -0.56;
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     for (int i = 0; i < NB_TEST; i++) {
       double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
       PointSensitivities point = PointSensitivities.of(
@@ -165,7 +165,7 @@ public class SabrSwaptionVolatilitiesTest {
     double[] points1 = new double[] {2.24, 3.45, -2.12, -0.56};
     double[] points2 = new double[] {-0.145, 1.01, -5.0, -11.0};
     double[] points3 = new double[] {1.3, -4.32, 2.1, -7.18};
-    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities prov = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     for (int i = 0; i < NB_TEST; i++) {
       PointSensitivities sensi1 = PointSensitivities.of(
           SwaptionSabrSensitivity.of(CONV, TEST_OPTION_EXPIRY[0], TEST_TENOR[i], ALPHA, USD, points1[0]),
@@ -207,10 +207,13 @@ public class SabrSwaptionVolatilitiesTest {
   }
 
   public void coverage() {
-    SabrParametersSwaptionVolatilities test1 = SabrParametersSwaptionVolatilities.of(NAME, DATE_TIME, PARAM);
+    SabrParametersSwaptionVolatilities test1 = SabrParametersSwaptionVolatilities.of(NAME, CONV, DATE_TIME, PARAM);
     coverImmutableBean(test1);
     SabrParametersSwaptionVolatilities test2 = SabrParametersSwaptionVolatilities.of(
-        NAME2, DATE_TIME.plusDays(1), SwaptionSabrRateVolatilityDataSet.SABR_PARAM_USD);
+        NAME2,
+        SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_EUR,
+        DATE_TIME.plusDays(1),
+        SwaptionSabrRateVolatilityDataSet.SABR_PARAM_USD);
     coverBeanEquals(test1, test2);
   }
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
@@ -60,7 +60,7 @@ public class SwaptionBlackVolatilityDataSets {
   public static final FixedIborSwapConvention USD_1Y_LIBOR3M =
       ImmutableFixedIborSwapConvention.of("USD-Swap", USD_FIXED_1Y_30U360, USD_IBOR_LIBOR3M);
   private static final SurfaceMetadata METADATA_STD =
-      Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_365F, USD_1Y_LIBOR3M);
+      Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_365F);
   private static final Surface SURFACE_STD =
       InterpolatedNodalSurface.of(METADATA_STD, TIMES, TENOR, BLACK_VOL, INTERPOLATOR_2D);
 
@@ -69,16 +69,18 @@ public class SwaptionBlackVolatilityDataSets {
   private static final ZoneId VAL_ZONE_STD = ZoneId.of("Europe/London");
   /** Black volatility provider */
   public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_SWAPTION_PROVIDER_USD_STD =
-      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
+      BlackSwaptionExpiryTenorVolatilities.of(
+          USD_1Y_LIBOR3M, VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
 
   /** constant volatility */
   public static final double VOLATILITY = 0.20;
   /** metadata for constant surface */
   public static final SurfaceMetadata META_DATA =
-      Surfaces.swaptionBlackExpiryTenor("Constant Surface", ACT_365F, USD_FIXED_6M_LIBOR_3M);
+      Surfaces.swaptionBlackExpiryTenor("Constant Surface", ACT_365F);
   private static final Surface CST_SURFACE = ConstantSurface.of(META_DATA, VOLATILITY);
   /** flat Black volatility provider */
   public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_CST_SWAPTION_PROVIDER_USD =
-      BlackSwaptionExpiryTenorVolatilities.of(VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), CST_SURFACE);
+      BlackSwaptionExpiryTenorVolatilities.of(
+          USD_FIXED_6M_LIBOR_3M, VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), CST_SURFACE);
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionCubeData.java
@@ -23,7 +23,6 @@ import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.surface.DefaultSurfaceMetadata;
 import com.opengamma.strata.market.surface.InterpolatedNodalSurface;
-import com.opengamma.strata.market.surface.SurfaceInfoType;
 import com.opengamma.strata.market.surface.SurfaceMetadata;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
@@ -143,13 +142,17 @@ public class SwaptionCubeData {
   }
   public static final double[] TENOR_TIME = {1, 2, 1, 2, 1, 2, 1, 2};
   private static final SurfaceMetadata METADATA_NORMAL = DefaultSurfaceMetadata.builder().surfaceName("ATM")
-      .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION)
-      .zValueType(ValueType.NORMAL_VOLATILITY).addInfo(SurfaceInfoType.SWAP_CONVENTION, EUR_FIXED_1Y_EURIBOR_6M)
-      .dayCount(DAY_COUNT).build();
+      .xValueType(ValueType.YEAR_FRACTION)
+      .yValueType(ValueType.YEAR_FRACTION)
+      .zValueType(ValueType.NORMAL_VOLATILITY)
+      .dayCount(DAY_COUNT)
+      .build();
   private static final SurfaceMetadata METADATA_LOGNORMAL = DefaultSurfaceMetadata.builder().surfaceName("ATM")
-      .xValueType(ValueType.YEAR_FRACTION).yValueType(ValueType.YEAR_FRACTION)
-      .zValueType(ValueType.BLACK_VOLATILITY).addInfo(SurfaceInfoType.SWAP_CONVENTION, EUR_FIXED_1Y_EURIBOR_6M)
-      .dayCount(DAY_COUNT).build();
+      .xValueType(ValueType.YEAR_FRACTION)
+      .yValueType(ValueType.YEAR_FRACTION)
+      .zValueType(ValueType.BLACK_VOLATILITY)
+      .dayCount(DAY_COUNT)
+      .build();
   private static final SurfaceInterpolator INTERPOLATOR_2D = GridSurfaceInterpolator.of(LINEAR, LINEAR);
   public static final InterpolatedNodalSurface ATM_NORMAL_SIMPLE_SURFACE = 
       InterpolatedNodalSurface.of(METADATA_NORMAL, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
@@ -158,7 +161,7 @@ public class SwaptionCubeData {
       InterpolatedNodalSurface.of(METADATA_LOGNORMAL, DoubleArray.ofUnsafe(EXPIRIES_SIMPLE_2_TIME), 
           DoubleArray.ofUnsafe(TENOR_TIME), DoubleArray.ofUnsafe(DATA_LOGNORMAL_ATM_SIMPLE), INTERPOLATOR_2D);
   public static final SwaptionVolatilities ATM_NORMAL_SIMPLE = 
-      NormalSwaptionExpiryTenorVolatilities.of(DATA_TIME, ATM_NORMAL_SIMPLE_SURFACE);
+      NormalSwaptionExpiryTenorVolatilities.of(EUR_FIXED_1Y_EURIBOR_6M, DATA_TIME, ATM_NORMAL_SIMPLE_SURFACE);
   public static final SwaptionVolatilities ATM_LOGNORMAL_SIMPLE = 
-      BlackSwaptionExpiryTenorVolatilities.of(DATA_TIME, ATM_LOGNORMAL_SIMPLE_SURFACE);
+      BlackSwaptionExpiryTenorVolatilities.of(EUR_FIXED_1Y_EURIBOR_6M, DATA_TIME, ATM_LOGNORMAL_SIMPLE_SURFACE);
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
@@ -62,7 +62,7 @@ public class SwaptionNormalVolatilityDataSets {
   public static final FixedIborSwapConvention USD_1Y_LIBOR3M =
       ImmutableFixedIborSwapConvention.of("USD-Swap", USD_FIXED_1Y_30U360, USD_IBOR_LIBOR3M);
   private static final SurfaceMetadata METADATA =
-      Surfaces.swaptionNormalExpiryTenor("Normal Vol", ACT_365F, USD_1Y_LIBOR3M);
+      Surfaces.swaptionNormalExpiryTenor("Normal Vol", ACT_365F);
   private static final InterpolatedNodalSurface SURFACE_STD =
       InterpolatedNodalSurface.of(METADATA, TIMES, TENORS, NORMAL_VOL, INTERPOLATOR_2D);
 
@@ -71,7 +71,7 @@ public class SwaptionNormalVolatilityDataSets {
   private static final ZoneId VAL_ZONE_STD = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME_STD = VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD);
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_STD =
-      NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME_STD, SURFACE_STD);
+      NormalSwaptionExpiryTenorVolatilities.of(USD_1Y_LIBOR3M, VAL_DATE_TIME_STD, SURFACE_STD);
 
   /**
    * Returns the swaption normal volatility surface shifted by a given amount. The shift is parallel.
@@ -80,11 +80,13 @@ public class SwaptionNormalVolatilityDataSets {
    */
   public static NormalSwaptionExpiryTenorVolatilities normalVolSwaptionProviderUsdStsShifted(double shift) {
     DoubleArray volShifted = NORMAL_VOL.map(v -> v + shift);
-    return NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME_STD, SURFACE_STD.withZValues(volShifted));
+    return NormalSwaptionExpiryTenorVolatilities.of(
+        USD_1Y_LIBOR3M, VAL_DATE_TIME_STD, SURFACE_STD.withZValues(volShifted));
   }
 
   public static NormalSwaptionExpiryTenorVolatilities normalVolSwaptionProviderUsdStd(LocalDate valuationDate) {
-    return NormalSwaptionExpiryTenorVolatilities.of(valuationDate.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
+    return NormalSwaptionExpiryTenorVolatilities.of(
+        USD_1Y_LIBOR3M, valuationDate.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
   }
 
   //     =====     Flat volatilities for testing     =====
@@ -96,7 +98,7 @@ public class SwaptionNormalVolatilityDataSets {
       InterpolatedNodalSurface.of(METADATA, TIMES_FLAT, TENOR_FLAT, NORMAL_VOL_FLAT, INTERPOLATOR_2D);
 
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT =
-      NormalSwaptionExpiryTenorVolatilities.of(VAL_DATE_TIME_STD, SURFACE_FLAT);
+      NormalSwaptionExpiryTenorVolatilities.of(USD_1Y_LIBOR3M, VAL_DATE_TIME_STD, SURFACE_FLAT);
 
   //     =====     Market data as of 2014-03-20     =====
 
@@ -131,6 +133,6 @@ public class SwaptionNormalVolatilityDataSets {
 
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_20150320 =
       NormalSwaptionExpiryTenorVolatilities.of(
-          VAL_DATE_20150320.atTime(VAL_TIME_20150320).atZone(VAL_ZONE_20150320), SURFACE_20150320);
+          USD_1Y_LIBOR3M, VAL_DATE_20150320.atTime(VAL_TIME_20150320).atZone(VAL_ZONE_20150320), SURFACE_20150320);
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrRateVolatilityDataSet.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrRateVolatilityDataSet.java
@@ -32,7 +32,6 @@ import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.surface.ConstantSurface;
 import com.opengamma.strata.market.surface.DefaultSurfaceMetadata;
 import com.opengamma.strata.market.surface.InterpolatedNodalSurface;
-import com.opengamma.strata.market.surface.SurfaceInfoType;
 import com.opengamma.strata.market.surface.SurfaceMetadata;
 import com.opengamma.strata.market.surface.Surfaces;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
@@ -95,7 +94,7 @@ public class SwaptionSabrRateVolatilityDataSet {
       0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.3, 0.5, 0.5, 0.3, 0.5, 0.5, 0.3, 0.5, 0.5, 0.3};
   static final SwaptionVolatilitiesName NAME = SwaptionVolatilitiesName.of("Test-SABR");
   static final SurfaceMetadata META_ALPHA =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, SWAP_CONVENTION_USD, ValueType.SABR_ALPHA);
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA);
   private static final InterpolatedNodalSurface SURFACE_ALPHA_USD = InterpolatedNodalSurface.of(
       META_ALPHA,
       DoubleArray.copyOf(EXPIRY_NODE_USD),
@@ -112,7 +111,7 @@ public class SwaptionSabrRateVolatilityDataSet {
   }
 
   static final SurfaceMetadata META_BETA_USD =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, SWAP_CONVENTION_USD, ValueType.SABR_BETA)
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, ValueType.SABR_BETA)
           .withParameterMetadata(PARAMETER_META_LIST_USD);
   private static final InterpolatedNodalSurface SURFACE_BETA_USD = InterpolatedNodalSurface.of(
       META_BETA_USD,
@@ -121,7 +120,7 @@ public class SwaptionSabrRateVolatilityDataSet {
       DoubleArray.copyOf(BETA_NODE_USD),
       INTERPOLATOR_2D);
   static final SurfaceMetadata META_RHO =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, SWAP_CONVENTION_USD, ValueType.SABR_RHO);
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, ValueType.SABR_RHO);
   private static final InterpolatedNodalSurface SURFACE_RHO_USD = InterpolatedNodalSurface.of(
       META_RHO,
       DoubleArray.copyOf(EXPIRY_NODE_USD),
@@ -129,7 +128,7 @@ public class SwaptionSabrRateVolatilityDataSet {
       DoubleArray.copyOf(RHO_NODE_USD),
       INTERPOLATOR_2D);
   static final SurfaceMetadata META_NU =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, SWAP_CONVENTION_USD, ValueType.SABR_NU);
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, ValueType.SABR_NU);
   private static final InterpolatedNodalSurface SURFACE_NU_USD = InterpolatedNodalSurface.of(
       META_NU,
       DoubleArray.copyOf(EXPIRY_NODE_USD),
@@ -172,8 +171,8 @@ public class SwaptionSabrRateVolatilityDataSet {
    */
   public static SabrParametersSwaptionVolatilities getVolatilitiesUsd(LocalDate valuationDate, boolean shift) {
     ZonedDateTime dateTime = valuationDate.atStartOfDay(ZoneOffset.UTC);
-    return shift ? SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_SHIFT_USD)
-        : SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_USD);
+    return shift ? SabrParametersSwaptionVolatilities.of(NAME, SWAP_CONVENTION_USD, dateTime, SABR_PARAM_SHIFT_USD)
+        : SabrParametersSwaptionVolatilities.of(NAME, SWAP_CONVENTION_USD, dateTime, SABR_PARAM_USD);
   }
 
   /*
@@ -198,7 +197,7 @@ public class SwaptionSabrRateVolatilityDataSet {
   private static final double[] BETA_TENOR_NODE_EUR = new double[] {
       0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100};
   private static final InterpolatedNodalSurface SURFACE_ALPHA_EUR = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, SWAP_CONVENTION_EUR, ValueType.SABR_ALPHA),
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA),
       DoubleArray.of(0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1, 2, 2, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10),
       DoubleArray.of(0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100),
       DoubleArray.of(
@@ -216,7 +215,7 @@ public class SwaptionSabrRateVolatilityDataSet {
   }
 
   static final SurfaceMetadata META_BETA_EUR =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, SWAP_CONVENTION_EUR, ValueType.SABR_BETA)
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, ValueType.SABR_BETA)
           .withParameterMetadata(PARAMETER_META_LIST_EUR);
   private static final InterpolatedNodalSurface SURFACE_BETA_EUR = InterpolatedNodalSurface.of(
       META_BETA_EUR,
@@ -226,7 +225,7 @@ public class SwaptionSabrRateVolatilityDataSet {
           0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5}),
       INTERPOLATOR_2D);
   private static final InterpolatedNodalSurface SURFACE_RHO_EUR = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, SWAP_CONVENTION_EUR, ValueType.SABR_RHO),
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, ValueType.SABR_RHO),
       DoubleArray.of(
           0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1, 2, 2, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10, 100, 100, 100, 100),
       DoubleArray.of(
@@ -241,7 +240,7 @@ public class SwaptionSabrRateVolatilityDataSet {
           -0.25, -0.25, 0, 0),
       INTERPOLATOR_2D);
   private static final InterpolatedNodalSurface SURFACE_NU_EUR = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, SWAP_CONVENTION_EUR, ValueType.SABR_NU),
+      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, ValueType.SABR_NU),
       DoubleArray.of(
           0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1, 2, 2, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10, 100, 100, 100, 100),
       DoubleArray.of(
@@ -255,8 +254,7 @@ public class SwaptionSabrRateVolatilityDataSet {
           0.50, 0.50, 0.30, 0.30,
           0.50, 0.50, 0.30, 0.30),
       INTERPOLATOR_2D);
-  private static final ConstantSurface SURFACE_SHIFT_EUR = ConstantSurface.of(
-      META_SHIFT.toBuilder().addInfo(SurfaceInfoType.SWAP_CONVENTION, SWAP_CONVENTION_EUR).build(), SHIFT);
+  private static final ConstantSurface SURFACE_SHIFT_EUR = ConstantSurface.of(META_SHIFT, SHIFT);
 
   static final SabrInterestRateParameters SABR_PARAM_EUR = SabrInterestRateParameters.of(
       SURFACE_ALPHA_EUR, SURFACE_BETA_EUR, SURFACE_RHO_EUR, SURFACE_NU_EUR, SabrVolatilityFormula.hagan());
@@ -300,7 +298,7 @@ public class SwaptionSabrRateVolatilityDataSet {
    */
   public static SabrParametersSwaptionVolatilities getVolatilitiesEur(LocalDate valuationDate, boolean shift) {
     ZonedDateTime dateTime = valuationDate.atStartOfDay(ZoneOffset.UTC);
-    return shift ? SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_SHIFT_EUR)
-        : SabrParametersSwaptionVolatilities.of(NAME, dateTime, SABR_PARAM_EUR);
+    return shift ? SabrParametersSwaptionVolatilities.of(NAME, SWAP_CONVENTION_EUR, dateTime, SABR_PARAM_SHIFT_EUR)
+        : SabrParametersSwaptionVolatilities.of(NAME, SWAP_CONVENTION_EUR, dateTime, SABR_PARAM_EUR);
   }
 }


### PR DESCRIPTION
`DiscountFactors` has the currency in the view, not the info-map.
`IborIndexRates` has the index in the view, not the info-map.
Change swaption volatilities to match by moving the convention.