### PR TITLE
Simplify ImmutableRatesProvider

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/ImmutableRatesProviderGenerator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/ImmutableRatesProviderGenerator.java
@@ -18,10 +18,8 @@ import com.google.common.collect.SetMultimap;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.Index;
-import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
-import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.CurveGroupDefinition;
 import com.opengamma.strata.market.curve.CurveGroupEntry;
@@ -31,7 +29,6 @@ import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.JacobianCalibrationMatrix;
 import com.opengamma.strata.market.curve.NodalCurveDefinition;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
-import com.opengamma.strata.pricer.rate.PriceIndexValues;
 
 /**
  * Generates a rates provider based on an existing provider.
@@ -134,10 +131,8 @@ public class ImmutableRatesProviderGenerator
     // collect curves for child provider based on existing provider
     Map<Currency, Curve> discountCurves = new HashMap<>();
     Map<Index, Curve> indexCurves = new HashMap<>();
-    Map<PriceIndex, PriceIndexValues> priceIndexValues = new HashMap<>();
     discountCurves.putAll(knownProvider.getDiscountCurves());
     indexCurves.putAll(knownProvider.getIndexCurves());
-    priceIndexValues.putAll(knownProvider.getPriceIndexValues());
 
     // generate curves from combined parameter array
     int startIndex = 0;
@@ -159,21 +154,12 @@ public class ImmutableRatesProviderGenerator
       }
       Set<Index> indices = forwardCurveNames.get(name);
       for (Index index : indices) {
-        if (index instanceof PriceIndex) {
-          PriceIndex priceIndex = (PriceIndex) index;
-          LocalDateDoubleTimeSeries ts = knownProvider.getTimeSeries().get(index);
-          ArgChecker.isTrue(ts != null, "Price index curves require a historical time series");
-          PriceIndexValues priceValue = PriceIndexValues.of(priceIndex, knownProvider.getValuationDate(), curve, ts);
-          priceIndexValues.put(priceIndex, priceValue);
-        } else {
-          indexCurves.put(index, curve);
-        }
+        indexCurves.put(index, curve);
       }
     }
     return knownProvider.toBuilder()
         .discountCurves(discountCurves)
         .indexCurves(indexCurves)
-        .priceIndexValues(priceIndexValues)
         .build();
   }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
@@ -87,15 +87,10 @@ public final class ImmutableRatesProvider
   /**
    * The forward curves, defaulted to an empty map.
    * The curve data, predicting the future, associated with each index.
+   * This is used for Ibor, Overnight and Price indices.
    */
   @PropertyDefinition(validate = "notNull")
   private final ImmutableMap<Index, Curve> indexCurves;
-  /**
-   * The price index values, defaulted to an empty map.
-   * The curve data, predicting the future, associated with each index.
-   */
-  @PropertyDefinition(validate = "notNull")
-  private final ImmutableMap<PriceIndex, PriceIndexValues> priceIndexValues;
   /**
    * The time-series, defaulted to an empty map.
    * The historic data associated with each index.
@@ -151,7 +146,6 @@ public final class ImmutableRatesProvider
         .fxRateProvider(fxRateProvider)
         .discountCurves(discountCurves)
         .indexCurves(indexCurves)
-        .priceIndexValues(priceIndexValues)
         .timeSeries(timeSeries);
   }
 
@@ -179,7 +173,7 @@ public final class ImmutableRatesProvider
 
   @Override
   public ImmutableSet<PriceIndex> getPriceIndices() {
-    return priceIndexValues.keySet().stream()
+    return indexCurves.keySet().stream()
         .filter(PriceIndex.class::isInstance)
         .map(PriceIndex.class::cast)
         .collect(toImmutableSet());
@@ -262,17 +256,14 @@ public final class ImmutableRatesProvider
   public OvernightIndexRates overnightIndexRates(OvernightIndex index) {
     LocalDateDoubleTimeSeries fixings = timeSeries(index);
     Curve curve = indexCurve(index);
-    DiscountFactors dfc = DiscountFactors.of(index.getCurrency(), getValuationDate(), curve);
-    return DiscountOvernightIndexRates.of(index, dfc, fixings);
+    return OvernightIndexRates.of(index, valuationDate, curve, fixings);
   }
 
   @Override
   public PriceIndexValues priceIndexValues(PriceIndex index) {
-    PriceIndexValues values = priceIndexValues.get(index);
-    if (values == null) {
-      throw new IllegalArgumentException("Unable to find index: " + index);
-    }
-    return values;
+    LocalDateDoubleTimeSeries fixings = timeSeries(index);
+    Curve curve = indexCurve(index);
+    return PriceIndexValues.of(index, valuationDate, curve, fixings);
   }
 
   //-------------------------------------------------------------------------
@@ -297,21 +288,13 @@ public final class ImmutableRatesProvider
           "conflict on discount curve, currency '{}' appears twice in the providers", entry.getKey());
       merged.discountCurve(entry.getKey(), entry.getValue());
     }
-    // ibor and overnight
+    // forward
     ImmutableMap<Index, Curve> indexMap1 = indexCurves;
     ImmutableMap<Index, Curve> indexMap2 = other.indexCurves;
     for (Entry<Index, Curve> entry : indexMap1.entrySet()) {
       ArgChecker.isTrue(!indexMap2.containsKey(entry.getKey()),
           "conflict on index curve, index '{}' appears twice in the providers", entry.getKey());
       merged.indexCurve(entry.getKey(), entry.getValue());
-    }
-    // price index
-    ImmutableMap<PriceIndex, PriceIndexValues> priceMap1 = priceIndexValues;
-    ImmutableMap<PriceIndex, PriceIndexValues> priceMap2 = other.priceIndexValues;
-    for (Entry<PriceIndex, PriceIndexValues> entry : priceMap1.entrySet()) {
-      ArgChecker.isTrue(!priceMap2.containsKey(entry.getKey()),
-          "conflict on price index curve, price index '{}' appears twice in the providers", entry.getKey());
-      merged.priceIndexValues(entry.getValue());
     }
     // time series
     Map<Index, LocalDateDoubleTimeSeries> tsMap1 = timeSeries;
@@ -345,7 +328,6 @@ public final class ImmutableRatesProvider
    * @param fxRateProvider  the value of the property, not null
    * @param discountCurves  the value of the property, not null
    * @param indexCurves  the value of the property, not null
-   * @param priceIndexValues  the value of the property, not null
    * @param timeSeries  the value of the property, not null
    */
   ImmutableRatesProvider(
@@ -353,19 +335,16 @@ public final class ImmutableRatesProvider
       FxRateProvider fxRateProvider,
       Map<Currency, Curve> discountCurves,
       Map<Index, Curve> indexCurves,
-      Map<PriceIndex, PriceIndexValues> priceIndexValues,
       Map<Index, LocalDateDoubleTimeSeries> timeSeries) {
     JodaBeanUtils.notNull(valuationDate, "valuationDate");
     JodaBeanUtils.notNull(fxRateProvider, "fxRateProvider");
     JodaBeanUtils.notNull(discountCurves, "discountCurves");
     JodaBeanUtils.notNull(indexCurves, "indexCurves");
-    JodaBeanUtils.notNull(priceIndexValues, "priceIndexValues");
     JodaBeanUtils.notNull(timeSeries, "timeSeries");
     this.valuationDate = valuationDate;
     this.fxRateProvider = fxRateProvider;
     this.discountCurves = ImmutableMap.copyOf(discountCurves);
     this.indexCurves = ImmutableMap.copyOf(indexCurves);
-    this.priceIndexValues = ImmutableMap.copyOf(priceIndexValues);
     this.timeSeries = ImmutableMap.copyOf(timeSeries);
   }
 
@@ -419,20 +398,11 @@ public final class ImmutableRatesProvider
   /**
    * Gets the forward curves, defaulted to an empty map.
    * The curve data, predicting the future, associated with each index.
+   * This is used for Ibor, Overnight and Price indices.
    * @return the value of the property, not null
    */
   public ImmutableMap<Index, Curve> getIndexCurves() {
     return indexCurves;
-  }
-
-  //-----------------------------------------------------------------------
-  /**
-   * Gets the price index values, defaulted to an empty map.
-   * The curve data, predicting the future, associated with each index.
-   * @return the value of the property, not null
-   */
-  public ImmutableMap<PriceIndex, PriceIndexValues> getPriceIndexValues() {
-    return priceIndexValues;
   }
 
   //-----------------------------------------------------------------------
@@ -457,7 +427,6 @@ public final class ImmutableRatesProvider
           JodaBeanUtils.equal(fxRateProvider, other.fxRateProvider) &&
           JodaBeanUtils.equal(discountCurves, other.discountCurves) &&
           JodaBeanUtils.equal(indexCurves, other.indexCurves) &&
-          JodaBeanUtils.equal(priceIndexValues, other.priceIndexValues) &&
           JodaBeanUtils.equal(timeSeries, other.timeSeries);
     }
     return false;
@@ -470,20 +439,18 @@ public final class ImmutableRatesProvider
     hash = hash * 31 + JodaBeanUtils.hashCode(fxRateProvider);
     hash = hash * 31 + JodaBeanUtils.hashCode(discountCurves);
     hash = hash * 31 + JodaBeanUtils.hashCode(indexCurves);
-    hash = hash * 31 + JodaBeanUtils.hashCode(priceIndexValues);
     hash = hash * 31 + JodaBeanUtils.hashCode(timeSeries);
     return hash;
   }
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(224);
+    StringBuilder buf = new StringBuilder(192);
     buf.append("ImmutableRatesProvider{");
     buf.append("valuationDate").append('=').append(valuationDate).append(',').append(' ');
     buf.append("fxRateProvider").append('=').append(fxRateProvider).append(',').append(' ');
     buf.append("discountCurves").append('=').append(discountCurves).append(',').append(' ');
     buf.append("indexCurves").append('=').append(indexCurves).append(',').append(' ');
-    buf.append("priceIndexValues").append('=').append(priceIndexValues).append(',').append(' ');
     buf.append("timeSeries").append('=').append(JodaBeanUtils.toString(timeSeries));
     buf.append('}');
     return buf.toString();
@@ -522,12 +489,6 @@ public final class ImmutableRatesProvider
     private final MetaProperty<ImmutableMap<Index, Curve>> indexCurves = DirectMetaProperty.ofImmutable(
         this, "indexCurves", ImmutableRatesProvider.class, (Class) ImmutableMap.class);
     /**
-     * The meta-property for the {@code priceIndexValues} property.
-     */
-    @SuppressWarnings({"unchecked", "rawtypes" })
-    private final MetaProperty<ImmutableMap<PriceIndex, PriceIndexValues>> priceIndexValues = DirectMetaProperty.ofImmutable(
-        this, "priceIndexValues", ImmutableRatesProvider.class, (Class) ImmutableMap.class);
-    /**
      * The meta-property for the {@code timeSeries} property.
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
@@ -542,7 +503,6 @@ public final class ImmutableRatesProvider
         "fxRateProvider",
         "discountCurves",
         "indexCurves",
-        "priceIndexValues",
         "timeSeries");
 
     /**
@@ -562,8 +522,6 @@ public final class ImmutableRatesProvider
           return discountCurves;
         case 886361302:  // indexCurves
           return indexCurves;
-        case 1422773131:  // priceIndexValues
-          return priceIndexValues;
         case 779431844:  // timeSeries
           return timeSeries;
       }
@@ -619,14 +577,6 @@ public final class ImmutableRatesProvider
     }
 
     /**
-     * The meta-property for the {@code priceIndexValues} property.
-     * @return the meta-property, not null
-     */
-    public MetaProperty<ImmutableMap<PriceIndex, PriceIndexValues>> priceIndexValues() {
-      return priceIndexValues;
-    }
-
-    /**
      * The meta-property for the {@code timeSeries} property.
      * @return the meta-property, not null
      */
@@ -646,8 +596,6 @@ public final class ImmutableRatesProvider
           return ((ImmutableRatesProvider) bean).getDiscountCurves();
         case 886361302:  // indexCurves
           return ((ImmutableRatesProvider) bean).getIndexCurves();
-        case 1422773131:  // priceIndexValues
-          return ((ImmutableRatesProvider) bean).getPriceIndexValues();
         case 779431844:  // timeSeries
           return ((ImmutableRatesProvider) bean).getTimeSeries();
       }
@@ -675,7 +623,6 @@ public final class ImmutableRatesProvider
     private FxRateProvider fxRateProvider;
     private Map<Currency, Curve> discountCurves = ImmutableMap.of();
     private Map<Index, Curve> indexCurves = ImmutableMap.of();
-    private Map<PriceIndex, PriceIndexValues> priceIndexValues = ImmutableMap.of();
     private Map<Index, LocalDateDoubleTimeSeries> timeSeries = ImmutableMap.of();
 
     /**
@@ -697,8 +644,6 @@ public final class ImmutableRatesProvider
           return discountCurves;
         case 886361302:  // indexCurves
           return indexCurves;
-        case 1422773131:  // priceIndexValues
-          return priceIndexValues;
         case 779431844:  // timeSeries
           return timeSeries;
         default:
@@ -721,9 +666,6 @@ public final class ImmutableRatesProvider
           break;
         case 886361302:  // indexCurves
           this.indexCurves = (Map<Index, Curve>) newValue;
-          break;
-        case 1422773131:  // priceIndexValues
-          this.priceIndexValues = (Map<PriceIndex, PriceIndexValues>) newValue;
           break;
         case 779431844:  // timeSeries
           this.timeSeries = (Map<Index, LocalDateDoubleTimeSeries>) newValue;
@@ -765,20 +707,18 @@ public final class ImmutableRatesProvider
           fxRateProvider,
           discountCurves,
           indexCurves,
-          priceIndexValues,
           timeSeries);
     }
 
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(224);
+      StringBuilder buf = new StringBuilder(192);
       buf.append("ImmutableRatesProvider.Builder{");
       buf.append("valuationDate").append('=').append(JodaBeanUtils.toString(valuationDate)).append(',').append(' ');
       buf.append("fxRateProvider").append('=').append(JodaBeanUtils.toString(fxRateProvider)).append(',').append(' ');
       buf.append("discountCurves").append('=').append(JodaBeanUtils.toString(discountCurves)).append(',').append(' ');
       buf.append("indexCurves").append('=').append(JodaBeanUtils.toString(indexCurves)).append(',').append(' ');
-      buf.append("priceIndexValues").append('=').append(JodaBeanUtils.toString(priceIndexValues)).append(',').append(' ');
       buf.append("timeSeries").append('=').append(JodaBeanUtils.toString(timeSeries));
       buf.append('}');
       return buf.toString();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/SimplePriceIndexValues.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/SimplePriceIndexValues.java
@@ -174,10 +174,10 @@ public final class SimplePriceIndexValues
     ArgChecker.notNull(index, "index");
     ArgChecker.notNull(valuationDate, "valuationDate");
     ArgChecker.notNull(fixings, "fixings");
-    ArgChecker.isFalse(fixings.isEmpty(), "fixings must not be empty");
+    ArgChecker.isFalse(fixings.isEmpty(), "Fixings must not be empty");
     ArgChecker.notNull(curve, "curve");
     ArgChecker.notNull(seasonality, "seasonality");
-    ArgChecker.isTrue(seasonality.size() == 12, "Seasonality list must contail 12 entries");
+    ArgChecker.isTrue(seasonality.size() == 12, "Seasonality list must contain 12 entries");
     curve.getMetadata().getXValueType().checkEquals(ValueType.MONTHS, "Incorrect x-value type for price curve");
     curve.getMetadata().getYValueType().checkEquals(ValueType.PRICE_INDEX, "Incorrect y-value type for price curve");
     this.index = index;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/CapitalIndexedBondCurveDataSet.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/CapitalIndexedBondCurveDataSet.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxMatrix;
-import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeriesBuilder;
@@ -33,8 +32,6 @@ import com.opengamma.strata.market.curve.interpolator.CurveInterpolators;
 import com.opengamma.strata.pricer.DiscountFactors;
 import com.opengamma.strata.pricer.ZeroRateDiscountFactors;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
-import com.opengamma.strata.pricer.rate.PriceIndexValues;
-import com.opengamma.strata.pricer.rate.SimplePriceIndexValues;
 
 /**
  * The data set for testing capital indexed bonds.
@@ -103,11 +100,9 @@ public class CapitalIndexedBondCurveDataSet {
    * @return the rates provider
    */
   public static ImmutableRatesProvider getRatesProvider(LocalDate valuationDate, LocalDateDoubleTimeSeries timeSeries) {
-    PriceIndexValues indexCurve = SimplePriceIndexValues.of(US_CPI_U, valuationDate, CPI_CURVE, timeSeries);
-    ImmutableMap<PriceIndex, PriceIndexValues> map = ImmutableMap.of(US_CPI_U, indexCurve);
     return ImmutableRatesProvider.builder(valuationDate)
         .fxRateProvider(FxMatrix.empty())
-        .priceIndexValues(map)
+        .priceIndexCurve(US_CPI_U, CPI_CURVE)
         .timeSeries(US_CPI_U, timeSeries)
         .build();
   }
@@ -122,11 +117,9 @@ public class CapitalIndexedBondCurveDataSet {
    * @return the rates provider
    */
   public static ImmutableRatesProvider getRatesProviderGb(LocalDate valuationDate, LocalDateDoubleTimeSeries timeSeries) {
-    PriceIndexValues indexCurve = SimplePriceIndexValues.of(GB_RPI, valuationDate, RPI_CURVE, timeSeries);
-    ImmutableMap<PriceIndex, PriceIndexValues> map = ImmutableMap.of(GB_RPI, indexCurve);
     return ImmutableRatesProvider.builder(valuationDate)
         .fxRateProvider(FxMatrix.empty())
-        .priceIndexValues(map)
+        .priceIndexCurve(GB_RPI, RPI_CURVE)
         .timeSeries(GB_RPI, timeSeries)
         .build();
   }
@@ -141,11 +134,9 @@ public class CapitalIndexedBondCurveDataSet {
    * @return the rates provider
    */
   public static ImmutableRatesProvider getRatesProviderJp(LocalDate valuationDate, LocalDateDoubleTimeSeries timeSeries) {
-    PriceIndexValues indexCurve = SimplePriceIndexValues.of(JP_CPI_EXF, valuationDate, CPIJ_CURVE, timeSeries);
-    ImmutableMap<PriceIndex, PriceIndexValues> map = ImmutableMap.of(JP_CPI_EXF, indexCurve);
     return ImmutableRatesProvider.builder(valuationDate)
         .fxRateProvider(FxMatrix.empty())
-        .priceIndexValues(map)
+        .priceIndexCurve(JP_CPI_EXF, CPIJ_CURVE)
         .timeSeries(JP_CPI_EXF, timeSeries)
         .build();
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/RatesProviderDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/datasets/RatesProviderDataSets.java
@@ -18,11 +18,11 @@ import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_6M;
 import static com.opengamma.strata.basics.index.OvernightIndices.EUR_EONIA;
 import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
+import static com.opengamma.strata.basics.index.PriceIndices.US_CPI_U;
 
 import java.time.LocalDate;
 
 import com.opengamma.strata.basics.currency.FxMatrix;
-import com.opengamma.strata.basics.index.PriceIndices;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.curve.Curve;
@@ -33,7 +33,6 @@ import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
 import com.opengamma.strata.market.curve.interpolator.CurveInterpolator;
 import com.opengamma.strata.market.curve.interpolator.CurveInterpolators;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
-import com.opengamma.strata.pricer.rate.PriceIndexValues;
 
 /**
  * RatesProvider data sets for testing.
@@ -175,10 +174,8 @@ public class RatesProviderDataSets {
       InterpolatedNodalCurve.of(USD_L3_METADATA_SIMPLE, TIMES_2, RATES_2_1_SIMPLE, INTERPOLATOR);
   private static final Curve USD_L6_SIMPLE =
       InterpolatedNodalCurve.of(USD_L6_METADATA_SIMPLE, TIMES_3, RATES_3_1_SIMPLE, INTERPOLATOR);
-  private static final InterpolatedNodalCurve PRICE_INDEX_CURVE =
+  private static final InterpolatedNodalCurve US_CPI_U_CURVE =
       InterpolatedNodalCurve.of(PRICE_INDEX_METADATA, TIMES_4, VALUES_4, INTERPOLATOR);
-  private static final PriceIndexValues USD_CPI =
-      PriceIndexValues.of(PriceIndices.US_CPI_U, VAL_DATE_2014_01_22, PRICE_INDEX_CURVE, PRICE_INDEX_TS);
 
   public static final ImmutableRatesProvider MULTI_USD = multiUsd(VAL_DATE_2014_01_22);
 
@@ -198,7 +195,8 @@ public class RatesProviderDataSets {
       .overnightIndexCurve(USD_FED_FUND, USD_DSC)
       .iborIndexCurve(USD_LIBOR_3M, USD_L3)
       .iborIndexCurve(USD_LIBOR_6M, USD_L6)
-      .priceIndexValues(USD_CPI)
+      .priceIndexCurve(US_CPI_U, US_CPI_U_CURVE)
+      .timeSeries(US_CPI_U, PRICE_INDEX_TS)
       .build();
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationEndInterpolatedRateComputationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationEndInterpolatedRateComputationFnTest.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.index.PriceIndexObservation;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
@@ -31,7 +30,6 @@ import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.InflationRateSensitivity;
-import com.opengamma.strata.pricer.rate.SimplePriceIndexValues;
 import com.opengamma.strata.product.rate.InflationEndInterpolatedRateComputation;
 
 /**
@@ -123,9 +121,9 @@ public class ForwardInflationEndInterpolatedRateComputationFnTest {
         DoubleArray.of(4, 5, 16, 17),
         DoubleArray.of(RATE_START, RATE_START_INTERP, rateEnd, rateEndInterp),
         INTERPOLATOR);
-    SimplePriceIndexValues values = SimplePriceIndexValues.of(GB_RPIX, VAL_DATE, curve, timeSeries);
     return ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(ImmutableMap.of(GB_RPIX, values))
+        .priceIndexCurve(GB_RPIX, curve)
+        .timeSeries(GB_RPIX, timeSeries)
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationEndMonthRateComputationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationEndMonthRateComputationFnTest.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.index.PriceIndexObservation;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
@@ -31,7 +30,6 @@ import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.InflationRateSensitivity;
-import com.opengamma.strata.pricer.rate.SimplePriceIndexValues;
 import com.opengamma.strata.product.rate.InflationEndMonthRateComputation;
 
 /**
@@ -94,9 +92,9 @@ public class ForwardInflationEndMonthRateComputationFnTest {
     LocalDateDoubleTimeSeries timeSeries = LocalDateDoubleTimeSeries.of(VAL_DATE.with(lastDayOfMonth()), 300);
     InterpolatedNodalCurve curve = InterpolatedNodalCurve.of(
         Curves.prices("GB-RPIX"), DoubleArray.of(4, 16), DoubleArray.of(RATE_START, rateEnd), INTERPOLATOR);
-    SimplePriceIndexValues values = SimplePriceIndexValues.of(GB_RPIX, VAL_DATE, curve, timeSeries);
     return ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(ImmutableMap.of(GB_RPIX, values))
+        .priceIndexCurve(GB_RPIX, curve)
+        .timeSeries(GB_RPIX, timeSeries)
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationInterpolatedRateComputationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationInterpolatedRateComputationFnTest.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.index.PriceIndexObservation;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
@@ -31,7 +30,6 @@ import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.InflationRateSensitivity;
-import com.opengamma.strata.pricer.rate.SimplePriceIndexValues;
 import com.opengamma.strata.product.rate.InflationInterpolatedRateComputation;
 
 /**
@@ -153,9 +151,9 @@ public class ForwardInflationInterpolatedRateComputationFnTest {
         DoubleArray.of(4, 5, 16, 17),
         DoubleArray.of(rateStart, rateStartInterp, rateEnd, rateEndInterp),
         INTERPOLATOR);
-    SimplePriceIndexValues values = SimplePriceIndexValues.of(GB_RPIX, VAL_DATE, curve, timeSeries);
     return ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(ImmutableMap.of(GB_RPIX, values))
+        .priceIndexCurve(GB_RPIX, curve)
+        .timeSeries(GB_RPIX, timeSeries)
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationMonthlyRateComputationFnTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/ForwardInflationMonthlyRateComputationFnTest.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.index.PriceIndexObservation;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
@@ -31,7 +30,6 @@ import com.opengamma.strata.market.explain.ExplainMapBuilder;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.InflationRateSensitivity;
-import com.opengamma.strata.pricer.rate.SimplePriceIndexValues;
 import com.opengamma.strata.product.rate.InflationMonthlyRateComputation;
 
 /**
@@ -117,9 +115,9 @@ public class ForwardInflationMonthlyRateComputationFnTest {
     LocalDateDoubleTimeSeries timeSeries = LocalDateDoubleTimeSeries.of(VAL_DATE.with(lastDayOfMonth()), 300);
     InterpolatedNodalCurve curve = InterpolatedNodalCurve.of(
         Curves.prices("GB-RPIX"), DoubleArray.of(4, 16), DoubleArray.of(rateStart, rateEnd), INTERPOLATOR);
-    SimplePriceIndexValues values = SimplePriceIndexValues.of(GB_RPIX, VAL_DATE, curve, timeSeries);
     return ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(ImmutableMap.of(GB_RPIX, values))
+        .priceIndexCurve(GB_RPIX, curve)
+        .timeSeries(GB_RPIX, timeSeries)
         .build();
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderCombineTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderCombineTest.java
@@ -13,7 +13,6 @@ import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
 import static com.opengamma.strata.basics.index.PriceIndices.GB_RPI;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
-import static com.opengamma.strata.collect.TestHelper.date;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -53,12 +52,8 @@ public class ImmutableRatesProviderCombineTest {
       Curves.zeroRates("USD-LIBOR-3M", ACT_ACT_ISDA), 0.96d);
   private static final Curve FED_FUND_CURVE = ConstantCurve.of(
       Curves.zeroRates("USD-FED_FUND", ACT_ACT_ISDA), 0.97d);
-  private static final PriceIndexValues GBPRI_CURVE = SimplePriceIndexValues.of(
-      GB_RPI,
-      VAL_DATE,
-      InterpolatedNodalCurve.of(
-          Curves.prices("GB-RPI"), DoubleArray.of(1d, 10d), DoubleArray.of(252d, 252d), INTERPOLATOR),
-      LocalDateDoubleTimeSeries.of(date(2013, 11, 30), 252));
+  private static final Curve GBPRI_CURVE = InterpolatedNodalCurve.of(
+      Curves.prices("GB-RPI"), DoubleArray.of(1d, 10d), DoubleArray.of(252d, 252d), INTERPOLATOR);
   private static final LocalDateDoubleTimeSeries TS = LocalDateDoubleTimeSeries.of(PREV_DATE, 0.62d);
 
   public void merge_content_2() {
@@ -70,7 +65,8 @@ public class ImmutableRatesProviderCombineTest {
         .discountCurve(USD, DISCOUNT_CURVE_USD)
         .iborIndexCurve(USD_LIBOR_3M, USD_LIBOR_CURVE)
         .overnightIndexCurve(USD_FED_FUND, FED_FUND_CURVE)
-        .priceIndexValues(GBPRI_CURVE)
+        .priceIndexCurve(GB_RPI, GBPRI_CURVE)
+        .timeSeries(GB_RPI, TS)
         .build();
     ImmutableRatesProvider merged = ImmutableRatesProvider.combined(FX_MATRIX, test1, test2);
     assertEquals(merged.getValuationDate(), VAL_DATE);
@@ -78,7 +74,7 @@ public class ImmutableRatesProviderCombineTest {
     assertEquals(merged.discountFactors(GBP), DiscountFactors.of(GBP, VAL_DATE, DISCOUNT_CURVE_GBP));
     assertEquals(merged.iborIndexRates(USD_LIBOR_3M), IborIndexRates.of(USD_LIBOR_3M, VAL_DATE, USD_LIBOR_CURVE));
     assertEquals(merged.overnightIndexRates(USD_FED_FUND), OvernightIndexRates.of(USD_FED_FUND, VAL_DATE, FED_FUND_CURVE));
-    assertEquals(merged.priceIndexValues(GB_RPI), GBPRI_CURVE);
+    assertEquals(merged.priceIndexValues(GB_RPI), PriceIndexValues.of(GB_RPI, VAL_DATE, GBPRI_CURVE, TS));
     assertEquals(merged.timeSeries(GBP_USD_WM), TS);
     assertEquals(merged.getFxRateProvider(), FX_MATRIX);
   }
@@ -94,7 +90,8 @@ public class ImmutableRatesProviderCombineTest {
         .build();
     ImmutableRatesProvider test3 = ImmutableRatesProvider.builder(VAL_DATE)
         .discountCurve(USD, DISCOUNT_CURVE_USD)
-        .priceIndexValues(GBPRI_CURVE)
+        .priceIndexCurve(GB_RPI, GBPRI_CURVE)
+        .timeSeries(GB_RPI, TS)
         .build();
     ImmutableRatesProvider merged = ImmutableRatesProvider.combined(FX_MATRIX, test1, test2, test3);
     assertEquals(merged.getValuationDate(), VAL_DATE);
@@ -102,7 +99,7 @@ public class ImmutableRatesProviderCombineTest {
     assertEquals(merged.discountFactors(GBP), DiscountFactors.of(GBP, VAL_DATE, DISCOUNT_CURVE_GBP));
     assertEquals(merged.iborIndexRates(USD_LIBOR_3M), IborIndexRates.of(USD_LIBOR_3M, VAL_DATE, USD_LIBOR_CURVE));
     assertEquals(merged.overnightIndexRates(USD_FED_FUND), OvernightIndexRates.of(USD_FED_FUND, VAL_DATE, FED_FUND_CURVE));
-    assertEquals(merged.priceIndexValues(GB_RPI), GBPRI_CURVE);
+    assertEquals(merged.priceIndexValues(GB_RPI), PriceIndexValues.of(GB_RPI, VAL_DATE, GBPRI_CURVE, TS));
     assertEquals(merged.timeSeries(GBP_USD_WM), TS);
     assertEquals(merged.getFxRateProvider(), FX_MATRIX);
   }
@@ -121,7 +118,7 @@ public class ImmutableRatesProviderCombineTest {
         .overnightIndexCurve(USD_FED_FUND, FED_FUND_CURVE)
         .build();
     ImmutableRatesProvider test_pi = ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(GBPRI_CURVE)
+        .priceIndexCurve(GB_RPI, GBPRI_CURVE)
         .build();
     assertThrowsIllegalArg(() -> ImmutableRatesProvider.combined(FX_MATRIX, test_dsc, test_dsc));
     assertThrowsIllegalArg(() -> ImmutableRatesProvider.combined(FX_MATRIX, test_ts, test_ts));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderParameterSensitivityTest.java
@@ -22,7 +22,6 @@ import java.time.YearMonth;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxMatrix;
@@ -200,13 +199,9 @@ public class ImmutableRatesProviderParameterSensitivityTest {
     CurveInterpolator interp = CurveInterpolators.NATURAL_CUBIC_SPLINE;
     String curveName = "GB_RPI_CURVE";
     InterpolatedNodalCurve interpCurve = InterpolatedNodalCurve.of(Curves.prices(curveName), x, y, interp);
-    PriceIndexValues values = SimplePriceIndexValues.of(
-        GB_RPI,
-        valuationDate,
-        interpCurve,
-        LocalDateDoubleTimeSeries.of(date(2013, 11, 30), 200));
     ImmutableRatesProvider provider = ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(ImmutableMap.of(GB_RPI, values))
+        .priceIndexCurve(GB_RPI, interpCurve)
+        .timeSeries(GB_RPI, LocalDateDoubleTimeSeries.of(date(2013, 11, 30), 200))
         .build();
 
     double pointSensiValue = 2.5;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
@@ -15,7 +15,6 @@ import static com.opengamma.strata.basics.index.PriceIndices.GB_RPI;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
-import static com.opengamma.strata.collect.TestHelper.date;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
@@ -61,12 +60,8 @@ public class ImmutableRatesProviderTest {
       Curves.zeroRates("USD-Discount", ACT_ACT_ISDA), 0.96d);
   private static final Curve FED_FUND_CURVE = ConstantCurve.of(
       Curves.zeroRates("USD-Discount", ACT_ACT_ISDA), 0.97d);
-  private static final PriceIndexValues GBPRI_CURVE = SimplePriceIndexValues.of(
-      GB_RPI,
-      VAL_DATE,
-      InterpolatedNodalCurve.of(
-          Curves.prices("GB-RPI"), DoubleArray.of(1d, 10d), DoubleArray.of(252d, 252d), INTERPOLATOR),
-      LocalDateDoubleTimeSeries.of(date(2013, 11, 30), 252));
+  private static final Curve GBPRI_CURVE = InterpolatedNodalCurve.of(
+      Curves.prices("GB-RPI"), DoubleArray.of(1d, 10d), DoubleArray.of(252d, 252d), INTERPOLATOR);
 
   //-------------------------------------------------------------------------
   public void test_builder() {
@@ -162,10 +157,13 @@ public class ImmutableRatesProviderTest {
 
   //-------------------------------------------------------------------------
   public void test_priceIndexValues() {
+    LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.of(VAL_DATE, 0.62d);
     ImmutableRatesProvider test = ImmutableRatesProvider.builder(VAL_DATE)
-        .priceIndexValues(GBPRI_CURVE)
+        .priceIndexCurve(GB_RPI, GBPRI_CURVE)
+        .timeSeries(GB_RPI, ts)
         .build();
     assertEquals(test.priceIndexValues(GB_RPI).getIndex(), GB_RPI);
+    assertEquals(test.priceIndexValues(GB_RPI).getFixings(), ts);
   }
 
   public void test_priceIndexValues_notKnown() {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/RatesFiniteDifferenceSensitivityCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/RatesFiniteDifferenceSensitivityCalculatorTest.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.index.Index;
-import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.tuple.Pair;
@@ -33,8 +32,6 @@ import com.opengamma.strata.pricer.bond.LegalEntityGroup;
 import com.opengamma.strata.pricer.datasets.LegalEntityDiscountingProviderDataSets;
 import com.opengamma.strata.pricer.datasets.RatesProviderDataSets;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
-import com.opengamma.strata.pricer.rate.PriceIndexValues;
-import com.opengamma.strata.pricer.rate.SimplePriceIndexValues;
 
 /**
  * Tests {@link RatesFiniteDifferenceSensitivityCalculator}.
@@ -101,12 +98,6 @@ public class RatesFiniteDifferenceSensitivityCalculatorTest {
     ImmutableMap<Index, Curve> mapIndex = provider.getIndexCurves();
     for (Entry<Index, Curve> entry : mapIndex.entrySet()) {
       InterpolatedNodalCurve curveInt = checkInterpolated(entry.getValue());
-      result += sumProduct(curveInt);
-    }
-    // Price index
-    ImmutableMap<PriceIndex, PriceIndexValues> mapPriceIndex = provider.getPriceIndexValues();
-    for (Entry<PriceIndex, PriceIndexValues> entry : mapPriceIndex.entrySet()) {
-      NodalCurve curveInt = ((SimplePriceIndexValues) entry.getValue()).getCurve();
       result += sumProduct(curveInt);
     }
     return CurrencyAmount.of(USD, result);


### PR DESCRIPTION
Always store curves and time-series separately
Ensures design is consistent across forward curves