### PR TITLE
Better method names for Surfaces

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/surface/Surfaces.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/surface/Surfaces.java
@@ -22,22 +22,44 @@ public final class Surfaces {
 
   //-------------------------------------------------------------------------
   /**
-   * Creates metadata for a surface providing Black expiry-strike volatility for Ibor caplet/floorlet.
+   * Creates metadata for a surface providing Black expiry-tenor volatility.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent strike
+   * The y-values represent tenor year fractions.
    * The z-values represent Black volatility.
    * 
    * @param name  the surface name
    * @param dayCount  the day count
    * @return the surface metadata
    */
-  public static SurfaceMetadata iborCapletFloorletBlackExpiryStrike(String name, DayCount dayCount) {
-    return iborCapletFloorletBlackExpiryStrike(SurfaceName.of(name), dayCount);
+  public static SurfaceMetadata blackVolatilityByExpiryTenor(String name, DayCount dayCount) {
+    return blackVolatilityByExpiryTenor(SurfaceName.of(name), dayCount);
   }
 
   /**
-   * Creates metadata for a surface providing Black expiry-strike volatility for Ibor caplet/floorlet.
+   * Creates metadata for a surface providing Black expiry-tenor volatility.
+   * <p>
+   * The x-values represent time to expiry year fractions as defined by the specified day count.
+   * The y-values represent tenor year fractions.
+   * The z-values represent Black volatility.
+   * 
+   * @param name  the surface name
+   * @param dayCount  the day count
+   * @return the surface metadata
+   */
+  public static SurfaceMetadata blackVolatilityByExpiryTenor(SurfaceName name, DayCount dayCount) {
+    return DefaultSurfaceMetadata.builder()
+        .surfaceName(name)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.YEAR_FRACTION)
+        .zValueType(ValueType.BLACK_VOLATILITY)
+        .dayCount(dayCount)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates metadata for a surface providing Black expiry-strike volatility.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
    * The y-values represent strike
@@ -47,7 +69,22 @@ public final class Surfaces {
    * @param dayCount  the day count
    * @return the surface metadata
    */
-  public static SurfaceMetadata iborCapletFloorletBlackExpiryStrike(SurfaceName name, DayCount dayCount) {
+  public static SurfaceMetadata blackVolatilityByExpiryStrike(String name, DayCount dayCount) {
+    return blackVolatilityByExpiryStrike(SurfaceName.of(name), dayCount);
+  }
+
+  /**
+   * Creates metadata for a surface providing Black expiry-strike volatility.
+   * <p>
+   * The x-values represent time to expiry year fractions as defined by the specified day count.
+   * The y-values represent strike
+   * The z-values represent Black volatility.
+   * 
+   * @param name  the surface name
+   * @param dayCount  the day count
+   * @return the surface metadata
+   */
+  public static SurfaceMetadata blackVolatilityByExpiryStrike(SurfaceName name, DayCount dayCount) {
     return DefaultSurfaceMetadata.builder()
         .surfaceName(name)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -59,22 +96,44 @@ public final class Surfaces {
 
   //-------------------------------------------------------------------------
   /**
-   * Creates metadata for a surface providing Normal expiry-strike volatility for Ibor caplet/floorlet.
+   * Creates metadata for a surface providing Normal expiry-tenor volatility.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent strike
+   * The y-values represent tenor year fractions.
    * The z-values represent Normal volatility.
    * 
    * @param name  the surface name
    * @param dayCount  the day count
    * @return the surface metadata
    */
-  public static SurfaceMetadata iborCapletFloorletNormalExpiryStrike(String name, DayCount dayCount) {
-    return iborCapletFloorletNormalExpiryStrike(SurfaceName.of(name), dayCount);
+  public static SurfaceMetadata normalVolatilityByExpiryTenor(String name, DayCount dayCount) {
+    return normalVolatilityByExpiryTenor(SurfaceName.of(name), dayCount);
   }
 
   /**
-   * Creates metadata for a surface providing Normal expiry-strike volatility for Ibor caplet/floorlet.
+   * Creates metadata for a surface providing Normal expiry-tenor volatility.
+   * <p>
+   * The x-values represent time to expiry year fractions as defined by the specified day count.
+   * The y-values represent tenor year fractions.
+   * The z-values represent Normal volatility.
+   * 
+   * @param name  the surface name
+   * @param dayCount  the day count
+   * @return the surface metadata
+   */
+  public static SurfaceMetadata normalVolatilityByExpiryTenor(SurfaceName name, DayCount dayCount) {
+    return DefaultSurfaceMetadata.builder()
+        .surfaceName(name)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.YEAR_FRACTION)
+        .zValueType(ValueType.NORMAL_VOLATILITY)
+        .dayCount(dayCount)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates metadata for a surface providing Normal expiry-strike volatility.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
    * The y-values represent strike
@@ -84,7 +143,22 @@ public final class Surfaces {
    * @param dayCount  the day count
    * @return the surface metadata
    */
-  public static SurfaceMetadata iborCapletFloorletNormalExpiryStrike(SurfaceName name, DayCount dayCount) {
+  public static SurfaceMetadata normalVolatilityByExpiryStrike(String name, DayCount dayCount) {
+    return normalVolatilityByExpiryStrike(SurfaceName.of(name), dayCount);
+  }
+
+  /**
+   * Creates metadata for a surface providing Normal expiry-strike volatility.
+   * <p>
+   * The x-values represent time to expiry year fractions as defined by the specified day count.
+   * The y-values represent strike
+   * The z-values represent Normal volatility.
+   * 
+   * @param name  the surface name
+   * @param dayCount  the day count
+   * @return the surface metadata
+   */
+  public static SurfaceMetadata normalVolatilityByExpiryStrike(SurfaceName name, DayCount dayCount) {
     return DefaultSurfaceMetadata.builder()
         .surfaceName(name)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -96,7 +170,7 @@ public final class Surfaces {
 
   //-------------------------------------------------------------------------
   /**
-   * Creates metadata for a surface providing Normal expiry-tenor volatility for swaptions.
+   * Creates metadata for a surface providing Normal expiry-simple moneyness volatility.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
    * The y-values represent simple moneyness.
@@ -107,16 +181,16 @@ public final class Surfaces {
    * @param moneynessType  the moneyness type, prices or rates
    * @return the surface metadata
    */
-  public static SurfaceMetadata iborFutureOptionNormalExpirySimpleMoneyness(
+  public static SurfaceMetadata normalVolatilityByExpirySimpleMoneyness(
       String name,
       DayCount dayCount,
       MoneynessType moneynessType) {
 
-    return iborFutureOptionNormalExpirySimpleMoneyness(SurfaceName.of(name), dayCount, moneynessType);
+    return normalVolatilityByExpirySimpleMoneyness(SurfaceName.of(name), dayCount, moneynessType);
   }
 
   /**
-   * Creates metadata for a surface providing Normal expiry-tenor volatility for swaptions.
+   * Creates metadata for a surface providing Normal expiry-simple moneyness volatility.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
    * The y-values represent simple moneyness.
@@ -127,7 +201,7 @@ public final class Surfaces {
    * @param moneynessType  the moneyness type, prices or rates
    * @return the surface metadata
    */
-  public static SurfaceMetadata iborFutureOptionNormalExpirySimpleMoneyness(
+  public static SurfaceMetadata normalVolatilityByExpirySimpleMoneyness(
       SurfaceName name,
       DayCount dayCount,
       MoneynessType moneynessType) {
@@ -144,184 +218,36 @@ public final class Surfaces {
 
   //-------------------------------------------------------------------------
   /**
-   * Creates metadata for a surface providing Black expiry-tenor volatility for swaptions.
+   * Creates metadata for a surface providing a SABR expiry-tenor parameter.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent tenor year fractions, rounded to the month.
-   * The z-values represent Black volatility.
+   * The y-values represent tenor year fractions.
    * 
    * @param name  the surface name
    * @param dayCount  the day count
+   * @param zType  the z-value type, which must be one of the four SABR values
    * @return the surface metadata
    */
-  public static SurfaceMetadata swaptionBlackExpiryTenor(String name, DayCount dayCount) {
-    return swaptionBlackExpiryTenor(SurfaceName.of(name), dayCount);
-  }
-
-  /**
-   * Creates metadata for a surface providing Black expiry-tenor volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent tenor year fractions, rounded to the month.
-   * The z-values represent Black volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionBlackExpiryTenor(SurfaceName name, DayCount dayCount) {
-    return DefaultSurfaceMetadata.builder()
-        .surfaceName(name)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.YEAR_FRACTION)
-        .zValueType(ValueType.BLACK_VOLATILITY)
-        .dayCount(dayCount)
-        .build();
-  }
-
-  //-------------------------------------------------------------------------
-  /**
-   * Creates metadata for a surface providing Normal expiry-tenor volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent tenor year fractions, rounded to the month.
-   * The z-values represent Normal volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionNormalExpiryTenor(String name, DayCount dayCount) {
-    return swaptionNormalExpiryTenor(SurfaceName.of(name), dayCount);
-  }
-
-  /**
-   * Creates metadata for a surface providing Normal expiry-tenor volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent tenor year fractions, rounded to the month.
-   * The z-values represent Normal volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionNormalExpiryTenor(SurfaceName name, DayCount dayCount) {
-    return DefaultSurfaceMetadata.builder()
-        .surfaceName(name)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.YEAR_FRACTION)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(dayCount)
-        .build();
-  }
-
-  //-------------------------------------------------------------------------
-  /**
-   * Creates metadata for a surface providing Normal expiry-simple moneyness volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent simple moneyness (strike - forward).
-   * The z-values represent Normal volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionNormalExpirySimpleMoneyness(String name, DayCount dayCount) {
-    return swaptionNormalExpirySimpleMoneyness(SurfaceName.of(name), dayCount);
-  }
-
-  /**
-   * Creates metadata for a surface providing Normal expiry-simple moneyness volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent simple moneyness (strike - forward).
-   * The z-values represent Normal volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionNormalExpirySimpleMoneyness(SurfaceName name, DayCount dayCount) {
-    return DefaultSurfaceMetadata.builder()
-        .surfaceName(name)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.SIMPLE_MONEYNESS)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(dayCount)
-        .build();
-  }
-
-  //-------------------------------------------------------------------------
-  /**
-   * Creates metadata for a surface providing Normal expiry-strike volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent strike.
-   * The z-values represent Normal volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionNormalExpiryStrike(String name, DayCount dayCount) {
-    return swaptionNormalExpiryStrike(SurfaceName.of(name), dayCount);
-  }
-
-  /**
-   * Creates metadata for a surface providing Normal expiry-strike volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent strike.
-   * The z-values represent Normal volatility.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionNormalExpiryStrike(SurfaceName name, DayCount dayCount) {
-    return DefaultSurfaceMetadata.builder()
-        .surfaceName(name)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.STRIKE)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(dayCount)
-        .build();
-  }
-
-  //-------------------------------------------------------------------------
-  /**
-   * Creates metadata for a surface providing SABR expiry-tenor volatility for swaptions.
-   * <p>
-   * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent tenor year fractions, rounded to the month.
-   * 
-   * @param name  the surface name
-   * @param dayCount  the day count
-   * @param zType  the z-value type
-   * @return the surface metadata
-   */
-  public static SurfaceMetadata swaptionSabrExpiryTenor(
+  public static SurfaceMetadata sabrParameterByExpiryTenor(
       String name,
       DayCount dayCount,
       ValueType zType) {
 
-    return swaptionSabrExpiryTenor(SurfaceName.of(name), dayCount, zType);
+    return sabrParameterByExpiryTenor(SurfaceName.of(name), dayCount, zType);
   }
 
   /**
-   * Creates metadata for a surface providing SABR expiry-tenor volatility for swaptions.
+   * Creates metadata for a surface providing a SABR expiry-tenor parameter.
    * <p>
    * The x-values represent time to expiry year fractions as defined by the specified day count.
-   * The y-values represent tenor year fractions, rounded to the month.
+   * The y-values represent tenor year fractions.
    * 
    * @param name  the surface name
    * @param dayCount  the day count
-   * @param zType  the z-value type
+   * @param zType  the z-value type, which must be one of the four SABR values
    * @return the surface metadata
    */
-  public static SurfaceMetadata swaptionSabrExpiryTenor(
+  public static SurfaceMetadata sabrParameterByExpiryTenor(
       SurfaceName name,
       DayCount dayCount,
       ValueType zType) {

--- a/modules/market/src/test/java/com/opengamma/strata/market/surface/SurfacesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/surface/SurfacesTest.java
@@ -24,8 +24,33 @@ public class SurfacesTest {
   private static final SurfaceName SURFACE_NAME = SurfaceName.of(NAME);
 
   //-------------------------------------------------------------------------
-  public void iborCapletFloorletBlackExpiryStrike_string() {
-    SurfaceMetadata test = Surfaces.iborCapletFloorletBlackExpiryStrike(NAME, ACT_360);
+  public void blackVolatilityByExpiryTenor_string() {
+    SurfaceMetadata test = Surfaces.blackVolatilityByExpiryTenor(NAME, ACT_360);
+    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
+        .surfaceName(SURFACE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.YEAR_FRACTION)
+        .zValueType(ValueType.BLACK_VOLATILITY)
+        .dayCount(ACT_360)
+        .build();
+    assertEquals(test, expected);
+  }
+
+  public void blackVolatilityByExpiryTenor_surfaceName() {
+    SurfaceMetadata test = Surfaces.blackVolatilityByExpiryTenor(SURFACE_NAME, ACT_360);
+    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
+        .surfaceName(SURFACE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.YEAR_FRACTION)
+        .zValueType(ValueType.BLACK_VOLATILITY)
+        .dayCount(ACT_360)
+        .build();
+    assertEquals(test, expected);
+  }
+
+  //-------------------------------------------------------------------------
+  public void blackVolatilityByExpiryStrike_string() {
+    SurfaceMetadata test = Surfaces.blackVolatilityByExpiryStrike(NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -36,8 +61,8 @@ public class SurfacesTest {
     assertEquals(test, expected);
   }
 
-  public void iborCapletFloorletBlackExpiryStrike_surfaceName() {
-    SurfaceMetadata test = Surfaces.iborCapletFloorletBlackExpiryStrike(SURFACE_NAME, ACT_360);
+  public void blackVolatilityByExpiryStrike_surfaceName() {
+    SurfaceMetadata test = Surfaces.blackVolatilityByExpiryStrike(SURFACE_NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -49,8 +74,33 @@ public class SurfacesTest {
   }
 
   //-------------------------------------------------------------------------
-  public void iborCapletFloorletNormalExpiryStrike_string() {
-    SurfaceMetadata test = Surfaces.iborCapletFloorletNormalExpiryStrike(NAME, ACT_360);
+  public void normalVolatilityByExpiryTenor_string() {
+    SurfaceMetadata test = Surfaces.normalVolatilityByExpiryTenor(NAME, ACT_360);
+    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
+        .surfaceName(SURFACE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.YEAR_FRACTION)
+        .zValueType(ValueType.NORMAL_VOLATILITY)
+        .dayCount(ACT_360)
+        .build();
+    assertEquals(test, expected);
+  }
+
+  public void normalVolatilityByExpiryTenor_surfaceName() {
+    SurfaceMetadata test = Surfaces.normalVolatilityByExpiryTenor(SURFACE_NAME, ACT_360);
+    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
+        .surfaceName(SURFACE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.YEAR_FRACTION)
+        .zValueType(ValueType.NORMAL_VOLATILITY)
+        .dayCount(ACT_360)
+        .build();
+    assertEquals(test, expected);
+  }
+
+  //-------------------------------------------------------------------------
+  public void normalVolatilityByExpiryStrike_string() {
+    SurfaceMetadata test = Surfaces.normalVolatilityByExpiryStrike(NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -61,8 +111,8 @@ public class SurfacesTest {
     assertEquals(test, expected);
   }
 
-  public void iborCapletFloorletNormalExpiryStrike_surfaceName() {
-    SurfaceMetadata test = Surfaces.iborCapletFloorletNormalExpiryStrike(SURFACE_NAME, ACT_360);
+  public void normalVolatilityByExpiryStrike_surfaceName() {
+    SurfaceMetadata test = Surfaces.normalVolatilityByExpiryStrike(SURFACE_NAME, ACT_360);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -74,8 +124,8 @@ public class SurfacesTest {
   }
 
   //-------------------------------------------------------------------------
-  public void iborFutureOptionNormalExpirySimpleMoneyness_string() {
-    SurfaceMetadata test = Surfaces.iborFutureOptionNormalExpirySimpleMoneyness(NAME, ACT_360, MoneynessType.PRICE);
+  public void normalVolatilityByExpirySimpleMoneyness_string() {
+    SurfaceMetadata test = Surfaces.normalVolatilityByExpirySimpleMoneyness(NAME, ACT_360, MoneynessType.PRICE);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -87,8 +137,8 @@ public class SurfacesTest {
     assertEquals(test, expected);
   }
 
-  public void iborFutureOptionNormalExpirySimpleMoneyness_surfaceName() {
-    SurfaceMetadata test = Surfaces.iborFutureOptionNormalExpirySimpleMoneyness(SURFACE_NAME, ACT_360, MoneynessType.PRICE);
+  public void normalVolatilityByExpirySimpleMoneyness_surfaceName() {
+    SurfaceMetadata test = Surfaces.normalVolatilityByExpirySimpleMoneyness(SURFACE_NAME, ACT_360, MoneynessType.PRICE);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -101,108 +151,8 @@ public class SurfacesTest {
   }
 
   //-------------------------------------------------------------------------
-  public void swaptionBlackExpiryTenor_string() {
-    SurfaceMetadata test = Surfaces.swaptionBlackExpiryTenor(NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.YEAR_FRACTION)
-        .zValueType(ValueType.BLACK_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  public void swaptionBlackExpiryTenor_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionBlackExpiryTenor(SURFACE_NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.YEAR_FRACTION)
-        .zValueType(ValueType.BLACK_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  //-------------------------------------------------------------------------
-  public void swaptionNormalExpiryTenor_string() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpiryTenor(NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.YEAR_FRACTION)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  public void swaptionNormalExpiryTenor_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpiryTenor(SURFACE_NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.YEAR_FRACTION)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  //-------------------------------------------------------------------------
-  public void swaptionNormalExpirySimpleMoneyness_string() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpirySimpleMoneyness(NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.SIMPLE_MONEYNESS)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  public void swaptionNormalExpirySimpleMoneyness_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpirySimpleMoneyness(SURFACE_NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.SIMPLE_MONEYNESS)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  //-------------------------------------------------------------------------
-  public void swaptionNormalExpiryStrike_string() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpiryStrike(NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.STRIKE)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  public void swaptionNormalExpiryStrike_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionNormalExpiryStrike(SURFACE_NAME, ACT_360);
-    SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
-        .surfaceName(SURFACE_NAME)
-        .xValueType(ValueType.YEAR_FRACTION)
-        .yValueType(ValueType.STRIKE)
-        .zValueType(ValueType.NORMAL_VOLATILITY)
-        .dayCount(ACT_360)
-        .build();
-    assertEquals(test, expected);
-  }
-
-  //-------------------------------------------------------------------------
-  public void swaptionSabrExpiryTenor_string() {
-    SurfaceMetadata test = Surfaces.swaptionSabrExpiryTenor(NAME, ACT_360, ValueType.SABR_BETA);
+  public void sabrParameterByExpiryTenor_string() {
+    SurfaceMetadata test = Surfaces.sabrParameterByExpiryTenor(NAME, ACT_360, ValueType.SABR_BETA);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)
@@ -213,8 +163,8 @@ public class SurfacesTest {
     assertEquals(test, expected);
   }
 
-  public void swaptionSabrExpiryTenor_surfaceName() {
-    SurfaceMetadata test = Surfaces.swaptionSabrExpiryTenor(SURFACE_NAME, ACT_360, ValueType.SABR_BETA);
+  public void sabrParameterByExpiryTenor_surfaceName() {
+    SurfaceMetadata test = Surfaces.sabrParameterByExpiryTenor(SURFACE_NAME, ACT_360, ValueType.SABR_BETA);
     SurfaceMetadata expected = DefaultSurfaceMetadata.builder()
         .surfaceName(SURFACE_NAME)
         .xValueType(ValueType.YEAR_FRACTION)

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/index/IborFutureOptionTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/index/IborFutureOptionTradeCalculationFunctionTest.java
@@ -75,7 +75,7 @@ public class IborFutureOptionTradeCalculationFunctionTest {
   private static final DoubleArray NORMAL_VOL_PRICES =
       DoubleArray.of(0.01, 0.011, 0.012, 0.010, 0.011, 0.012, 0.013, 0.012, 0.012, 0.013, 0.014, 0.014);
   private static final InterpolatedNodalSurface PARAMETERS_PRICE = InterpolatedNodalSurface.of(
-      Surfaces.iborFutureOptionNormalExpirySimpleMoneyness("Price", ACT_365F, MoneynessType.PRICE),
+      Surfaces.normalVolatilityByExpirySimpleMoneyness("Price", ACT_365F, MoneynessType.PRICE),
       TIMES,
       MONEYNESS_PRICES,
       NORMAL_VOL_PRICES,

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilities.java
@@ -95,7 +95,7 @@ public final class BlackIborCapletFloorletExpiryStrikeVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#iborCapletFloorletBlackExpiryStrike(String, DayCount)}.
+   * {@link Surfaces#blackVolatilityByExpiryStrike(String, DayCount)}.
    * 
    * @param index  the Ibor index for which the data is valid
    * @param valuationDateTime  the valuation date-time

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilities.java
@@ -95,7 +95,7 @@ public final class NormalIborCapletFloorletExpiryStrikeVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#iborCapletFloorletNormalExpiryStrike(String, DayCount)}.
+   * {@link Surfaces#normalVolatilityByExpiryStrike(String, DayCount)}.
    * 
    * @param index  the Ibor index for which the data is valid
    * @param valuationDateTime  the valuation date-time

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilities.java
@@ -96,7 +96,7 @@ public final class NormalIborFutureOptionExpirySimpleMoneynessVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#iborFutureOptionNormalExpirySimpleMoneyness(String, DayCount, MoneynessType)}.
+   * {@link Surfaces#normalVolatilityByExpirySimpleMoneyness(String, DayCount, MoneynessType)}.
    * 
    * @param index  the Ibor index
    * @param surface  the implied volatility surface

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/model/SabrInterestRateParameters.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/model/SabrInterestRateParameters.java
@@ -113,7 +113,7 @@ public final class SabrInterestRateParameters
    *   {@link SurfaceInfoType#DAY_COUNT}, if present on other surfaces it must match that on the Alpha
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionSabrExpiryTenor(String, DayCount, ValueType)}.
+   * {@link Surfaces#sabrParameterByExpiryTenor(String, DayCount, ValueType)}.
    * 
    * @param alphaSurface  the alpha surface
    * @param betaSurface  the beta surface
@@ -151,7 +151,7 @@ public final class SabrInterestRateParameters
    * If it does, the day count and convention must match that on the alpha surface.
    * <p>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionSabrExpiryTenor(String, DayCount, ValueType)}.
+   * {@link Surfaces#sabrParameterByExpiryTenor(String, DayCount, ValueType)}.
    * 
    * @param alphaSurface  the alpha surface
    * @param betaSurface  the beta surface

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
@@ -93,7 +93,7 @@ public final class BlackSwaptionExpiryTenorVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionBlackExpiryTenor(String, DayCount)}.
+   * {@link Surfaces#blackVolatilityByExpiryTenor(String, DayCount)}.
    * 
    * @param convention  the swap convention that the volatilities are to be used for
    * @param valuationDateTime  the valuation date-time

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilities.java
@@ -31,6 +31,7 @@ import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.data.MarketDataName;
 import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.model.MoneynessType;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivity;
 import com.opengamma.strata.market.param.ParameterMetadata;
@@ -93,7 +94,7 @@ public final class NormalSwaptionExpirySimpleMoneynessVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionNormalExpirySimpleMoneyness(String, DayCount)}.
+   * {@link Surfaces#normalVolatilityByExpirySimpleMoneyness(String, DayCount, MoneynessType)}.
    * 
    * @param convention  the swap convention that the volatilities are to be used for
    * @param valuationDateTime  the valuation date-time

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilities.java
@@ -93,7 +93,7 @@ public final class NormalSwaptionExpiryStrikeVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionNormalExpiryStrike(String, DayCount)}.
+   * {@link Surfaces#normalVolatilityByExpiryStrike(String, DayCount)}.
    * 
    * @param convention  the swap convention that the volatilities are to be used for
    * @param valuationDateTime  the valuation date-time

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilities.java
@@ -93,7 +93,7 @@ public final class NormalSwaptionExpiryTenorVolatilities
    * <li>The day count must be set in the additional information using {@link SurfaceInfoType#DAY_COUNT}
    * </ul>
    * Suitable surface metadata can be created using
-   * {@link Surfaces#swaptionNormalExpiryTenor(String, DayCount)}.
+   * {@link Surfaces#normalVolatilityByExpiryTenor(String, DayCount)}.
    * 
    * @param convention  the swap convention that the volatilities are to be used for
    * @param valuationDateTime  the valuation date-time

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibrator.java
@@ -290,13 +290,13 @@ public class SabrSwaptionCalibrator {
         nuArray = nuArray.concat(sabrPt.getNu());
       }
     }
-    SurfaceMetadata metadataAlpha = Surfaces.swaptionSabrExpiryTenor(
+    SurfaceMetadata metadataAlpha = Surfaces.sabrParameterByExpiryTenor(
         name.getName() + "-Alpha", dayCount, ValueType.SABR_ALPHA)
         .withParameterMetadata(parameterMetadata);
-    SurfaceMetadata metadataRho = Surfaces.swaptionSabrExpiryTenor(
+    SurfaceMetadata metadataRho = Surfaces.sabrParameterByExpiryTenor(
         name.getName() + "-Rho", dayCount, ValueType.SABR_RHO)
         .withParameterMetadata(parameterMetadata);
-    SurfaceMetadata metadataNu = Surfaces.swaptionSabrExpiryTenor(
+    SurfaceMetadata metadataNu = Surfaces.sabrParameterByExpiryTenor(
         name.getName() + "-Nu", dayCount, ValueType.SABR_NU)
         .withParameterMetadata(parameterMetadata);
     InterpolatedNodalSurface alphaSurface = InterpolatedNodalSurface
@@ -457,7 +457,7 @@ public class SabrSwaptionCalibrator {
         dataSensitivityAlpha.add(DoubleArray.of(calibrationResult.getSecond()));
       }
     }
-    SurfaceMetadata metadataAlpha = Surfaces.swaptionSabrExpiryTenor(
+    SurfaceMetadata metadataAlpha = Surfaces.sabrParameterByExpiryTenor(
         name.getName() + "-Alpha", dayCount, ValueType.SABR_ALPHA)
         .withParameterMetadata(parameterMetadata);
     InterpolatedNodalSurface alphaSurface = InterpolatedNodalSurface

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilitiesTest.java
@@ -61,7 +61,7 @@ public class BlackIborCapletFloorletExpiryStrikeVolatilitiesTest {
           GenericVolatilitySurfaceYearFractionParameterMetadata.of(TIME.get(i), SimpleStrike.of(STRIKE.get(i)));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.iborCapletFloorletBlackExpiryStrike("CAP_VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.blackVolatilityByExpiryStrike("CAP_VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, STRIKE, VOL, INTERPOLATOR_2D);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/IborCapletFloorletDataSet.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/IborCapletFloorletDataSet.java
@@ -103,7 +103,7 @@ public class IborCapletFloorletDataSet {
   private static final DoubleArray STRIKES = DoubleArray.of(0.01, 0.02, 0.03, 0.01, 0.02, 0.03, 0.01, 0.02, 0.03);
   private static final DoubleArray BLACK_VOLS = DoubleArray.of(0.35, 0.30, 0.28, 0.34, 0.25, 0.23, 0.25, 0.20, 0.18);
   private static final SurfaceMetadata BLACK_METADATA = 
-      Surfaces.iborCapletFloorletBlackExpiryStrike("Black Vol", ACT_ACT_ISDA);
+      Surfaces.blackVolatilityByExpiryStrike("Black Vol", ACT_ACT_ISDA);
   private static final Surface BLACK_SURFACE_EXP_STR =
       InterpolatedNodalSurface.of(BLACK_METADATA, EXPIRIES, STRIKES, BLACK_VOLS, INTERPOLATOR_2D);
 
@@ -123,7 +123,7 @@ public class IborCapletFloorletDataSet {
   // Normal volatilities provider
   private static final DoubleArray NORMAL_VOLS = DoubleArray.of(0.09, 0.08, 0.05, 0.07, 0.05, 0.04, 0.06, 0.05, 0.03);
   private static final SurfaceMetadata NORMAL_METADATA =
-      Surfaces.iborCapletFloorletNormalExpiryStrike("Normal Vol", ACT_ACT_ISDA);
+      Surfaces.normalVolatilityByExpiryStrike("Normal Vol", ACT_ACT_ISDA);
   private static final Surface NORMAL_SURFACE_EXP_STR =
       InterpolatedNodalSurface.of(NORMAL_METADATA, EXPIRIES, STRIKES, NORMAL_VOLS, INTERPOLATOR_2D);
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilitiesTest.java
@@ -59,7 +59,7 @@ public class NormalIborCapletFloorletExpiryStrikeVolatilitiesTest {
           GenericVolatilitySurfaceYearFractionParameterMetadata.of(TIME.get(i), SimpleStrike.of(STRIKE.get(i)));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.iborCapletFloorletNormalExpiryStrike("CAP_VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.normalVolatilityByExpiryStrike("CAP_VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, STRIKE, VOL, INTERPOLATOR_2D);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest.java
@@ -49,13 +49,13 @@ public class NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest {
   private static final DoubleArray NORMAL_VOL_RATES =
       DoubleArray.of(0.010, 0.012, 0.011, 0.01, 0.012, 0.013, 0.012, 0.011, 0.014, 0.014, 0.013, 0.012);
   private static final InterpolatedNodalSurface PARAMETERS_PRICE = InterpolatedNodalSurface.of(
-      Surfaces.iborFutureOptionNormalExpirySimpleMoneyness("Price", ACT_365F, MoneynessType.PRICE),
+      Surfaces.normalVolatilityByExpirySimpleMoneyness("Price", ACT_365F, MoneynessType.PRICE),
       TIMES,
       MONEYNESS_PRICES,
       NORMAL_VOL_PRICES,
       INTERPOLATOR_2D);
   private static final InterpolatedNodalSurface PARAMETERS_RATE = InterpolatedNodalSurface.of(
-      Surfaces.iborFutureOptionNormalExpirySimpleMoneyness("Rate", ACT_365F, MoneynessType.RATES),
+      Surfaces.normalVolatilityByExpirySimpleMoneyness("Rate", ACT_365F, MoneynessType.RATES),
       TIMES,
       MONEYNESS_RATES,
       NORMAL_VOL_RATES,
@@ -126,7 +126,7 @@ public class NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest {
     for (int i = 0; i < NORMAL_VOL_RATES.size(); i++) {
       DoubleArray v = NORMAL_VOL_RATES.with(i, NORMAL_VOL_RATES.get(i) + shift);
       InterpolatedNodalSurface param = InterpolatedNodalSurface.of(
-          Surfaces.iborFutureOptionNormalExpirySimpleMoneyness("Rate", ACT_365F, MoneynessType.RATES),
+          Surfaces.normalVolatilityByExpirySimpleMoneyness("Rate", ACT_365F, MoneynessType.RATES),
           TIMES,
           MONEYNESS_RATES,
           v,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedProductPricerTest.java
@@ -52,7 +52,7 @@ public class NormalIborFutureOptionMarginedProductPricerTest {
       0.011, 0.012, 0.013, 0.012,
       0.012, 0.013, 0.014, 0.014);
   private static final InterpolatedNodalSurface PARAMETERS_PRICE = InterpolatedNodalSurface.of(
-      Surfaces.iborFutureOptionNormalExpirySimpleMoneyness("Test", ACT_365F, MoneynessType.PRICE),
+      Surfaces.normalVolatilityByExpirySimpleMoneyness("Test", ACT_365F, MoneynessType.PRICE),
       TIMES,
       MONEYNESS_PRICES,
       NORMAL_VOL,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedTradePricerTest.java
@@ -50,7 +50,7 @@ public class NormalIborFutureOptionMarginedTradePricerTest {
   private static final DoubleArray NORMAL_VOL =
       DoubleArray.of(0.01, 0.011, 0.012, 0.010, 0.011, 0.012, 0.013, 0.012, 0.012, 0.013, 0.014, 0.014);
   private static final InterpolatedNodalSurface PARAMETERS_PRICE = InterpolatedNodalSurface.of(
-      Surfaces.iborFutureOptionNormalExpirySimpleMoneyness("Test", ACT_365F, MoneynessType.PRICE),
+      Surfaces.normalVolatilityByExpirySimpleMoneyness("Test", ACT_365F, MoneynessType.PRICE),
       TIMES,
       MONEYNESS_PRICES,
       NORMAL_VOL,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/model/SabrInterestRateParametersTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/model/SabrInterestRateParametersTest.java
@@ -29,16 +29,16 @@ public class SabrInterestRateParametersTest {
 
   private static final GridSurfaceInterpolator GRID = GridSurfaceInterpolator.of(LINEAR, LINEAR);
   private static final InterpolatedNodalSurface ALPHA_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrAlpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA),
+      Surfaces.sabrParameterByExpiryTenor("SabrAlpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(0.2, 0.2, 0.2, 0.2), GRID);
   private static final InterpolatedNodalSurface BETA_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrBeta", ACT_ACT_ISDA, ValueType.SABR_BETA),
+      Surfaces.sabrParameterByExpiryTenor("SabrBeta", ACT_ACT_ISDA, ValueType.SABR_BETA),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(1, 1, 1, 1), GRID);
   private static final InterpolatedNodalSurface RHO_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrRho", ACT_ACT_ISDA, ValueType.SABR_RHO),
+      Surfaces.sabrParameterByExpiryTenor("SabrRho", ACT_ACT_ISDA, ValueType.SABR_RHO),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(-0.5, -0.5, -0.5, -0.5), GRID);
   private static final InterpolatedNodalSurface NU_SURFACE = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("SabrNu", ACT_ACT_ISDA, ValueType.SABR_NU),
+      Surfaces.sabrParameterByExpiryTenor("SabrNu", ACT_ACT_ISDA, ValueType.SABR_NU),
       DoubleArray.of(0, 0, 10, 10), DoubleArray.of(0, 10, 0, 10), DoubleArray.of(0.5, 0.5, 0.5, 0.5), GRID);
   private static final SabrVolatilityFormula FORMULA = SabrVolatilityFormula.hagan();
   private static final SabrInterestRateParameters PARAMETERS =

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
@@ -111,7 +111,7 @@ public class BlackSwaptionCashParYieldProductPricerTest {
   private static final DoubleArray TENOR = DoubleArray.of(2, 10, 2, 10, 2, 10);
   private static final DoubleArray VOL = DoubleArray.of(0.35, 0.30, 0.34, 0.25, 0.25, 0.20);
   private static final FixedIborSwapConvention SWAP_CONVENTION = FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M;
-  private static final SurfaceMetadata METADATA = Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_ACT_ISDA);
+  private static final SurfaceMetadata METADATA = Surfaces.blackVolatilityByExpiryTenor("Black Vol", ACT_ACT_ISDA);
   private static final Surface SURFACE = InterpolatedNodalSurface.of(METADATA, EXPIRY, TENOR, VOL, INTERPOLATOR_2D);
   private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER =
       BlackSwaptionExpiryTenorVolatilities.of(SWAP_CONVENTION, VAL_DATE.atStartOfDay(ZoneOffset.UTC), SURFACE);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
@@ -60,7 +60,7 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
           SwaptionSurfaceExpiryTenorParameterMetadata.of(TIME.get(i), TENOR.get(i));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.swaptionBlackExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.blackVolatilityByExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, TENOR, VOL, INTERPOLATOR_2D);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilitiesTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.tuple.DoublesPair;
+import com.opengamma.strata.market.model.MoneynessType;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivity;
 import com.opengamma.strata.market.param.ParameterMetadata;
@@ -66,7 +67,8 @@ public class NormalSwaptionExpirySimpleMoneynessVolatilitiesTest {
           SwaptionSurfaceExpirySimpleMoneynessParameterMetadata.of(TIME.get(i), SIMPLE_MONEYNESS.get(i));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.swaptionNormalExpirySimpleMoneyness("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.normalVolatilityByExpirySimpleMoneyness(
+        "GOVT1-SWAPTION-VOL", ACT_365F, MoneynessType.RATES).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, SIMPLE_MONEYNESS, VOL, INTERPOLATOR_2D);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilitiesTest.java
@@ -66,7 +66,7 @@ public class NormalSwaptionExpiryStrikeVolatilitiesTest {
           SwaptionSurfaceExpiryStrikeParameterMetadata.of(TIME.get(i), STRIKE.get(i));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.swaptionNormalExpiryStrike("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.normalVolatilityByExpiryStrike("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, STRIKE, VOL, INTERPOLATOR_2D);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
@@ -66,7 +66,7 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
           SwaptionSurfaceExpiryTenorParameterMetadata.of(TIME.get(i), TENOR.get(i));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.swaptionNormalExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.normalVolatilityByExpiryTenor("GOVT1-SWAPTION-VOL", ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, TENOR, VOL, INTERPOLATOR_2D);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -446,7 +446,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), false);
     double impliedVol = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
-        Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount());
+        Surfaces.blackVolatilityByExpiryTenor("CST", VOL_PROVIDER.getDayCount());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
         VOL_PROVIDER.getConvention(), VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -346,7 +346,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesUsd(VAL_DATE, false);
     double impliedVol = SWAPTION_PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
-        Surfaces.swaptionBlackExpiryTenor("CST", VOL_PROVIDER.getDayCount());
+        Surfaces.blackVolatilityByExpiryTenor("CST", VOL_PROVIDER.getDayCount());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
         VOL_PROVIDER.getConvention(), VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
@@ -60,7 +60,7 @@ public class SwaptionBlackVolatilityDataSets {
   public static final FixedIborSwapConvention USD_1Y_LIBOR3M =
       ImmutableFixedIborSwapConvention.of("USD-Swap", USD_FIXED_1Y_30U360, USD_IBOR_LIBOR3M);
   private static final SurfaceMetadata METADATA_STD =
-      Surfaces.swaptionBlackExpiryTenor("Black Vol", ACT_365F);
+      Surfaces.blackVolatilityByExpiryTenor("Black Vol", ACT_365F);
   private static final Surface SURFACE_STD =
       InterpolatedNodalSurface.of(METADATA_STD, TIMES, TENOR, BLACK_VOL, INTERPOLATOR_2D);
 
@@ -76,7 +76,7 @@ public class SwaptionBlackVolatilityDataSets {
   public static final double VOLATILITY = 0.20;
   /** metadata for constant surface */
   public static final SurfaceMetadata META_DATA =
-      Surfaces.swaptionBlackExpiryTenor("Constant Surface", ACT_365F);
+      Surfaces.blackVolatilityByExpiryTenor("Constant Surface", ACT_365F);
   private static final Surface CST_SURFACE = ConstantSurface.of(META_DATA, VOLATILITY);
   /** flat Black volatility provider */
   public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_CST_SWAPTION_PROVIDER_USD =

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
@@ -62,7 +62,7 @@ public class SwaptionNormalVolatilityDataSets {
   public static final FixedIborSwapConvention USD_1Y_LIBOR3M =
       ImmutableFixedIborSwapConvention.of("USD-Swap", USD_FIXED_1Y_30U360, USD_IBOR_LIBOR3M);
   private static final SurfaceMetadata METADATA =
-      Surfaces.swaptionNormalExpiryTenor("Normal Vol", ACT_365F);
+      Surfaces.normalVolatilityByExpiryTenor("Normal Vol", ACT_365F);
   private static final InterpolatedNodalSurface SURFACE_STD =
       InterpolatedNodalSurface.of(METADATA, TIMES, TENORS, NORMAL_VOL, INTERPOLATOR_2D);
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrRateVolatilityDataSet.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrRateVolatilityDataSet.java
@@ -94,7 +94,7 @@ public class SwaptionSabrRateVolatilityDataSet {
       0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.3, 0.5, 0.5, 0.3, 0.5, 0.5, 0.3, 0.5, 0.5, 0.3};
   static final SwaptionVolatilitiesName NAME = SwaptionVolatilitiesName.of("Test-SABR");
   static final SurfaceMetadata META_ALPHA =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA);
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA);
   private static final InterpolatedNodalSurface SURFACE_ALPHA_USD = InterpolatedNodalSurface.of(
       META_ALPHA,
       DoubleArray.copyOf(EXPIRY_NODE_USD),
@@ -111,7 +111,7 @@ public class SwaptionSabrRateVolatilityDataSet {
   }
 
   static final SurfaceMetadata META_BETA_USD =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, ValueType.SABR_BETA)
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, ValueType.SABR_BETA)
           .withParameterMetadata(PARAMETER_META_LIST_USD);
   private static final InterpolatedNodalSurface SURFACE_BETA_USD = InterpolatedNodalSurface.of(
       META_BETA_USD,
@@ -120,7 +120,7 @@ public class SwaptionSabrRateVolatilityDataSet {
       DoubleArray.copyOf(BETA_NODE_USD),
       INTERPOLATOR_2D);
   static final SurfaceMetadata META_RHO =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, ValueType.SABR_RHO);
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, ValueType.SABR_RHO);
   private static final InterpolatedNodalSurface SURFACE_RHO_USD = InterpolatedNodalSurface.of(
       META_RHO,
       DoubleArray.copyOf(EXPIRY_NODE_USD),
@@ -128,7 +128,7 @@ public class SwaptionSabrRateVolatilityDataSet {
       DoubleArray.copyOf(RHO_NODE_USD),
       INTERPOLATOR_2D);
   static final SurfaceMetadata META_NU =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, ValueType.SABR_NU);
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, ValueType.SABR_NU);
   private static final InterpolatedNodalSurface SURFACE_NU_USD = InterpolatedNodalSurface.of(
       META_NU,
       DoubleArray.copyOf(EXPIRY_NODE_USD),
@@ -197,7 +197,7 @@ public class SwaptionSabrRateVolatilityDataSet {
   private static final double[] BETA_TENOR_NODE_EUR = new double[] {
       0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100};
   private static final InterpolatedNodalSurface SURFACE_ALPHA_EUR = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA),
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Alpha", ACT_ACT_ISDA, ValueType.SABR_ALPHA),
       DoubleArray.of(0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1, 2, 2, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10),
       DoubleArray.of(0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100, 0, 1, 10, 100),
       DoubleArray.of(
@@ -215,7 +215,7 @@ public class SwaptionSabrRateVolatilityDataSet {
   }
 
   static final SurfaceMetadata META_BETA_EUR =
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, ValueType.SABR_BETA)
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Beta", ACT_ACT_ISDA, ValueType.SABR_BETA)
           .withParameterMetadata(PARAMETER_META_LIST_EUR);
   private static final InterpolatedNodalSurface SURFACE_BETA_EUR = InterpolatedNodalSurface.of(
       META_BETA_EUR,
@@ -225,7 +225,7 @@ public class SwaptionSabrRateVolatilityDataSet {
           0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5}),
       INTERPOLATOR_2D);
   private static final InterpolatedNodalSurface SURFACE_RHO_EUR = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, ValueType.SABR_RHO),
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Rho", ACT_ACT_ISDA, ValueType.SABR_RHO),
       DoubleArray.of(
           0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1, 2, 2, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10, 100, 100, 100, 100),
       DoubleArray.of(
@@ -240,7 +240,7 @@ public class SwaptionSabrRateVolatilityDataSet {
           -0.25, -0.25, 0, 0),
       INTERPOLATOR_2D);
   private static final InterpolatedNodalSurface SURFACE_NU_EUR = InterpolatedNodalSurface.of(
-      Surfaces.swaptionSabrExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, ValueType.SABR_NU),
+      Surfaces.sabrParameterByExpiryTenor("Test-SABR-Nu", ACT_ACT_ISDA, ValueType.SABR_NU),
       DoubleArray.of(
           0, 0, 0, 0, 0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1, 2, 2, 2, 2, 5, 5, 5, 5, 10, 10, 10, 10, 100, 100, 100, 100),
       DoubleArray.of(


### PR DESCRIPTION
No need to refer to the asset class in the method name