### PR TITLE
Use volatilities name in point sensitivity

### DIFF
--- a/modules/measure/src/test/java/com/opengamma/strata/measure/swaption/SwaptionTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/swaption/SwaptionTradeCalculationFunctionTest.java
@@ -93,7 +93,7 @@ public class SwaptionTradeCalculationFunctionTest {
   private static final IborIndex INDEX = IborIndices.USD_LIBOR_3M;
 
   public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_STD;
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_STD;
   private static final CurveId DISCOUNT_CURVE_ID = CurveId.of("Default", "Discount");
   private static final CurveId FORWARD_CURVE_ID = CurveId.of("Default", "Forward");
   private static final SwaptionVolatilitiesId VOL_ID = SwaptionVolatilitiesId.of("SwaptionVols.Normal.USD");

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilities.java
@@ -187,15 +187,15 @@ public final class BlackIborCapletFloorletExpiryStrikeVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof IborCapletFloorletSensitivity) {
         IborCapletFloorletSensitivity pt = (IborCapletFloorletSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(IborCapletFloorletSensitivity point) {
-    ArgChecker.isTrue(point.getIndex().equals(index),
-        "Ibor index of provider must be the same as Ibor index of point sensitivity");
     double expiry = point.getExpiry();
     double strike = point.getStrike();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, strike);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/IborCapletFloorletSensitivity.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/IborCapletFloorletSensitivity.java
@@ -27,7 +27,6 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import com.google.common.collect.ComparisonChain;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRateProvider;
-import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.market.sensitivity.MutablePointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -42,10 +41,10 @@ public final class IborCapletFloorletSensitivity
     implements PointSensitivity, PointSensitivityBuilder, ImmutableBean, Serializable {
 
   /**
-   * The Ibor index.
+   * The name of the volatilities.
    */
   @PropertyDefinition(validate = "notNull")
-  private final IborIndex index;
+  private final IborCapletFloorletVolatilitiesName volatilitiesName;
   /**
    * The time to expiry of the option as a year fraction.
    */
@@ -74,9 +73,9 @@ public final class IborCapletFloorletSensitivity
 
   //-------------------------------------------------------------------------
   /**
-   * Obtains an instance, specifying sensitivity currency.
+   * Obtains an instance.
    * 
-   * @param index  the Ibor index for which the data is valid
+   * @param volatilitiesName  the name of the volatilities
    * @param expiry  the time to expiry of the option as a year fraction
    * @param strike  the strike rate
    * @param forward  the forward rate
@@ -85,36 +84,14 @@ public final class IborCapletFloorletSensitivity
    * @return the point sensitivity object
    */
   public static IborCapletFloorletSensitivity of(
-      IborIndex index,
+      IborCapletFloorletVolatilitiesName volatilitiesName,
       double expiry,
       double strike,
       double forward,
       Currency sensitivityCurrency,
       double sensitivity) {
 
-    return new IborCapletFloorletSensitivity(index, expiry, strike, forward, sensitivityCurrency, sensitivity);
-  }
-
-  /**
-   * Obtains an instance based on the index.
-   * <p>
-   * The currency is defaulted from the index.
-   * 
-   * @param index  the Ibor index for which the data is valid
-   * @param expiry  the time to expiry of the option as a year fraction
-   * @param strike  the strike rate
-   * @param forward  the forward rate
-   * @param sensitivity  the value of the sensitivity
-   * @return the point sensitivity object
-   */
-  public static IborCapletFloorletSensitivity of(
-      IborIndex index,
-      double expiry,
-      double strike,
-      double forward,
-      double sensitivity) {
-
-    return new IborCapletFloorletSensitivity(index, expiry, strike, forward, index.getCurrency(), sensitivity);
+    return new IborCapletFloorletSensitivity(volatilitiesName, expiry, strike, forward, sensitivityCurrency, sensitivity);
   }
 
   //-------------------------------------------------------------------------
@@ -123,12 +100,12 @@ public final class IborCapletFloorletSensitivity
     if (this.currency.equals(currency)) {
       return this;
     }
-    return new IborCapletFloorletSensitivity(index, expiry, strike, forward, currency, sensitivity);
+    return new IborCapletFloorletSensitivity(volatilitiesName, expiry, strike, forward, currency, sensitivity);
   }
 
   @Override
   public IborCapletFloorletSensitivity withSensitivity(double sensitivity) {
-    return new IborCapletFloorletSensitivity(index, expiry, strike, forward, currency, sensitivity);
+    return new IborCapletFloorletSensitivity(volatilitiesName, expiry, strike, forward, currency, sensitivity);
   }
 
   @Override
@@ -136,11 +113,11 @@ public final class IborCapletFloorletSensitivity
     if (other instanceof IborCapletFloorletSensitivity) {
       IborCapletFloorletSensitivity otherSwpt = (IborCapletFloorletSensitivity) other;
       return ComparisonChain.start()
+          .compare(volatilitiesName, otherSwpt.volatilitiesName)
           .compare(currency, otherSwpt.currency)
           .compare(expiry, otherSwpt.expiry)
           .compare(strike, otherSwpt.strike)
           .compare(forward, otherSwpt.forward)
-          .compare(index.toString(), otherSwpt.index.toString())
           .result();
     }
     return getClass().getSimpleName().compareTo(other.getClass().getSimpleName());
@@ -154,12 +131,13 @@ public final class IborCapletFloorletSensitivity
   //-------------------------------------------------------------------------
   @Override
   public IborCapletFloorletSensitivity multipliedBy(double factor) {
-    return new IborCapletFloorletSensitivity(index, expiry, strike, forward, currency, sensitivity * factor);
+    return new IborCapletFloorletSensitivity(volatilitiesName, expiry, strike, forward, currency, sensitivity * factor);
   }
 
   @Override
   public IborCapletFloorletSensitivity mapSensitivity(DoubleUnaryOperator operator) {
-    return new IborCapletFloorletSensitivity(index, expiry, strike, forward, currency, operator.applyAsDouble(sensitivity));
+    return new IborCapletFloorletSensitivity(
+        volatilitiesName, expiry, strike, forward, currency, operator.applyAsDouble(sensitivity));
   }
 
   @Override
@@ -197,16 +175,16 @@ public final class IborCapletFloorletSensitivity
   private static final long serialVersionUID = 1L;
 
   private IborCapletFloorletSensitivity(
-      IborIndex index,
+      IborCapletFloorletVolatilitiesName volatilitiesName,
       double expiry,
       double strike,
       double forward,
       Currency currency,
       double sensitivity) {
-    JodaBeanUtils.notNull(index, "index");
+    JodaBeanUtils.notNull(volatilitiesName, "volatilitiesName");
     JodaBeanUtils.notNull(expiry, "expiry");
     JodaBeanUtils.notNull(currency, "currency");
-    this.index = index;
+    this.volatilitiesName = volatilitiesName;
     this.expiry = expiry;
     this.strike = strike;
     this.forward = forward;
@@ -231,11 +209,11 @@ public final class IborCapletFloorletSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the Ibor index.
+   * Gets the name of the volatilities.
    * @return the value of the property, not null
    */
-  public IborIndex getIndex() {
-    return index;
+  public IborCapletFloorletVolatilitiesName getVolatilitiesName() {
+    return volatilitiesName;
   }
 
   //-----------------------------------------------------------------------
@@ -293,7 +271,7 @@ public final class IborCapletFloorletSensitivity
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       IborCapletFloorletSensitivity other = (IborCapletFloorletSensitivity) obj;
-      return JodaBeanUtils.equal(index, other.index) &&
+      return JodaBeanUtils.equal(volatilitiesName, other.volatilitiesName) &&
           JodaBeanUtils.equal(expiry, other.expiry) &&
           JodaBeanUtils.equal(strike, other.strike) &&
           JodaBeanUtils.equal(forward, other.forward) &&
@@ -306,7 +284,7 @@ public final class IborCapletFloorletSensitivity
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
-    hash = hash * 31 + JodaBeanUtils.hashCode(index);
+    hash = hash * 31 + JodaBeanUtils.hashCode(volatilitiesName);
     hash = hash * 31 + JodaBeanUtils.hashCode(expiry);
     hash = hash * 31 + JodaBeanUtils.hashCode(strike);
     hash = hash * 31 + JodaBeanUtils.hashCode(forward);
@@ -319,7 +297,7 @@ public final class IborCapletFloorletSensitivity
   public String toString() {
     StringBuilder buf = new StringBuilder(224);
     buf.append("IborCapletFloorletSensitivity{");
-    buf.append("index").append('=').append(index).append(',').append(' ');
+    buf.append("volatilitiesName").append('=').append(volatilitiesName).append(',').append(' ');
     buf.append("expiry").append('=').append(expiry).append(',').append(' ');
     buf.append("strike").append('=').append(strike).append(',').append(' ');
     buf.append("forward").append('=').append(forward).append(',').append(' ');
@@ -340,10 +318,10 @@ public final class IborCapletFloorletSensitivity
     static final Meta INSTANCE = new Meta();
 
     /**
-     * The meta-property for the {@code index} property.
+     * The meta-property for the {@code volatilitiesName} property.
      */
-    private final MetaProperty<IborIndex> index = DirectMetaProperty.ofImmutable(
-        this, "index", IborCapletFloorletSensitivity.class, IborIndex.class);
+    private final MetaProperty<IborCapletFloorletVolatilitiesName> volatilitiesName = DirectMetaProperty.ofImmutable(
+        this, "volatilitiesName", IborCapletFloorletSensitivity.class, IborCapletFloorletVolatilitiesName.class);
     /**
      * The meta-property for the {@code expiry} property.
      */
@@ -374,7 +352,7 @@ public final class IborCapletFloorletSensitivity
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "index",
+        "volatilitiesName",
         "expiry",
         "strike",
         "forward",
@@ -390,8 +368,8 @@ public final class IborCapletFloorletSensitivity
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          return index;
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case -1289159373:  // expiry
           return expiry;
         case -891985998:  // strike
@@ -423,11 +401,11 @@ public final class IborCapletFloorletSensitivity
 
     //-----------------------------------------------------------------------
     /**
-     * The meta-property for the {@code index} property.
+     * The meta-property for the {@code volatilitiesName} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<IborIndex> index() {
-      return index;
+    public MetaProperty<IborCapletFloorletVolatilitiesName> volatilitiesName() {
+      return volatilitiesName;
     }
 
     /**
@@ -474,8 +452,8 @@ public final class IborCapletFloorletSensitivity
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          return ((IborCapletFloorletSensitivity) bean).getIndex();
+        case 2100884654:  // volatilitiesName
+          return ((IborCapletFloorletSensitivity) bean).getVolatilitiesName();
         case -1289159373:  // expiry
           return ((IborCapletFloorletSensitivity) bean).getExpiry();
         case -891985998:  // strike
@@ -507,7 +485,7 @@ public final class IborCapletFloorletSensitivity
    */
   private static final class Builder extends DirectFieldsBeanBuilder<IborCapletFloorletSensitivity> {
 
-    private IborIndex index;
+    private IborCapletFloorletVolatilitiesName volatilitiesName;
     private double expiry;
     private double strike;
     private double forward;
@@ -524,8 +502,8 @@ public final class IborCapletFloorletSensitivity
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          return index;
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case -1289159373:  // expiry
           return expiry;
         case -891985998:  // strike
@@ -544,8 +522,8 @@ public final class IborCapletFloorletSensitivity
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          this.index = (IborIndex) newValue;
+        case 2100884654:  // volatilitiesName
+          this.volatilitiesName = (IborCapletFloorletVolatilitiesName) newValue;
           break;
         case -1289159373:  // expiry
           this.expiry = (Double) newValue;
@@ -595,7 +573,7 @@ public final class IborCapletFloorletSensitivity
     @Override
     public IborCapletFloorletSensitivity build() {
       return new IborCapletFloorletSensitivity(
-          index,
+          volatilitiesName,
           expiry,
           strike,
           forward,
@@ -608,7 +586,7 @@ public final class IborCapletFloorletSensitivity
     public String toString() {
       StringBuilder buf = new StringBuilder(224);
       buf.append("IborCapletFloorletSensitivity.Builder{");
-      buf.append("index").append('=').append(JodaBeanUtils.toString(index)).append(',').append(' ');
+      buf.append("volatilitiesName").append('=').append(JodaBeanUtils.toString(volatilitiesName)).append(',').append(' ');
       buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
       buf.append("strike").append('=').append(JodaBeanUtils.toString(strike)).append(',').append(' ');
       buf.append("forward").append('=').append(JodaBeanUtils.toString(forward)).append(',').append(' ');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilities.java
@@ -187,15 +187,15 @@ public final class NormalIborCapletFloorletExpiryStrikeVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof IborCapletFloorletSensitivity) {
         IborCapletFloorletSensitivity pt = (IborCapletFloorletSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(IborCapletFloorletSensitivity point) {
-    ArgChecker.isTrue(point.getIndex().equals(index),
-        "Ibor index of provider must be the same as Ibor index of point sensitivity");
     double expiry = point.getExpiry();
     double strike = point.getStrike();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, strike);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/VolatilityIborCapletFloorletPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/VolatilityIborCapletFloorletPeriodPricer.java
@@ -261,7 +261,7 @@ public class VolatilityIborCapletFloorletPeriodPricer {
     double df = ratesProvider.discountFactor(currency, period.getPaymentDate());
     double vega = df * period.getYearFraction() * volatilities.priceVega(expiry, putCall, strike, forward, volatility);
     return IborCapletFloorletSensitivity.of(
-        period.getIndex(),
+        volatilities.getName(),
         expiry,
         strike,
         forward,

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/cms/SabrExtrapolationReplicationCmsPeriodPricer.java
@@ -34,6 +34,7 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.pricer.swaption.SabrSwaptionVolatilities;
 import com.opengamma.strata.pricer.swaption.SwaptionSabrSensitivity;
+import com.opengamma.strata.pricer.swaption.SwaptionVolatilitiesName;
 import com.opengamma.strata.product.cms.CmsPeriod;
 import com.opengamma.strata.product.cms.CmsPeriodType;
 import com.opengamma.strata.product.common.PutCall;
@@ -42,7 +43,6 @@ import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.SwapIndex;
 import com.opengamma.strata.product.swap.SwapLegType;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 
 /**
  *  Computes the price of a CMS coupon/caplet/floorlet by swaption replication on a shifted SABR formula with extrapolation.
@@ -422,12 +422,12 @@ public class SabrExtrapolationReplicationCmsPeriodPricer {
       totalSensi[loopparameter] =
           (strikePartPrice[loopparameter] + integralPart) * cmsPeriod.getNotional() * cmsPeriod.getYearFraction();
     }
-    FixedIborSwapConvention conv = cmsPeriod.getIndex().getTemplate().getConvention();
+    SwaptionVolatilitiesName name = swaptionVolatilities.getName();
     return PointSensitivityBuilder.of(
-        SwaptionSabrSensitivity.of(conv, expiryTime, tenor, ALPHA, ccy, totalSensi[0]),
-        SwaptionSabrSensitivity.of(conv, expiryTime, tenor, BETA, ccy, totalSensi[1]),
-        SwaptionSabrSensitivity.of(conv, expiryTime, tenor, RHO, ccy, totalSensi[2]),
-        SwaptionSabrSensitivity.of(conv, expiryTime, tenor, NU, ccy, totalSensi[3]));
+        SwaptionSabrSensitivity.of(name, expiryTime, tenor, ALPHA, ccy, totalSensi[0]),
+        SwaptionSabrSensitivity.of(name, expiryTime, tenor, BETA, ccy, totalSensi[1]),
+        SwaptionSabrSensitivity.of(name, expiryTime, tenor, RHO, ccy, totalSensi[2]),
+        SwaptionSabrSensitivity.of(name, expiryTime, tenor, NU, ccy, totalSensi[3]));
   }
 
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionFlatVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionFlatVolatilities.java
@@ -181,7 +181,9 @@ public final class BlackFxOptionFlatVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof FxOptionSensitivity) {
         FxOptionSensitivity pt = (FxOptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionSmileVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionSmileVolatilities.java
@@ -148,7 +148,9 @@ public final class BlackFxOptionSmileVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof FxOptionSensitivity) {
         FxOptionSensitivity pt = (FxOptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionSurfaceVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionSurfaceVolatilities.java
@@ -187,7 +187,9 @@ public final class BlackFxOptionSurfaceVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof FxOptionSensitivity) {
         FxOptionSensitivity pt = (FxOptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricer.java
@@ -294,6 +294,7 @@ public class BlackFxSingleBarrierOptionProductPricer {
     double todayFx = ratesProvider.fxRate(currencyPair);
     double forward = todayFx * dfBase / dfCounter;
     return FxOptionSensitivity.of(
+        volatilities.getName(),
         currencyPair,
         volatilities.relativeTime(underlyingOption.getExpiry()),
         underlyingOption.getStrike(),

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricer.java
@@ -352,6 +352,7 @@ public class BlackFxVanillaOptionProductPricer {
     CurrencyPair strikePair = underlying.getCurrencyPair();
     CurrencyAmount valueVega = presentValueVega(option, ratesProvider, volatilities);
     return FxOptionSensitivity.of(
+        volatilities.getName(),
         strikePair,
         volatilities.relativeTime(option.getExpiry()),
         option.getStrike(),

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/FxOptionSensitivity.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/FxOptionSensitivity.java
@@ -42,6 +42,11 @@ public final class FxOptionSensitivity
     implements PointSensitivity, PointSensitivityBuilder, ImmutableBean, Serializable {
 
   /**
+   * The name of the volatilities.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final FxOptionVolatilitiesName volatilitiesName;
+  /**
    * The currency pair for which the sensitivity is presented.
    */
   @PropertyDefinition(validate = "notNull")
@@ -76,6 +81,7 @@ public final class FxOptionSensitivity
   /**
    * Obtains an instance, specifying sensitivity currency.
    * 
+   * @param volatilitiesName  the name of the volatilities
    * @param currencyPair  the currency pair
    * @param expiry  the time to expiry of the option as a year fraction
    * @param strike  the strike rate
@@ -85,6 +91,7 @@ public final class FxOptionSensitivity
    * @return the point sensitivity object
    */
   public static FxOptionSensitivity of(
+      FxOptionVolatilitiesName volatilitiesName,
       CurrencyPair currencyPair,
       double expiry,
       double strike,
@@ -92,7 +99,8 @@ public final class FxOptionSensitivity
       Currency sensitivityCurrency,
       double sensitivity) {
 
-    return new FxOptionSensitivity(currencyPair, expiry, strike, forward, sensitivityCurrency, sensitivity);
+    return new FxOptionSensitivity(
+        volatilitiesName, currencyPair, expiry, strike, forward, sensitivityCurrency, sensitivity);
   }
 
   //-------------------------------------------------------------------------
@@ -101,12 +109,12 @@ public final class FxOptionSensitivity
     if (this.currency.equals(currency)) {
       return this;
     }
-    return new FxOptionSensitivity(currencyPair, expiry, strike, forward, currency, sensitivity);
+    return new FxOptionSensitivity(volatilitiesName, currencyPair, expiry, strike, forward, currency, sensitivity);
   }
 
   @Override
   public FxOptionSensitivity withSensitivity(double sensitivity) {
-    return new FxOptionSensitivity(currencyPair, expiry, strike, forward, currency, sensitivity);
+    return new FxOptionSensitivity(volatilitiesName, currencyPair, expiry, strike, forward, currency, sensitivity);
   }
 
   @Override
@@ -114,6 +122,7 @@ public final class FxOptionSensitivity
     if (other instanceof FxOptionSensitivity) {
       FxOptionSensitivity otherOption = (FxOptionSensitivity) other;
       return ComparisonChain.start()
+          .compare(volatilitiesName, otherOption.volatilitiesName)
           .compare(currencyPair.toString(), otherOption.currencyPair.toString())
           .compare(expiry, otherOption.expiry)
           .compare(strike, otherOption.strike)
@@ -133,13 +142,13 @@ public final class FxOptionSensitivity
   @Override
   public FxOptionSensitivity multipliedBy(double factor) {
     return new FxOptionSensitivity(
-        currencyPair, expiry, strike, forward, currency, sensitivity * factor);
+        volatilitiesName, currencyPair, expiry, strike, forward, currency, sensitivity * factor);
   }
 
   @Override
   public FxOptionSensitivity mapSensitivity(DoubleUnaryOperator operator) {
     return new FxOptionSensitivity(
-        currencyPair, expiry, strike, forward, currency, operator.applyAsDouble(sensitivity));
+        volatilitiesName, currencyPair, expiry, strike, forward, currency, operator.applyAsDouble(sensitivity));
   }
 
   @Override
@@ -177,15 +186,18 @@ public final class FxOptionSensitivity
   private static final long serialVersionUID = 1L;
 
   private FxOptionSensitivity(
+      FxOptionVolatilitiesName volatilitiesName,
       CurrencyPair currencyPair,
       double expiry,
       double strike,
       double forward,
       Currency currency,
       double sensitivity) {
+    JodaBeanUtils.notNull(volatilitiesName, "volatilitiesName");
     JodaBeanUtils.notNull(currencyPair, "currencyPair");
     JodaBeanUtils.notNull(expiry, "expiry");
     JodaBeanUtils.notNull(currency, "currency");
+    this.volatilitiesName = volatilitiesName;
     this.currencyPair = currencyPair;
     this.expiry = expiry;
     this.strike = strike;
@@ -207,6 +219,15 @@ public final class FxOptionSensitivity
   @Override
   public Set<String> propertyNames() {
     return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the name of the volatilities.
+   * @return the value of the property, not null
+   */
+  public FxOptionVolatilitiesName getVolatilitiesName() {
+    return volatilitiesName;
   }
 
   //-----------------------------------------------------------------------
@@ -273,7 +294,8 @@ public final class FxOptionSensitivity
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       FxOptionSensitivity other = (FxOptionSensitivity) obj;
-      return JodaBeanUtils.equal(currencyPair, other.currencyPair) &&
+      return JodaBeanUtils.equal(volatilitiesName, other.volatilitiesName) &&
+          JodaBeanUtils.equal(currencyPair, other.currencyPair) &&
           JodaBeanUtils.equal(expiry, other.expiry) &&
           JodaBeanUtils.equal(strike, other.strike) &&
           JodaBeanUtils.equal(forward, other.forward) &&
@@ -286,6 +308,7 @@ public final class FxOptionSensitivity
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(volatilitiesName);
     hash = hash * 31 + JodaBeanUtils.hashCode(currencyPair);
     hash = hash * 31 + JodaBeanUtils.hashCode(expiry);
     hash = hash * 31 + JodaBeanUtils.hashCode(strike);
@@ -297,8 +320,9 @@ public final class FxOptionSensitivity
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(224);
+    StringBuilder buf = new StringBuilder(256);
     buf.append("FxOptionSensitivity{");
+    buf.append("volatilitiesName").append('=').append(volatilitiesName).append(',').append(' ');
     buf.append("currencyPair").append('=').append(currencyPair).append(',').append(' ');
     buf.append("expiry").append('=').append(expiry).append(',').append(' ');
     buf.append("strike").append('=').append(strike).append(',').append(' ');
@@ -319,6 +343,11 @@ public final class FxOptionSensitivity
      */
     static final Meta INSTANCE = new Meta();
 
+    /**
+     * The meta-property for the {@code volatilitiesName} property.
+     */
+    private final MetaProperty<FxOptionVolatilitiesName> volatilitiesName = DirectMetaProperty.ofImmutable(
+        this, "volatilitiesName", FxOptionSensitivity.class, FxOptionVolatilitiesName.class);
     /**
      * The meta-property for the {@code currencyPair} property.
      */
@@ -354,6 +383,7 @@ public final class FxOptionSensitivity
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
+        "volatilitiesName",
         "currencyPair",
         "expiry",
         "strike",
@@ -370,6 +400,8 @@ public final class FxOptionSensitivity
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case 1005147787:  // currencyPair
           return currencyPair;
         case -1289159373:  // expiry
@@ -402,6 +434,14 @@ public final class FxOptionSensitivity
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code volatilitiesName} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<FxOptionVolatilitiesName> volatilitiesName() {
+      return volatilitiesName;
+    }
+
     /**
      * The meta-property for the {@code currencyPair} property.
      * @return the meta-property, not null
@@ -454,6 +494,8 @@ public final class FxOptionSensitivity
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
+        case 2100884654:  // volatilitiesName
+          return ((FxOptionSensitivity) bean).getVolatilitiesName();
         case 1005147787:  // currencyPair
           return ((FxOptionSensitivity) bean).getCurrencyPair();
         case -1289159373:  // expiry
@@ -487,6 +529,7 @@ public final class FxOptionSensitivity
    */
   private static final class Builder extends DirectFieldsBeanBuilder<FxOptionSensitivity> {
 
+    private FxOptionVolatilitiesName volatilitiesName;
     private CurrencyPair currencyPair;
     private double expiry;
     private double strike;
@@ -504,6 +547,8 @@ public final class FxOptionSensitivity
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case 1005147787:  // currencyPair
           return currencyPair;
         case -1289159373:  // expiry
@@ -524,6 +569,9 @@ public final class FxOptionSensitivity
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
+        case 2100884654:  // volatilitiesName
+          this.volatilitiesName = (FxOptionVolatilitiesName) newValue;
+          break;
         case 1005147787:  // currencyPair
           this.currencyPair = (CurrencyPair) newValue;
           break;
@@ -575,6 +623,7 @@ public final class FxOptionSensitivity
     @Override
     public FxOptionSensitivity build() {
       return new FxOptionSensitivity(
+          volatilitiesName,
           currencyPair,
           expiry,
           strike,
@@ -586,8 +635,9 @@ public final class FxOptionSensitivity
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(224);
+      StringBuilder buf = new StringBuilder(256);
       buf.append("FxOptionSensitivity.Builder{");
+      buf.append("volatilitiesName").append('=').append(JodaBeanUtils.toString(volatilitiesName)).append(',').append(' ');
       buf.append("currencyPair").append('=').append(JodaBeanUtils.toString(currencyPair)).append(',').append(' ');
       buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
       buf.append("strike").append('=').append(JodaBeanUtils.toString(strike)).append(',').append(' ');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/IborFutureOptionSensitivity.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/IborFutureOptionSensitivity.java
@@ -28,7 +28,6 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import com.google.common.collect.ComparisonChain;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRateProvider;
-import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.market.sensitivity.MutablePointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
@@ -43,10 +42,10 @@ public final class IborFutureOptionSensitivity
     implements PointSensitivity, PointSensitivityBuilder, ImmutableBean, Serializable {
 
   /**
-   * The index on which the underlying future fixes.
+   * The name of the volatilities.
    */
   @PropertyDefinition(validate = "notNull")
-  private final IborIndex index;
+  private final IborFutureOptionVolatilitiesName volatilitiesName;
   /**
    * The time to expiry of the option as a year fraction.
    */
@@ -80,34 +79,9 @@ public final class IborFutureOptionSensitivity
 
   //-------------------------------------------------------------------------
   /**
-   * Obtains an instance based on the index.
-   * <p>
-   * The currency is defaulted from the index.
+   * Obtains an instance.
    * 
-   * @param index  the index of the curve
-   * @param expiry  the time to expiry of the option as a year fraction
-   * @param fixingDate  the fixing date of the underlying future
-   * @param strikePrice  the strike price of the option
-   * @param futurePrice  the price of the underlying future
-   * @param sensitivity  the value of the sensitivity
-   * @return the point sensitivity object
-   */
-  public static IborFutureOptionSensitivity of(
-      IborIndex index,
-      double expiry,
-      LocalDate fixingDate,
-      double strikePrice,
-      double futurePrice,
-      double sensitivity) {
-
-    return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, index.getCurrency(), sensitivity);
-  }
-
-  /**
-   * Obtains an instance based on the index, specifying the sensitivity currency.
-   * 
-   * @param index  the index of the curve
+   * @param volatilitiesName  the name of the volatilities
    * @param expiry  the expiry date-time of the option as a year fraction
    * @param fixingDate  the fixing date of the underlying future
    * @param strikePrice  the strike price of the option
@@ -117,7 +91,7 @@ public final class IborFutureOptionSensitivity
    * @return the point sensitivity object
    */
   public static IborFutureOptionSensitivity of(
-      IborIndex index,
+      IborFutureOptionVolatilitiesName volatilitiesName,
       double expiry,
       LocalDate fixingDate,
       double strikePrice,
@@ -126,7 +100,7 @@ public final class IborFutureOptionSensitivity
       double sensitivity) {
 
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, sensitivityCurrency, sensitivity);
+        volatilitiesName, expiry, fixingDate, strikePrice, futurePrice, sensitivityCurrency, sensitivity);
   }
 
   //-------------------------------------------------------------------------
@@ -136,13 +110,13 @@ public final class IborFutureOptionSensitivity
       return this;
     }
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
+        volatilitiesName, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
   }
 
   @Override
   public IborFutureOptionSensitivity withSensitivity(double sensitivity) {
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
+        volatilitiesName, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity);
   }
 
   @Override
@@ -150,12 +124,12 @@ public final class IborFutureOptionSensitivity
     if (other instanceof IborFutureOptionSensitivity) {
       IborFutureOptionSensitivity otherOption = (IborFutureOptionSensitivity) other;
       return ComparisonChain.start()
-          .compare(index.toString(), otherOption.index.toString())
+          .compare(volatilitiesName, otherOption.volatilitiesName)
+          .compare(currency, otherOption.currency)
           .compare(expiry, otherOption.expiry)
           .compare(fixingDate, otherOption.fixingDate)
           .compare(strikePrice, otherOption.strikePrice)
           .compare(futurePrice, otherOption.futurePrice)
-          .compare(currency, otherOption.currency)
           .result();
     }
     return getClass().getSimpleName().compareTo(other.getClass().getSimpleName());
@@ -170,13 +144,13 @@ public final class IborFutureOptionSensitivity
   @Override
   public IborFutureOptionSensitivity multipliedBy(double factor) {
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity * factor);
+        volatilitiesName, expiry, fixingDate, strikePrice, futurePrice, currency, sensitivity * factor);
   }
 
   @Override
   public IborFutureOptionSensitivity mapSensitivity(DoubleUnaryOperator operator) {
     return new IborFutureOptionSensitivity(
-        index, expiry, fixingDate, strikePrice, futurePrice, currency, operator.applyAsDouble(sensitivity));
+        volatilitiesName, expiry, fixingDate, strikePrice, futurePrice, currency, operator.applyAsDouble(sensitivity));
   }
 
   @Override
@@ -214,18 +188,18 @@ public final class IborFutureOptionSensitivity
   private static final long serialVersionUID = 1L;
 
   private IborFutureOptionSensitivity(
-      IborIndex index,
+      IborFutureOptionVolatilitiesName volatilitiesName,
       double expiry,
       LocalDate fixingDate,
       double strikePrice,
       double futurePrice,
       Currency currency,
       double sensitivity) {
-    JodaBeanUtils.notNull(index, "index");
+    JodaBeanUtils.notNull(volatilitiesName, "volatilitiesName");
     JodaBeanUtils.notNull(expiry, "expiry");
     JodaBeanUtils.notNull(fixingDate, "fixingDate");
     JodaBeanUtils.notNull(currency, "currency");
-    this.index = index;
+    this.volatilitiesName = volatilitiesName;
     this.expiry = expiry;
     this.fixingDate = fixingDate;
     this.strikePrice = strikePrice;
@@ -251,11 +225,11 @@ public final class IborFutureOptionSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the index on which the underlying future fixes.
+   * Gets the name of the volatilities.
    * @return the value of the property, not null
    */
-  public IborIndex getIndex() {
-    return index;
+  public IborFutureOptionVolatilitiesName getVolatilitiesName() {
+    return volatilitiesName;
   }
 
   //-----------------------------------------------------------------------
@@ -322,7 +296,7 @@ public final class IborFutureOptionSensitivity
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       IborFutureOptionSensitivity other = (IborFutureOptionSensitivity) obj;
-      return JodaBeanUtils.equal(index, other.index) &&
+      return JodaBeanUtils.equal(volatilitiesName, other.volatilitiesName) &&
           JodaBeanUtils.equal(expiry, other.expiry) &&
           JodaBeanUtils.equal(fixingDate, other.fixingDate) &&
           JodaBeanUtils.equal(strikePrice, other.strikePrice) &&
@@ -336,7 +310,7 @@ public final class IborFutureOptionSensitivity
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
-    hash = hash * 31 + JodaBeanUtils.hashCode(index);
+    hash = hash * 31 + JodaBeanUtils.hashCode(volatilitiesName);
     hash = hash * 31 + JodaBeanUtils.hashCode(expiry);
     hash = hash * 31 + JodaBeanUtils.hashCode(fixingDate);
     hash = hash * 31 + JodaBeanUtils.hashCode(strikePrice);
@@ -350,7 +324,7 @@ public final class IborFutureOptionSensitivity
   public String toString() {
     StringBuilder buf = new StringBuilder(256);
     buf.append("IborFutureOptionSensitivity{");
-    buf.append("index").append('=').append(index).append(',').append(' ');
+    buf.append("volatilitiesName").append('=').append(volatilitiesName).append(',').append(' ');
     buf.append("expiry").append('=').append(expiry).append(',').append(' ');
     buf.append("fixingDate").append('=').append(fixingDate).append(',').append(' ');
     buf.append("strikePrice").append('=').append(strikePrice).append(',').append(' ');
@@ -372,10 +346,10 @@ public final class IborFutureOptionSensitivity
     static final Meta INSTANCE = new Meta();
 
     /**
-     * The meta-property for the {@code index} property.
+     * The meta-property for the {@code volatilitiesName} property.
      */
-    private final MetaProperty<IborIndex> index = DirectMetaProperty.ofImmutable(
-        this, "index", IborFutureOptionSensitivity.class, IborIndex.class);
+    private final MetaProperty<IborFutureOptionVolatilitiesName> volatilitiesName = DirectMetaProperty.ofImmutable(
+        this, "volatilitiesName", IborFutureOptionSensitivity.class, IborFutureOptionVolatilitiesName.class);
     /**
      * The meta-property for the {@code expiry} property.
      */
@@ -411,7 +385,7 @@ public final class IborFutureOptionSensitivity
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "index",
+        "volatilitiesName",
         "expiry",
         "fixingDate",
         "strikePrice",
@@ -428,8 +402,8 @@ public final class IborFutureOptionSensitivity
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          return index;
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case -1289159373:  // expiry
           return expiry;
         case 1255202043:  // fixingDate
@@ -463,11 +437,11 @@ public final class IborFutureOptionSensitivity
 
     //-----------------------------------------------------------------------
     /**
-     * The meta-property for the {@code index} property.
+     * The meta-property for the {@code volatilitiesName} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<IborIndex> index() {
-      return index;
+    public MetaProperty<IborFutureOptionVolatilitiesName> volatilitiesName() {
+      return volatilitiesName;
     }
 
     /**
@@ -522,8 +496,8 @@ public final class IborFutureOptionSensitivity
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          return ((IborFutureOptionSensitivity) bean).getIndex();
+        case 2100884654:  // volatilitiesName
+          return ((IborFutureOptionSensitivity) bean).getVolatilitiesName();
         case -1289159373:  // expiry
           return ((IborFutureOptionSensitivity) bean).getExpiry();
         case 1255202043:  // fixingDate
@@ -557,7 +531,7 @@ public final class IborFutureOptionSensitivity
    */
   private static final class Builder extends DirectFieldsBeanBuilder<IborFutureOptionSensitivity> {
 
-    private IborIndex index;
+    private IborFutureOptionVolatilitiesName volatilitiesName;
     private double expiry;
     private LocalDate fixingDate;
     private double strikePrice;
@@ -575,8 +549,8 @@ public final class IborFutureOptionSensitivity
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          return index;
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case -1289159373:  // expiry
           return expiry;
         case 1255202043:  // fixingDate
@@ -597,8 +571,8 @@ public final class IborFutureOptionSensitivity
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
-        case 100346066:  // index
-          this.index = (IborIndex) newValue;
+        case 2100884654:  // volatilitiesName
+          this.volatilitiesName = (IborFutureOptionVolatilitiesName) newValue;
           break;
         case -1289159373:  // expiry
           this.expiry = (Double) newValue;
@@ -651,7 +625,7 @@ public final class IborFutureOptionSensitivity
     @Override
     public IborFutureOptionSensitivity build() {
       return new IborFutureOptionSensitivity(
-          index,
+          volatilitiesName,
           expiry,
           fixingDate,
           strikePrice,
@@ -665,7 +639,7 @@ public final class IborFutureOptionSensitivity
     public String toString() {
       StringBuilder buf = new StringBuilder(256);
       buf.append("IborFutureOptionSensitivity.Builder{");
-      buf.append("index").append('=').append(JodaBeanUtils.toString(index)).append(',').append(' ');
+      buf.append("volatilitiesName").append('=').append(JodaBeanUtils.toString(volatilitiesName)).append(',').append(' ');
       buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
       buf.append("fixingDate").append('=').append(JodaBeanUtils.toString(fixingDate)).append(',').append(' ');
       buf.append("strikePrice").append('=').append(JodaBeanUtils.toString(strikePrice)).append(',').append(' ');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilities.java
@@ -192,15 +192,15 @@ public final class NormalIborFutureOptionExpirySimpleMoneynessVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof IborFutureOptionSensitivity) {
         IborFutureOptionSensitivity pt = (IborFutureOptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(IborFutureOptionSensitivity point) {
-    ArgChecker.isTrue(point.getIndex().equals(index),
-        "Index of volatilities must be the same as index of sensitivity");
     double simpleMoneyness = moneynessOnPrice ?
         point.getStrikePrice() - point.getFuturePrice() : point.getFuturePrice() - point.getStrikePrice();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(point.getExpiry(), simpleMoneyness);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionMarginedProductPricer.java
@@ -308,7 +308,7 @@ public class NormalIborFutureOptionMarginedProductPricer {
 
     double vega = NormalFormulaRepository.vega(futurePrice, strike, timeToExpiry, volatility, futureOption.getPutCall());
     return IborFutureOptionSensitivity.of(
-        future.getIndex(), timeToExpiry, future.getLastTradeDate(), strike, futurePrice, vega);
+        volatilities.getName(), timeToExpiry, future.getLastTradeDate(), strike, futurePrice, future.getCurrency(), vega);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
@@ -185,15 +185,15 @@ public final class BlackSwaptionExpiryTenorVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof SwaptionSensitivity) {
         SwaptionSensitivity pt = (SwaptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(SwaptionSensitivity point) {
-    ArgChecker.isTrue(point.getConvention().equals(convention),
-        "Swap convention of provider must be the same as swap convention of swaption sensitivity");
     double expiry = point.getExpiry();
     double tenor = point.getTenor();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, tenor);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilities.java
@@ -187,15 +187,15 @@ public final class NormalSwaptionExpirySimpleMoneynessVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof SwaptionSensitivity) {
         SwaptionSensitivity pt = (SwaptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(SwaptionSensitivity point) {
-    ArgChecker.isTrue(point.getConvention().equals(convention),
-        "Swap convention of provider must be the same as swap convention of swaption sensitivity");
     double expiry = point.getExpiry();
     double moneyness = point.getStrike() - point.getForward();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, moneyness);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilities.java
@@ -185,15 +185,15 @@ public final class NormalSwaptionExpiryStrikeVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof SwaptionSensitivity) {
         SwaptionSensitivity pt = (SwaptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(SwaptionSensitivity point) {
-    ArgChecker.isTrue(point.getConvention().equals(convention),
-        "Swap convention of provider must be the same as swap convention of swaption sensitivity");
     double expiry = point.getExpiry();
     double strike = point.getStrike();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, strike);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilities.java
@@ -185,15 +185,15 @@ public final class NormalSwaptionExpiryTenorVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof SwaptionSensitivity) {
         SwaptionSensitivity pt = (SwaptionSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
   }
 
   private CurrencyParameterSensitivity parameterSensitivity(SwaptionSensitivity point) {
-    ArgChecker.isTrue(point.getConvention().equals(convention),
-        "Swap convention of provider must be the same as swap convention of swaption sensitivity");
     double expiry = point.getExpiry();
     double tenor = point.getTenor();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, tenor);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrParametersSwaptionVolatilities.java
@@ -247,7 +247,9 @@ public final class SabrParametersSwaptionVolatilities
     for (PointSensitivity point : pointSensitivities.getSensitivities()) {
       if (point instanceof SwaptionSabrSensitivity) {
         SwaptionSabrSensitivity pt = (SwaptionSabrSensitivity) point;
-        sens = sens.combinedWith(parameterSensitivity(pt));
+        if (pt.getVolatilitiesName().equals(getName())) {
+          sens = sens.combinedWith(parameterSensitivity(pt));
+        }
       }
     }
     return sens;
@@ -255,8 +257,6 @@ public final class SabrParametersSwaptionVolatilities
 
   // convert a single point sensitivity
   private CurrencyParameterSensitivity parameterSensitivity(SwaptionSabrSensitivity point) {
-    ArgChecker.isTrue(point.getConvention().equals(getConvention()),
-        "Swap convention of provider must be the same as swap convention of swaption sensitivity");
     Surface surface = getSurface(point.getSensitivityType());
     double expiry = point.getExpiry();
     UnitParameterSensitivity unitSens = surface.zValueParameterSensitivity(expiry, point.getTenor());

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
@@ -23,7 +23,6 @@ import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.Swap;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 import com.opengamma.strata.product.swaption.CashSwaptionSettlement;
 import com.opengamma.strata.product.swaption.ResolvedSwaption;
 
@@ -141,13 +140,13 @@ public class SabrSwaptionCashParYieldProductPricer
     double vega = numeraire * swaption.getLongShort().sign() *
         BlackFormulaRepository.vega(forward + shift, strike + shift, expiry, volatility);
     // sensitivities
-    FixedIborSwapConvention conv = swaptionVolatilities.getConvention();
     Currency ccy = fixedLeg.getCurrency();
+    SwaptionVolatilitiesName name = swaptionVolatilities.getName();
     return PointSensitivityBuilder.of(
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, ALPHA, ccy, vega * derivative.get(2)),
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, BETA, ccy, vega * derivative.get(3)),
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, RHO, ccy, vega * derivative.get(4)),
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, NU, ccy, vega * derivative.get(5)));
+        SwaptionSabrSensitivity.of(name, expiry, tenor, ALPHA, ccy, vega * derivative.get(2)),
+        SwaptionSabrSensitivity.of(name, expiry, tenor, BETA, ccy, vega * derivative.get(3)),
+        SwaptionSabrSensitivity.of(name, expiry, tenor, RHO, ccy, vega * derivative.get(4)),
+        SwaptionSabrSensitivity.of(name, expiry, tenor, NU, ccy, vega * derivative.get(5)));
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
@@ -22,7 +22,6 @@ import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.Swap;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 import com.opengamma.strata.product.swaption.ResolvedSwaption;
 
 /**
@@ -137,13 +136,13 @@ public class SabrSwaptionPhysicalProductPricer
     double vega = Math.abs(pvbp) * BlackFormulaRepository.vega(forward + shift, strike + shift, expiry, volatility)
         * swaption.getLongShort().sign();
     // sensitivities
-    FixedIborSwapConvention conv = swaptionVolatilities.getConvention();
     Currency ccy = fixedLeg.getCurrency();
+    SwaptionVolatilitiesName name = swaptionVolatilities.getName();
     return PointSensitivityBuilder.of(
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, ALPHA, ccy, vega * derivative.get(2)),
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, BETA, ccy, vega * derivative.get(3)),
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, RHO, ccy, vega * derivative.get(4)),
-        SwaptionSabrSensitivity.of(conv, expiry, tenor, NU, ccy, vega * derivative.get(5)));
+        SwaptionSabrSensitivity.of(name, expiry, tenor, ALPHA, ccy, vega * derivative.get(2)),
+        SwaptionSabrSensitivity.of(name, expiry, tenor, BETA, ccy, vega * derivative.get(3)),
+        SwaptionSabrSensitivity.of(name, expiry, tenor, RHO, ccy, vega * derivative.get(4)),
+        SwaptionSabrSensitivity.of(name, expiry, tenor, NU, ccy, vega * derivative.get(5)));
   }
 
 }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionSabrSensitivity.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SwaptionSabrSensitivity.java
@@ -31,7 +31,6 @@ import com.opengamma.strata.market.model.SabrParameterType;
 import com.opengamma.strata.market.sensitivity.MutablePointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivity;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 
 /**
  * Sensitivity of a swaption to SABR model parameters.
@@ -43,10 +42,10 @@ public final class SwaptionSabrSensitivity
     implements PointSensitivity, PointSensitivityBuilder, ImmutableBean, Serializable {
 
   /**
-  * The convention of the swap for which the data is valid.
-  */
+   * The name of the volatilities.
+   */
   @PropertyDefinition(validate = "notNull")
-  private final FixedIborSwapConvention convention;
+  private final SwaptionVolatilitiesName volatilitiesName;
   /**
    * The time to expiry of the option as a year fraction.
    */
@@ -77,7 +76,7 @@ public final class SwaptionSabrSensitivity
   /**
    * Obtains an instance from the specified elements.
    * 
-   * @param convention  the convention of the swap for which the data is valid
+   * @param volatilitiesName  the name of the volatilities
    * @param expiry  the time to expiry of the option as a year fraction
    * @param tenor  the underlying swap tenor
    * @param sensitivityType  the type of the sensitivity
@@ -86,7 +85,7 @@ public final class SwaptionSabrSensitivity
    * @return the sensitivity object
    */
   public static SwaptionSabrSensitivity of(
-      FixedIborSwapConvention convention,
+      SwaptionVolatilitiesName volatilitiesName,
       double expiry,
       double tenor,
       SabrParameterType sensitivityType,
@@ -94,7 +93,7 @@ public final class SwaptionSabrSensitivity
       double sensitivity) {
 
     return new SwaptionSabrSensitivity(
-        convention,
+        volatilitiesName,
         expiry,
         tenor,
         sensitivityType,
@@ -108,12 +107,12 @@ public final class SwaptionSabrSensitivity
     if (this.currency.equals(currency)) {
       return this;
     }
-    return new SwaptionSabrSensitivity(convention, expiry, tenor, sensitivityType, currency, sensitivity);
+    return new SwaptionSabrSensitivity(volatilitiesName, expiry, tenor, sensitivityType, currency, sensitivity);
   }
 
   @Override
   public SwaptionSabrSensitivity withSensitivity(double sensitivity) {
-    return new SwaptionSabrSensitivity(convention, expiry, tenor, sensitivityType, currency, sensitivity);
+    return new SwaptionSabrSensitivity(volatilitiesName, expiry, tenor, sensitivityType, currency, sensitivity);
   }
 
   @Override
@@ -121,11 +120,11 @@ public final class SwaptionSabrSensitivity
     if (other instanceof SwaptionSabrSensitivity) {
       SwaptionSabrSensitivity otherSwpt = (SwaptionSabrSensitivity) other;
       return ComparisonChain.start()
+          .compare(volatilitiesName, otherSwpt.volatilitiesName)
           .compare(currency, otherSwpt.currency)
           .compare(expiry, otherSwpt.expiry)
           .compare(tenor, otherSwpt.tenor)
           .compare(sensitivityType, otherSwpt.sensitivityType)
-          .compare(convention.toString(), otherSwpt.convention.toString())
           .result();
     }
     return getClass().getSimpleName().compareTo(other.getClass().getSimpleName());
@@ -139,13 +138,13 @@ public final class SwaptionSabrSensitivity
   //-------------------------------------------------------------------------
   @Override
   public SwaptionSabrSensitivity multipliedBy(double factor) {
-    return new SwaptionSabrSensitivity(convention, expiry, tenor, sensitivityType, currency, sensitivity * factor);
+    return new SwaptionSabrSensitivity(volatilitiesName, expiry, tenor, sensitivityType, currency, sensitivity * factor);
   }
 
   @Override
   public SwaptionSabrSensitivity mapSensitivity(DoubleUnaryOperator operator) {
     return new SwaptionSabrSensitivity(
-        convention, expiry, tenor, sensitivityType, currency, operator.applyAsDouble(sensitivity));
+        volatilitiesName, expiry, tenor, sensitivityType, currency, operator.applyAsDouble(sensitivity));
   }
 
   @Override
@@ -183,15 +182,15 @@ public final class SwaptionSabrSensitivity
   private static final long serialVersionUID = 1L;
 
   private SwaptionSabrSensitivity(
-      FixedIborSwapConvention convention,
+      SwaptionVolatilitiesName volatilitiesName,
       double expiry,
       double tenor,
       SabrParameterType sensitivityType,
       Currency currency,
       double sensitivity) {
-    JodaBeanUtils.notNull(convention, "convention");
+    JodaBeanUtils.notNull(volatilitiesName, "volatilitiesName");
     JodaBeanUtils.notNull(expiry, "expiry");
-    this.convention = convention;
+    this.volatilitiesName = volatilitiesName;
     this.expiry = expiry;
     this.tenor = tenor;
     this.sensitivityType = sensitivityType;
@@ -216,11 +215,11 @@ public final class SwaptionSabrSensitivity
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the convention of the swap for which the data is valid.
+   * Gets the name of the volatilities.
    * @return the value of the property, not null
    */
-  public FixedIborSwapConvention getConvention() {
-    return convention;
+  public SwaptionVolatilitiesName getVolatilitiesName() {
+    return volatilitiesName;
   }
 
   //-----------------------------------------------------------------------
@@ -278,7 +277,7 @@ public final class SwaptionSabrSensitivity
     }
     if (obj != null && obj.getClass() == this.getClass()) {
       SwaptionSabrSensitivity other = (SwaptionSabrSensitivity) obj;
-      return JodaBeanUtils.equal(convention, other.convention) &&
+      return JodaBeanUtils.equal(volatilitiesName, other.volatilitiesName) &&
           JodaBeanUtils.equal(expiry, other.expiry) &&
           JodaBeanUtils.equal(tenor, other.tenor) &&
           JodaBeanUtils.equal(sensitivityType, other.sensitivityType) &&
@@ -291,7 +290,7 @@ public final class SwaptionSabrSensitivity
   @Override
   public int hashCode() {
     int hash = getClass().hashCode();
-    hash = hash * 31 + JodaBeanUtils.hashCode(convention);
+    hash = hash * 31 + JodaBeanUtils.hashCode(volatilitiesName);
     hash = hash * 31 + JodaBeanUtils.hashCode(expiry);
     hash = hash * 31 + JodaBeanUtils.hashCode(tenor);
     hash = hash * 31 + JodaBeanUtils.hashCode(sensitivityType);
@@ -304,7 +303,7 @@ public final class SwaptionSabrSensitivity
   public String toString() {
     StringBuilder buf = new StringBuilder(224);
     buf.append("SwaptionSabrSensitivity{");
-    buf.append("convention").append('=').append(convention).append(',').append(' ');
+    buf.append("volatilitiesName").append('=').append(volatilitiesName).append(',').append(' ');
     buf.append("expiry").append('=').append(expiry).append(',').append(' ');
     buf.append("tenor").append('=').append(tenor).append(',').append(' ');
     buf.append("sensitivityType").append('=').append(sensitivityType).append(',').append(' ');
@@ -325,10 +324,10 @@ public final class SwaptionSabrSensitivity
     static final Meta INSTANCE = new Meta();
 
     /**
-     * The meta-property for the {@code convention} property.
+     * The meta-property for the {@code volatilitiesName} property.
      */
-    private final MetaProperty<FixedIborSwapConvention> convention = DirectMetaProperty.ofImmutable(
-        this, "convention", SwaptionSabrSensitivity.class, FixedIborSwapConvention.class);
+    private final MetaProperty<SwaptionVolatilitiesName> volatilitiesName = DirectMetaProperty.ofImmutable(
+        this, "volatilitiesName", SwaptionSabrSensitivity.class, SwaptionVolatilitiesName.class);
     /**
      * The meta-property for the {@code expiry} property.
      */
@@ -359,7 +358,7 @@ public final class SwaptionSabrSensitivity
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
-        "convention",
+        "volatilitiesName",
         "expiry",
         "tenor",
         "sensitivityType",
@@ -375,8 +374,8 @@ public final class SwaptionSabrSensitivity
     @Override
     protected MetaProperty<?> metaPropertyGet(String propertyName) {
       switch (propertyName.hashCode()) {
-        case 2039569265:  // convention
-          return convention;
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case -1289159373:  // expiry
           return expiry;
         case 110246592:  // tenor
@@ -408,11 +407,11 @@ public final class SwaptionSabrSensitivity
 
     //-----------------------------------------------------------------------
     /**
-     * The meta-property for the {@code convention} property.
+     * The meta-property for the {@code volatilitiesName} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<FixedIborSwapConvention> convention() {
-      return convention;
+    public MetaProperty<SwaptionVolatilitiesName> volatilitiesName() {
+      return volatilitiesName;
     }
 
     /**
@@ -459,8 +458,8 @@ public final class SwaptionSabrSensitivity
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
       switch (propertyName.hashCode()) {
-        case 2039569265:  // convention
-          return ((SwaptionSabrSensitivity) bean).getConvention();
+        case 2100884654:  // volatilitiesName
+          return ((SwaptionSabrSensitivity) bean).getVolatilitiesName();
         case -1289159373:  // expiry
           return ((SwaptionSabrSensitivity) bean).getExpiry();
         case 110246592:  // tenor
@@ -492,7 +491,7 @@ public final class SwaptionSabrSensitivity
    */
   private static final class Builder extends DirectFieldsBeanBuilder<SwaptionSabrSensitivity> {
 
-    private FixedIborSwapConvention convention;
+    private SwaptionVolatilitiesName volatilitiesName;
     private double expiry;
     private double tenor;
     private SabrParameterType sensitivityType;
@@ -509,8 +508,8 @@ public final class SwaptionSabrSensitivity
     @Override
     public Object get(String propertyName) {
       switch (propertyName.hashCode()) {
-        case 2039569265:  // convention
-          return convention;
+        case 2100884654:  // volatilitiesName
+          return volatilitiesName;
         case -1289159373:  // expiry
           return expiry;
         case 110246592:  // tenor
@@ -529,8 +528,8 @@ public final class SwaptionSabrSensitivity
     @Override
     public Builder set(String propertyName, Object newValue) {
       switch (propertyName.hashCode()) {
-        case 2039569265:  // convention
-          this.convention = (FixedIborSwapConvention) newValue;
+        case 2100884654:  // volatilitiesName
+          this.volatilitiesName = (SwaptionVolatilitiesName) newValue;
           break;
         case -1289159373:  // expiry
           this.expiry = (Double) newValue;
@@ -580,7 +579,7 @@ public final class SwaptionSabrSensitivity
     @Override
     public SwaptionSabrSensitivity build() {
       return new SwaptionSabrSensitivity(
-          convention,
+          volatilitiesName,
           expiry,
           tenor,
           sensitivityType,
@@ -593,7 +592,7 @@ public final class SwaptionSabrSensitivity
     public String toString() {
       StringBuilder buf = new StringBuilder(224);
       buf.append("SwaptionSabrSensitivity.Builder{");
-      buf.append("convention").append('=').append(JodaBeanUtils.toString(convention)).append(',').append(' ');
+      buf.append("volatilitiesName").append('=').append(JodaBeanUtils.toString(volatilitiesName)).append(',').append(' ');
       buf.append("expiry").append('=').append(JodaBeanUtils.toString(expiry)).append(',').append(' ');
       buf.append("tenor").append('=').append(JodaBeanUtils.toString(tenor)).append(',').append(' ');
       buf.append("sensitivityType").append('=').append(JodaBeanUtils.toString(sensitivityType)).append(',').append(' ');

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -20,12 +20,12 @@ import com.opengamma.strata.product.common.PutCall;
 import com.opengamma.strata.product.common.SettlementType;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 import com.opengamma.strata.product.rate.RateComputation;
-import com.opengamma.strata.product.swap.SwapPaymentPeriod;
 import com.opengamma.strata.product.swap.RatePaymentPeriod;
 import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.Swap;
 import com.opengamma.strata.product.swap.SwapLegType;
+import com.opengamma.strata.product.swap.SwapPaymentPeriod;
 import com.opengamma.strata.product.swaption.CashSwaptionSettlement;
 import com.opengamma.strata.product.swaption.CashSwaptionSettlementMethod;
 import com.opengamma.strata.product.swaption.ResolvedSwaption;
@@ -329,7 +329,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     double strike = calculateStrike(fixedLeg);
     if (expiry < 0d) { // Option has expired already
       return SwaptionSensitivity.of(
-          swaptionVolatilities.getConvention(), expiry, tenor, strike, 0d, fixedLeg.getCurrency(), 0d);
+          swaptionVolatilities.getName(), expiry, tenor, strike, 0d, fixedLeg.getCurrency(), 0d);
     }
     double forward = getSwapPricer().parRate(underlying, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
@@ -337,7 +337,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     PutCall putCall = PutCall.ofPut(fixedLeg.getPayReceive().isReceive());
     double vega = numeraire * swaptionVolatilities.priceVega(expiry, tenor, putCall, strike, forward, volatility);
     return SwaptionSensitivity.of(
-        swaptionVolatilities.getConvention(),
+        swaptionVolatilities.getName(),
         expiry,
         tenor,
         strike,

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -327,7 +327,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     if (expiry < 0d) { // Option has expired already
       return SwaptionSensitivity.of(
-          swaptionVolatilities.getConvention(), expiry, tenor, strike, 0d, fixedLeg.getCurrency(), 0d);
+          swaptionVolatilities.getName(), expiry, tenor, strike, 0d, fixedLeg.getCurrency(), 0d);
     }
     double forward = getSwapPricer().parRate(underlying, ratesProvider);
     double numeraire = Math.abs(pvbp);
@@ -335,7 +335,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     PutCall putCall = PutCall.ofPut(fixedLeg.getPayReceive().isReceive());
     double vega = numeraire * swaptionVolatilities.priceVega(expiry, tenor, putCall, strike, forward, volatility);
     return SwaptionSensitivity.of(
-        swaptionVolatilities.getConvention(),
+        swaptionVolatilities.getName(),
         expiry,
         tenor,
         strike,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilitiesTest.java
@@ -139,7 +139,7 @@ public class BlackIborCapletFloorletExpiryStrikeVolatilitiesTest {
       for (int k = 0; k < NB_TEST; k++) {
         double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
         IborCapletFloorletSensitivity point = IborCapletFloorletSensitivity.of(
-            GBP_LIBOR_3M, expiryTime, TEST_STRIKE[k], TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
+            VOLS.getName(), expiryTime, TEST_STRIKE[k], TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
         double[] sensFd = new double[nData];
         for (int j = 0; j < nData; j++) {
           DoubleArray volDataUp = VOL.subArray(0, nData).with(j, VOL.get(j) + eps);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/IborCapletFloorletSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/IborCapletFloorletSensitivityTest.java
@@ -7,8 +7,6 @@ package com.opengamma.strata.pricer.capfloor;
 
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
-import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
-import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -34,22 +32,13 @@ public class IborCapletFloorletSensitivityTest {
   private static final double FORWARD = 0.015d;
   private static final double STRIKE = 0.001d;
   private static final double SENSITIVITY = 0.54d;
+  private static final IborCapletFloorletVolatilitiesName NAME = IborCapletFloorletVolatilitiesName.of("Test");
+  private static final IborCapletFloorletVolatilitiesName NAME2 = IborCapletFloorletVolatilitiesName.of("Test2");
 
-  public void test_of_noCurrency() {
+  public void test_of() {
     IborCapletFloorletSensitivity test =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, SENSITIVITY);
-    assertEquals(test.getIndex(), GBP_LIBOR_3M);
-    assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiry(), EXPIRY);
-    assertEquals(test.getStrike(), STRIKE);
-    assertEquals(test.getForward(), FORWARD);
-    assertEquals(test.getSensitivity(), SENSITIVITY);
-  }
-
-  public void test_of_withCurrency() {
-    IborCapletFloorletSensitivity test =
-        IborCapletFloorletSensitivity.of(USD_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
-    assertEquals(test.getIndex(), USD_LIBOR_3M);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+    assertEquals(test.getVolatilitiesName(), NAME);
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getExpiry(), EXPIRY);
     assertEquals(test.getStrike(), STRIKE);
@@ -60,10 +49,9 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_withCurrency() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, SENSITIVITY);
-    assertSame(base.withCurrency(GBP), base);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity expected =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, USD, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, USD, SENSITIVITY);
     IborCapletFloorletSensitivity test = base.withCurrency(USD);
     assertEquals(test, expected);
   }
@@ -71,10 +59,10 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_withSensitivity() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(USD_LIBOR_3M, EXPIRY, STRIKE, FORWARD, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     double sensi = 23.5;
     IborCapletFloorletSensitivity expected =
-        IborCapletFloorletSensitivity.of(USD_LIBOR_3M, EXPIRY, STRIKE, FORWARD, sensi);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, sensi);
     IborCapletFloorletSensitivity test = base.withSensitivity(sensi);
     assertEquals(test, expected);
   }
@@ -82,19 +70,19 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_compareKey() {
     IborCapletFloorletSensitivity a1 =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity a2 =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity b =
-        IborCapletFloorletSensitivity.of(USD_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME2, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity c =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY + 1, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY + 1, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity d =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, 0.009, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, 0.009, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity e =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, 0.005, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, 0.005, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity f =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, USD, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, USD, SENSITIVITY);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, 2d, 32d);
     assertEquals(a1.compareKey(a2), 0);
     assertEquals(a1.compareKey(b) < 0, true);
@@ -114,12 +102,12 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_convertedTo() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     double rate = 1.5d;
     FxMatrix matrix = FxMatrix.of(CurrencyPair.of(GBP, USD), rate);
     IborCapletFloorletSensitivity test1 = base.convertedTo(USD, matrix);
     IborCapletFloorletSensitivity expected =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, USD, SENSITIVITY * rate);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, USD, SENSITIVITY * rate);
     assertEquals(test1, expected);
     IborCapletFloorletSensitivity test2 = base.convertedTo(GBP, matrix);
     assertEquals(test2, base);
@@ -128,10 +116,10 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     double factor = 3.5d;
     IborCapletFloorletSensitivity expected =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY * factor);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY * factor);
     IborCapletFloorletSensitivity test = base.multipliedBy(3.5d);
     assertEquals(test, expected);
   }
@@ -139,9 +127,9 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_mapSensitivity() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity expected =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, 1d / SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, 1d / SENSITIVITY);
     IborCapletFloorletSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
   }
@@ -149,7 +137,7 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_normalize() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity test = base.normalize();
     assertSame(test, base);
   }
@@ -157,7 +145,7 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_buildInto() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
     assertSame(test, combo);
@@ -167,7 +155,7 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_build() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
   }
@@ -175,7 +163,7 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_cloned() {
     IborCapletFloorletSensitivity base =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     IborCapletFloorletSensitivity test = base.cloned();
     assertSame(test, base);
   }
@@ -183,16 +171,16 @@ public class IborCapletFloorletSensitivityTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     IborCapletFloorletSensitivity test1 =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     coverImmutableBean(test1);
     IborCapletFloorletSensitivity test2 =
-        IborCapletFloorletSensitivity.of(USD_LIBOR_3M, EXPIRY + 2d, 0.98, 0.99, 32d);
+        IborCapletFloorletSensitivity.of(NAME2, EXPIRY + 2d, 0.98, 0.99, USD, 32d);
     coverBeanEquals(test1, test2);
   }
 
   public void test_serialization() {
     IborCapletFloorletSensitivity test =
-        IborCapletFloorletSensitivity.of(GBP_LIBOR_3M, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
+        IborCapletFloorletSensitivity.of(NAME, EXPIRY, STRIKE, FORWARD, GBP, SENSITIVITY);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilitiesTest.java
@@ -42,6 +42,7 @@ import com.opengamma.strata.product.common.PutCall;
 @Test
 public class NormalIborCapletFloorletExpiryStrikeVolatilitiesTest {
 
+  private static final String NAME = "CAP_VOL";
   private static final SurfaceInterpolator INTERPOLATOR_2D = GridSurfaceInterpolator.of(LINEAR, LINEAR);
   private static final DoubleArray TIME =
       DoubleArray.of(0.25, 0.25, 0.25, 0.25, 0.5, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0, 1.0);
@@ -59,7 +60,7 @@ public class NormalIborCapletFloorletExpiryStrikeVolatilitiesTest {
           GenericVolatilitySurfaceYearFractionParameterMetadata.of(TIME.get(i), SimpleStrike.of(STRIKE.get(i)));
       list.add(parameterMetadata);
     }
-    METADATA = Surfaces.normalVolatilityByExpiryStrike("CAP_VOL", ACT_365F).withParameterMetadata(list);
+    METADATA = Surfaces.normalVolatilityByExpiryStrike(NAME, ACT_365F).withParameterMetadata(list);
   }
   private static final InterpolatedNodalSurface SURFACE =
       InterpolatedNodalSurface.of(METADATA, TIME, STRIKE, VOL, INTERPOLATOR_2D);
@@ -137,7 +138,7 @@ public class NormalIborCapletFloorletExpiryStrikeVolatilitiesTest {
       for (int k = 0; k < NB_TEST; k++) {
         double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
         IborCapletFloorletSensitivity point = IborCapletFloorletSensitivity.of(
-            GBP_LIBOR_3M, expiryTime, TEST_STRIKE[k], TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
+            IborCapletFloorletVolatilitiesName.of(NAME), expiryTime, TEST_STRIKE[k], TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
         CurrencyParameterSensitivity sensActual = VOLS.parameterSensitivity(point).getSensitivities().get(0);
         DoubleArray computed = sensActual.getSensitivity();
         for (int j = 0; j < nData; ++j) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxSingleBarrierOptionProductPricerTest.java
@@ -58,15 +58,15 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5(VAL_DATETIME);
   private static final ImmutableRatesProvider RATE_PROVIDER =
       RatesProviderFxDataSets.createProviderEurUsdActActIsda(VAL_DATE);
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER_FLAT =
+  private static final BlackFxOptionSmileVolatilities VOLS_FLAT =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5Flat(VAL_DATETIME);
   // providers - valuation at expiry
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER_EXPIRY =
+  private static final BlackFxOptionSmileVolatilities VOLS_EXPIRY =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5(EXPIRY_DATETIME);
   private static final ImmutableRatesProvider RATE_PROVIDER_EXPIRY =
       RatesProviderFxDataSets.createProviderEurUsdActActIsda(EXPIRY_DATE);
   // provider - valuation after expiry
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER_AFTER =
+  private static final BlackFxOptionSmileVolatilities VOLS_AFTER =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5(EXPIRY_DATETIME.plusDays(1));
   private static final ImmutableRatesProvider RATE_PROVIDER_AFTER =
       RatesProviderFxDataSets.createProviderEurUsdActActIsda(EXPIRY_DATE.plusDays(1));
@@ -181,12 +181,12 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_price_presentValue_atExpiry() {
-    double computedPriceCall = PRICER.price(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    double computedPriceCallZero = PRICER.price(CALL_UKO, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    double computedPricePut = PRICER.price(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvCall = PRICER.presentValue(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvCallZero = PRICER.presentValue(CALL_UKO, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvPut = PRICER.presentValue(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+    double computedPriceCall = PRICER.price(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    double computedPriceCallZero = PRICER.price(CALL_UKO, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    double computedPricePut = PRICER.price(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvCall = PRICER.presentValue(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvCallZero = PRICER.presentValue(CALL_UKO, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvPut = PRICER.presentValue(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     double expectedPriceCall = REBATE_AMOUNT / NOTIONAL;
     double expectedPricePut = STRIKE_RATE - SPOT;
     assertEquals(computedPriceCall, expectedPriceCall, TOL);
@@ -198,10 +198,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_price_presentValue_afterExpiry() {
-    double computedPriceCall = PRICER.price(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    double computedPricePut = PRICER.price(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvCall = PRICER.presentValue(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvPut = PRICER.presentValue(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+    double computedPriceCall = PRICER.price(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    double computedPricePut = PRICER.price(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvCall = PRICER.presentValue(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvPut = PRICER.presentValue(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
     assertEquals(computedPriceCall, 0d, TOL);
     assertEquals(computedPricePut, 0d, TOL);
     assertEquals(computedPvCall.getAmount(), 0d, TOL);
@@ -348,17 +348,17 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
 
   public void test_presentValueSensitivity_atExpiry() {
     for (ResolvedFxSingleBarrierOption option : OPTION_ALL) {
-      PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyStrike(option, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+      PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyStrike(option, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
       CurrencyParameterSensitivities computed = RATE_PROVIDER_EXPIRY.parameterSensitivity(point.build());
       CurrencyParameterSensitivities expected = FD_CAL.sensitivity(RATE_PROVIDER_EXPIRY,
-          p -> PRICER.presentValue(option, p, VOL_PROVIDER_EXPIRY));
+          p -> PRICER.presentValue(option, p, VOLS_EXPIRY));
       assertTrue(computed.equalWithTolerance(expected, FD_EPS * NOTIONAL * 10d));
     }
   }
 
   public void test_presentValueSensitivity_afterExpiry() {
     for (ResolvedFxSingleBarrierOption option : OPTION_ALL) {
-      PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyStrike(option, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+      PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyStrike(option, RATE_PROVIDER_AFTER, VOLS_AFTER);
       assertEquals(point, PointSensitivityBuilder.none());
     }
   }
@@ -403,12 +403,12 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_vega_presentValueSensitivityVolatility_atExpiry() {
-    double computedVegaCall = PRICER.vega(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+    double computedVegaCall = PRICER.vega(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     PointSensitivityBuilder computedCall =
-        PRICER.presentValueSensitivityModelParamsVolatility(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    double computedVegaPut = PRICER.vega(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+        PRICER.presentValueSensitivityModelParamsVolatility(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    double computedVegaPut = PRICER.vega(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     PointSensitivityBuilder computedPut =
-        PRICER.presentValueSensitivityModelParamsVolatility(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+        PRICER.presentValueSensitivityModelParamsVolatility(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     assertEquals(computedVegaCall, 0d);
     assertEquals(computedCall, PointSensitivityBuilder.none());
     assertEquals(computedVegaPut, 0d);
@@ -416,12 +416,12 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_vega_presentValueSensitivityVolatility_afterExpiry() {
-    double computedVegaCall = PRICER.vega(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+    double computedVegaCall = PRICER.vega(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
     PointSensitivityBuilder computedCall =
-        PRICER.presentValueSensitivityModelParamsVolatility(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    double computedVegaPut = PRICER.vega(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+        PRICER.presentValueSensitivityModelParamsVolatility(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    double computedVegaPut = PRICER.vega(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
     PointSensitivityBuilder computedPut =
-        PRICER.presentValueSensitivityModelParamsVolatility(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+        PRICER.presentValueSensitivityModelParamsVolatility(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
     assertEquals(computedVegaCall, 0d);
     assertEquals(computedCall, PointSensitivityBuilder.none());
     assertEquals(computedVegaPut, 0d);
@@ -431,11 +431,11 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_currencyExposure() {
     for (ResolvedFxSingleBarrierOption option : OPTION_ALL) {
-      CurrencyAmount pv = PRICER.presentValue(option, RATE_PROVIDER, VOL_PROVIDER_FLAT);
-      MultiCurrencyAmount computed = PRICER.currencyExposure(option, RATE_PROVIDER, VOL_PROVIDER_FLAT);
+      CurrencyAmount pv = PRICER.presentValue(option, RATE_PROVIDER, VOLS_FLAT);
+      MultiCurrencyAmount computed = PRICER.currencyExposure(option, RATE_PROVIDER, VOLS_FLAT);
       FxMatrix fxMatrix = FxMatrix.builder().addRate(EUR, USD, SPOT + FD_EPS).build();
       ImmutableRatesProvider provBumped = RATE_PROVIDER.toBuilder().fxRateProvider(fxMatrix).build();
-      CurrencyAmount pvBumped = PRICER.presentValue(option, provBumped, VOL_PROVIDER_FLAT);
+      CurrencyAmount pvBumped = PRICER.presentValue(option, provBumped, VOLS_FLAT);
       double ceCounterFD = pvBumped.getAmount() - pv.getAmount();
       double ceBaseFD = pvBumped.getAmount() / (SPOT + FD_EPS) - pv.getAmount() / SPOT;
       assertEquals(computed.getAmount(EUR).getAmount() * FD_EPS, ceCounterFD, NOTIONAL * TOL);
@@ -445,11 +445,11 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
 
   public void test_currencyExposure_atExpiry() {
     for (ResolvedFxSingleBarrierOption option : OPTION_ALL) {
-      CurrencyAmount pv = PRICER.presentValue(option, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-      MultiCurrencyAmount computed = PRICER.currencyExposure(option, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+      CurrencyAmount pv = PRICER.presentValue(option, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+      MultiCurrencyAmount computed = PRICER.currencyExposure(option, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
       FxMatrix fxMatrix = FxMatrix.builder().addRate(EUR, USD, SPOT + FD_EPS).build();
       ImmutableRatesProvider provBumped = RATE_PROVIDER_EXPIRY.toBuilder().fxRateProvider(fxMatrix).build();
-      CurrencyAmount pvBumped = PRICER.presentValue(option, provBumped, VOL_PROVIDER_EXPIRY);
+      CurrencyAmount pvBumped = PRICER.presentValue(option, provBumped, VOLS_EXPIRY);
       double ceCounterFD = pvBumped.getAmount() - pv.getAmount();
       double ceBaseFD = pvBumped.getAmount() / (SPOT + FD_EPS) - pv.getAmount() / SPOT;
       assertEquals(computed.getAmount(EUR).getAmount() * FD_EPS, ceCounterFD, NOTIONAL * TOL);
@@ -459,7 +459,7 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
 
   public void test_currencyExposure_afterExpiry() {
     for (ResolvedFxSingleBarrierOption option : OPTION_ALL) {
-      MultiCurrencyAmount computed = PRICER.currencyExposure(option, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+      MultiCurrencyAmount computed = PRICER.currencyExposure(option, RATE_PROVIDER_AFTER, VOLS_AFTER);
       assertEquals(computed, MultiCurrencyAmount.empty());
     }
   }
@@ -494,10 +494,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_delta_presentValueDelta_atExpiry() {
-    double computedDeltaCall = PRICER.delta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    double computedDeltaPut = PRICER.delta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvDeltaCall = PRICER.presentValueDelta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvDeltaPut = PRICER.presentValueDelta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+    double computedDeltaCall = PRICER.delta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    double computedDeltaPut = PRICER.delta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvDeltaCall = PRICER.presentValueDelta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvDeltaPut = PRICER.presentValueDelta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     double expectedDeltaPut = -1d;
     assertEquals(computedDeltaCall, 0d, TOL);
     assertEquals(computedDeltaPut, expectedDeltaPut, TOL);
@@ -506,10 +506,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_delta_presentValueDelta_afterExpiry() {
-    double computedDeltaCall = PRICER.delta(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    double computedDeltaPut = PRICER.delta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvDeltaCall = PRICER.presentValueDelta(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvDeltaPut = PRICER.presentValueDelta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+    double computedDeltaCall = PRICER.delta(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    double computedDeltaPut = PRICER.delta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvDeltaCall = PRICER.presentValueDelta(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvDeltaPut = PRICER.presentValueDelta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
     assertEquals(computedDeltaCall, 0d, TOL);
     assertEquals(computedDeltaPut, 0d, TOL);
     assertEquals(computedPvDeltaCall.getAmount(), 0d, TOL);
@@ -546,10 +546,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_gamma_presentValueGamma_atExpiry() {
-    double computedGammaCall = PRICER.gamma(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    double computedGammaPut = PRICER.gamma(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvGammaCall = PRICER.presentValueGamma(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvGammaPut = PRICER.presentValueGamma(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+    double computedGammaCall = PRICER.gamma(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    double computedGammaPut = PRICER.gamma(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvGammaCall = PRICER.presentValueGamma(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvGammaPut = PRICER.presentValueGamma(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     assertEquals(computedGammaCall, 0d, TOL);
     assertEquals(computedGammaPut, 0d, TOL);
     assertEquals(computedPvGammaCall.getAmount(), 0d, TOL);
@@ -557,10 +557,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_gamma_presentValueGamma_afterExpiry() {
-    double computedGammaCall = PRICER.gamma(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    double computedGammaPut = PRICER.gamma(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvGammaCall = PRICER.presentValueGamma(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvGammaPut = PRICER.presentValueGamma(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+    double computedGammaCall = PRICER.gamma(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    double computedGammaPut = PRICER.gamma(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvGammaCall = PRICER.presentValueGamma(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvGammaPut = PRICER.presentValueGamma(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
     assertEquals(computedGammaCall, 0d, TOL);
     assertEquals(computedGammaPut, 0d, TOL);
     assertEquals(computedPvGammaCall.getAmount(), 0d, TOL);
@@ -599,10 +599,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_theta_presentValueTheta_atExpiry() {
-    double computedThetaCall = PRICER.theta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    double computedThetaPut = PRICER.theta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvThetaCall = PRICER.presentValueTheta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
-    CurrencyAmount computedPvThetaPut = PRICER.presentValueTheta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOL_PROVIDER_EXPIRY);
+    double computedThetaCall = PRICER.theta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    double computedThetaPut = PRICER.theta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvThetaCall = PRICER.presentValueTheta(CALL_UKI, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
+    CurrencyAmount computedPvThetaPut = PRICER.presentValueTheta(PUT_UKO_BASE, RATE_PROVIDER_EXPIRY, VOLS_EXPIRY);
     double rateBase = RATE_PROVIDER_EXPIRY.discountFactors(EUR).zeroRate(PAY_DATE);
     double rateCounter = RATE_PROVIDER_EXPIRY.discountFactors(USD).zeroRate(PAY_DATE);
     double expectedThetaCall = -(REBATE_AMOUNT / NOTIONAL) * rateCounter;
@@ -616,10 +616,10 @@ public class BlackFxSingleBarrierOptionProductPricerTest {
   }
 
   public void test_theta_presentValueTheta_afterExpiry() {
-    double computedThetaCall = PRICER.theta(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    double computedThetaPut = PRICER.theta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvThetaCall = PRICER.presentValueTheta(CALL_UKI, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
-    CurrencyAmount computedPvThetaPut = PRICER.presentValueTheta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER);
+    double computedThetaCall = PRICER.theta(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    double computedThetaPut = PRICER.theta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvThetaCall = PRICER.presentValueTheta(CALL_UKI, RATE_PROVIDER_AFTER, VOLS_AFTER);
+    CurrencyAmount computedPvThetaPut = PRICER.presentValueTheta(PUT_UKO_BASE, RATE_PROVIDER_AFTER, VOLS_AFTER);
     assertEquals(computedThetaCall, 0d, TOL);
     assertEquals(computedThetaPut, 0d, TOL);
     assertEquals(computedPvThetaCall.getAmount(), 0d, TOL);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/BlackFxVanillaOptionProductPricerTest.java
@@ -351,7 +351,8 @@ public class BlackFxVanillaOptionProductPricerTest {
     double forward = PRICER.getDiscountingFxSingleProductPricer().forwardFxRate(FX_PRODUCT_HIGH, RATES_PROVIDER)
         .fxRate(CURRENCY_PAIR);
     double vol = SMILE_TERM.volatility(timeToExpiry, STRIKE_RATE_HIGH, forward);
-    FxOptionSensitivity expected = FxOptionSensitivity.of(CURRENCY_PAIR, timeToExpiry, STRIKE_RATE_HIGH, forward, USD,
+    FxOptionSensitivity expected = FxOptionSensitivity.of(
+        VOLS.getName(), CURRENCY_PAIR, timeToExpiry, STRIKE_RATE_HIGH, forward, USD,
         -NOTIONAL * df * BlackFormulaRepository.vega(forward, STRIKE_RATE_HIGH, timeToExpiry, vol));
     assertTrue(computedCall.build().equalWithTolerance(expected.build(), NOTIONAL * TOL));
     assertTrue(computedPut.build().equalWithTolerance(expected.build().multipliedBy(-1d), NOTIONAL * TOL));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/FxOptionSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/FxOptionSensitivityTest.java
@@ -33,9 +33,11 @@ public class FxOptionSensitivityTest {
   private static final double FORWARD = 0.8d;
   private static final double STRIKE = 0.95d;
   private static final double SENSI_VALUE = 1.24d;
+  private static final FxOptionVolatilitiesName NAME = FxOptionVolatilitiesName.of("Test");
+  private static final FxOptionVolatilitiesName NAME2 = FxOptionVolatilitiesName.of("Test2");
 
   public void test_of() {
-    FxOptionSensitivity test = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity test = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getExpiry(), EXPIRY);
     assertEquals(test.getForward(), FORWARD);
@@ -45,7 +47,7 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_withCurrency() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity test1 = base.withCurrency(EUR);
     assertEquals(test1.getCurrency(), EUR);
     assertEquals(test1.getExpiry(), EXPIRY);
@@ -58,7 +60,7 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_withSensitivity() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     double newSensi = 22.5;
     FxOptionSensitivity test = base.withSensitivity(newSensi);
     assertEquals(test.getCurrency(), GBP);
@@ -70,14 +72,14 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_compareExcludingSensitivity() {
-    FxOptionSensitivity a1 = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity a2 = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity a1 = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity a2 = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity b = FxOptionSensitivity.of(
-        CurrencyPair.of(EUR, USD), EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity c = FxOptionSensitivity.of(PAIR, EXPIRY + 1, STRIKE, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity d = FxOptionSensitivity.of(PAIR, EXPIRY, 0.96, FORWARD, GBP, SENSI_VALUE);
-    FxOptionSensitivity e = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, 0.81, GBP, SENSI_VALUE);
-    FxOptionSensitivity f = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, EUR, SENSI_VALUE);
+        NAME, CurrencyPair.of(EUR, USD), EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity c = FxOptionSensitivity.of(NAME, PAIR, EXPIRY + 1, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity d = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, 0.96, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity e = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, 0.81, GBP, SENSI_VALUE);
+    FxOptionSensitivity f = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, EUR, SENSI_VALUE);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, 2d, 32d);
     assertEquals(a1.compareKey(a2), 0);
     assertEquals(a1.compareKey(b) < 0, true);
@@ -95,30 +97,30 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_multipliedBy() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     double factor = 5.2d;
     FxOptionSensitivity expected = FxOptionSensitivity.of(
-        PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE * factor);
+        NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE * factor);
     FxOptionSensitivity test = base.multipliedBy(factor);
     assertEquals(test, expected);
   }
 
   public void test_mapSensitivity() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity expected = FxOptionSensitivity.of(
-        PAIR, EXPIRY, STRIKE, FORWARD, GBP, 1.0 / SENSI_VALUE);
+        NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, 1.0 / SENSI_VALUE);
     FxOptionSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
   }
 
   public void test_normalize() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity test = base.normalize();
     assertSame(test, base);
   }
 
   public void test_buildInto() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
     assertSame(test, combo);
@@ -126,26 +128,26 @@ public class FxOptionSensitivityTest {
   }
 
   public void test_build() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
   }
 
   public void test_cloned() {
-    FxOptionSensitivity base = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity base = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     FxOptionSensitivity test = base.cloned();
     assertSame(test, base);
   }
 
   public void coverage() {
-    FxOptionSensitivity test1 = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity test1 = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     coverImmutableBean(test1);
-    FxOptionSensitivity test2 = FxOptionSensitivity.of(CurrencyPair.of(EUR, USD), EXPIRY, 0.8, 0.9, EUR, 1.1);
+    FxOptionSensitivity test2 = FxOptionSensitivity.of(NAME2, CurrencyPair.of(EUR, USD), EXPIRY, 0.8, 0.9, EUR, 1.1);
     coverBeanEquals(test1, test2);
   }
 
   public void test_serialization() {
-    FxOptionSensitivity test = FxOptionSensitivity.of(PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
+    FxOptionSensitivity test = FxOptionSensitivity.of(NAME, PAIR, EXPIRY, STRIKE, FORWARD, GBP, SENSI_VALUE);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/ImpliedTrinomialTreeFxOptionCalibratorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/ImpliedTrinomialTreeFxOptionCalibratorTest.java
@@ -42,9 +42,9 @@ public class ImpliedTrinomialTreeFxOptionCalibratorTest {
   private static final LocalDate EXPIRY_DATE = LocalDate.of(2012, 9, 15);
   private static final ZonedDateTime EXPIRY_DATETIME = EXPIRY_DATE.atStartOfDay(ZONE);
   // providers
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER =
+  private static final BlackFxOptionSmileVolatilities VOLS =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5(VAL_DATETIME);
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER_MRKT =
+  private static final BlackFxOptionSmileVolatilities VOLS_MRKT =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5Market(VAL_DATETIME);
   private static final ImmutableRatesProvider RATE_PROVIDER =
       RatesProviderFxDataSets.createProviderEurUsdFlat(VAL_DATE);
@@ -61,9 +61,9 @@ public class ImpliedTrinomialTreeFxOptionCalibratorTest {
       .build();
   private static final ImpliedTrinomialTreeFxOptionCalibrator CALIB = new ImpliedTrinomialTreeFxOptionCalibrator(39);
   private static final RecombiningTrinomialTreeData TREE_DATA =
-      CALIB.calibrateTrinomialTree(CALL, RATE_PROVIDER, VOL_PROVIDER);
+      CALIB.calibrateTrinomialTree(CALL, RATE_PROVIDER, VOLS);
   private static final RecombiningTrinomialTreeData TREE_DATA_MRKT =
-      CALIB.calibrateTrinomialTree(CALL, RATE_PROVIDER, VOL_PROVIDER_MRKT);
+      CALIB.calibrateTrinomialTree(CALL, RATE_PROVIDER, VOLS_MRKT);
   private static final TrinomialTree TREE = new TrinomialTree();
 
   public void test_recoverVolatility() {
@@ -78,12 +78,12 @@ public class ImpliedTrinomialTreeFxOptionCalibratorTest {
       OptionFunction func = EuropeanVanillaOptionFunction.of(strike, timeToExpiry, PutCall.CALL, nSteps);
       double price = TREE.optionPrice(func, TREE_DATA);
       double impliedVol = BlackFormulaRepository.impliedVolatility(price / dfDom, forward, strike, timeToExpiry, true);
-      double orgVol = VOL_PROVIDER.volatility(FX_PRODUCT.getCurrencyPair(), timeToExpiry, strike, forward);
+      double orgVol = VOLS.volatility(FX_PRODUCT.getCurrencyPair(), timeToExpiry, strike, forward);
       assertEquals(impliedVol, orgVol, orgVol * 0.1); // large tol
       double priceMrkt = TREE.optionPrice(func, TREE_DATA_MRKT);
       double impliedVolMrkt =
           BlackFormulaRepository.impliedVolatility(priceMrkt / dfDom, forward, strike, timeToExpiry, true);
-      double orgVolMrkt = VOL_PROVIDER_MRKT.volatility(FX_PRODUCT.getCurrencyPair(), timeToExpiry, strike, forward);
+      double orgVolMrkt = VOLS_MRKT.volatility(FX_PRODUCT.getCurrencyPair(), timeToExpiry, strike, forward);
       assertEquals(impliedVolMrkt, orgVolMrkt, orgVolMrkt * 0.1); // large tol
     }
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fxopt/ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest.java
@@ -46,17 +46,17 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
   // providers - flat
   private static final ImmutableRatesProvider RATE_PROVIDER_FLAT =
       RatesProviderFxDataSets.createProviderEurUsdFlat(VAL_DATE);
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER_FLAT =
+  private static final BlackFxOptionSmileVolatilities VOLS_FLAT =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5FlatFlat(VAL_DATETIME);
   // providers
   private static final ImmutableRatesProvider RATE_PROVIDER =
       RatesProviderFxDataSets.createProviderEURUSD(VAL_DATE);
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER =
+  private static final BlackFxOptionSmileVolatilities VOLS =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5(VAL_DATETIME);
   // providers - after maturity
   private static final ImmutableRatesProvider RATE_PROVIDER_AFTER =
       RatesProviderFxDataSets.createProviderEURUSD(EXPIRY_DATE.plusDays(1));
-  private static final BlackFxOptionSmileVolatilities VOL_PROVIDER_AFTER =
+  private static final BlackFxOptionSmileVolatilities VOLS_AFTER =
       FxVolatilitySmileDataSet.createVolatilitySmileProvider5(EXPIRY_DATETIME.plusDays(1));
 
   private static final double NOTIONAL = 100_000_000d;
@@ -96,11 +96,11 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
   private static final ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer PRICER_39 =
       new ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer(39);
   private static final RecombiningTrinomialTreeData DATA_39 =
-      PRICER_39.getCalibrator().calibrateTrinomialTree(CALL, RATE_PROVIDER, VOL_PROVIDER);
+      PRICER_39.getCalibrator().calibrateTrinomialTree(CALL, RATE_PROVIDER, VOLS);
   private static final ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer PRICER_70 =
       new ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer(70);
   private static final RecombiningTrinomialTreeData DATA_70_FLAT =
-      PRICER_70.getCalibrator().calibrateTrinomialTree(CALL, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
+      PRICER_70.getCalibrator().calibrateTrinomialTree(CALL, RATE_PROVIDER_FLAT, VOLS_FLAT);
   private static final BlackFxSingleBarrierOptionProductPricer BLACK_PRICER = BlackFxSingleBarrierOptionProductPricer.DEFAULT;
   private static final BlackFxVanillaOptionProductPricer VANILLA_PRICER = BlackFxVanillaOptionProductPricer.DEFAULT;
 
@@ -113,28 +113,28 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
       SimpleConstantContinuousBarrier dko =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_OUT, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDko = ResolvedFxSingleBarrierOption.of(CALL, dko);
-      double priceDkoBlack = BLACK_PRICER.price(optionDko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceDko = PRICER_70.price(optionDko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceDkoBlack = BLACK_PRICER.price(optionDko, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceDko = PRICER_70.price(optionDko, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceDko, priceDkoBlack, tol);
       SimpleConstantContinuousBarrier dki =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_IN, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDki = ResolvedFxSingleBarrierOption.of(CALL, dki);
-      double priceDkiBlack = BLACK_PRICER.price(optionDki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceDki = PRICER_70.price(optionDki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceDkiBlack = BLACK_PRICER.price(optionDki, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceDki = PRICER_70.price(optionDki, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceDki, priceDkiBlack, tol);
       // down barrier
       double higherBarrier = 1.45 + 0.025 * i;
       SimpleConstantContinuousBarrier uko =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_OUT, higherBarrier);
       ResolvedFxSingleBarrierOption optionUko = ResolvedFxSingleBarrierOption.of(CALL, uko);
-      double priceUkoBlack = BLACK_PRICER.price(optionUko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceUko = PRICER_70.price(optionUko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceUkoBlack = BLACK_PRICER.price(optionUko, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceUko = PRICER_70.price(optionUko, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceUko, priceUkoBlack, tol);
       SimpleConstantContinuousBarrier uki =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_IN, higherBarrier);
       ResolvedFxSingleBarrierOption optionUki = ResolvedFxSingleBarrierOption.of(CALL, uki);
-      double priceUkiBlack = BLACK_PRICER.price(optionUki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceUki = PRICER_70.price(optionUki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceUkiBlack = BLACK_PRICER.price(optionUki, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceUki = PRICER_70.price(optionUki, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceUki, priceUkiBlack, tol);
     }
   }
@@ -148,17 +148,17 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
       SimpleConstantContinuousBarrier dko =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_OUT, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDko = ResolvedFxSingleBarrierOption.of(CALL, dko, REBATE_BASE);
-      MultiCurrencyAmount ceDkoBlack = BLACK_PRICER.currencyExposure(optionDko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
+      MultiCurrencyAmount ceDkoBlack = BLACK_PRICER.currencyExposure(optionDko, RATE_PROVIDER_FLAT, VOLS_FLAT);
       MultiCurrencyAmount ceDko =
-          PRICER_70.currencyExposure(optionDko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+          PRICER_70.currencyExposure(optionDko, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEquals(ceDko.getAmount(EUR).getAmount(), ceDkoBlack.getAmount(EUR).getAmount(), NOTIONAL * tol);
       assertEquals(ceDko.getAmount(USD).getAmount(), ceDkoBlack.getAmount(USD).getAmount(), NOTIONAL * tol);
       SimpleConstantContinuousBarrier dki =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_IN, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDki = ResolvedFxSingleBarrierOption.of(CALL, dki, REBATE);
-      MultiCurrencyAmount ceDkiBlack = BLACK_PRICER.currencyExposure(optionDki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
+      MultiCurrencyAmount ceDkiBlack = BLACK_PRICER.currencyExposure(optionDki, RATE_PROVIDER_FLAT, VOLS_FLAT);
       MultiCurrencyAmount ceDki =
-          PRICER_70.currencyExposure(optionDki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+          PRICER_70.currencyExposure(optionDki, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEquals(ceDki.getAmount(EUR).getAmount(), ceDkiBlack.getAmount(EUR).getAmount(), NOTIONAL * tol);
       assertEquals(ceDki.getAmount(USD).getAmount(), ceDkiBlack.getAmount(USD).getAmount(), NOTIONAL * tol);
       // down barrier
@@ -166,17 +166,17 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
       SimpleConstantContinuousBarrier uko =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_OUT, higherBarrier);
       ResolvedFxSingleBarrierOption optionUko = ResolvedFxSingleBarrierOption.of(CALL, uko, REBATE);
-      MultiCurrencyAmount ceUkoBlack = BLACK_PRICER.currencyExposure(optionUko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
+      MultiCurrencyAmount ceUkoBlack = BLACK_PRICER.currencyExposure(optionUko, RATE_PROVIDER_FLAT, VOLS_FLAT);
       MultiCurrencyAmount ceUko =
-          PRICER_70.currencyExposure(optionUko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+          PRICER_70.currencyExposure(optionUko, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEquals(ceUko.getAmount(EUR).getAmount(), ceUkoBlack.getAmount(EUR).getAmount(), NOTIONAL * tol);
       assertEquals(ceUko.getAmount(USD).getAmount(), ceUkoBlack.getAmount(USD).getAmount(), NOTIONAL * tol);
       SimpleConstantContinuousBarrier uki =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_IN, higherBarrier);
       ResolvedFxSingleBarrierOption optionUki = ResolvedFxSingleBarrierOption.of(CALL, uki, REBATE_BASE);
-      MultiCurrencyAmount ceUkiBlack = BLACK_PRICER.currencyExposure(optionUki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
+      MultiCurrencyAmount ceUkiBlack = BLACK_PRICER.currencyExposure(optionUki, RATE_PROVIDER_FLAT, VOLS_FLAT);
       MultiCurrencyAmount ceUki =
-          PRICER_70.currencyExposure(optionUki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+          PRICER_70.currencyExposure(optionUki, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEquals(ceUki.getAmount(EUR).getAmount(), ceUkiBlack.getAmount(EUR).getAmount(), NOTIONAL * tol);
       assertEquals(ceUki.getAmount(USD).getAmount(), ceUkiBlack.getAmount(USD).getAmount(), NOTIONAL * tol);
     }
@@ -191,28 +191,28 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
       SimpleConstantContinuousBarrier dko =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_OUT, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDko = ResolvedFxSingleBarrierOption.of(PUT, dko, REBATE_BASE);
-      double priceDkoBlack = BLACK_PRICER.price(optionDko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceDko = PRICER_70.price(optionDko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceDkoBlack = BLACK_PRICER.price(optionDko, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceDko = PRICER_70.price(optionDko, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceDko, priceDkoBlack, tol);
       SimpleConstantContinuousBarrier dki =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_IN, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDki = ResolvedFxSingleBarrierOption.of(PUT, dki, REBATE_BASE);
-      double priceDkiBlack = BLACK_PRICER.price(optionDki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceDki = PRICER_70.price(optionDki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceDkiBlack = BLACK_PRICER.price(optionDki, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceDki = PRICER_70.price(optionDki, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceDki, priceDkiBlack, tol);
       // down barrier
       double higherBarrier = 1.45 + 0.025 * i;
       SimpleConstantContinuousBarrier uko =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_OUT, higherBarrier);
       ResolvedFxSingleBarrierOption optionUko = ResolvedFxSingleBarrierOption.of(PUT, uko, REBATE);
-      double priceUkoBlack = BLACK_PRICER.price(optionUko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceUko = PRICER_70.price(optionUko, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceUkoBlack = BLACK_PRICER.price(optionUko, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceUko = PRICER_70.price(optionUko, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceUko, priceUkoBlack, tol);
       SimpleConstantContinuousBarrier uki =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_IN, higherBarrier);
       ResolvedFxSingleBarrierOption optionUki = ResolvedFxSingleBarrierOption.of(PUT, uki, REBATE);
-      double priceUkiBlack = BLACK_PRICER.price(optionUki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT);
-      double priceUki = PRICER_70.price(optionUki, RATE_PROVIDER_FLAT, VOL_PROVIDER_FLAT, DATA_70_FLAT);
+      double priceUkiBlack = BLACK_PRICER.price(optionUki, RATE_PROVIDER_FLAT, VOLS_FLAT);
+      double priceUki = PRICER_70.price(optionUki, RATE_PROVIDER_FLAT, VOLS_FLAT, DATA_70_FLAT);
       assertEqualsRelative(priceUki, priceUkiBlack, tol);
     }
   }
@@ -229,21 +229,21 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
       SimpleConstantContinuousBarrier dko =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_OUT, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDko = ResolvedFxSingleBarrierOption.of(CALL, dko);
-      double priceDko = PRICER_39.price(optionDko, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceDko = PRICER_39.price(optionDko, RATE_PROVIDER, VOLS, DATA_39);
       SimpleConstantContinuousBarrier dki =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_IN, lowerBarrier);
       ResolvedFxSingleBarrierOption optionDki = ResolvedFxSingleBarrierOption.of(CALL, dki);
-      double priceDki = PRICER_39.price(optionDki, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceDki = PRICER_39.price(optionDki, RATE_PROVIDER, VOLS, DATA_39);
       // down barrier
       double higherBarrier = 1.4 + 0.006 * (i + 1);
       SimpleConstantContinuousBarrier uko =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_OUT, higherBarrier);
       ResolvedFxSingleBarrierOption optionUko = ResolvedFxSingleBarrierOption.of(CALL, uko);
-      double priceUko = PRICER_39.price(optionUko, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceUko = PRICER_39.price(optionUko, RATE_PROVIDER, VOLS, DATA_39);
       SimpleConstantContinuousBarrier uki =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_IN, higherBarrier);
       ResolvedFxSingleBarrierOption optionUki = ResolvedFxSingleBarrierOption.of(CALL, uki);
-      double priceUki = PRICER_39.price(optionUki, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceUki = PRICER_39.price(optionUki, RATE_PROVIDER, VOLS, DATA_39);
       assertTrue(priceDkoPrev > priceDko);
       assertTrue(priceDkiPrev < priceDki);
       assertTrue(priceUkoPrev < priceUko);
@@ -258,23 +258,23 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
   @Test
   public void test_inOutParity() {
     double tol = 1.0e-2;
-    double callPrice = VANILLA_PRICER.price(CALL, RATE_PROVIDER, VOL_PROVIDER);
-    double putPrice = VANILLA_PRICER.price(PUT, RATE_PROVIDER, VOL_PROVIDER);
+    double callPrice = VANILLA_PRICER.price(CALL, RATE_PROVIDER, VOLS);
+    double putPrice = VANILLA_PRICER.price(PUT, RATE_PROVIDER, VOLS);
     for (int i = 0; i < 11; ++i) {
       // up barrier
       double lowerBarrier = 1.1 + 0.025 * i;
       SimpleConstantContinuousBarrier dko =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_OUT, lowerBarrier);
       ResolvedFxSingleBarrierOption callDko = ResolvedFxSingleBarrierOption.of(CALL, dko);
-      double priceCallDko = PRICER_39.price(callDko, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceCallDko = PRICER_39.price(callDko, RATE_PROVIDER, VOLS, DATA_39);
       ResolvedFxSingleBarrierOption putDko = ResolvedFxSingleBarrierOption.of(PUT, dko);
-      double pricePutDko = PRICER_39.price(putDko, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double pricePutDko = PRICER_39.price(putDko, RATE_PROVIDER, VOLS, DATA_39);
       SimpleConstantContinuousBarrier dki =
           SimpleConstantContinuousBarrier.of(BarrierType.DOWN, KnockType.KNOCK_IN, lowerBarrier);
       ResolvedFxSingleBarrierOption callDki = ResolvedFxSingleBarrierOption.of(CALL, dki);
-      double priceCallDki = PRICER_39.price(callDki, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceCallDki = PRICER_39.price(callDki, RATE_PROVIDER, VOLS, DATA_39);
       ResolvedFxSingleBarrierOption putDki = ResolvedFxSingleBarrierOption.of(PUT, dki);
-      double pricePutDki = PRICER_39.price(putDki, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double pricePutDki = PRICER_39.price(putDki, RATE_PROVIDER, VOLS, DATA_39);
       assertEqualsRelative(priceCallDko + priceCallDki, callPrice, tol);
       assertEqualsRelative(pricePutDko + pricePutDki, putPrice, tol);
       // down barrier
@@ -282,15 +282,15 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
       SimpleConstantContinuousBarrier uko =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_OUT, higherBarrier);
       ResolvedFxSingleBarrierOption callUko = ResolvedFxSingleBarrierOption.of(CALL, uko);
-      double priceCallUko = PRICER_39.price(callUko, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceCallUko = PRICER_39.price(callUko, RATE_PROVIDER, VOLS, DATA_39);
       ResolvedFxSingleBarrierOption putUko = ResolvedFxSingleBarrierOption.of(PUT, uko);
-      double pricePutUko = PRICER_39.price(putUko, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double pricePutUko = PRICER_39.price(putUko, RATE_PROVIDER, VOLS, DATA_39);
       SimpleConstantContinuousBarrier uki =
           SimpleConstantContinuousBarrier.of(BarrierType.UP, KnockType.KNOCK_IN, higherBarrier);
       ResolvedFxSingleBarrierOption callUki = ResolvedFxSingleBarrierOption.of(CALL, uki);
-      double priceCallUki = PRICER_39.price(callUki, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double priceCallUki = PRICER_39.price(callUki, RATE_PROVIDER, VOLS, DATA_39);
       ResolvedFxSingleBarrierOption putUki = ResolvedFxSingleBarrierOption.of(PUT, uki);
-      double pricePutUki = PRICER_39.price(putUki, RATE_PROVIDER, VOL_PROVIDER, DATA_39);
+      double pricePutUki = PRICER_39.price(putUki, RATE_PROVIDER, VOLS, DATA_39);
       assertEqualsRelative(priceCallUko + priceCallUki, callPrice, tol);
       assertEqualsRelative(pricePutUko + pricePutUki, putPrice, tol);
     }
@@ -301,10 +301,10 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
     ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer pricer =
         new ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer(21);
     CurrencyParameterSensitivities computed =
-        pricer.presentValueRatesSensitivity(CALL_UKI_C, RATE_PROVIDER, VOL_PROVIDER);
+        pricer.presentValueRatesSensitivity(CALL_UKI_C, RATE_PROVIDER, VOLS);
     RatesFiniteDifferenceSensitivityCalculator calc = new RatesFiniteDifferenceSensitivityCalculator(1.0e-5);
     CurrencyParameterSensitivities expected =
-        calc.sensitivity(RATE_PROVIDER, p -> pricer.presentValue(CALL_UKI_C, p, VOL_PROVIDER));
+        calc.sensitivity(RATE_PROVIDER, p -> pricer.presentValue(CALL_UKI_C, p, VOLS));
     assertTrue(computed.equalWithTolerance(expected, 1.0e-13));
   }
 
@@ -313,30 +313,30 @@ public class ImpliedTrinomialTreeFxSingleBarrierOptionProductPricerTest {
     ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer pricer =
         new ImpliedTrinomialTreeFxSingleBarrierOptionProductPricer(5);
     RecombiningTrinomialTreeData data =
-        pricer.getCalibrator().calibrateTrinomialTree(CALL_DKO.getUnderlyingOption(), RATE_PROVIDER, VOL_PROVIDER);
-    double price = pricer.price(CALL_UKI_C, RATE_PROVIDER, VOL_PROVIDER);
-    double priceWithData = pricer.price(CALL_UKI_C, RATE_PROVIDER, VOL_PROVIDER, data);
+        pricer.getCalibrator().calibrateTrinomialTree(CALL_DKO.getUnderlyingOption(), RATE_PROVIDER, VOLS);
+    double price = pricer.price(CALL_UKI_C, RATE_PROVIDER, VOLS);
+    double priceWithData = pricer.price(CALL_UKI_C, RATE_PROVIDER, VOLS, data);
     assertEquals(price, priceWithData);
-    CurrencyAmount pv = pricer.presentValue(CALL_DKO, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvWithData = pricer.presentValue(CALL_DKO, RATE_PROVIDER, VOL_PROVIDER, data);
+    CurrencyAmount pv = pricer.presentValue(CALL_DKO, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvWithData = pricer.presentValue(CALL_DKO, RATE_PROVIDER, VOLS, data);
     assertEquals(pv, pvWithData);
-    MultiCurrencyAmount ce = pricer.currencyExposure(CALL_UKI_C, RATE_PROVIDER, VOL_PROVIDER);
-    MultiCurrencyAmount ceWithData = pricer.currencyExposure(CALL_UKI_C, RATE_PROVIDER, VOL_PROVIDER, data);
+    MultiCurrencyAmount ce = pricer.currencyExposure(CALL_UKI_C, RATE_PROVIDER, VOLS);
+    MultiCurrencyAmount ceWithData = pricer.currencyExposure(CALL_UKI_C, RATE_PROVIDER, VOLS, data);
     assertEquals(ce, ceWithData);
   }
 
   public void test_expired_calibration() {
     assertThrowsIllegalArg(() -> PRICER_39.getCalibrator().calibrateTrinomialTree(CALL_DKO.getUnderlyingOption(),
-        RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER));
+        RATE_PROVIDER_AFTER, VOLS_AFTER));
     // pricing also fails because trinomial data can not be obtained
-    assertThrowsIllegalArg(() -> PRICER_39.price(CALL_DKO, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER));
-    assertThrowsIllegalArg(() -> PRICER_39.presentValue(CALL_DKO, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER));
-    assertThrowsIllegalArg(() -> PRICER_39.currencyExposure(CALL_DKO, RATE_PROVIDER_AFTER, VOL_PROVIDER_AFTER));
+    assertThrowsIllegalArg(() -> PRICER_39.price(CALL_DKO, RATE_PROVIDER_AFTER, VOLS_AFTER));
+    assertThrowsIllegalArg(() -> PRICER_39.presentValue(CALL_DKO, RATE_PROVIDER_AFTER, VOLS_AFTER));
+    assertThrowsIllegalArg(() -> PRICER_39.currencyExposure(CALL_DKO, RATE_PROVIDER_AFTER, VOLS_AFTER));
   }
 
   public void test_dataMismatch() {
     assertThrowsIllegalArg(() -> PRICER_70.presentValueRatesSensitivity(CALL_DKO, RATE_PROVIDER,
-        VOL_PROVIDER, DATA_39));
+        VOLS, DATA_39));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/IborFutureOptionSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/IborFutureOptionSensitivityTest.java
@@ -7,8 +7,6 @@ package com.opengamma.strata.pricer.index;
 
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
-import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
-import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -33,22 +31,13 @@ import com.opengamma.strata.pricer.ZeroRateSensitivity;
 @Test
 public class IborFutureOptionSensitivityTest {
 
-  public void test_of_noCurrency() {
-    IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, 32d);
-    assertEquals(test.getIndex(), GBP_LIBOR_3M);
-    assertEquals(test.getCurrency(), GBP);
-    assertEquals(test.getExpiry(), 12d);
-    assertEquals(test.getFixingDate(), date(2015, 8, 28));
-    assertEquals(test.getStrikePrice(), 0.98);
-    assertEquals(test.getFuturePrice(), 0.99);
-    assertEquals(test.getSensitivity(), 32d);
-  }
+  private static final IborFutureOptionVolatilitiesName NAME = IborFutureOptionVolatilitiesName.of("Test");
+  private static final IborFutureOptionVolatilitiesName NAME2 = IborFutureOptionVolatilitiesName.of("Test2");
 
-  public void test_of_withCurrency() {
+  public void test_of() {
     IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
-    assertEquals(test.getIndex(), GBP_LIBOR_3M);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+    assertEquals(test.getVolatilitiesName(), NAME);
     assertEquals(test.getCurrency(), GBP);
     assertEquals(test.getExpiry(), 12d);
     assertEquals(test.getFixingDate(), date(2015, 8, 28));
@@ -60,11 +49,11 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_withCurrency() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertSame(base.withCurrency(GBP), base);
 
     IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, USD, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     IborFutureOptionSensitivity test = base.withCurrency(USD);
     assertEquals(test, expected);
   }
@@ -72,9 +61,9 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_withSensitivity() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 20d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 20d);
     IborFutureOptionSensitivity test = base.withSensitivity(20d);
     assertEquals(test, expected);
   }
@@ -82,21 +71,21 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_compareKey() {
     IborFutureOptionSensitivity a1 = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity a2 = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity b = IborFutureOptionSensitivity.of(
-        USD_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME2, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity c = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 13d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 13d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity d = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 9, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 9, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity e = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.99, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.99, 0.99, GBP, 32d);
     IborFutureOptionSensitivity f = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 1.00, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 1.00, GBP, 32d);
     IborFutureOptionSensitivity g = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, USD, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, USD, 32d);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, 2d, 32d);
     assertEquals(a1.compareKey(a2), 0);
     assertEquals(a1.compareKey(b) < 0, true);
@@ -122,12 +111,12 @@ public class IborFutureOptionSensitivityTest {
     double forward = 0.99d;
     double sensi = 32d;
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, fixingDate, strike, forward, GBP, sensi);
+        NAME, 12d, fixingDate, strike, forward, GBP, sensi);
     double rate = 1.5d;
     FxMatrix matrix = FxMatrix.of(CurrencyPair.of(GBP, USD), rate);
     IborFutureOptionSensitivity test1 = (IborFutureOptionSensitivity) base.convertedTo(USD, matrix);
     IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, fixingDate, strike, forward, USD, sensi * rate);
+        NAME, 12d, fixingDate, strike, forward, USD, sensi * rate);
     assertEquals(test1, expected);
     IborFutureOptionSensitivity test2 = (IborFutureOptionSensitivity) base.convertedTo(GBP, matrix);
     assertEquals(test2, base);
@@ -136,9 +125,9 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d * 3.5d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d * 3.5d);
     IborFutureOptionSensitivity test = base.multipliedBy(3.5d);
     assertEquals(test, expected);
   }
@@ -146,9 +135,9 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_mapSensitivity() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity expected = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 1 / 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 1 / 32d);
     IborFutureOptionSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
   }
@@ -156,7 +145,7 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_normalize() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity test = base.normalize();
     assertSame(test, base);
   }
@@ -164,7 +153,7 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_buildInto() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
     assertSame(test, combo);
@@ -174,7 +163,7 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_build() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
   }
@@ -182,7 +171,7 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_cloned() {
     IborFutureOptionSensitivity base = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     IborFutureOptionSensitivity test = base.cloned();
     assertSame(test, base);
   }
@@ -190,16 +179,16 @@ public class IborFutureOptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     coverImmutableBean(test);
     IborFutureOptionSensitivity test2 = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, USD, 32d);
+        NAME2, 13d, date(2015, 8, 29), 0.99, 0.995, USD, 33d);
     coverBeanEquals(test, test2);
   }
 
   public void test_serialization() {
     IborFutureOptionSensitivity test = IborFutureOptionSensitivity.of(
-        GBP_LIBOR_3M, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
+        NAME, 12d, date(2015, 8, 28), 0.98, 0.99, GBP, 32d);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest.java
@@ -118,8 +118,8 @@ public class NormalIborFutureOptionExpirySimpleMoneynessVolatilitiesTest {
     double strikePrice = 1.0025;
     double futurePrice = 0.9975;
     double sensitivity = 123456;
-    IborFutureOptionSensitivity point =
-        IborFutureOptionSensitivity.of(EUR_EURIBOR_3M, expiry, fixing, strikePrice, futurePrice, sensitivity);
+    IborFutureOptionSensitivity point = IborFutureOptionSensitivity.of(
+        VOL_SIMPLE_MONEY_RATE.getName(), expiry, fixing, strikePrice, futurePrice, EUR, sensitivity);
     CurrencyParameterSensitivities ps = VOL_SIMPLE_MONEY_RATE.parameterSensitivity(point);
     double shift = 1.0E-6;
     double v0 = VOL_SIMPLE_MONEY_RATE.volatility(expiry, fixing, strikePrice, futurePrice);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilitiesTest.java
@@ -68,7 +68,7 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
   private static final LocalTime VAL_TIME = LocalTime.of(13, 45);
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
-  private static final BlackSwaptionExpiryTenorVolatilities PROVIDER =
+  private static final BlackSwaptionExpiryTenorVolatilities VOLS =
       BlackSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
@@ -83,40 +83,40 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void test_valuationDate() {
-    assertEquals(PROVIDER.getValuationDateTime(), VAL_DATE_TIME);
+    assertEquals(VOLS.getValuationDateTime(), VAL_DATE_TIME);
   }
 
   public void test_swapConvention() {
-    assertEquals(PROVIDER.getConvention(), CONVENTION);
+    assertEquals(VOLS.getConvention(), CONVENTION);
   }
 
   public void test_findData() {
-    assertEquals(PROVIDER.findData(SURFACE.getName()), Optional.of(SURFACE));
-    assertEquals(PROVIDER.findData(SurfaceName.of("Rubbish")), Optional.empty());
+    assertEquals(VOLS.findData(SURFACE.getName()), Optional.of(SURFACE));
+    assertEquals(VOLS.findData(SurfaceName.of("Rubbish")), Optional.empty());
   }
 
   public void test_tenor() {
-    double test1 = PROVIDER.tenor(VAL_DATE, VAL_DATE);
+    double test1 = VOLS.tenor(VAL_DATE, VAL_DATE);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 28));
+    double test2 = VOLS.tenor(VAL_DATE, date(2018, 2, 28));
     assertEquals(test2, 3d);
-    double test3 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 10));
+    double test3 = VOLS.tenor(VAL_DATE, date(2018, 2, 10));
     assertEquals(test3, 3d);
   }
 
   public void test_relativeTime() {
-    double test1 = PROVIDER.relativeTime(VAL_DATE_TIME);
+    double test1 = VOLS.relativeTime(VAL_DATE_TIME);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
-    double test3 = PROVIDER.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test2 = VOLS.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test3 = VOLS.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
     assertEquals(test2, -test3); // consistency checked
   }
 
   public void test_volatility() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       double volExpected = SURFACE.zValue(expiryTime, TEST_TENOR[i]);
-      double volComputed = PROVIDER.volatility(
+      double volComputed = VOLS.volatility(
           TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);
     }
@@ -126,10 +126,10 @@ public class BlackSwaptionExpiryTenorVolatilitiesTest {
     double eps = 1.0e-6;
     int nData = TIME.size();
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       SwaptionSensitivity point = SwaptionSensitivity.of(
-          CONVENTION, expiryTime, TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
-      CurrencyParameterSensitivities sensActual = PROVIDER.parameterSensitivity(point);
+          VOLS.getName(), expiryTime, TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
+      CurrencyParameterSensitivities sensActual = VOLS.parameterSensitivity(point);
       DoubleArray computed = sensActual.getSensitivity(SURFACE.getName(), GBP).getSensitivity();
       for (int j = 0; j < nData; j++) {
         DoubleArray volDataUp = VOL.with(j, VOL.get(j) + eps);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
@@ -153,10 +153,10 @@ public class BlackSwaptionPhysicalProductPricerTest {
       new RatesFiniteDifferenceSensitivityCalculator(FD_SHIFT);
 
   private static final ImmutableRatesProvider MULTI_USD = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_CST_SWAPTION_PROVIDER_USD =
-      SwaptionBlackVolatilityDataSets.BLACK_VOL_CST_SWAPTION_PROVIDER_USD;
-  private static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_SWAPTION_PROVIDER_USD_STD =
-      SwaptionBlackVolatilityDataSets.BLACK_VOL_SWAPTION_PROVIDER_USD_STD;
+  private static final BlackSwaptionExpiryTenorVolatilities BLACK_VOLS_CST_USD =
+      SwaptionBlackVolatilityDataSets.BLACK_SWAPTION_VOLS_CST_USD;
+  private static final BlackSwaptionExpiryTenorVolatilities BLACK_VOLS_USD_STD =
+      SwaptionBlackVolatilityDataSets.BLACK_SWAPTION_VOLS_USD_STD;
 
   private static final double TOLERANCE_PV = 1.0E-2;
   private static final double TOLERANCE_PV_DELTA = 1.0E+2;
@@ -166,51 +166,51 @@ public class BlackSwaptionPhysicalProductPricerTest {
   //-------------------------------------------------------------------------
   public void validate_physical_settlement() {
     assertThrowsIllegalArg(() -> PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC_CASH, MULTI_USD,
-        BLACK_VOL_SWAPTION_PROVIDER_USD_STD));
+        BLACK_VOLS_USD_STD));
   }
 
   //-------------------------------------------------------------------------
   public void test_implied_volatility() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
-    double volExpected = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volExpected = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
     double volComputed = PRICER_SWAPTION_BLACK
-        .impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(volComputed, volExpected, TOLERANCE_RATE);
   }
 
   public void test_implied_volatility_after_expiry() {
     assertThrowsIllegalArg(() -> PRICER_SWAPTION_BLACK.impliedVolatility(SWAPTION_PAST, MULTI_USD,
-        BLACK_VOL_SWAPTION_PROVIDER_USD_STD));
+        BLACK_VOLS_USD_STD));
   }
 
   //-------------------------------------------------------------------------
   public void present_value_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
-    double expiry = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = BLACK_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     double pvExpected = Math.abs(pvbp) * BlackFormulaRepository.price(forward, STRIKE, expiry, volatility, false);
     CurrencyAmount pvComputed =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvComputed.getCurrency(), USD);
     assertEquals(pvComputed.getAmount(), pvExpected, TOLERANCE_PV);
   }
 
   public void present_value_long_short_parity() {
     CurrencyAmount pvLong =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvShort =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvLong.getAmount(), -pvShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_payer_receiver_parity() {
     CurrencyAmount pvLongPay =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvShortRec =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     MultiCurrencyAmount pvSwapPay =
         PRICER_SWAP.presentValue(RSWAP_PAY, MULTI_USD);
     assertEquals(pvLongPay.getAmount() + pvShortRec.getAmount(), pvSwapPay.getAmount(USD).getAmount(), TOLERANCE_PV);
@@ -218,15 +218,15 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   public void present_value_at_expiry() {
     CurrencyAmount pvRec =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvRec.getAmount(), 0.0d, TOLERANCE_PV);
     CurrencyAmount pvPay =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvPay.getAmount(), PRICER_SWAP.presentValue(RSWAP_PAY, MULTI_USD).getAmount(USD).getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_after_expiry() {
-    CurrencyAmount pv = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_PAST, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+    CurrencyAmount pv = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pv.getAmount(), 0.0d, TOLERANCE_PV);
   }
 
@@ -234,46 +234,46 @@ public class BlackSwaptionPhysicalProductPricerTest {
   public void present_value_delta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
-    double expiry = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = BLACK_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     double pvDeltaExpected = BlackFormulaRepository.delta(forward, STRIKE, expiry, volatility, false) * Math.abs(pvbp);
     CurrencyAmount pvDeltaComputed =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvDeltaComputed.getCurrency(), USD);
     assertEquals(pvDeltaComputed.getAmount(), pvDeltaExpected, TOLERANCE_PV);
   }
 
   public void present_value_delta_long_short_parity() {
     CurrencyAmount pvDeltaLong =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvDeltaShort =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvDeltaLong.getAmount(), -pvDeltaShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_delta_payer_receiver_parity() {
     CurrencyAmount pvDeltaLongPay =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvDeltaShortRec =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_PAY.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     assertEquals(pvDeltaLongPay.getAmount() + pvDeltaShortRec.getAmount(), Math.abs(pvbp), TOLERANCE_PV);
   }
 
   public void present_value_delta_at_expiry() {
     CurrencyAmount pvDeltaRec =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvDeltaRec.getAmount(), 0d, TOLERANCE_PV);
     CurrencyAmount pvDeltaPay =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_PAY.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     assertEquals(pvDeltaPay.getAmount(), Math.abs(pvbp), TOLERANCE_PV);
   }
 
   public void present_value_delta_after_expiry() {
     CurrencyAmount pvDelta =
-        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_PAST, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvDelta.getAmount(), 0d, TOLERANCE_PV);
   }
 
@@ -281,44 +281,44 @@ public class BlackSwaptionPhysicalProductPricerTest {
   public void present_value_gamma_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
-    double expiry = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = BLACK_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     double pvGammaExpected = BlackFormulaRepository.gamma(forward, STRIKE, expiry, volatility) * Math.abs(pvbp);
     CurrencyAmount pvGammaComputed =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvGammaComputed.getCurrency(), USD);
     assertEquals(pvGammaComputed.getAmount(), pvGammaExpected, TOLERANCE_PV);
   }
 
   public void present_value_gamma_long_short_parity() {
     CurrencyAmount pvGammaLong =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvGammaShort =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvGammaLong.getAmount(), -pvGammaShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_gamma_payer_receiver_parity() {
     CurrencyAmount pvGammaLongPay =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvGammaShortRec =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvGammaLongPay.getAmount() + pvGammaShortRec.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_gamma_at_expiry() {
     CurrencyAmount pvGammaRec =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvGammaRec.getAmount(), 0d, TOLERANCE_PV);
     CurrencyAmount pvGammaPay =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvGammaPay.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_gamma_after_expiry() {
     CurrencyAmount pvGamma =
-        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_PAST, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvGamma.getAmount(), 0d, TOLERANCE_PV);
   }
 
@@ -326,72 +326,72 @@ public class BlackSwaptionPhysicalProductPricerTest {
   public void present_value_theta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
-    double expiry = BLACK_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = BLACK_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     double pvThetaExpected = BlackFormulaRepository.driftlessTheta(forward, STRIKE, expiry, volatility) * Math.abs(pvbp);
     CurrencyAmount pvThetaComputed =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvThetaComputed.getCurrency(), USD);
     assertEquals(pvThetaComputed.getAmount(), pvThetaExpected, TOLERANCE_PV);
   }
 
   public void present_value_theta_long_short_parity() {
     CurrencyAmount pvThetaLong =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvThetaShort =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvThetaLong.getAmount(), -pvThetaShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_theta_payer_receiver_parity() {
     CurrencyAmount pvThetaLongPay =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvThetaShortRec =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvThetaLongPay.getAmount() + pvThetaShortRec.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_theta_at_expiry() {
     CurrencyAmount pvThetaRec =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvThetaRec.getAmount(), 0d, TOLERANCE_PV);
     CurrencyAmount pvThetaPay =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvThetaPay.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_theta_after_expiry() {
     CurrencyAmount pvTheta =
-        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_PAST, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvTheta.getAmount(), 0d, TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------  
   public void currency_exposure() {
     CurrencyAmount pv =
-        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     MultiCurrencyAmount ce =
-        PRICER_SWAPTION_BLACK.currencyExposure(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_BLACK.currencyExposure(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_FD() {
     PointSensitivities pvpt = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_CST_SWAPTION_PROVIDER_USD)
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_CST_USD)
         .build();
     CurrencyParameterSensitivities pvpsAd = MULTI_USD.parameterSensitivity(pvpt);
     CurrencyParameterSensitivities pvpsFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(MULTI_USD,
-        (p) -> PRICER_SWAPTION_BLACK.presentValue(SWAPTION_SHORT_REC, p, BLACK_VOL_CST_SWAPTION_PROVIDER_USD));
+        (p) -> PRICER_SWAPTION_BLACK.presentValue(SWAPTION_SHORT_REC, p, BLACK_VOLS_CST_USD));
     assertTrue(pvpsAd.equalWithTolerance(pvpsFd, TOLERANCE_PV_DELTA));
   }
 
   public void present_value_sensitivity_long_short_parity() {
     PointSensitivities pvptLong = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD).build();
     PointSensitivities pvptShort = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD)
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD)
         .build();
     CurrencyParameterSensitivities pvpsLong = MULTI_USD.parameterSensitivity(pvptLong);
     CurrencyParameterSensitivities pvpsShort = MULTI_USD.parameterSensitivity(pvptShort);
@@ -400,9 +400,9 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivity_payer_receiver_parity() {
     PointSensitivities pvptLongPay = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD).build();
     PointSensitivities pvptShortRec = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD)
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD)
         .build();
     PointSensitivities pvptSwapRec = PRICER_SWAP.presentValueSensitivity(RSWAP_PAY, MULTI_USD).build();
     CurrencyParameterSensitivities pvpsLongPay = MULTI_USD.parameterSensitivity(pvptLongPay);
@@ -413,12 +413,12 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivity_at_expiry() {
     PointSensitivities sensiRec = PRICER_SWAPTION_BLACK.presentValueSensitivityRatesStickyStrike(
-        SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD).build();
     for (PointSensitivity sensi : sensiRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
     PointSensitivities sensiPay = PRICER_SWAPTION_BLACK.presentValueSensitivityRatesStickyStrike(
-        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD).build();
     PointSensitivities sensiPaySwap = PRICER_SWAP.presentValueSensitivity(RSWAP_PAY, MULTI_USD).build();
     assertTrue(MULTI_USD.parameterSensitivity(sensiPay).equalWithTolerance(
         MULTI_USD.parameterSensitivity(sensiPaySwap), TOLERANCE_PV));
@@ -426,7 +426,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivity_after_expiry() {
     PointSensitivityBuilder pvpts = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAST, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvpts, PointSensitivityBuilder.none());
   }
 
@@ -439,17 +439,17 @@ public class BlackSwaptionPhysicalProductPricerTest {
         SwaptionBlackVolatilityDataSets.META_DATA, SwaptionBlackVolatilityDataSets.VOLATILITY - shiftVol);
     CurrencyAmount pvP = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
         BlackSwaptionExpiryTenorVolatilities.of(
-            BLACK_VOL_CST_SWAPTION_PROVIDER_USD.getConvention(), VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceUp));
+            BLACK_VOLS_CST_USD.getConvention(), VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceUp));
     CurrencyAmount pvM = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
         BlackSwaptionExpiryTenorVolatilities.of(
-            BLACK_VOL_CST_SWAPTION_PROVIDER_USD.getConvention(), VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceDw));
+            BLACK_VOLS_CST_USD.getConvention(), VAL_DATE.atStartOfDay(ZoneOffset.UTC), surfaceDw));
     double pvnvsFd = (pvP.getAmount() - pvM.getAmount()) / (2 * shiftVol);
     SwaptionSensitivity pvnvsAd = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_CST_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_CST_USD);
     assertEquals(pvnvsAd.getCurrency(), USD);
     assertEquals(pvnvsAd.getSensitivity(), pvnvsFd, TOLERANCE_PV_VEGA);
-    assertEquals(pvnvsAd.getConvention(), USD_FIXED_6M_LIBOR_3M);
-    assertEquals(pvnvsAd.getExpiry(), BLACK_VOL_CST_SWAPTION_PROVIDER_USD.relativeTime(SWAPTION_LONG_PAY.getExpiry()));
+    assertEquals(pvnvsAd.getVolatilitiesName(), BLACK_VOLS_CST_USD.getName());
+    assertEquals(pvnvsAd.getExpiry(), BLACK_VOLS_CST_USD.relativeTime(SWAPTION_LONG_PAY.getExpiry()));
     assertEquals(pvnvsAd.getTenor(), SWAP_TENOR_YEAR, TOLERANCE_RATE);
     assertEquals(pvnvsAd.getStrike(), STRIKE, TOLERANCE_RATE);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
@@ -458,32 +458,32 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivityBlackVolatility_long_short_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvptLongPay.getSensitivity(), -pvptShortRec.getSensitivity(), TOLERANCE_PV_VEGA);
   }
 
   public void present_value_sensitivityBlackVolatility_payer_receiver_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(pvptLongPay.getSensitivity() + pvptShortRec.getSensitivity(), 0, TOLERANCE_PV_VEGA);
   }
 
   public void present_value_sensitivityBlackVolatility_at_expiry() {
     SwaptionSensitivity sensiRec = PRICER_SWAPTION_BLACK.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(sensiRec.getSensitivity(), 0d, TOLERANCE_PV);
     SwaptionSensitivity sensiPay = PRICER_SWAPTION_BLACK.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(sensiPay.getSensitivity(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_sensitivityBlackVolatility_after_expiry() {
     SwaptionSensitivity v = PRICER_SWAPTION_BLACK
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAST, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertEquals(v.getSensitivity(), 0.0d, TOLERANCE_PV_VEGA);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerCashParYieldTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerCashParYieldTest.java
@@ -89,8 +89,8 @@ public class BlackSwaptionTradePricerCashParYieldTest {
       .build();
 
   private static final ImmutableRatesProvider RATE_PROVIDER = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final BlackSwaptionExpiryTenorVolatilities VOL_PROVIDER =
-      SwaptionBlackVolatilityDataSets.BLACK_VOL_CST_SWAPTION_PROVIDER_USD;
+  private static final BlackSwaptionExpiryTenorVolatilities VOLS =
+      SwaptionBlackVolatilityDataSets.BLACK_SWAPTION_VOLS_CST_USD;
 
   private static final VolatilitySwaptionTradePricer PRICER_COMMON = VolatilitySwaptionTradePricer.DEFAULT;
   private static final BlackSwaptionTradePricer PRICER_TRADE = BlackSwaptionTradePricer.DEFAULT;
@@ -101,32 +101,32 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   public void present_value_premium_forward() {
-    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
     // test via VolatilitySwaptionTradePricer
-    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv, pvTrade);
   }
 
   public void present_value_premium_valuedate() {
-    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
   }
 
   public void present_value_premium_past() {
-    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount(), NOTIONAL * TOL);
   }
 
   //-------------------------------------------------------------------------
   public void currency_exposure_premium_forward() {
-    CurrencyAmount pv = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    MultiCurrencyAmount ce = PRICER_TRADE.currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pv = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    MultiCurrencyAmount ce = PRICER_TRADE.currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), NOTIONAL * TOL);
   }
 
@@ -149,9 +149,9 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade =
-        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
-        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct =
@@ -161,9 +161,9 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * TOL));
@@ -171,9 +171,9 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade =
-        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
-        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * TOL));
@@ -182,9 +182,9 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   //-------------------------------------------------------------------------
   public void present_value_black_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaProduct = PRICER_PRODUCT
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(vegaTrade.getSensitivities().get(0).getSensitivity(), vegaProduct.getSensitivity(), NOTIONAL * TOL);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerPhysicalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerPhysicalTest.java
@@ -95,8 +95,8 @@ public class BlackSwaptionTradePricerPhysicalTest {
   private static final DiscountingPaymentPricer PRICER_PAYMENT = DiscountingPaymentPricer.DEFAULT;
 
   private static final ImmutableRatesProvider MULTI_USD = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_SWAPTION_PROVIDER_USD =
-      SwaptionBlackVolatilityDataSets.BLACK_VOL_SWAPTION_PROVIDER_USD_STD;
+  private static final BlackSwaptionExpiryTenorVolatilities BLACK_VOLS_USD =
+      SwaptionBlackVolatilityDataSets.BLACK_SWAPTION_VOLS_USD_STD;
 
   private static final double TOLERANCE_PV = 1.0E-2;
   private static final double TOLERANCE_PV_DELTA = 1.0E+2;
@@ -105,22 +105,22 @@ public class BlackSwaptionTradePricerPhysicalTest {
   //-------------------------------------------------------------------------
   public void present_value_premium_forward() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, MULTI_USD);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), TOLERANCE_PV);
     // test via VolatilitySwaptionTradePricer
-    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     assertEquals(pv, pvTrade);
   }
 
   public void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
         PRICER_TRADE
-            .presentValue(SWAPTION_PRETOD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+            .presentValue(SWAPTION_PRETOD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, MULTI_USD);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), TOLERANCE_PV);
   }
@@ -128,18 +128,18 @@ public class BlackSwaptionTradePricerPhysicalTest {
   public void present_value_premium_past() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, MULTI_USD,
-            BLACK_VOL_SWAPTION_PROVIDER_USD);
+            BLACK_VOLS_USD);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount(), TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------
   public void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
-        .presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     MultiCurrencyAmount ce = PRICER_TRADE
-        .currencyExposure(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .currencyExposure(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), TOLERANCE_PV);
   }
 
@@ -162,9 +162,9 @@ public class BlackSwaptionTradePricerPhysicalTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, MULTI_USD);
     CurrencyParameterSensitivities pvpsTrade = MULTI_USD.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct =
@@ -174,9 +174,9 @@ public class BlackSwaptionTradePricerPhysicalTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyParameterSensitivities pvpsTrade = MULTI_USD.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = MULTI_USD.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, TOLERANCE_PV_DELTA));
@@ -184,9 +184,9 @@ public class BlackSwaptionTradePricerPhysicalTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyParameterSensitivities pvpsTrade = MULTI_USD.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = MULTI_USD.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, TOLERANCE_PV_DELTA));
@@ -195,9 +195,9 @@ public class BlackSwaptionTradePricerPhysicalTest {
   //-------------------------------------------------------------------------
   public void present_value_black_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     SwaptionSensitivity vegaProduct = PRICER_PRODUCT
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     assertEquals(vegaTrade.getSensitivities().get(0).getSensitivity(), vegaProduct.getSensitivity(), TOLERANCE_PV_VEGA);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
@@ -156,10 +156,10 @@ public class NormalSwaptionCashParYieldProductPricerTest {
       .resolve(REF_DATA);
   // volatility and rate providers
   private static final ImmutableRatesProvider RATE_PROVIDER = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final NormalSwaptionExpiryTenorVolatilities VOL_PROVIDER =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_STD;
-  private static final NormalSwaptionVolatilities VOL_PROVIDER_FLAT =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT;
+  private static final NormalSwaptionExpiryTenorVolatilities VOLS =
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_STD;
+  private static final NormalSwaptionVolatilities VOLS_FLAT =
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_FLAT;
   // test parameters
   private static final double FD_EPS = 1.0E-7;
   private static final double TOL = 1.0e-12;
@@ -173,14 +173,14 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   public void test_presentValue() {
-    CurrencyAmount pvRecComputed = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPayComputed = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvRecComputed = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPayComputed = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), forward);
-    double volatility = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
+    double volatility = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
     double discount = RATE_PROVIDER.discountFactor(USD, SETTLE_DATE);
     NormalFunctionData normalData = NormalFunctionData.of(forward, annuityCash * discount, volatility);
-    double expiry = VOL_PROVIDER.relativeTime(SWAPTION_REC_LONG.getExpiry());
+    double expiry = VOLS.relativeTime(SWAPTION_REC_LONG.getExpiry());
     EuropeanVanillaOption optionRec = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     EuropeanVanillaOption optionPay = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.CALL);
     double pvRecExpected = NORMAL.getPriceFunction(optionRec).apply(normalData);
@@ -192,8 +192,8 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   public void test_presentValue_at_expiry() {
-    CurrencyAmount pvRec = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvRec = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), forward);
     double discount = RATE_PROVIDER.discountFactor(USD, SETTLE_DATE);
@@ -202,17 +202,17 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   public void test_presentValue_after_expiry() {
-    CurrencyAmount pvRec = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvRec = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(pvRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(pvPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValue_parity() {
-    CurrencyAmount pvRecLong = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvRecShort = PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPayLong = PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPayShort = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvRecLong = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvRecShort = PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPayLong = PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPayShort = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(pvRecLong.getAmount(), -pvRecShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvPayLong.getAmount(), -pvPayShort.getAmount(), NOTIONAL * TOL);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -232,21 +232,21 @@ public class NormalSwaptionCashParYieldProductPricerTest {
         .longShort(LongShort.LONG)
         .underlying(SWAP_REC)
         .build();
-    assertThrowsIllegalArg(() -> PRICER_SWAPTION.presentValue(swaption.resolve(REF_DATA), RATE_PROVIDER, VOL_PROVIDER));
+    assertThrowsIllegalArg(() -> PRICER_SWAPTION.presentValue(swaption.resolve(REF_DATA), RATE_PROVIDER, VOLS));
   }
 
   //-------------------------------------------------------------------------
   public void test_presentValueDelta() {
     CurrencyAmount pvDeltaRecComputed =
-        PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaPayComputed =
-        PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), forward);
-    double volatility = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
+    double volatility = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
     double discount = RATE_PROVIDER.discountFactor(USD, SETTLE_DATE);
     NormalFunctionData normalData = NormalFunctionData.of(forward, annuityCash * discount, volatility);
-    double expiry = VOL_PROVIDER.relativeTime(SWAPTION_REC_LONG.getExpiry());
+    double expiry = VOLS.relativeTime(SWAPTION_REC_LONG.getExpiry());
     EuropeanVanillaOption optionRec = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     EuropeanVanillaOption optionPay = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.CALL);
     double pvDeltaRecExpected = NORMAL.getDelta(optionRec, normalData);
@@ -259,9 +259,9 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueDelta_at_expiry() {
     CurrencyAmount pvDeltaRec =
-        PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaPay =
-        PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), forward);
     double discount = RATE_PROVIDER.discountFactor(USD, SETTLE_DATE);
@@ -270,17 +270,17 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   public void test_presentValueDelta_after_expiry() {
-    CurrencyAmount pvDeltaRec = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvDeltaPay = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvDeltaRec = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvDeltaPay = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(pvDeltaRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(pvDeltaPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueDelta_parity() {
-    CurrencyAmount pvDeltaRecLong = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvDeltaRecShort = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvDeltaPayLong = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvDeltaPayShort = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvDeltaRecLong = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvDeltaRecShort = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvDeltaPayLong = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvDeltaPayShort = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(pvDeltaRecLong.getAmount(), -pvDeltaRecShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvDeltaPayLong.getAmount(), -pvDeltaPayShort.getAmount(), NOTIONAL * TOL);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -294,15 +294,15 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueGamma() {
     CurrencyAmount pvGammaRecComputed =
-        PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaPayComputed =
-        PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), forward);
-    double volatility = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
+    double volatility = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
     double discount = RATE_PROVIDER.discountFactor(USD, SETTLE_DATE);
     NormalFunctionData normalData = NormalFunctionData.of(forward, annuityCash * discount, volatility);
-    double expiry = VOL_PROVIDER.relativeTime(SWAPTION_REC_LONG.getExpiry());
+    double expiry = VOLS.relativeTime(SWAPTION_REC_LONG.getExpiry());
     EuropeanVanillaOption optionRec = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     EuropeanVanillaOption optionPay = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.CALL);
     double pvGammaRecExpected = NORMAL.getGamma(optionRec, normalData);
@@ -315,25 +315,25 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueGamma_at_expiry() {
     CurrencyAmount pvGammaRec =
-        PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaPay =
-        PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     assertEquals(pvGammaRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(pvGammaPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueGamma_after_expiry() {
-    CurrencyAmount pvGammaRec = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvGammaPay = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvGammaRec = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvGammaPay = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(pvGammaRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(pvGammaPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueGamma_parity() {
-    CurrencyAmount pvGammaRecLong = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvGammaRecShort = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvGammaPayLong = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvGammaPayShort = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvGammaRecLong = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvGammaRecShort = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvGammaPayLong = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvGammaPayShort = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(pvGammaRecLong.getAmount(), -pvGammaRecShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvGammaPayLong.getAmount(), -pvGammaPayShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvGammaPayLong.getAmount(), pvGammaRecLong.getAmount(), NOTIONAL * TOL);
@@ -343,16 +343,16 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueTheta() {
     CurrencyAmount pvThetaRecComputed =
-        PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaPayComputed =
-        PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), forward);
-    double volatility = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE,
+    double volatility = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE,
         forward);
     double discount = RATE_PROVIDER.discountFactor(USD, SETTLE_DATE);
     NormalFunctionData normalData = NormalFunctionData.of(forward, annuityCash * discount, volatility);
-    double expiry = VOL_PROVIDER.relativeTime(SWAPTION_REC_LONG.getExpiry());
+    double expiry = VOLS.relativeTime(SWAPTION_REC_LONG.getExpiry());
     EuropeanVanillaOption optionRec = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     EuropeanVanillaOption optionPay = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.CALL);
     double pvThetaRecExpected = NORMAL.getTheta(optionRec, normalData);
@@ -365,25 +365,25 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueTheta_at_expiry() {
     CurrencyAmount pvThetaRec =
-        PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaPay =
-        PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     assertEquals(pvThetaRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(pvThetaPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueTheta_after_expiry() {
-    CurrencyAmount pvThetaRec = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvThetaPay = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvThetaRec = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvThetaPay = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(pvThetaRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(pvThetaPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueTheta_parity() {
-    CurrencyAmount pvThetaRecLong = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvThetaRecShort = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvThetaPayLong = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvThetaPayShort = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvThetaRecLong = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvThetaRecShort = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvThetaPayLong = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvThetaPayShort = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(pvThetaRecLong.getAmount(), -pvThetaRecShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvThetaPayLong.getAmount(), -pvThetaPayShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvThetaPayLong.getAmount(), pvThetaRecLong.getAmount(), NOTIONAL * TOL);
@@ -392,46 +392,46 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------  
   public void test_currencyExposure() {
-    MultiCurrencyAmount computedRec = PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    MultiCurrencyAmount computedPay = PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    MultiCurrencyAmount computedRec = PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    MultiCurrencyAmount computedPay = PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointRec =
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
-        .plus(PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER));
+        .plus(PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), expectedRec.getAmount(USD).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
-        .plus(PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER));
+        .plus(PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS));
     assertEquals(computedPay.size(), 1);
     assertEquals(computedPay.getAmount(USD).getAmount(), expectedPay.getAmount(USD).getAmount(), NOTIONAL * TOL);
   }
 
   public void test_currencyExposure_at_expiry() {
     MultiCurrencyAmount computedRec =
-        PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay =
-        PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointRec =
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
-        .plus(PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER));
+        .plus(PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), expectedRec.getAmount(USD).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
-        .plus(PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER));
+        .plus(PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS));
     assertEquals(computedPay.size(), 1);
     assertEquals(computedPay.getAmount(USD).getAmount(), expectedPay.getAmount(USD).getAmount(), NOTIONAL * TOL);
   }
 
   public void test_currencyExposure_after_expiry() {
     MultiCurrencyAmount computedRec =
-        PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay =
-        PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(USD).getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(computedPay.size(), 1);
@@ -441,58 +441,58 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_impliedVolatility() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
-    double expected = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
-    double computedRec = PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    double computedPay = PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    double expected = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
+    double computedRec = PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    double computedPay = PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(computedRec, expected, TOL);
     assertEquals(computedPay, expected, TOL);
   }
 
   public void test_impliedVolatility_at_expiry() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
-    double expected = VOL_PROVIDER.volatility(
+    double expected = VOLS.volatility(
         VAL_DATE.atTime(SWAPTION_EXPIRY_TIME).atZone(SWAPTION_EXPIRY_ZONE), SWAP_TENOR_YEAR, STRIKE, forward);
-    double computedRec = PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
-    double computedPay = PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+    double computedRec = PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
+    double computedPay = PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     assertEquals(computedRec, expected, TOL);
     assertEquals(computedPay, expected, TOL);
   }
 
   public void test_impliedVolatility_after_expiry() {
-    assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER));
-    assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER));
+    assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS));
+    assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS));
   }
 
   //-------------------------------------------------------------------------
   public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
     CurrencyAmount pvLongRec =
-        PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     double impliedLongRecComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
         SWAPTION_REC_LONG, RATE_PROVIDER, ACT_365F, pvLongRec.getAmount());
     double impliedLongRecInterpolated =
-        PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     assertEquals(impliedLongRecComputed, impliedLongRecInterpolated, TOL);
 
     CurrencyAmount pvLongPay =
-        PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
     double impliedLongPayComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
         SWAPTION_PAY_LONG, RATE_PROVIDER, ACT_365F, pvLongPay.getAmount());
     double impliedLongPayInterpolated =
-        PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.impliedVolatility(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
     assertEquals(impliedLongPayComputed, impliedLongPayInterpolated, TOL);
 
     CurrencyAmount pvShortRec =
-        PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     double impliedShortRecComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
         SWAPTION_REC_SHORT, RATE_PROVIDER, ACT_365F, pvShortRec.getAmount());
     double impliedShortRecInterpolated =
-        PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(impliedShortRecComputed, impliedShortRecInterpolated, TOL);
   }
 
   public void implied_volatility_wrong_sign() {
     CurrencyAmount pvLongRec =
-        PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     assertThrowsIllegalArg(() -> PRICER_SWAPTION.impliedVolatilityFromPresentValue(
         SWAPTION_REC_LONG, RATE_PROVIDER, ACT_365F, -pvLongRec.getAmount()));
   }
@@ -500,51 +500,51 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivityRatesStickyStrike() {
     PointSensitivities pointRec = PRICER_SWAPTION
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER_FLAT).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS_FLAT).build();
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec);
     CurrencyParameterSensitivities expectedRec = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
-        RATE_PROVIDER, (p) -> PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, p, VOL_PROVIDER_FLAT));
+        RATE_PROVIDER, (p) -> PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, p, VOLS_FLAT));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 200d));
     PointSensitivities pointPay = PRICER_SWAPTION
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER_FLAT).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS_FLAT).build();
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay);
     CurrencyParameterSensitivities expectedPay = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
-        RATE_PROVIDER, (p) -> PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, p, VOL_PROVIDER_FLAT));
+        RATE_PROVIDER, (p) -> PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, p, VOLS_FLAT));
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 200d));
   }
 
   public void test_presentValueSensitivityRatesStickyStrike_at_expiry() {
     PointSensitivities pointRec = PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(
-        SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER).build();
+        SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
     PointSensitivities pointPay = PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(
-        SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER).build();
+        SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS).build();
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay);
     CurrencyParameterSensitivities expectedPay = FINITE_DIFFERENCE_CALCULATOR.sensitivity(
-        RATE_PROVIDER, (p) -> PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, p, VOL_PROVIDER_FLAT));
+        RATE_PROVIDER, (p) -> PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, p, VOLS_FLAT));
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 100d));
   }
 
   public void test_presentValueSensitivityRatesStickyStrike_after_expiry() {
     PointSensitivityBuilder pointRec = PRICER_SWAPTION
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointPay = PRICER_SWAPTION
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(pointRec, PointSensitivityBuilder.none());
     assertEquals(pointPay, PointSensitivityBuilder.none());
   }
 
   public void test_presentValueSensitivityRatesStickyStrike_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiPayLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiPayShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS).build());
     assertTrue(pvSensiRecLong.equalWithTolerance(pvSensiRecShort.multipliedBy(-1d), NOTIONAL * TOL));
     assertTrue(pvSensiPayLong.equalWithTolerance(pvSensiPayShort.multipliedBy(-1d), NOTIONAL * TOL));
 
@@ -567,7 +567,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivityNormalVolatility() {
     SwaptionSensitivity computedRec = PRICER_SWAPTION
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvRecUp = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER,
         SwaptionNormalVolatilityDataSets.normalVolSwaptionProviderUsdStsShifted(FD_EPS));
     CurrencyAmount pvRecDw = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER,
@@ -575,13 +575,13 @@ public class NormalSwaptionCashParYieldProductPricerTest {
     double expectedRec = 0.5 * (pvRecUp.getAmount() - pvRecDw.getAmount()) / FD_EPS;
     assertEquals(computedRec.getCurrency(), USD);
     assertEquals(computedRec.getSensitivity(), expectedRec, FD_EPS * NOTIONAL);
-    assertEquals(computedRec.getConvention(), SwaptionNormalVolatilityDataSets.USD_1Y_LIBOR3M);
-    assertEquals(computedRec.getExpiry(), VOL_PROVIDER.relativeTime(SWAPTION_REC_LONG.getExpiry()));
+    assertEquals(computedRec.getVolatilitiesName(), VOLS.getName());
+    assertEquals(computedRec.getExpiry(), VOLS.relativeTime(SWAPTION_REC_LONG.getExpiry()));
     assertEquals(computedRec.getTenor(), SWAP_TENOR_YEAR, TOL);
     assertEquals(computedRec.getStrike(), STRIKE, TOL);
     assertEquals(computedRec.getForward(), PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER), TOL);
     SwaptionSensitivity computedPay = PRICER_SWAPTION
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvUpPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER,
         SwaptionNormalVolatilityDataSets.normalVolSwaptionProviderUsdStsShifted(FD_EPS));
     CurrencyAmount pvDwPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER,
@@ -589,8 +589,8 @@ public class NormalSwaptionCashParYieldProductPricerTest {
     double expectedPay = 0.5 * (pvUpPay.getAmount() - pvDwPay.getAmount()) / FD_EPS;
     assertEquals(computedPay.getCurrency(), USD);
     assertEquals(computedPay.getSensitivity(), expectedPay, FD_EPS * NOTIONAL);
-    assertEquals(computedPay.getConvention(), SwaptionNormalVolatilityDataSets.USD_1Y_LIBOR3M);
-    assertEquals(computedPay.getExpiry(), VOL_PROVIDER.relativeTime(SWAPTION_PAY_SHORT.getExpiry()));
+    assertEquals(computedPay.getVolatilitiesName(), VOLS.getName());
+    assertEquals(computedPay.getExpiry(), VOLS.relativeTime(SWAPTION_PAY_SHORT.getExpiry()));
     assertEquals(computedPay.getTenor(), SWAP_TENOR_YEAR, TOL);
     assertEquals(computedPay.getStrike(), STRIKE, TOL);
     assertEquals(computedPay.getForward(), PRICER_SWAP.parRate(RSWAP_PAY, RATE_PROVIDER), TOL);
@@ -598,31 +598,31 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivityNormalVolatility_at_expiry() {
     SwaptionSensitivity sensiRec =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     assertEquals(sensiRec.getSensitivity(), 0d, NOTIONAL * TOL);
     SwaptionSensitivity sensiPay =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     assertEquals(sensiPay.getSensitivity(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueSensitivityNormalVolatility_after_expiry() {
     SwaptionSensitivity sensiRec =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     SwaptionSensitivity sensiPay =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertEquals(sensiRec.getSensitivity(), 0.0d, NOTIONAL * TOL);
     assertEquals(sensiPay.getSensitivity(), 0.0d, NOTIONAL * TOL);
   }
 
   public void test_presentValueSensitivityNormalVolatility_parity() {
     SwaptionSensitivity pvSensiRecLong =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     SwaptionSensitivity pvSensiRecShort =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     SwaptionSensitivity pvSensiPayLong =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
     SwaptionSensitivity pvSensiPayShort =
-        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(pvSensiRecLong.getSensitivity(), -pvSensiRecShort.getSensitivity(), NOTIONAL * TOL);
     assertEquals(pvSensiPayLong.getSensitivity(), -pvSensiPayShort.getSensitivity(), NOTIONAL * TOL);
     assertEquals(pvSensiRecLong.getSensitivity(), pvSensiPayLong.getSensitivity(), NOTIONAL * TOL);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilitiesTest.java
@@ -76,7 +76,7 @@ public class NormalSwaptionExpirySimpleMoneynessVolatilitiesTest {
   private static final LocalTime VAL_TIME = LocalTime.of(13, 45);
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
-  private static final NormalSwaptionExpirySimpleMoneynessVolatilities PROVIDER =
+  private static final NormalSwaptionExpirySimpleMoneynessVolatilities VOLS =
       NormalSwaptionExpirySimpleMoneynessVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
@@ -91,40 +91,40 @@ public class NormalSwaptionExpirySimpleMoneynessVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void test_valuationDate() {
-    assertEquals(PROVIDER.getValuationDateTime(), VAL_DATE_TIME);
+    assertEquals(VOLS.getValuationDateTime(), VAL_DATE_TIME);
   }
 
   public void test_swapConvention() {
-    assertEquals(PROVIDER.getConvention(), CONVENTION);
+    assertEquals(VOLS.getConvention(), CONVENTION);
   }
 
   public void test_findData() {
-    assertEquals(PROVIDER.findData(SURFACE.getName()), Optional.of(SURFACE));
-    assertEquals(PROVIDER.findData(SurfaceName.of("Rubbish")), Optional.empty());
+    assertEquals(VOLS.findData(SURFACE.getName()), Optional.of(SURFACE));
+    assertEquals(VOLS.findData(SurfaceName.of("Rubbish")), Optional.empty());
   }
 
   public void test_tenor() {
-    double test1 = PROVIDER.tenor(VAL_DATE, VAL_DATE);
+    double test1 = VOLS.tenor(VAL_DATE, VAL_DATE);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 28));
+    double test2 = VOLS.tenor(VAL_DATE, date(2018, 2, 28));
     assertEquals(test2, 3d);
-    double test3 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 10));
+    double test3 = VOLS.tenor(VAL_DATE, date(2018, 2, 10));
     assertEquals(test3, 3d);
   }
 
   public void test_relativeTime() {
-    double test1 = PROVIDER.relativeTime(VAL_DATE_TIME);
+    double test1 = VOLS.relativeTime(VAL_DATE_TIME);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
-    double test3 = PROVIDER.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test2 = VOLS.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test3 = VOLS.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
     assertEquals(test2, -test3); // consistency checked
   }
 
   public void test_volatility() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       double volExpected = SURFACE.zValue(expiryTime, TEST_STRIKE[i] - TEST_FORWARD[i]);
-      double volComputed = PROVIDER.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD[i]);
+      double volComputed = VOLS.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD[i]);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);
     }
   }
@@ -133,10 +133,10 @@ public class NormalSwaptionExpirySimpleMoneynessVolatilitiesTest {
     double eps = 1.0e-6;
     int nData = TIME.size();
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       SwaptionSensitivity point = SwaptionSensitivity.of(
-          CONVENTION, expiryTime, TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD[i], GBP, TEST_SENSITIVITY[i]);
-      CurrencyParameterSensitivities sensActual = PROVIDER.parameterSensitivity(point);
+          VOLS.getName(), expiryTime, TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD[i], GBP, TEST_SENSITIVITY[i]);
+      CurrencyParameterSensitivities sensActual = VOLS.parameterSensitivity(point);
       CurrencyParameterSensitivity sensi = sensActual.getSensitivity(SURFACE.getName(), GBP);
       DoubleArray computed = sensi.getSensitivity();
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilitiesTest.java
@@ -74,7 +74,7 @@ public class NormalSwaptionExpiryStrikeVolatilitiesTest {
   private static final LocalTime VAL_TIME = LocalTime.of(13, 45);
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
-  private static final NormalSwaptionExpiryStrikeVolatilities PROVIDER =
+  private static final NormalSwaptionExpiryStrikeVolatilities VOLS =
       NormalSwaptionExpiryStrikeVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
@@ -89,40 +89,40 @@ public class NormalSwaptionExpiryStrikeVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void test_valuationDate() {
-    assertEquals(PROVIDER.getValuationDateTime(), VAL_DATE_TIME);
+    assertEquals(VOLS.getValuationDateTime(), VAL_DATE_TIME);
   }
 
   public void test_swapConvention() {
-    assertEquals(PROVIDER.getConvention(), CONVENTION);
+    assertEquals(VOLS.getConvention(), CONVENTION);
   }
 
   public void test_findData() {
-    assertEquals(PROVIDER.findData(SURFACE.getName()), Optional.of(SURFACE));
-    assertEquals(PROVIDER.findData(SurfaceName.of("Rubbish")), Optional.empty());
+    assertEquals(VOLS.findData(SURFACE.getName()), Optional.of(SURFACE));
+    assertEquals(VOLS.findData(SurfaceName.of("Rubbish")), Optional.empty());
   }
 
   public void test_tenor() {
-    double test1 = PROVIDER.tenor(VAL_DATE, VAL_DATE);
+    double test1 = VOLS.tenor(VAL_DATE, VAL_DATE);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 28));
+    double test2 = VOLS.tenor(VAL_DATE, date(2018, 2, 28));
     assertEquals(test2, 3d);
-    double test3 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 10));
+    double test3 = VOLS.tenor(VAL_DATE, date(2018, 2, 10));
     assertEquals(test3, 3d);
   }
 
   public void test_relativeTime() {
-    double test1 = PROVIDER.relativeTime(VAL_DATE_TIME);
+    double test1 = VOLS.relativeTime(VAL_DATE_TIME);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
-    double test3 = PROVIDER.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test2 = VOLS.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test3 = VOLS.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
     assertEquals(test2, -test3); // consistency checked
   }
 
   public void test_volatility() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       double volExpected = SURFACE.zValue(expiryTime, TEST_STRIKE[i]);
-      double volComputed = PROVIDER.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD);
+      double volComputed = VOLS.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);
     }
   }
@@ -131,10 +131,10 @@ public class NormalSwaptionExpiryStrikeVolatilitiesTest {
     double eps = 1.0e-6;
     int nData = TIME.size();
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       SwaptionSensitivity point = SwaptionSensitivity.of(
-          CONVENTION, expiryTime, TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
-      CurrencyParameterSensitivities sensActual = PROVIDER.parameterSensitivity(point);
+          VOLS.getName(), expiryTime, TEST_TENOR, TEST_STRIKE[i], TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
+      CurrencyParameterSensitivities sensActual = VOLS.parameterSensitivity(point);
       CurrencyParameterSensitivity sensi = sensActual.getSensitivity(SURFACE.getName(), GBP);
       DoubleArray computed = sensi.getSensitivity();
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilitiesTest.java
@@ -74,7 +74,7 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
   private static final LocalTime VAL_TIME = LocalTime.of(13, 45);
   private static final ZoneId LONDON_ZONE = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME = VAL_DATE.atTime(VAL_TIME).atZone(LONDON_ZONE);
-  private static final NormalSwaptionExpiryTenorVolatilities PROVIDER =
+  private static final NormalSwaptionExpiryTenorVolatilities VOLS =
       NormalSwaptionExpiryTenorVolatilities.of(CONVENTION, VAL_DATE_TIME, SURFACE);
 
   private static final ZonedDateTime[] TEST_OPTION_EXPIRY = new ZonedDateTime[] {
@@ -89,40 +89,40 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
 
   //-------------------------------------------------------------------------
   public void test_valuationDate() {
-    assertEquals(PROVIDER.getValuationDateTime(), VAL_DATE_TIME);
+    assertEquals(VOLS.getValuationDateTime(), VAL_DATE_TIME);
   }
 
   public void test_swapConvention() {
-    assertEquals(PROVIDER.getConvention(), CONVENTION);
+    assertEquals(VOLS.getConvention(), CONVENTION);
   }
 
   public void test_findData() {
-    assertEquals(PROVIDER.findData(SURFACE.getName()), Optional.of(SURFACE));
-    assertEquals(PROVIDER.findData(SurfaceName.of("Rubbish")), Optional.empty());
+    assertEquals(VOLS.findData(SURFACE.getName()), Optional.of(SURFACE));
+    assertEquals(VOLS.findData(SurfaceName.of("Rubbish")), Optional.empty());
   }
 
   public void test_tenor() {
-    double test1 = PROVIDER.tenor(VAL_DATE, VAL_DATE);
+    double test1 = VOLS.tenor(VAL_DATE, VAL_DATE);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 28));
+    double test2 = VOLS.tenor(VAL_DATE, date(2018, 2, 28));
     assertEquals(test2, 3d);
-    double test3 = PROVIDER.tenor(VAL_DATE, date(2018, 2, 10));
+    double test3 = VOLS.tenor(VAL_DATE, date(2018, 2, 10));
     assertEquals(test3, 3d);
   }
 
   public void test_relativeTime() {
-    double test1 = PROVIDER.relativeTime(VAL_DATE_TIME);
+    double test1 = VOLS.relativeTime(VAL_DATE_TIME);
     assertEquals(test1, 0d);
-    double test2 = PROVIDER.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
-    double test3 = PROVIDER.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test2 = VOLS.relativeTime(date(2018, 2, 17).atStartOfDay(LONDON_ZONE));
+    double test3 = VOLS.relativeTime(date(2012, 2, 17).atStartOfDay(LONDON_ZONE));
     assertEquals(test2, -test3); // consistency checked
   }
 
   public void test_volatility() {
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       double volExpected = SURFACE.zValue(expiryTime, TEST_TENOR[i]);
-      double volComputed = PROVIDER.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
+      double volComputed = VOLS.volatility(TEST_OPTION_EXPIRY[i], TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD);
       assertEquals(volComputed, volExpected, TOLERANCE_VOL);
     }
   }
@@ -131,10 +131,10 @@ public class NormalSwaptionExpiryTenorVolatilitiesTest {
     double eps = 1.0e-6;
     int nData = TIME.size();
     for (int i = 0; i < NB_TEST; i++) {
-      double expiryTime = PROVIDER.relativeTime(TEST_OPTION_EXPIRY[i]);
+      double expiryTime = VOLS.relativeTime(TEST_OPTION_EXPIRY[i]);
       SwaptionSensitivity point = SwaptionSensitivity.of(
-          CONVENTION, expiryTime, TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
-      CurrencyParameterSensitivities sensActual = PROVIDER.parameterSensitivity(point);
+          VOLS.getName(), expiryTime, TEST_TENOR[i], TEST_STRIKE, TEST_FORWARD, GBP, TEST_SENSITIVITY[i]);
+      CurrencyParameterSensitivities sensActual = VOLS.parameterSensitivity(point);
       CurrencyParameterSensitivity sensi = sensActual.getSensitivity(SURFACE.getName(), GBP);
       DoubleArray computed = sensi.getSensitivity();
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
@@ -154,10 +154,10 @@ public class NormalSwaptionPhysicalProductPricerTest {
       new RatesFiniteDifferenceSensitivityCalculator(FD_SHIFT);
 
   private static final ImmutableRatesProvider MULTI_USD = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_STD =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_STD;
-  private static final NormalSwaptionVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT;
+  private static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOLS_USD_STD =
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_STD;
+  private static final NormalSwaptionVolatilities NORMAL_VOLS_USD_FLAT =
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_FLAT;
 
   private static final double TOLERANCE_PV = 1.0E-2;
   private static final double TOLERANCE_PV_DELTA = 1.0E+2;
@@ -167,54 +167,54 @@ public class NormalSwaptionPhysicalProductPricerTest {
   //-------------------------------------------------------------------------
   public void validate_physical_settlement() {
     assertThrowsIllegalArg(() -> PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC_CASH, MULTI_USD,
-        NORMAL_VOL_SWAPTION_PROVIDER_USD_STD));
+        NORMAL_VOLS_USD_STD));
   }
 
   //-------------------------------------------------------------------------
   public void test_implied_volatility() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
-    double volExpected = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volExpected = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
     double volComputed = PRICER_SWAPTION_NORMAL
-        .impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(volComputed, volExpected, TOLERANCE_RATE);
   }
 
   public void test_implied_volatility_after_expiry() {
     assertThrowsIllegalArg(() -> PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_PAST, MULTI_USD,
-        NORMAL_VOL_SWAPTION_PROVIDER_USD_STD));
+        NORMAL_VOLS_USD_STD));
   }
 
   //-------------------------------------------------------------------------
   public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
     CurrencyAmount pvLongRec =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     double impliedLongRecComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
         SWAPTION_LONG_REC, MULTI_USD, ACT_365F, pvLongRec.getAmount());
     double impliedLongRecInterpolated =
-        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(impliedLongRecComputed, impliedLongRecInterpolated, TOLERANCE_RATE);
 
     CurrencyAmount pvShortRec =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     double impliedShortRecComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
         SWAPTION_SHORT_REC, MULTI_USD, ACT_365F, pvShortRec.getAmount());
     double impliedShortRecInterpolated =
-        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(impliedShortRecComputed, impliedShortRecInterpolated, TOLERANCE_RATE);
 
     CurrencyAmount pvLongPay =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     double impliedLongPayComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
         SWAPTION_LONG_PAY, MULTI_USD, ACT_365F, pvLongPay.getAmount());
     double impliedLongPayInterpolated =
-        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(impliedLongPayComputed, impliedLongPayInterpolated, TOLERANCE_RATE);
   }
 
   public void implied_volatility_wrong_sign() {
     CurrencyAmount pvLongRec =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThrowsIllegalArg(() -> PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
         SWAPTION_LONG_REC, MULTI_USD, ACT_365F, -pvLongRec.getAmount()));
   }
@@ -223,31 +223,31 @@ public class NormalSwaptionPhysicalProductPricerTest {
   public void present_value_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
     NormalFunctionData normalData = NormalFunctionData.of(forward, Math.abs(pvbp), volatility);
-    double expiry = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = NORMAL_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     EuropeanVanillaOption option = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     double pvExpected = NORMAL.getPriceFunction(option).apply(normalData);
     CurrencyAmount pvComputed =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvComputed.getCurrency(), USD);
     assertEquals(pvComputed.getAmount(), pvExpected, TOLERANCE_PV);
   }
 
   public void present_value_long_short_parity() {
     CurrencyAmount pvLong =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvShort =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvLong.getAmount(), -pvShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_payer_receiver_parity() {
     CurrencyAmount pvLongPay =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvShortRec =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     MultiCurrencyAmount pvSwapPay =
         PRICER_SWAP.presentValue(RSWAP_PAY, MULTI_USD);
     assertEquals(pvLongPay.getAmount() + pvShortRec.getAmount(), pvSwapPay.getAmount(USD).getAmount(), TOLERANCE_PV);
@@ -255,15 +255,15 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   public void present_value_at_expiry() {
     CurrencyAmount pvRec =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvRec.getAmount(), 0.0d, TOLERANCE_PV);
     CurrencyAmount pvPay =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvPay.getAmount(), PRICER_SWAP.presentValue(RSWAP_PAY, MULTI_USD).getAmount(USD).getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_after_expiry() {
-    CurrencyAmount pv = PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_PAST, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+    CurrencyAmount pv = PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pv.getAmount(), 0.0d, TOLERANCE_PV);
   }
 
@@ -271,48 +271,48 @@ public class NormalSwaptionPhysicalProductPricerTest {
   public void present_value_delta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
     NormalFunctionData normalData = NormalFunctionData.of(forward, Math.abs(pvbp), volatility);
-    double expiry = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = NORMAL_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     EuropeanVanillaOption option = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     double pvDeltaExpected = NORMAL.getDelta(option, normalData);
     CurrencyAmount pvDeltaComputed =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvDeltaComputed.getCurrency(), USD);
     assertEquals(pvDeltaComputed.getAmount(), pvDeltaExpected, TOLERANCE_PV);
   }
 
   public void present_value_delta_long_short_parity() {
     CurrencyAmount pvDeltaLong =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvDeltaShort =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvDeltaLong.getAmount(), -pvDeltaShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_delta_payer_receiver_parity() {
     CurrencyAmount pvDeltaLongPay =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvDeltaShortRec =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     assertEquals(pvDeltaLongPay.getAmount() + pvDeltaShortRec.getAmount(), Math.abs(pvbp), TOLERANCE_PV);
   }
 
   public void present_value_delta_at_expiry() {
     CurrencyAmount pvDeltaRec =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvDeltaRec.getAmount(), 0d, TOLERANCE_PV);
     CurrencyAmount pvDeltaPay =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     assertEquals(pvDeltaPay.getAmount(), Math.abs(pvbp), TOLERANCE_PV);
   }
 
   public void present_value_delta_after_expiry() {
     CurrencyAmount pvDelta =
-        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_PAST, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvDelta.getAmount(), 0d, TOLERANCE_PV);
   }
 
@@ -320,46 +320,46 @@ public class NormalSwaptionPhysicalProductPricerTest {
   public void present_value_gamma_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
     NormalFunctionData normalData = NormalFunctionData.of(forward, Math.abs(pvbp), volatility);
-    double expiry = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = NORMAL_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     EuropeanVanillaOption option = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     double pvGammaExpected = NORMAL.getGamma(option, normalData);
     CurrencyAmount pvGammaComputed =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvGammaComputed.getCurrency(), USD);
     assertEquals(pvGammaComputed.getAmount(), pvGammaExpected, TOLERANCE_PV);
   }
 
   public void present_value_gamma_long_short_parity() {
     CurrencyAmount pvGammaLong =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvGammaShort =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvGammaLong.getAmount(), -pvGammaShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_gamma_payer_receiver_parity() {
     CurrencyAmount pvGammaLongPay =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvGammaShortRec =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvGammaLongPay.getAmount() + pvGammaShortRec.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_gamma_at_expiry() {
     CurrencyAmount pvGammaRec =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvGammaRec.getAmount(), 0d, TOLERANCE_PV);
     CurrencyAmount pvGammaPay =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvGammaPay.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_gamma_after_expiry() {
     CurrencyAmount pvGamma =
-        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_PAST, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvGamma.getAmount(), 0d, TOLERANCE_PV);
   }
 
@@ -367,73 +367,73 @@ public class NormalSwaptionPhysicalProductPricerTest {
   public void present_value_theta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
-    double volatility = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
+    double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
     NormalFunctionData normalData = NormalFunctionData.of(forward, Math.abs(pvbp), volatility);
-    double expiry = NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
+    double expiry = NORMAL_VOLS_USD_STD.relativeTime(SWAPTION_LONG_REC.getExpiry());
     EuropeanVanillaOption option = EuropeanVanillaOption.of(STRIKE, expiry, PutCall.PUT);
     double pvThetaExpected = NORMAL.getTheta(option, normalData);
     CurrencyAmount pvThetaComputed =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvThetaComputed.getCurrency(), USD);
     assertEquals(pvThetaComputed.getAmount(), pvThetaExpected, TOLERANCE_PV);
   }
 
   public void present_value_theta_long_short_parity() {
     CurrencyAmount pvThetaLong =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvThetaShort =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvThetaLong.getAmount(), -pvThetaShort.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_theta_payer_receiver_parity() {
     CurrencyAmount pvThetaLongPay =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvThetaShortRec =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvThetaLongPay.getAmount() + pvThetaShortRec.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_theta_at_expiry() {
     CurrencyAmount pvThetaRec =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvThetaRec.getAmount(), 0d, TOLERANCE_PV);
     CurrencyAmount pvThetaPay =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvThetaPay.getAmount(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_theta_after_expiry() {
     CurrencyAmount pvTheta =
-        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_PAST, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvTheta.getAmount(), 0d, TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------  
   public void currency_exposure() {
     CurrencyAmount pv =
-        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     MultiCurrencyAmount ce =
-        PRICER_SWAPTION_NORMAL.currencyExposure(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        PRICER_SWAPTION_NORMAL.currencyExposure(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_FD() {
     PointSensitivities pvpt = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_FLAT).build();
     CurrencyParameterSensitivities pvpsAd = MULTI_USD.parameterSensitivity(pvpt);
     CurrencyParameterSensitivities pvpsFd = FINITE_DIFFERENCE_CALCULATOR.sensitivity(MULTI_USD,
-        (p) -> PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, p, NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT));
+        (p) -> PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_SHORT_REC, p, NORMAL_VOLS_USD_FLAT));
     assertTrue(pvpsAd.equalWithTolerance(pvpsFd, TOLERANCE_PV_DELTA));
   }
 
   public void present_value_sensitivity_long_short_parity() {
     PointSensitivities pvptLong = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     PointSensitivities pvptShort = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     CurrencyParameterSensitivities pvpsLong = MULTI_USD.parameterSensitivity(pvptLong);
     CurrencyParameterSensitivities pvpsShort = MULTI_USD.parameterSensitivity(pvptShort);
     assertTrue(pvpsLong.equalWithTolerance(pvpsShort.multipliedBy(-1.0), TOLERANCE_PV_DELTA));
@@ -441,9 +441,9 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivity_payer_receiver_parity() {
     PointSensitivities pvptLongPay = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     PointSensitivities pvptShortRec = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     PointSensitivities pvptSwapRec = PRICER_SWAP.presentValueSensitivity(RSWAP_PAY, MULTI_USD).build();
     CurrencyParameterSensitivities pvpsLongPay = MULTI_USD.parameterSensitivity(pvptLongPay);
     CurrencyParameterSensitivities pvpsShortRec = MULTI_USD.parameterSensitivity(pvptShortRec);
@@ -453,12 +453,12 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivity_at_expiry() {
     PointSensitivities sensiRec = PRICER_SWAPTION_NORMAL.presentValueSensitivityRatesStickyStrike(
-        SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     for (PointSensitivity sensi : sensiRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
     PointSensitivities sensiPay = PRICER_SWAPTION_NORMAL.presentValueSensitivityRatesStickyStrike(
-        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD).build();
+        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     PointSensitivities sensiPaySwap = PRICER_SWAP.presentValueSensitivity(RSWAP_PAY, MULTI_USD).build();
     assertTrue(MULTI_USD.parameterSensitivity(sensiPay).equalWithTolerance(
         MULTI_USD.parameterSensitivity(sensiPaySwap), TOLERANCE_PV));
@@ -466,7 +466,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivity_after_expiry() {
     PointSensitivityBuilder pvpts = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAST, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvpts, PointSensitivityBuilder.none());
   }
 
@@ -479,11 +479,11 @@ public class NormalSwaptionPhysicalProductPricerTest {
         SwaptionNormalVolatilityDataSets.normalVolSwaptionProviderUsdStsShifted(-shiftVol));
     double pvnvsFd = (pvP.getAmount() - pvM.getAmount()) / (2 * shiftVol);
     SwaptionSensitivity pvnvsAd = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvnvsAd.getCurrency(), USD);
     assertEquals(pvnvsAd.getSensitivity(), pvnvsFd, TOLERANCE_PV_VEGA);
-    assertEquals(pvnvsAd.getConvention(), SwaptionNormalVolatilityDataSets.USD_1Y_LIBOR3M);
-    assertEquals(pvnvsAd.getExpiry(), NORMAL_VOL_SWAPTION_PROVIDER_USD_STD.relativeTime(SWAPTION_LONG_PAY.getExpiry()));
+    assertEquals(pvnvsAd.getVolatilitiesName(), NORMAL_VOLS_USD_STD.getName());
+    assertEquals(pvnvsAd.getExpiry(), NORMAL_VOLS_USD_STD.relativeTime(SWAPTION_LONG_PAY.getExpiry()));
     assertEquals(pvnvsAd.getTenor(), SWAP_TENOR_YEAR, TOLERANCE_RATE);
     assertEquals(pvnvsAd.getStrike(), STRIKE, TOLERANCE_RATE);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
@@ -492,32 +492,32 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   public void present_value_sensitivityNormalVolatility_long_short_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvptLongPay.getSensitivity(), -pvptShortRec.getSensitivity(), TOLERANCE_PV_VEGA);
   }
 
   public void present_value_sensitivityNormalVolatility_payer_receiver_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(pvptLongPay.getSensitivity() + pvptShortRec.getSensitivity(), 0, TOLERANCE_PV_VEGA);
   }
 
   public void present_value_sensitivityBlackVolatility_at_expiry() {
     SwaptionSensitivity sensiRec = PRICER_SWAPTION_NORMAL.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(sensiRec.getSensitivity(), 0d, TOLERANCE_PV);
     SwaptionSensitivity sensiPay = PRICER_SWAPTION_NORMAL.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        SWAPTION_PAY_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(sensiPay.getSensitivity(), 0d, TOLERANCE_PV);
   }
 
   public void present_value_sensitivityNormalVolatility_after_expiry() {
     SwaptionSensitivity v = PRICER_SWAPTION_NORMAL
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAST, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD_STD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertEquals(v.getSensitivity(), 0.0d, TOLERANCE_PV_VEGA);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerCashParYieldTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerCashParYieldTest.java
@@ -88,8 +88,8 @@ public class NormalSwaptionTradePricerCashParYieldTest {
       .build();
 
   private static final ImmutableRatesProvider RATE_PROVIDER = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final NormalSwaptionExpiryTenorVolatilities VOL_PROVIDER =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_STD;
+  private static final NormalSwaptionExpiryTenorVolatilities VOLS =
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_STD;
 
   private static final VolatilitySwaptionTradePricer PRICER_COMMON = VolatilitySwaptionTradePricer.DEFAULT;
   private static final NormalSwaptionTradePricer PRICER_TRADE = NormalSwaptionTradePricer.DEFAULT;
@@ -100,32 +100,32 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   public void present_value_premium_forward() {
-    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
     // test via VolatilitySwaptionTradePricer
-    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv, pvTrade);
   }
 
   public void present_value_premium_valuedate() {
-    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
   }
 
   public void present_value_premium_past() {
-    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount(), NOTIONAL * TOL);
   }
 
   //-------------------------------------------------------------------------
   public void currency_exposure_premium_forward() {
-    CurrencyAmount pv = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
-    MultiCurrencyAmount ce = PRICER_TRADE.currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pv = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    MultiCurrencyAmount ce = PRICER_TRADE.currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), NOTIONAL * TOL);
   }
 
@@ -148,9 +148,9 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade =
-        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
-        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct =
@@ -160,9 +160,9 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade =
-        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
-        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * TOL));
@@ -170,9 +170,9 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade =
-        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
-        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * TOL));
@@ -181,9 +181,9 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   //-------------------------------------------------------------------------
   public void present_value_normal_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade =
-        PRICER_TRADE.presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaProduct =
-        PRICER_PRODUCT.presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(vegaTrade.getSensitivities().get(0).getSensitivity(), vegaProduct.getSensitivity(), NOTIONAL * TOL);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerPhysicalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerPhysicalTest.java
@@ -93,8 +93,8 @@ public class NormalSwaptionTradePricerPhysicalTest {
   private static final DiscountingPaymentPricer PRICER_PAYMENT = DiscountingPaymentPricer.DEFAULT;
 
   private static final ImmutableRatesProvider MULTI_USD = RatesProviderDataSets.multiUsd(VAL_DATE);
-  private static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD =
-      SwaptionNormalVolatilityDataSets.NORMAL_VOL_SWAPTION_PROVIDER_USD_STD;
+  private static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOLS_USD =
+      SwaptionNormalVolatilityDataSets.NORMAL_SWAPTION_VOLS_USD_STD;
 
   private static final double TOLERANCE_PV = 1.0E-2;
   private static final double TOLERANCE_PV_DELTA = 1.0E+2;
@@ -103,39 +103,39 @@ public class NormalSwaptionTradePricerPhysicalTest {
   //-------------------------------------------------------------------------
   public void present_value_premium_forward() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, MULTI_USD);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), TOLERANCE_PV);
     // test via VolatilitySwaptionTradePricer
-    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     assertEquals(pv, pvTrade);
   }
 
   public void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, MULTI_USD);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), TOLERANCE_PV);
   }
 
   public void present_value_premium_past() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount(), TOLERANCE_PV);
   }
 
   //-------------------------------------------------------------------------
   public void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
-        .presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     MultiCurrencyAmount ce = PRICER_TRADE
-        .currencyExposure(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .currencyExposure(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), TOLERANCE_PV);
   }
 
@@ -158,9 +158,9 @@ public class NormalSwaptionTradePricerPhysicalTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, MULTI_USD);
     CurrencyParameterSensitivities pvpsTrade = MULTI_USD.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct =
@@ -170,9 +170,9 @@ public class NormalSwaptionTradePricerPhysicalTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyParameterSensitivities pvpsTrade = MULTI_USD.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = MULTI_USD.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, TOLERANCE_PV_DELTA));
@@ -180,9 +180,9 @@ public class NormalSwaptionTradePricerPhysicalTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyParameterSensitivities pvpsTrade = MULTI_USD.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = MULTI_USD.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, TOLERANCE_PV_DELTA));
@@ -191,9 +191,9 @@ public class NormalSwaptionTradePricerPhysicalTest {
   //-------------------------------------------------------------------------
   public void present_value_normal_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     SwaptionSensitivity vegaProduct = PRICER_PRODUCT
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOL_SWAPTION_PROVIDER_USD);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     assertEquals(vegaTrade.getSensitivities().get(0).getSensitivity(), vegaProduct.getSensitivity(), TOLERANCE_PV_VEGA);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -211,13 +211,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
       .build().
       resolve(REF_DATA);
 
-  private static final SabrParametersSwaptionVolatilities VOL_PROVIDER_REG =
+  private static final SabrParametersSwaptionVolatilities VOLS_REG =
       SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), false);
-  private static final SabrParametersSwaptionVolatilities VOL_PROVIDER =
+  private static final SabrParametersSwaptionVolatilities VOLS =
       SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), true);
-  private static final SabrParametersSwaptionVolatilities VOL_PROVIDER_AT_MATURITY =
+  private static final SabrParametersSwaptionVolatilities VOLS_AT_MATURITY =
       SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(MATURITY.toLocalDate(), true);
-  private static final SabrParametersSwaptionVolatilities VOL_PROVIDER_AFTER_MATURITY =
+  private static final SabrParametersSwaptionVolatilities VOLS_AFTER_MATURITY =
       SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(MATURITY.toLocalDate().plusDays(1), true);
   private static final ImmutableRatesProvider RATE_PROVIDER =
       SwaptionSabrRateVolatilityDataSet.getRatesProviderEur(VAL_DATE_TIME.toLocalDate());
@@ -236,17 +236,17 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   public void validate_cash_settlement() {
-    assertThrowsIllegalArg(() -> PRICER.presentValue(SWAPTION_PHYS, RATE_PROVIDER, VOL_PROVIDER));
+    assertThrowsIllegalArg(() -> PRICER.presentValue(SWAPTION_PHYS, RATE_PROVIDER, VOLS));
   }
 
   //-------------------------------------------------------------------------
   public void test_presentValue() {
-    CurrencyAmount computedRec = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount computedPay = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount computedRec = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount computedPay = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RFIXED_LEG_REC, forward);
-    double expiry = VOL_PROVIDER.relativeTime(MATURITY);
-    double volatility = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), TENOR_YEAR, RATE, forward);
+    double expiry = VOLS.relativeTime(MATURITY);
+    double volatility = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), TENOR_YEAR, RATE, forward);
     double df = RATE_PROVIDER.discountFactor(EUR, SETTLE);
     double expectedRec = df * annuityCash * BlackFormulaRepository.price(forward + SwaptionSabrRateVolatilityDataSet.SHIFT,
         RATE + SwaptionSabrRateVolatilityDataSet.SHIFT, expiry, volatility, false);
@@ -260,9 +260,9 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValue_atMaturity() {
     CurrencyAmount computedRec =
-        PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount computedPay =
-        PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER_AT_MATURITY);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RFIXED_LEG_REC, forward);
     double df = RATE_PROVIDER_AT_MATURITY.discountFactor(EUR, SETTLE);
@@ -272,18 +272,18 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValue_afterExpiry() {
     CurrencyAmount computedRec =
-        PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     CurrencyAmount computedPay =
-        PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertEquals(computedRec.getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(computedPay.getAmount(), 0d, NOTIONAL * TOL);
   }
 
   public void test_presentValue_parity() {
-    CurrencyAmount pvRecLong = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvRecShort = PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPayLong = PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount pvPayShort = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pvRecLong = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvRecShort = PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPayLong = PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount pvPayShort = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(pvRecLong.getAmount(), -pvRecShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvPayLong.getAmount(), -pvPayShort.getAmount(), NOTIONAL * TOL);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -296,13 +296,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValue_parity_atMaturity() {
     CurrencyAmount pvRecLong =
-        PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount pvRecShort =
-        PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount pvPayLong =
-        PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount pvPayShort =
-        PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertEquals(pvRecLong.getAmount(), -pvRecShort.getAmount(), NOTIONAL * TOL);
     assertEquals(pvPayLong.getAmount(), -pvPayShort.getAmount(), NOTIONAL * TOL);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER_AT_MATURITY);
@@ -315,46 +315,46 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   public void test_currencyExposure() {
-    MultiCurrencyAmount computedRec = PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    MultiCurrencyAmount computedPay = PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    MultiCurrencyAmount computedRec = PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    MultiCurrencyAmount computedPay = PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
-        .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER));
+        .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), expectedRec.getAmount(EUR).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
-        .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER));
+        .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS));
     assertEquals(computedPay.size(), 1);
     assertEquals(computedPay.getAmount(EUR).getAmount(), expectedPay.getAmount(EUR).getAmount(), NOTIONAL * TOL);
   }
 
   public void test_currencyExposure_atMaturity() {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     MultiCurrencyAmount expectedRec = RATE_PROVIDER.currencyExposure(pointRec.build())
-        .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
+        .plus(PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY));
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), expectedRec.getAmount(EUR).getAmount(), NOTIONAL * TOL);
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     MultiCurrencyAmount expectedPay = RATE_PROVIDER.currencyExposure(pointPay.build())
-        .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY));
+        .plus(PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY));
     assertEquals(computedPay.size(), 1);
     assertEquals(computedPay.getAmount(EUR).getAmount(), expectedPay.getAmount(EUR).getAmount(), NOTIONAL * TOL);
   }
 
   public void test_currencyExposure_afterMaturity() {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertEquals(computedRec.size(), 1);
     assertEquals(computedRec.getAmount(EUR).getAmount(), 0d, NOTIONAL * TOL);
     assertEquals(computedPay.size(), 1);
@@ -363,30 +363,30 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   public void test_impliedVolatility() {
-    double computedRec = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    double computedPay = PRICER.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    double computedRec = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    double computedPay = PRICER.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
-    double expected = VOL_PROVIDER.volatility(MATURITY, TENOR_YEAR, RATE, forward);
+    double expected = VOLS.volatility(MATURITY, TENOR_YEAR, RATE, forward);
     assertEquals(computedRec, expected, TOL);
     assertEquals(computedPay, expected, TOL);
   }
 
   public void test_impliedVolatility_atMaturity() {
     double computedRec =
-        PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     double computedPay =
-        PRICER.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER_AT_MATURITY);
-    double expected = VOL_PROVIDER_AT_MATURITY.volatility(MATURITY, TENOR_YEAR, RATE, forward);
+    double expected = VOLS_AT_MATURITY.volatility(MATURITY, TENOR_YEAR, RATE, forward);
     assertEquals(computedRec, expected, TOL);
     assertEquals(computedPay, expected, TOL);
   }
 
   public void test_impliedVolatility_afterMaturity() {
     assertThrowsIllegalArg(() -> PRICER.impliedVolatility(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY));
+        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY));
     assertThrowsIllegalArg(() -> PRICER.impliedVolatility(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY));
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY));
   }
 
   //-------------------------------------------------------------------------
@@ -397,17 +397,17 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     CashSwaptionSettlement cashSettlement = (CashSwaptionSettlement) SWAPTION_REC_LONG.getSwaptionSettlement();
     double discountSettle = RATE_PROVIDER.discountFactor(fixedLeg.getCurrency(), cashSettlement.getSettlementDate());
     double pvbpCash = Math.abs(annuityCash * discountSettle);
-    CurrencyAmount deltaRec = PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    CurrencyAmount deltaPay = PRICER.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount deltaRec = PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    CurrencyAmount deltaPay = PRICER.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(deltaRec.getAmount() + deltaPay.getAmount(), -pvbpCash, TOLERANCE_DELTA);
   }
 
   public void test_presentValueDelta_afterMaturity() {
     CurrencyAmount deltaRec =
-        PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertEquals(deltaRec.getAmount(), 0, TOLERANCE_DELTA);
     CurrencyAmount deltaPay =
-        PRICER.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        PRICER.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertEquals(deltaPay.getAmount(), 0, TOLERANCE_DELTA);
   }
 
@@ -419,26 +419,26 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     double discountSettle = RATE_PROVIDER_AT_MATURITY.discountFactor(fixedLeg.getCurrency(), cashSettlement.getSettlementDate());
     double pvbpCash = Math.abs(annuityCash * discountSettle);
     CurrencyAmount deltaRec =
-        PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertEquals(deltaRec.getAmount(), RATE > forward ? -pvbpCash : 0, TOLERANCE_DELTA);
     CurrencyAmount deltaPay =
-        PRICER.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueDelta(SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertEquals(deltaPay.getAmount(), RATE > forward ? 0 : pvbpCash, TOLERANCE_DELTA);
   }
 
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivityRatesStickyModel() {
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec =
-        FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER));
+        FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOLS));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 200d));
     PointSensitivityBuilder pointPay =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities computedPay = RATE_PROVIDER.parameterSensitivity(pointPay.build());
     CurrencyParameterSensitivities expectedPay =
-        FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_PAY_SHORT, (p), VOL_PROVIDER));
+        FD_CAL.sensitivity(RATE_PROVIDER, (p) -> PRICER.presentValue(SWAPTION_PAY_SHORT, (p), VOLS));
     assertTrue(computedPay.equalWithTolerance(expectedPay, NOTIONAL * FD_EPS * 200d));
   }
 
@@ -446,9 +446,9 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), false);
     double impliedVol = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
-        Surfaces.blackVolatilityByExpiryTenor("CST", VOL_PROVIDER.getDayCount());
+        Surfaces.blackVolatilityByExpiryTenor("CST", VOLS.getDayCount());
     SwaptionVolatilities volCst = BlackSwaptionExpiryTenorVolatilities.of(
-        VOL_PROVIDER.getConvention(), VOL_PROVIDER.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
+        VOLS.getConvention(), VOLS.getValuationDateTime(), ConstantSurface.of(blackMeta, impliedVol));
     // To obtain a constant volatility surface which create a sticky strike sensitivity
     PointSensitivityBuilder pointRec =
         PRICER.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
@@ -467,14 +467,14 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivityRatesStickyModel_atMaturity() {
     PointSensitivityBuilder pointRec =
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
         RATE_PROVIDER_AT_MATURITY.parameterSensitivity(pointRec.build());
     CurrencyParameterSensitivities expectedRec = FD_CAL.sensitivity(
-        RATE_PROVIDER_AT_MATURITY, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOL_PROVIDER_AT_MATURITY));
+        RATE_PROVIDER_AT_MATURITY, (p) -> PRICER.presentValue(SWAPTION_REC_LONG, (p), VOLS_AT_MATURITY));
     assertTrue(computedRec.equalWithTolerance(expectedRec, NOTIONAL * FD_EPS * 100d));
     PointSensitivities pointPay = PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT,
-        RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
+        RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
@@ -482,12 +482,12 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivityRatesStickyModel_afterMaturity() {
     PointSensitivities pointRec = PRICER.presentValueSensitivityRatesStickyModel(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
+        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
     PointSensitivities pointPay = PRICER.presentValueSensitivityRatesStickyModel(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointPay.getSensitivities()) {
       assertEquals(Math.abs(sensi.getSensitivity()), 0d);
     }
@@ -495,13 +495,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivityRatesStickyModel_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiPayLong = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiPayShort = RATE_PROVIDER.parameterSensitivity(
-        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build());
+        PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS).build());
     assertTrue(pvSensiRecLong.equalWithTolerance(pvSensiRecShort.multipliedBy(-1d), NOTIONAL * TOL));
     assertTrue(pvSensiPayLong.equalWithTolerance(pvSensiPayShort.multipliedBy(-1d), NOTIONAL * TOL));
 
@@ -524,49 +524,49 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   //-------------------------------------------------------------------------
   public void test_presentValueVega_parity() {
     SwaptionSensitivity vegaRec = PRICER
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaPay = PRICER
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     assertEquals(vegaRec.getSensitivity(), -vegaPay.getSensitivity(), TOLERANCE_DELTA);
   }
 
   public void test_presentValueVega_atMaturity() {
     SwaptionSensitivity vegaRec = PRICER.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertEquals(vegaRec.getSensitivity(), 0, TOLERANCE_DELTA);
     SwaptionSensitivity vegaPay = PRICER.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY);
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertEquals(vegaPay.getSensitivity(), 0, TOLERANCE_DELTA);
   }
 
   public void test_presentValueVega_afterMaturity() {
     SwaptionSensitivity vegaRec = PRICER.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertEquals(vegaRec.getSensitivity(), 0, TOLERANCE_DELTA);
     SwaptionSensitivity vegaPay = PRICER.presentValueSensitivityModelParamsVolatility(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY);
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertEquals(vegaPay.getSensitivity(), 0, TOLERANCE_DELTA);
   }
 
   public void test_presentValueVega_SwaptionSensitivity() {
     SwaptionSensitivity vegaRec = PRICER
-        .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER);
-    assertEquals(VOL_PROVIDER.parameterSensitivity(vegaRec), CurrencyParameterSensitivities.empty());
+        .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
+    assertEquals(VOLS.parameterSensitivity(vegaRec), CurrencyParameterSensitivities.empty());
   }
 
   //-------------------------------------------------------------------------
   public void test_presentValueSensitivityModelParamsSabr() {
     PointSensitivities sensiRec =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities sensiPay =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS).build();
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(RFIXED_LEG_REC, forward);
-    double expiry = VOL_PROVIDER.relativeTime(MATURITY);
-    double volatility = VOL_PROVIDER.volatility(SWAPTION_REC_LONG.getExpiry(), TENOR_YEAR, RATE, forward);
+    double expiry = VOLS.relativeTime(MATURITY);
+    double volatility = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), TENOR_YEAR, RATE, forward);
     double df = RATE_PROVIDER.discountFactor(EUR, SETTLE);
     double[] volSensi =
-        VOL_PROVIDER.getParameters().volatilityAdjoint(expiry, TENOR_YEAR, RATE, forward).getDerivatives().toArray();
+        VOLS.getParameters().volatilityAdjoint(expiry, TENOR_YEAR, RATE, forward).getDerivatives().toArray();
     double vegaRec = df * annuityCash * BlackFormulaRepository.vega(forward + SwaptionSabrRateVolatilityDataSet.SHIFT,
         RATE + SwaptionSabrRateVolatilityDataSet.SHIFT, expiry, volatility);
     double vegaPay = -df * annuityCash * BlackFormulaRepository.vega(forward + SwaptionSabrRateVolatilityDataSet.SHIFT,
@@ -585,7 +585,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     for (PointSensitivity point : points.getSensitivities()) {
       SwaptionSabrSensitivity sens = (SwaptionSabrSensitivity) point;
       assertEquals(sens.getCurrency(), EUR);
-      assertEquals(sens.getConvention(), SwaptionSabrRateVolatilityDataSet.SWAP_CONVENTION_EUR);
+      assertEquals(sens.getVolatilitiesName(), VOLS.getName());
       if (sens.getSensitivityType() == type) {
         assertEquals(sens.getSensitivity(), expected, NOTIONAL * TOL);
         return;
@@ -596,13 +596,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivityModelParamsSabr_atMaturity() {
     PointSensitivities sensiRec = PRICER.presentValueSensitivityModelParamsSabr(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
+        SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY).build();
     assertSensitivity(sensiRec, SabrParameterType.ALPHA, 0);
     assertSensitivity(sensiRec, SabrParameterType.BETA, 0);
     assertSensitivity(sensiRec, SabrParameterType.RHO, 0);
     assertSensitivity(sensiRec, SabrParameterType.NU, 0);
     PointSensitivities sensiPay = PRICER.presentValueSensitivityModelParamsSabr(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOL_PROVIDER_AT_MATURITY).build();
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY).build();
     assertSensitivity(sensiPay, SabrParameterType.ALPHA, 0);
     assertSensitivity(sensiPay, SabrParameterType.BETA, 0);
     assertSensitivity(sensiPay, SabrParameterType.RHO, 0);
@@ -611,22 +611,22 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void test_presentValueSensitivityModelParamsSabr_afterMaturity() {
     PointSensitivities sensiRec = PRICER.presentValueSensitivityModelParamsSabr(
-        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
+        SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     assertEquals(sensiRec.getSensitivities().size(), 0);
     PointSensitivities sensiPay = PRICER.presentValueSensitivityModelParamsSabr(
-        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOL_PROVIDER_AFTER_MATURITY).build();
+        SWAPTION_PAY_SHORT, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     assertEquals(sensiPay.getSensitivities().size(), 0);
   }
 
   public void test_presentValueSensitivityModelParamsSabr_parity() {
     PointSensitivities pvSensiRecLong =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities pvSensiRecShort =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS).build();
     PointSensitivities pvSensiPayLong =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities pvSensiPayShort =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS).build();
 
     assertSensitivity(pvSensiRecLong, pvSensiRecShort, SabrParameterType.ALPHA, -1);
     assertSensitivity(pvSensiPayLong, pvSensiPayShort, SabrParameterType.ALPHA, -1);
@@ -664,10 +664,10 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   public void regressionPresentValue() {
-    CurrencyAmount pvLongPay = PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
-    CurrencyAmount pvShortPay = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOL_PROVIDER_REG);
-    CurrencyAmount pvLongRec = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
-    CurrencyAmount pvShortRec = PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOL_PROVIDER_REG);
+    CurrencyAmount pvLongPay = PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REG);
+    CurrencyAmount pvShortPay = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS_REG);
+    CurrencyAmount pvLongRec = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS_REG);
+    CurrencyAmount pvShortRec = PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS_REG);
     assertEquals(pvLongPay.getAmount(), 2419978.690066857, NOTIONAL * TOL);
     assertEquals(pvShortPay.getAmount(), -2419978.690066857, NOTIONAL * TOL);
     assertEquals(pvLongRec.getAmount(), 3498144.2628540806, NOTIONAL * TOL);
@@ -677,7 +677,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   public void regressionCurveSensitivity() {
     double[] sensiDscExp = new double[] {0.0, 0.0, 0.0, 0.0, -1.1942174487944763E7, -1565567.6976298545};
     double[] sensiFwdExp = new double[] {0.0, 0.0, 0.0, 0.0, -2.3978768078237808E8, 4.8392987803482056E8};
-    PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG);
+    PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REG);
     CurrencyParameterSensitivities sensi = RATE_PROVIDER.parameterSensitivity(point.build());
     double[] sensiDscCmp = sensi.getSensitivity(SwaptionSabrRateVolatilityDataSet.META_DSC_EUR.getCurveName(), EUR)
         .getSensitivity().toArray();
@@ -689,14 +689,14 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   public void regressionSurfaceSensitivity() {
     PointSensitivities pointComputed =
-        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_LONG, RATE_PROVIDER, VOL_PROVIDER_REG).build();
+        PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REG).build();
     assertSensitivity(pointComputed, SabrParameterType.ALPHA, 4.862767907309804E7);
     assertSensitivity(pointComputed, SabrParameterType.BETA, -1.1095143998998241E7);
     assertSensitivity(pointComputed, SabrParameterType.RHO, 575158.6667143379);
     assertSensitivity(pointComputed, SabrParameterType.NU, 790627.3506603877);
 
     CurrencyParameterSensitivities sensiComputed =
-        VOL_PROVIDER_REG.parameterSensitivity(pointComputed);
+        VOLS_REG.parameterSensitivity(pointComputed);
     double[][] alphaExp = new double[][] {
         {0.0, 0.0, 0.0}, {0.5, 0.0, 0.0}, {1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {5.0, 0.0, 0.0}, {10.0, 0.0, 0.0},
         {0.0, 1.0, 0.0}, {0.5, 1.0, 0.0}, {1.0, 1.0, 0.0}, {2.0, 1.0, 0.0}, {5.0, 1.0, 2.3882653164816026E7},

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
@@ -85,7 +85,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   // providers
   private static final ImmutableRatesProvider RATE_PROVIDER =
       SwaptionSabrRateVolatilityDataSet.getRatesProviderUsd(VAL_DATE);
-  private static final SabrSwaptionVolatilities VOL_PROVIDER =
+  private static final SabrSwaptionVolatilities VOLS =
       SwaptionSabrRateVolatilityDataSet.getVolatilitiesUsd(VAL_DATE, true);
 
   private static final double TOL = 1.0e-12;
@@ -98,39 +98,39 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_premium_forward() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
     // test via VolatilitySwaptionTradePricer
-    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv, pvTrade);
   }
 
   public void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
   }
 
   public void present_value_premium_past() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount(), NOTIONAL * TOL);
   }
 
   //-------------------------------------------------------------------------
   public void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
-        .presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount ce = PRICER_TRADE
-        .currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), NOTIONAL * TOL);
   }
 
@@ -153,9 +153,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade =
         RATE_PROVIDER.parameterSensitivity(pvcsTrade);
@@ -166,9 +166,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -176,9 +176,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -187,9 +187,9 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
-        .presentValueSensitivityModelParamsSabr(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsSabr(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivities vegaProduct = PRICER_PRODUCT
-        .presentValueSensitivityModelParamsSabr(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER).build();
+        .presentValueSensitivityModelParamsSabr(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS).build();
     assertEquals(vegaTrade, vegaProduct);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
@@ -82,7 +82,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
   // providers
   private static final ImmutableRatesProvider RATE_PROVIDER =
       SwaptionSabrRateVolatilityDataSet.getRatesProviderUsd(VAL_DATE);
-  private static final SabrSwaptionVolatilities VOL_PROVIDER =
+  private static final SabrSwaptionVolatilities VOLS =
       SwaptionSabrRateVolatilityDataSet.getVolatilitiesUsd(VAL_DATE, true);
 
   private static final double TOL = 1.0e-12;
@@ -94,39 +94,39 @@ public class SabrSwaptionPhysicalTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_premium_forward() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
     // test via VolatilitySwaptionTradePricer
-    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+    CurrencyAmount pv = PRICER_COMMON.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv, pvTrade);
   }
 
   public void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, RATE_PROVIDER);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount() + pvPremium.getAmount(), NOTIONAL * TOL);
   }
 
   public void present_value_premium_past() {
     CurrencyAmount pvTrade =
-        PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
-        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pvTrade.getAmount(), pvProduct.getAmount(), NOTIONAL * TOL);
   }
 
   //-------------------------------------------------------------------------
   public void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
-        .presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount ce = PRICER_TRADE
-        .currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertEquals(pv.getAmount(), ce.getAmount(USD).getAmount(), NOTIONAL * TOL);
   }
 
@@ -149,9 +149,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsPremium = PRICER_PAYMENT.presentValueSensitivity(PREMIUM_FWD_PAY, RATE_PROVIDER);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct =
@@ -161,9 +161,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   public void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -171,9 +171,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   public void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
-        .presentValueSensitivityRatesStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
-        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityRatesStickyModel(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities pvpsTrade = RATE_PROVIDER.parameterSensitivity(pvcsTrade);
     CurrencyParameterSensitivities pvpsProduct = RATE_PROVIDER.parameterSensitivity(pvcsProduct.build());
     assertTrue(pvpsTrade.equalWithTolerance(pvpsProduct, NOTIONAL * NOTIONAL * TOL));
@@ -182,9 +182,9 @@ public class SabrSwaptionPhysicalTradePricerTest {
   //-------------------------------------------------------------------------
   public void present_value_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
-        .presentValueSensitivityModelParamsSabr(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOL_PROVIDER);
+        .presentValueSensitivityModelParamsSabr(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivities vegaProduct = PRICER_PRODUCT
-        .presentValueSensitivityModelParamsSabr(SWAPTION_LONG_REC, RATE_PROVIDER, VOL_PROVIDER).build();
+        .presentValueSensitivityModelParamsSabr(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS).build();
     assertEquals(vegaTrade, vegaProduct);
   }
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilitiesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionVolatilitiesTest.java
@@ -126,10 +126,10 @@ public class SabrSwaptionVolatilitiesTest {
     for (int i = 0; i < NB_TEST; i++) {
       double expiryTime = prov.relativeTime(TEST_OPTION_EXPIRY[i]);
       PointSensitivities point = PointSensitivities.of(
-          SwaptionSabrSensitivity.of(CONV, expiryTime, TEST_TENOR[i], ALPHA, USD, alphaSensi),
-          SwaptionSabrSensitivity.of(CONV, expiryTime, TEST_TENOR[i], BETA, USD, betaSensi),
-          SwaptionSabrSensitivity.of(CONV, expiryTime, TEST_TENOR[i], RHO, USD, rhoSensi),
-          SwaptionSabrSensitivity.of(CONV, expiryTime, TEST_TENOR[i], NU, USD, nuSensi));
+          SwaptionSabrSensitivity.of(NAME, expiryTime, TEST_TENOR[i], ALPHA, USD, alphaSensi),
+          SwaptionSabrSensitivity.of(NAME, expiryTime, TEST_TENOR[i], BETA, USD, betaSensi),
+          SwaptionSabrSensitivity.of(NAME, expiryTime, TEST_TENOR[i], RHO, USD, rhoSensi),
+          SwaptionSabrSensitivity.of(NAME, expiryTime, TEST_TENOR[i], NU, USD, nuSensi));
       CurrencyParameterSensitivities sensiComputed = prov.parameterSensitivity(point);
       UnitParameterSensitivity alphaSensitivities = prov.getParameters().getAlphaSurface()
           .zValueParameterSensitivity(expiryTime, TEST_TENOR[i]);
@@ -179,20 +179,20 @@ public class SabrSwaptionVolatilitiesTest {
     double expiryTime3 = prov.relativeTime(TEST_OPTION_EXPIRY[3]);
     for (int i = 0; i < NB_TEST; i++) {
       PointSensitivities sensi1 = PointSensitivities.of(
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], ALPHA, USD, points1[0]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], BETA, USD, points1[1]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], RHO, USD, points1[2]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], NU, USD, points1[3]));
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], ALPHA, USD, points1[0]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], BETA, USD, points1[1]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], RHO, USD, points1[2]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], NU, USD, points1[3]));
       PointSensitivities sensi2 = PointSensitivities.of(
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], ALPHA, USD, points2[0]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], BETA, USD, points2[1]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], RHO, USD, points2[2]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime0, TEST_TENOR[i], NU, USD, points2[3]));
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], ALPHA, USD, points2[0]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], BETA, USD, points2[1]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], RHO, USD, points2[2]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime0, TEST_TENOR[i], NU, USD, points2[3]));
       PointSensitivities sensi3 = PointSensitivities.of(
-          SwaptionSabrSensitivity.of(CONV, expiryTime3, TEST_TENOR[i], ALPHA, USD, points3[0]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime3, TEST_TENOR[i], BETA, USD, points3[1]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime3, TEST_TENOR[i], RHO, USD, points3[2]),
-          SwaptionSabrSensitivity.of(CONV, expiryTime3, TEST_TENOR[i], NU, USD, points3[3]));
+          SwaptionSabrSensitivity.of(NAME, expiryTime3, TEST_TENOR[i], ALPHA, USD, points3[0]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime3, TEST_TENOR[i], BETA, USD, points3[1]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime3, TEST_TENOR[i], RHO, USD, points3[2]),
+          SwaptionSabrSensitivity.of(NAME, expiryTime3, TEST_TENOR[i], NU, USD, points3[3]));
       PointSensitivities sensis = sensi1.combinedWith(sensi2).combinedWith(sensi3).normalized();
       CurrencyParameterSensitivities computed = prov.parameterSensitivity(sensis);
       CurrencyParameterSensitivities expected = prov.parameterSensitivity(sensi1)

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionBlackVolatilityDataSets.java
@@ -68,7 +68,7 @@ public class SwaptionBlackVolatilityDataSets {
   private static final LocalTime VAL_TIME_STD = LocalTime.of(13, 45);
   private static final ZoneId VAL_ZONE_STD = ZoneId.of("Europe/London");
   /** Black volatility provider */
-  public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_SWAPTION_PROVIDER_USD_STD =
+  public static final BlackSwaptionExpiryTenorVolatilities BLACK_SWAPTION_VOLS_USD_STD =
       BlackSwaptionExpiryTenorVolatilities.of(
           USD_1Y_LIBOR3M, VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), SURFACE_STD);
 
@@ -79,7 +79,7 @@ public class SwaptionBlackVolatilityDataSets {
       Surfaces.blackVolatilityByExpiryTenor("Constant Surface", ACT_365F);
   private static final Surface CST_SURFACE = ConstantSurface.of(META_DATA, VOLATILITY);
   /** flat Black volatility provider */
-  public static final BlackSwaptionExpiryTenorVolatilities BLACK_VOL_CST_SWAPTION_PROVIDER_USD =
+  public static final BlackSwaptionExpiryTenorVolatilities BLACK_SWAPTION_VOLS_CST_USD =
       BlackSwaptionExpiryTenorVolatilities.of(
           USD_FIXED_6M_LIBOR_3M, VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD), CST_SURFACE);
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionNormalVolatilityDataSets.java
@@ -70,7 +70,7 @@ public class SwaptionNormalVolatilityDataSets {
   private static final LocalTime VAL_TIME_STD = LocalTime.of(13, 45);
   private static final ZoneId VAL_ZONE_STD = ZoneId.of("Europe/London");
   private static final ZonedDateTime VAL_DATE_TIME_STD = VAL_DATE_STD.atTime(VAL_TIME_STD).atZone(VAL_ZONE_STD);
-  public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_STD =
+  public static final NormalSwaptionExpiryTenorVolatilities NORMAL_SWAPTION_VOLS_USD_STD =
       NormalSwaptionExpiryTenorVolatilities.of(USD_1Y_LIBOR3M, VAL_DATE_TIME_STD, SURFACE_STD);
 
   /**
@@ -97,7 +97,7 @@ public class SwaptionNormalVolatilityDataSets {
   private static final InterpolatedNodalSurface SURFACE_FLAT =
       InterpolatedNodalSurface.of(METADATA, TIMES_FLAT, TENOR_FLAT, NORMAL_VOL_FLAT, INTERPOLATOR_2D);
 
-  public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_FLAT =
+  public static final NormalSwaptionExpiryTenorVolatilities NORMAL_SWAPTION_VOLS_USD_FLAT =
       NormalSwaptionExpiryTenorVolatilities.of(USD_1Y_LIBOR3M, VAL_DATE_TIME_STD, SURFACE_FLAT);
 
   //     =====     Market data as of 2014-03-20     =====
@@ -131,7 +131,7 @@ public class SwaptionNormalVolatilityDataSets {
   private static final LocalTime VAL_TIME_20150320 = LocalTime.of(18, 00);
   private static final ZoneId VAL_ZONE_20150320 = ZoneId.of("Europe/London");
 
-  public static final NormalSwaptionExpiryTenorVolatilities NORMAL_VOL_SWAPTION_PROVIDER_USD_20150320 =
+  public static final NormalSwaptionExpiryTenorVolatilities NORMAL_SWAPTION_VOLS_USD_20150320 =
       NormalSwaptionExpiryTenorVolatilities.of(
           USD_1Y_LIBOR3M, VAL_DATE_20150320.atTime(VAL_TIME_20150320).atZone(VAL_ZONE_20150320), SURFACE_20150320);
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSabrSensitivityTest.java
@@ -22,8 +22,6 @@ import com.opengamma.strata.market.sensitivity.MutablePointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.ZeroRateSensitivity;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 
 /**
  * Test {@link SwaptionSabrSensitivity}.
@@ -31,15 +29,16 @@ import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 @Test
 public class SwaptionSabrSensitivityTest {
 
-  private static final FixedIborSwapConvention SWAP_CONV = FixedIborSwapConventions.GBP_FIXED_1Y_LIBOR_3M;
   private static final double EXPIRY = 1d;
   private static final double TENOR = 3d;
+  private static final SwaptionVolatilitiesName NAME = SwaptionVolatilitiesName.of("Test");
+  private static final SwaptionVolatilitiesName NAME2 = SwaptionVolatilitiesName.of("Test2");
 
   //-------------------------------------------------------------------------
   public void test_of() {
     SwaptionSabrSensitivity test = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
-    assertEquals(test.getConvention(), SWAP_CONV);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+    assertEquals(test.getVolatilitiesName(), NAME);
     assertEquals(test.getExpiry(), EXPIRY);
     assertEquals(test.getTenor(), TENOR);
     assertEquals(test.getSensitivityType(), SabrParameterType.ALPHA);
@@ -50,11 +49,11 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_withCurrency() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     assertSame(base.withCurrency(GBP), base);
 
     SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, USD, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, USD, 32d);
     SwaptionSabrSensitivity test = base.withCurrency(USD);
     assertEquals(test, expected);
   }
@@ -62,9 +61,9 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_withSensitivity() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 20d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 20d);
     SwaptionSabrSensitivity test = base.withSensitivity(20d);
     assertEquals(test, expected);
   }
@@ -72,15 +71,15 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_compareKey() {
     SwaptionSabrSensitivity a1 = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity a2 = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity b = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, USD, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, USD, 32d);
     SwaptionSabrSensitivity c = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY + 1, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY + 1, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity d = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR + 1, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR + 1, SabrParameterType.ALPHA, GBP, 32d);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, 2d, 32d);
     assertEquals(a1.compareKey(a2), 0);
     assertEquals(a1.compareKey(b) < 0, true);
@@ -95,9 +94,9 @@ public class SwaptionSabrSensitivityTest {
   public void test_convertedTo() {
     FxRate rate = FxRate.of(GBP, USD, 1.5d);
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, USD, 32d * 1.5d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, USD, 32d * 1.5d);
     assertEquals(base.convertedTo(USD, rate), expected);
     assertEquals(base.convertedTo(GBP, rate), base);
   }
@@ -105,9 +104,9 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d * 3.5d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d * 3.5d);
     SwaptionSabrSensitivity test = base.multipliedBy(3.5d);
     assertEquals(test, expected);
   }
@@ -115,9 +114,9 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_mapSensitivity() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity expected = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 1 / 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 1 / 32d);
     SwaptionSabrSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
   }
@@ -125,7 +124,7 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_normalize() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity test = base.normalize();
     assertSame(test, base);
   }
@@ -133,9 +132,9 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_combinedWith() {
     SwaptionSabrSensitivity base1 = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity base2 = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 22d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 22d);
     MutablePointSensitivities expected = new MutablePointSensitivities();
     expected.add(base1).add(base2);
     PointSensitivityBuilder test = base1.combinedWith(base2);
@@ -144,7 +143,7 @@ public class SwaptionSabrSensitivityTest {
 
   public void test_combinedWith_mutable() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     MutablePointSensitivities expected = new MutablePointSensitivities();
     expected.add(base);
     PointSensitivityBuilder test = base.combinedWith(new MutablePointSensitivities());
@@ -154,7 +153,7 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_buildInto() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
     assertSame(test, combo);
@@ -164,7 +163,7 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_build() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
   }
@@ -172,7 +171,7 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_cloned() {
     SwaptionSabrSensitivity base = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     SwaptionSabrSensitivity test = base.cloned();
     assertSame(test, base);
   }
@@ -180,10 +179,10 @@ public class SwaptionSabrSensitivityTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     SwaptionSabrSensitivity test = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     coverImmutableBean(test);
     SwaptionSabrSensitivity test2 = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY + 1, TENOR + 1, SabrParameterType.BETA, GBP, 2d);
+        NAME2, EXPIRY + 1, TENOR + 1, SabrParameterType.BETA, GBP, 2d);
     coverBeanEquals(test, test2);
     ZeroRateSensitivity test3 = ZeroRateSensitivity.of(USD, 0.5d, 2d);
     coverBeanEquals(test, test3);
@@ -191,7 +190,7 @@ public class SwaptionSabrSensitivityTest {
 
   public void test_serialization() {
     SwaptionSabrSensitivity test = SwaptionSabrSensitivity.of(
-        SWAP_CONV, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
+        NAME, EXPIRY, TENOR, SabrParameterType.ALPHA, GBP, 32d);
     assertSerialization(test);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSensitivityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SwaptionSensitivityTest.java
@@ -21,8 +21,6 @@ import com.opengamma.strata.market.sensitivity.MutablePointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.ZeroRateSensitivity;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
-import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 
 /**
  * Test {@link SwaptionSensitivity}.
@@ -30,16 +28,17 @@ import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 @Test
 public class SwaptionSensitivityTest {
 
-  private static final FixedIborSwapConvention SWAP_CONV = FixedIborSwapConventions.GBP_FIXED_1Y_LIBOR_3M;
   private static final double EXPIRY = 1d;
   private static final double TENOR = 3d;
   private static final double STRIKE = 7d;
   private static final double FORWARD = 9d;
+  private static final SwaptionVolatilitiesName NAME = SwaptionVolatilitiesName.of("Test");
+  private static final SwaptionVolatilitiesName NAME2 = SwaptionVolatilitiesName.of("Test2");
 
   //-------------------------------------------------------------------------
   public void test_of() {
-    SwaptionSensitivity test = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    assertEquals(test.getConvention(), SWAP_CONV);
+    SwaptionSensitivity test = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    assertEquals(test.getVolatilitiesName(), NAME);
     assertEquals(test.getExpiry(), EXPIRY);
     assertEquals(test.getTenor(), TENOR);
     assertEquals(test.getStrike(), STRIKE);
@@ -50,31 +49,31 @@ public class SwaptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_withCurrency() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     assertSame(base.withCurrency(GBP), base);
 
-    SwaptionSensitivity expected = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, USD, 32d);
+    SwaptionSensitivity expected = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, USD, 32d);
     SwaptionSensitivity test = base.withCurrency(USD);
     assertEquals(test, expected);
   }
 
   //-------------------------------------------------------------------------
   public void test_withSensitivity() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity expected = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 20d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity expected = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 20d);
     SwaptionSensitivity test = base.withSensitivity(20d);
     assertEquals(test, expected);
   }
 
   //-------------------------------------------------------------------------
   public void test_compareKey() {
-    SwaptionSensitivity a1 = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity a2 = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity b = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, USD, 32d);
-    SwaptionSensitivity c = SwaptionSensitivity.of(SWAP_CONV, EXPIRY + 1, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity d = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR + 1, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity e = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE + 1, FORWARD, GBP, 32d);
-    SwaptionSensitivity f = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD + 1, GBP, 32d);
+    SwaptionSensitivity a1 = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity a2 = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity b = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, USD, 32d);
+    SwaptionSensitivity c = SwaptionSensitivity.of(NAME, EXPIRY + 1, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity d = SwaptionSensitivity.of(NAME, EXPIRY, TENOR + 1, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity e = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE + 1, FORWARD, GBP, 32d);
+    SwaptionSensitivity f = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD + 1, GBP, 32d);
     ZeroRateSensitivity other = ZeroRateSensitivity.of(GBP, 2d, 32d);
     assertEquals(a1.compareKey(a2), 0);
     assertEquals(a1.compareKey(b) < 0, true);
@@ -90,39 +89,39 @@ public class SwaptionSensitivityTest {
   //-------------------------------------------------------------------------
   public void test_convertedTo() {
     FxRate rate = FxRate.of(GBP, USD, 1.5d);
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity expected = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, USD, 32d * 1.5d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity expected = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, USD, 32d * 1.5d);
     assertEquals(base.convertedTo(USD, rate), expected);
     assertEquals(base.convertedTo(GBP, rate), base);
   }
 
   //-------------------------------------------------------------------------
   public void test_multipliedBy() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity expected = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d * 3.5d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity expected = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d * 3.5d);
     SwaptionSensitivity test = base.multipliedBy(3.5d);
     assertEquals(test, expected);
   }
 
   //-------------------------------------------------------------------------
   public void test_mapSensitivity() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity expected = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 1 / 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity expected = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 1 / 32d);
     SwaptionSensitivity test = base.mapSensitivity(s -> 1 / s);
     assertEquals(test, expected);
   }
 
   //-------------------------------------------------------------------------
   public void test_normalize() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     SwaptionSensitivity test = base.normalize();
     assertSame(test, base);
   }
 
   //-------------------------------------------------------------------------
   public void test_combinedWith() {
-    SwaptionSensitivity base1 = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
-    SwaptionSensitivity base2 = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 22d);
+    SwaptionSensitivity base1 = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base2 = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 22d);
     MutablePointSensitivities expected = new MutablePointSensitivities();
     expected.add(base1).add(base2);
     PointSensitivityBuilder test = base1.combinedWith(base2);
@@ -130,7 +129,7 @@ public class SwaptionSensitivityTest {
   }
 
   public void test_combinedWith_mutable() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     MutablePointSensitivities expected = new MutablePointSensitivities();
     expected.add(base);
     PointSensitivityBuilder test = base.combinedWith(new MutablePointSensitivities());
@@ -139,7 +138,7 @@ public class SwaptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_buildInto() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     MutablePointSensitivities combo = new MutablePointSensitivities();
     MutablePointSensitivities test = base.buildInto(combo);
     assertSame(test, combo);
@@ -148,31 +147,31 @@ public class SwaptionSensitivityTest {
 
   //-------------------------------------------------------------------------
   public void test_build() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     PointSensitivities test = base.build();
     assertEquals(test.getSensitivities(), ImmutableList.of(base));
   }
 
   //-------------------------------------------------------------------------
   public void test_cloned() {
-    SwaptionSensitivity base = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity base = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     SwaptionSensitivity test = base.cloned();
     assertSame(test, base);
   }
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    SwaptionSensitivity test = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity test = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     coverImmutableBean(test);
     SwaptionSensitivity test2 = SwaptionSensitivity.of(
-        SWAP_CONV, EXPIRY + 1, TENOR + 1, STRIKE + 1, FORWARD + 1, USD, 32d);
+        NAME2, EXPIRY + 1, TENOR + 1, STRIKE + 1, FORWARD + 1, USD, 32d);
     coverBeanEquals(test, test2);
     ZeroRateSensitivity test3 = ZeroRateSensitivity.of(USD, 0.5d, 2d);
     coverBeanEquals(test, test3);
   }
 
   public void test_serialization() {
-    SwaptionSensitivity test = SwaptionSensitivity.of(SWAP_CONV, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
+    SwaptionSensitivity test = SwaptionSensitivity.of(NAME, EXPIRY, TENOR, STRIKE, FORWARD, GBP, 32d);
     assertSerialization(test);
   }
 


### PR DESCRIPTION
Better captures the target.
Parameter sensitivity 

PR also renames volatilities objects in test cases (automated refactor)