### PR TITLE
Treat EOM roll convention as advisory

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -658,23 +658,17 @@ public final class PeriodicSchedule
    * @return the non-null roll convention
    */
   public RollConvention calculatedRollConvention() {
-    // determine roll convention from stub convention, using EOM as a flag
-    if (stubConvention != null) {
-      // special handling for EOM as it is advisory rather than mandatory
-      if (rollConvention == RollConventions.EOM) {
-        RollConvention derived = stubConvention.toRollConvention(
-            calculatedFirstRegularStartDate(), calculatedLastRegularEndDate(), frequency, true);
-        return (derived == RollConventions.NONE ? RollConventions.EOM : derived);
-      }
-      // avoid RollConventions.NONE if possible
-      if (rollConvention == null || rollConvention == RollConventions.NONE) {
-        return stubConvention.toRollConvention(
-            calculatedFirstRegularStartDate(), calculatedLastRegularEndDate(), frequency, false);
-      }
+    // determine roll convention from stub convention
+    StubConvention stubConv = MoreObjects.firstNonNull(stubConvention, StubConvention.NONE);
+    // special handling for EOM as it is advisory rather than mandatory
+    if (rollConvention == RollConventions.EOM) {
+      RollConvention derived = stubConv.toRollConvention(
+          calculatedFirstRegularStartDate(), calculatedLastRegularEndDate(), frequency, true);
+      return (derived == RollConventions.NONE ? RollConventions.EOM : derived);
     }
     // avoid RollConventions.NONE if possible
     if (rollConvention == null || rollConvention == RollConventions.NONE) {
-      return StubConvention.NONE.toRollConvention(
+      return stubConv.toRollConvention(
           calculatedFirstRegularStartDate(), calculatedLastRegularEndDate(), frequency, false);
     }
     // use RollConventions.NONE if nothing else applies

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -328,8 +328,12 @@ public class PeriodicScheduleTest {
         {NOV_30_2013, NOV_30, P3M, STUB_NONE, EOM, null, null,
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_31, AUG_31, NOV_30),
             ImmutableList.of(date(2013, NOVEMBER, 29), FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28))},
-        // EOM flag true, but not EOM, thus roll on 30th
+        // EOM flag true, but not EOM, thus roll on 30th (stub convention defined)
         {MAY_30, NOV_30, P3M, STUB_NONE, EOM, null, null,
+            ImmutableList.of(MAY_30, AUG_30, NOV_30),
+            ImmutableList.of(MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28))},
+        // EOM flag true, but not EOM, thus roll on 30th (no stub convention defined)
+        {MAY_30, NOV_30, P3M, null, EOM, null, null,
             ImmutableList.of(MAY_30, AUG_30, NOV_30),
             ImmutableList.of(MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28))},
         // EOM flag true and is EOM, double stub, thus roll at EOM


### PR DESCRIPTION
Was previously treated as mandatory when a stub convention was provided
Fixes #1232