### PR TITLE
Expiry as double in FX option sensitivities

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricer.java
@@ -293,7 +293,7 @@ public class BlackFxSingleBarrierOptionProductPricer {
     double forward = todayFx * dfBase / dfCounter;
     return FxOptionSensitivity.of(
         currencyPair,
-        underlyingOption.getExpiry(),
+        volatilityProvider.relativeTime(underlyingOption.getExpiry()),
         underlyingOption.getStrike(),
         forward,
         ccyCounter,

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricer.java
@@ -351,8 +351,13 @@ public class BlackFxVanillaOptionProductPricer {
     FxRate forward = fxPricer.forwardFxRate(underlying, ratesProvider);
     CurrencyPair strikePair = underlying.getCurrencyPair();
     CurrencyAmount valueVega = presentValueVega(option, ratesProvider, volatilityProvider);
-    return FxOptionSensitivity.of(strikePair, option.getExpiry(), option.getStrike(), forward.fxRate(strikePair),
-        valueVega.getCurrency(), valueVega.getAmount());
+    return FxOptionSensitivity.of(
+        strikePair,
+        volatilityProvider.relativeTime(option.getExpiry()),
+        option.getStrike(),
+        forward.fxRate(strikePair),
+        valueVega.getCurrency(),
+        valueVega.getAmount());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackVolatilityFlatFxProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackVolatilityFlatFxProvider.java
@@ -105,7 +105,7 @@ public final class BlackVolatilityFlatFxProvider
   @Override
   public CurrencyParameterSensitivity surfaceParameterSensitivity(FxOptionSensitivity point) {
     // transforms curve sensitivity to surface sensitivity
-    double expiryTime = relativeTime(point.getExpiryDateTime());
+    double expiryTime = point.getExpiry();
     UnitParameterSensitivity yValueParameterSensitivity = curve.yValueParameterSensitivity(expiryTime);
     DoubleArray times = curve.getXValues();
     double pointValue = point.getSensitivity();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySmileFxProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySmileFxProvider.java
@@ -109,7 +109,7 @@ final class BlackVolatilitySmileFxProvider
 
   @Override
   public CurrencyParameterSensitivity surfaceParameterSensitivity(FxOptionSensitivity point) {
-    double expiryTime = relativeTime(point.getExpiryDateTime());
+    double expiryTime = point.getExpiry();
     double strike = currencyPair.isInverse(point.getCurrencyPair()) ? 1d / point.getStrike() : point.getStrike();
     double forward = currencyPair.isInverse(point.getCurrencyPair()) ? 1d / point.getForward() : point.getForward();
     double pointValue = point.getSensitivity();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySurfaceFxProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySurfaceFxProvider.java
@@ -102,7 +102,7 @@ public final class BlackVolatilitySurfaceFxProvider
 
   @Override
   public CurrencyParameterSensitivity surfaceParameterSensitivity(FxOptionSensitivity point) {
-    double expiryTime = relativeTime(point.getExpiryDateTime());
+    double expiryTime = point.getExpiry();
     double strike = point.getCurrencyPair().isInverse(currencyPair) ? 1d / point.getStrike() : point.getStrike();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiryTime, strike);
     return unitSens.multipliedBy(point.getCurrency(), point.getSensitivity());

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/VannaVolgaFxVanillaOptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/VannaVolgaFxVanillaOptionProductPricer.java
@@ -206,14 +206,19 @@ public class VannaVolgaFxVanillaOptionProductPricer {
       sensiSmile = sensiSmile.combinedWith(
           FxOptionSensitivity.of(
               currencyPair,
-              option.getExpiry(),
+              timeToExpiry,
               strikes[i],
               forwardRate,
               ccyCounter,
               df * signedNotional * x[i] * vegaFwdSmile));
     }
     FxOptionSensitivity sensiAtm = FxOptionSensitivity.of(
-        currencyPair, option.getExpiry(), strikes[1], forwardRate, ccyCounter, df * signedNotional * vegaAtm);
+        currencyPair,
+        timeToExpiry,
+        strikes[1],
+        forwardRate,
+        ccyCounter,
+        df * signedNotional * vegaAtm);
     return sensiAtm.combinedWith(sensiSmile);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricerTest.java
@@ -392,14 +392,14 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
     assertEquals(computedCall.getCurrencyPair(), CURRENCY_PAIR);
     assertEquals(computedCall.getStrike(), STRIKE_RATE);
     assertEquals(computedCall.getForward(), forward, TOL);
-    assertEquals(computedCall.getExpiryDateTime(), EXPIRY_DATETIME);
+    assertEquals(computedCall.getExpiry(), timeToExpiry);
     assertEquals(computedVegaPut, expectedPut, TOL);
     assertEquals(computedPut.getSensitivity(), -expectedPut * NOTIONAL, TOL * NOTIONAL);
     assertEquals(computedPut.getCurrency(), USD);
     assertEquals(computedPut.getCurrencyPair(), CURRENCY_PAIR);
     assertEquals(computedPut.getStrike(), STRIKE_RATE);
     assertEquals(computedPut.getForward(), forward, TOL);
-    assertEquals(computedPut.getExpiryDateTime(), EXPIRY_DATETIME);
+    assertEquals(computedPut.getExpiry(), timeToExpiry);
   }
 
   public void test_vega_presentValueSensitivityVolatility_atExpiry() {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricerTest.java
@@ -355,7 +355,7 @@ public class BlackFxVanillaOptionProductPricerTest {
     double forward = PRICER.getDiscountingFxSingleProductPricer().forwardFxRate(FX_PRODUCT_HIGH, RATES_PROVIDER)
         .fxRate(CURRENCY_PAIR);
     double vol = SMILE_TERM.volatility(timeToExpiry, STRIKE_RATE_HIGH, forward);
-    FxOptionSensitivity expected = FxOptionSensitivity.of(CURRENCY_PAIR, EXPIRY, STRIKE_RATE_HIGH, forward, USD,
+    FxOptionSensitivity expected = FxOptionSensitivity.of(CURRENCY_PAIR, timeToExpiry, STRIKE_RATE_HIGH, forward, USD,
         -NOTIONAL * df * BlackFormulaRepository.vega(forward, STRIKE_RATE_HIGH, timeToExpiry, vol));
     assertTrue(computedCall.build().equalWithTolerance(expected.build(), NOTIONAL * TOL));
     assertTrue(computedPut.build().equalWithTolerance(expected.build().multipliedBy(-1d), NOTIONAL * TOL));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackVolatilityFlatFxProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackVolatilityFlatFxProviderTest.java
@@ -109,8 +109,9 @@ public class BlackVolatilityFlatFxProviderTest {
   public void test_surfaceParameterSensitivity() {
     for (int i = 0; i < NB_EXPIRY; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
+        double timeToExpiry = PROVIDER.relativeTime(TEST_EXPIRY[i]);
         FxOptionSensitivity sensi = FxOptionSensitivity.of(
-            CURRENCY_PAIR, TEST_EXPIRY[i], TEST_STRIKE[j], FORWARD[i], GBP, 1d);
+            CURRENCY_PAIR, timeToExpiry, TEST_STRIKE[j], FORWARD[i], GBP, 1d);
         CurrencyParameterSensitivity computed = PROVIDER.surfaceParameterSensitivity(sensi);
         Iterator<ParameterMetadata> itr = computed.getParameterMetadata().iterator();
         for (double value : computed.getSensitivity().toArray()) {
@@ -127,8 +128,9 @@ public class BlackVolatilityFlatFxProviderTest {
   public void test_surfaceParameterSensitivity_inverse() {
     for (int i = 0; i < NB_EXPIRY; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
+        double timeToExpiry = PROVIDER.relativeTime(TEST_EXPIRY[i]);
         FxOptionSensitivity sensi = FxOptionSensitivity.of(
-            CURRENCY_PAIR.inverse(), TEST_EXPIRY[i], 1d / TEST_STRIKE[j], 1d / FORWARD[i], GBP, 1d);
+            CURRENCY_PAIR.inverse(), timeToExpiry, 1d / TEST_STRIKE[j], 1d / FORWARD[i], GBP, 1d);
         CurrencyParameterSensitivity computed = PROVIDER.surfaceParameterSensitivity(sensi);
         Iterator<ParameterMetadata> itr = computed.getParameterMetadata().iterator();
         for (double value : computed.getSensitivity().toArray()) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySmileFxProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySmileFxProviderTest.java
@@ -114,8 +114,9 @@ public class BlackVolatilitySmileFxProviderTest {
   public void test_surfaceParameterSensitivity() {
     for (int i = 0; i < NB_EXPIRY; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
+        double timeToExpiry = PROVIDER.relativeTime(TEST_EXPIRY[i]);
         FxOptionSensitivity sensi = FxOptionSensitivity.of(
-            CURRENCY_PAIR, TEST_EXPIRY[i], TEST_STRIKE[j], FORWARD[i], GBP, 1d);
+            CURRENCY_PAIR, timeToExpiry, TEST_STRIKE[j], FORWARD[i], GBP, 1d);
         CurrencyParameterSensitivity computed = PROVIDER.surfaceParameterSensitivity(sensi);
         Iterator<ParameterMetadata> itr = computed.getParameterMetadata().iterator();
         for (double value : computed.getSensitivity().toArray()) {
@@ -134,8 +135,9 @@ public class BlackVolatilitySmileFxProviderTest {
   public void test_surfaceParameterSensitivity_inverse() {
     for (int i = 0; i < NB_EXPIRY; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
+        double timeToExpiry = PROVIDER.relativeTime(TEST_EXPIRY[i]);
         FxOptionSensitivity sensi = FxOptionSensitivity.of(
-            CURRENCY_PAIR.inverse(), TEST_EXPIRY[i], 1d / TEST_STRIKE[j], 1d / FORWARD[i], GBP, 1d);
+            CURRENCY_PAIR.inverse(), timeToExpiry, 1d / TEST_STRIKE[j], 1d / FORWARD[i], GBP, 1d);
         CurrencyParameterSensitivity computed = PROVIDER.surfaceParameterSensitivity(sensi);
         Iterator<ParameterMetadata> itr = computed.getParameterMetadata().iterator();
         for (double value : computed.getSensitivity().toArray()) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySurfaceFxProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackVolatilitySurfaceFxProviderTest.java
@@ -110,8 +110,9 @@ public class BlackVolatilitySurfaceFxProviderTest {
   public void test_nodeSensitivity() {
     for (int i = 0; i < NB_EXPIRY; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
+        double timeToExpiry = PROVIDER.relativeTime(TEST_EXPIRY[i]);
         FxOptionSensitivity sensi = FxOptionSensitivity.of(
-            CURRENCY_PAIR, TEST_EXPIRY[i], TEST_STRIKE[j], FORWARD[i], GBP, 1d);
+            CURRENCY_PAIR, timeToExpiry, TEST_STRIKE[j], FORWARD[i], GBP, 1d);
         CurrencyParameterSensitivity computed = PROVIDER.surfaceParameterSensitivity(sensi);
         for (int k = 0; k < SURFACE.getParameterCount(); k++) {
           double value = computed.getSensitivity().get(k);
@@ -128,8 +129,9 @@ public class BlackVolatilitySurfaceFxProviderTest {
   public void test_nodeSensitivity_inverse() {
     for (int i = 0; i < NB_EXPIRY; i++) {
       for (int j = 0; j < NB_STRIKE; ++j) {
+        double timeToExpiry = PROVIDER.relativeTime(TEST_EXPIRY[i]);
         FxOptionSensitivity sensi = FxOptionSensitivity.of(
-            CURRENCY_PAIR.inverse(), TEST_EXPIRY[i], 1d / TEST_STRIKE[j], 1d / FORWARD[i], GBP, 1d);
+            CURRENCY_PAIR.inverse(), timeToExpiry, 1d / TEST_STRIKE[j], 1d / FORWARD[i], GBP, 1d);
         CurrencyParameterSensitivity computed = PROVIDER.surfaceParameterSensitivity(sensi);
         for (int k = 0; k < SURFACE.getParameterCount(); k++) {
           double value = computed.getSensitivity().get(k);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/FxOptionSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/FxOptionSensitivityTest.java
@@ -14,11 +14,6 @@ import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -33,19 +28,16 @@ import com.opengamma.strata.pricer.ZeroRateSensitivity;
 @Test
 public class FxOptionSensitivityTest {
 
-  private static final LocalDate EXPIRY_DATE = LocalDate.of(2015, 1, 23);
-  private static final LocalTime EXPIRY_TIME = LocalTime.of(12, 15);
-  private static final ZoneId EXPIRY_ZONE = ZoneId.of("Z");
-  private static final ZonedDateTime EXPIRY_DATE_TIME = ZonedDateTime.of(EXPIRY_DATE, EXPIRY_TIME, EXPIRY_ZONE);
+  private static final double EXPIRY = 2d;
   private static final CurrencyPair PAIR = CurrencyPair.of(EUR, GBP);
   private static final double FORWARD = 0.8d;
   private static final double STRIKE = 0.95d;
   private static final double SENSI_VALUE = 1.24d;
 
   public void test_of() {
-    FxOptionSensitivity test = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity test = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiryDateTime(), EXPIRY_DATE_TIME);
+    assertEquals(test.getExpiry(), EXPIRY);
     assertEquals(test.getForward(), FORWARD);
     assertEquals(test.getCurrencyPair(), PAIR);
     assertEquals(test.getSensitivity(), SENSI_VALUE);
@@ -53,10 +45,10 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_withCurrency() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity test1 = base.withCurrency(EUR);
     assertEquals(test1.getCurrency(), EUR);
-    assertEquals(test1.getExpiryDateTime(), EXPIRY_DATE_TIME);
+    assertEquals(test1.getExpiry(), EXPIRY);
     assertEquals(test1.getForward(), FORWARD);
     assertEquals(test1.getCurrencyPair(), PAIR);
     assertEquals(test1.getSensitivity(), SENSI_VALUE);
@@ -66,11 +58,11 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_withSensitivity() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     double newSensi = 22.5;
     FxOptionSensitivity test = base.withSensitivity(newSensi);
     assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiryDateTime(), EXPIRY_DATE_TIME);
+    assertEquals(test.getExpiry(), EXPIRY);
     assertEquals(test.getForward(), FORWARD);
     assertEquals(test.getCurrencyPair(), PAIR);
     assertEquals(test.getSensitivity(), newSensi);
@@ -78,15 +70,14 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_compareExcludingSensitivity() {
-    FxOptionSensitivity a1 = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity a2 = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity a1 = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity a2 = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity b = FxOptionSensitivity.of(
-        CurrencyPair.of(EUR, USD), EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity c = FxOptionSensitivity.of(PAIR, ZonedDateTime.of(
-        LocalDate.of(2015, 2, 23), LocalTime.of(10, 15), ZoneId.of("Z")), STRIKE, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity d = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, 0.96, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity e = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, 0.81, GBP, SENSI_VALUE);
-    FxOptionSensitivity f = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, EUR, SENSI_VALUE);
+        CurrencyPair.of(EUR, USD), EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity c = FxOptionSensitivity.of(PAIR, EXPIRY + 1, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity d = FxOptionSensitivity.of(PAIR, EXPIRY, 0.96, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity e = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, 0.81, GBP, SENSI_VALUE);
+    FxOptionSensitivity f = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, EUR, SENSI_VALUE);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, 2d, 32d);
     assertEquals(a1.compareKey(a2), 0);
     assertEquals(a1.compareKey(b) < 0, true);
@@ -104,30 +95,30 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_multipliedBy() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     double factor = 5.2d;
     FxOptionSensitivity expected = FxOptionSensitivity.of(
-        PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE * factor);
+        PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE * factor);
     FxOptionSensitivity test = base.multipliedBy(factor);
     assertEquals(test, expected);
   }
 
   public void test_mapSensitivity() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity expected = FxOptionSensitivity.of(
-        PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, 1.0 / SENSI_VALUE);
+        PAIR, EXPIRY, STRIKE, FORWARD, GBP, 1.0 / SENSI_VALUE);
     FxOptionSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
   }
 
   public void test_normalize() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity test = base.normalize();
     assertSame(test, base);
   }
 
   public void test_buildInto() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
     assertSame(test, combo);
@@ -135,26 +126,26 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_build() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
   }
 
   public void test_cloned() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity test = base.cloned();
     assertSame(test, base);
   }
 
   public void coverage() {
-    FxOptionSensitivity test1 = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity test1 = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     coverImmutableBean(test1);
-    FxOptionSensitivity test2 = FxOptionSensitivity.of(CurrencyPair.of(EUR, USD), EXPIRY_DATE_TIME, 0.8, 0.9, EUR, 1.1);
+    FxOptionSensitivity test2 = FxOptionSensitivity.of(CurrencyPair.of(EUR, USD), EXPIRY, 0.8, 0.9, EUR, 1.1);
     coverBeanEquals(test1, test2);
   }
 
   public void test_serialization() {
-    FxOptionSensitivity test = FxOptionSensitivity.of(PAIR, EXPIRY_DATE_TIME, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity test = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/VannaVolgaFxVanillaOptionProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/VannaVolgaFxVanillaOptionProductPricerTest.java
@@ -227,7 +227,7 @@ public class VannaVolgaFxVanillaOptionProductPricerTest {
         assertEquals(sensi.getForward(), forwardRate, TOL);
         assertEquals(sensi.getCurrency(), USD);
         assertEquals(sensi.getCurrencyPair(), CURRENCY_PAIR);
-        assertEquals(sensi.getExpiryDateTime(), EXPIRY);
+        assertEquals(sensi.getExpiry(), timeToExpiry);
       }
     }
   }


### PR DESCRIPTION
No need for point sensitivities to hold date-time