### PR TITLE
Better handling of optional fields in CSV

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvRow.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvRow.java
@@ -96,11 +96,13 @@ public final class CsvRow {
 
   /**
    * Gets the number of fields.
+   * <p>
+   * This will never be less than the number of headers.
    * 
    * @return the number of fields
    */
   public int fieldCount() {
-    return fields.size();
+    return Math.max(fields.size(), headers.size());
   }
 
   /**
@@ -111,6 +113,9 @@ public final class CsvRow {
    * @throws IndexOutOfBoundsException if the field index is invalid
    */
   public String field(int index) {
+    if (index >= fields.size() && index < headers.size()) {
+      return "";
+    }
     return fields.get(index);
   }
 
@@ -140,7 +145,7 @@ public final class CsvRow {
    */
   public Optional<String> findField(String header) {
     return Optional.ofNullable(searchHeaders.get(header.toLowerCase(Locale.ENGLISH)))
-        .map(idx -> fields.get(idx));
+        .map(idx -> field(idx));
   }
 
   /**
@@ -168,7 +173,7 @@ public final class CsvRow {
   public Optional<String> findField(Pattern headerPattern) {
     for (int i = 0; i < headers.size(); i++) {
       if (headerPattern.matcher(headers.get(i)).matches()) {
-        return Optional.of(fields.get(i));
+        return Optional.of(field(i));
       }
     }
     return Optional.empty();

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvFileTest.java
@@ -62,6 +62,11 @@ public class CsvFileTest {
       "a,b,c,b,c\n" +
       "aa,b1,c1,b2,c2\n";
 
+  private final String CSV6 = "" +
+      "a,b,c\n" +
+      "r11\n" +
+      "r21,r22";
+
   //-------------------------------------------------------------------------
   public void test_of_ioException() {
     assertThrows(
@@ -175,6 +180,22 @@ public class CsvFileTest {
     assertEquals(csvFile.row(0).subRow(1, 3).getField("c"), "c1");
     assertEquals(csvFile.row(0).subRow(3).getField("b"), "b2");
     assertEquals(csvFile.row(0).subRow(3).getField("c"), "c2");
+  }
+
+  public void test_short_data_row() {
+    CsvFile csvFile = CsvFile.of(CharSource.wrap(CSV6), true);
+    assertEquals(csvFile.headers(), ImmutableList.of("a", "b", "c"));
+    assertEquals(csvFile.row(0).getField("a"), "r11");
+    assertEquals(csvFile.row(0).getField("b"), "");
+    assertEquals(csvFile.row(0).getField("c"), "");
+    assertEquals(csvFile.row(0).field(0), "r11");
+    assertEquals(csvFile.row(0).field(1), "");
+    assertEquals(csvFile.row(0).field(2), "");
+    assertThrows(() -> csvFile.row(0).field(4), IndexOutOfBoundsException.class);
+
+    assertEquals(csvFile.row(1).getField("a"), "r21");
+    assertEquals(csvFile.row(1).getField("b"), "r22");
+    assertEquals(csvFile.row(1).getField("c"), "");
   }
 
   public void test_comment_blank_no_header() {


### PR DESCRIPTION
If a header is specified without associated data, it should not error