### PR TITLE
Summing factory methods for multi currency arrays

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/MultiCurrencyAmountArray.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/MultiCurrencyAmountArray.java
@@ -39,6 +39,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
+import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -330,6 +331,18 @@ public final class MultiCurrencyAmountArray
       }
     }
     return MultiCurrencyAmountArray.of(builder.build());
+  }
+
+  /**
+   * Returns a multi currency amount array representing the total of the input arrays.
+   * <p>
+   * If the input contains the same currency more than once, the amounts are added together.
+   *
+   * @param arrays  the amount arrays
+   * @return the total amounts
+   */
+  public static MultiCurrencyAmountArray total(Iterable<CurrencyAmountArray> arrays) {
+    return Guavate.stream(arrays).collect(toMultiCurrencyAmountArray());
   }
 
   /**

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/MultiCurrencyAmountArrayTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/MultiCurrencyAmountArrayTest.java
@@ -340,6 +340,23 @@ public class MultiCurrencyAmountArrayTest {
     assertThat(arrays.stream().collect(toMultiCurrencyAmountArray())).isEqualTo(expected);
   }
 
+  public void total() {
+    List<CurrencyAmountArray> arrays = ImmutableList.of(
+        CurrencyAmountArray.of(USD, DoubleArray.of(10, 20, 30)),
+        CurrencyAmountArray.of(USD, DoubleArray.of(5, 6, 7)),
+        CurrencyAmountArray.of(EUR, DoubleArray.of(2, 4, 6)),
+        CurrencyAmountArray.of(GBP, DoubleArray.of(11, 12, 13)),
+        CurrencyAmountArray.of(GBP, DoubleArray.of(1, 2, 3)));
+
+    Map<Currency, DoubleArray> expectedMap = ImmutableMap.of(
+        USD, DoubleArray.of(15, 26, 37),
+        EUR, DoubleArray.of(2, 4, 6),
+        GBP, DoubleArray.of(12, 14, 16));
+
+    MultiCurrencyAmountArray expected = MultiCurrencyAmountArray.of(expectedMap);
+    assertThat(MultiCurrencyAmountArray.total(arrays)).isEqualTo(expected);
+  }
+
   public void collectorDifferentArrayLengths() {
     List<CurrencyAmountArray> arrays = ImmutableList.of(
         CurrencyAmountArray.of(USD, DoubleArray.of(10, 20, 30)),

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/MultiCurrencyScenarioArray.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/MultiCurrencyScenarioArray.java
@@ -36,6 +36,7 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.CurrencyAmountArray;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmountArray;
+import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -199,6 +200,18 @@ public final class MultiCurrencyScenarioArray
       }
     }
     return CurrencyScenarioArray.of(reportingCurrency, DoubleArray.ofUnsafe(singleCurrencyValues));
+  }
+
+  /**
+   * Returns a multi currency scenario array representing the total of the input arrays.
+   * <p>
+   * If the input contains the same currency more than once, the amounts are added together.
+   *
+   * @param arrays  the amount arrays
+   * @return the total amounts
+   */
+  public static MultiCurrencyScenarioArray total(Iterable<CurrencyScenarioArray> arrays) {
+    return Guavate.stream(arrays).collect(toMultiCurrencyScenarioArray());
   }
 
   /**

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/MultiCurrencyScenarioArrayTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/MultiCurrencyScenarioArrayTest.java
@@ -211,6 +211,23 @@ public class MultiCurrencyScenarioArrayTest {
     assertThat(arrays.stream().collect(toMultiCurrencyScenarioArray())).isEqualTo(expected);
   }
 
+  public void total() {
+    List<CurrencyScenarioArray> arrays = ImmutableList.of(
+        CurrencyScenarioArray.of(USD, DoubleArray.of(10, 20, 30)),
+        CurrencyScenarioArray.of(USD, DoubleArray.of(5, 6, 7)),
+        CurrencyScenarioArray.of(EUR, DoubleArray.of(2, 4, 6)),
+        CurrencyScenarioArray.of(GBP, DoubleArray.of(11, 12, 13)),
+        CurrencyScenarioArray.of(GBP, DoubleArray.of(1, 2, 3)));
+
+    Map<Currency, DoubleArray> expectedMap = ImmutableMap.of(
+        USD, DoubleArray.of(15, 26, 37),
+        EUR, DoubleArray.of(2, 4, 6),
+        GBP, DoubleArray.of(12, 14, 16));
+
+    MultiCurrencyScenarioArray expected = MultiCurrencyScenarioArray.of(expectedMap);
+    assertThat(MultiCurrencyScenarioArray.total(arrays)).isEqualTo(expected);
+  }
+
   public void collectorDifferentArrayLengths() {
     List<CurrencyScenarioArray> arrays = ImmutableList.of(
         CurrencyScenarioArray.of(USD, DoubleArray.of(10, 20, 30)),


### PR DESCRIPTION
`MultiCurrencyAmount` has a factory method named `total` which accepts multiple `CurrencyAmount` instances. This PR adds the equivalent methods to `MultiCurrencyAmountArray` and `MultiCurrencyScenarioArray`.