### PR TITLE
Allow source to be specified for scenario FX rates

### DIFF
--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/DefaultScenarioFxRateProvider.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/DefaultScenarioFxRateProvider.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.data.scenario;
 
 import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketDataFxRateProvider;
+import com.opengamma.strata.data.ObservableSource;
 
 /**
  * A provider of FX rates which takes its data from one scenario in a set of data for multiple scenarios.
@@ -18,9 +19,15 @@ class DefaultScenarioFxRateProvider implements ScenarioFxRateProvider {
    */
   private final ScenarioMarketData marketData;
 
+  /**
+   * The source of the FX rates.
+   */
+  private final ObservableSource source;
+
   // creates an instance
-  DefaultScenarioFxRateProvider(ScenarioMarketData marketData) {
+  DefaultScenarioFxRateProvider(ScenarioMarketData marketData, ObservableSource source) {
     this.marketData = marketData;
+    this.source = source;
   }
 
   @Override
@@ -30,7 +37,7 @@ class DefaultScenarioFxRateProvider implements ScenarioFxRateProvider {
 
   @Override
   public FxRateProvider fxRateProvider(int scenarioIndex) {
-    return MarketDataFxRateProvider.of(marketData.scenario(scenarioIndex));
+    return MarketDataFxRateProvider.of(marketData.scenario(scenarioIndex), source);
   }
 
 }

--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/ScenarioFxRateProvider.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/ScenarioFxRateProvider.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.data.scenario;
 
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRateProvider;
+import com.opengamma.strata.data.ObservableSource;
 
 /**
  * A provider of FX rates for scenarios.
@@ -27,7 +28,18 @@ public interface ScenarioFxRateProvider {
    * @return a scenario FX rate provider which takes its data from the provided market data
    */
   public static ScenarioFxRateProvider of(ScenarioMarketData marketData) {
-    return new DefaultScenarioFxRateProvider(marketData);
+    return new DefaultScenarioFxRateProvider(marketData, ObservableSource.NONE);
+  }
+
+  /**
+   * Returns a scenario FX rate provider which takes its data from the provided market data.
+   *
+   * @param marketData  market data containing FX rates
+   * @param source  the source of the FX rates
+   * @return a scenario FX rate provider which takes its data from the provided market data
+   */
+  public static ScenarioFxRateProvider of(ScenarioMarketData marketData, ObservableSource source) {
+    return new DefaultScenarioFxRateProvider(marketData, source);
   }
 
   /**

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ScenarioFxRateProviderTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ScenarioFxRateProviderTest.java
@@ -15,6 +15,7 @@ import org.testng.annotations.Test;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.data.FxRateId;
+import com.opengamma.strata.data.ObservableSource;
 
 @Test
 public class ScenarioFxRateProviderTest {
@@ -36,5 +37,18 @@ public class ScenarioFxRateProviderTest {
 
   public void fxRate() {
     assertThat(fxRateProvider.fxRate(Currency.GBP, Currency.USD, 0)).isEqualTo(1.4d);
+  }
+
+  public void specifySource() {
+    ObservableSource testSource = ObservableSource.of("test");
+    ScenarioMarketData marketData = ImmutableScenarioMarketData.builder(LocalDate.of(2011, 3, 8))
+        .addValue(FxRateId.of(Currency.GBP, Currency.USD), FxRate.of(Currency.GBP, Currency.USD, 1.4d))
+        .addValue(FxRateId.of(Currency.GBP, Currency.USD, testSource), FxRate.of(Currency.GBP, Currency.USD, 1.41d))
+        .build();
+
+    ScenarioFxRateProvider defaultRateProvider = ScenarioFxRateProvider.of(marketData);
+    ScenarioFxRateProvider sourceRateProvider = ScenarioFxRateProvider.of(marketData, testSource);
+    assertThat(defaultRateProvider.fxRate(Currency.GBP, Currency.USD, 0)).isEqualTo(1.4d);
+    assertThat(sourceRateProvider.fxRate(Currency.GBP, Currency.USD, 0)).isEqualTo(1.41d);
   }
 }


### PR DESCRIPTION
It is possible to specify the source of FX rates when creating a rates provider for a single scenario but not for multiple scenarios.