### PR TITLE
Create column name directly from measure

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/Column.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/Column.java
@@ -90,7 +90,7 @@ public final class Column implements ImmutableBean {
    * @return a column with the specified measure
    */
   public static Column of(Measure measure) {
-    ColumnName name = ColumnName.of(measure.toString());
+    ColumnName name = ColumnName.of(measure);
     return new Column(name, measure, null, CalculationParameters.empty());
   }
 
@@ -104,7 +104,7 @@ public final class Column implements ImmutableBean {
    * @return a column with the specified measure
    */
   public static Column of(Measure measure, Currency currency) {
-    ColumnName name = ColumnName.of(measure.toString());
+    ColumnName name = ColumnName.of(measure);
     return new Column(name, measure, ReportingCurrency.of(currency), CalculationParameters.empty());
   }
 
@@ -121,7 +121,7 @@ public final class Column implements ImmutableBean {
    * @return a column with the specified measure and reporting currency
    */
   public static Column of(Measure measure, CalculationParameter... parameters) {
-    ColumnName name = ColumnName.of(measure.toString());
+    ColumnName name = ColumnName.of(measure);
     return new Column(name, measure, null, CalculationParameters.of(parameters));
   }
 
@@ -139,7 +139,7 @@ public final class Column implements ImmutableBean {
    * @return a column with the specified measure and reporting currency
    */
   public static Column of(Measure measure, Currency currency, CalculationParameter... parameters) {
-    ColumnName name = ColumnName.of(measure.toString());
+    ColumnName name = ColumnName.of(measure);
     return new Column(name, measure, ReportingCurrency.of(currency), CalculationParameters.of(parameters));
   }
 

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/ColumnName.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/ColumnName.java
@@ -40,7 +40,6 @@ public final class ColumnName
    * @param measure  the measure to extract the name from
    * @return a column with the same name as the measure
    */
-  @FromString
   public static ColumnName of(Measure measure) {
     return new ColumnName(measure.getName());
   }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/ColumnName.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/ColumnName.java
@@ -33,6 +33,19 @@ public final class ColumnName
   }
 
   /**
+   * Obtains an instance from the specified measure.
+   * <p>
+   * The column name will be the same as the name of the measure.
+   *
+   * @param measure  the measure to extract the name from
+   * @return a column with the same name as the measure
+   */
+  @FromString
+  public static ColumnName of(Measure measure) {
+    return new ColumnName(measure.getName());
+  }
+
+  /**
    * Creates an instance.
    * 
    * @param name  the name of the column

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/ColumnNameTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/ColumnNameTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.calc;
+
+import static com.opengamma.strata.collect.TestHelper.assertJodaConvert;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link ColumnName}.
+ */
+@Test
+public class ColumnNameTest {
+
+  //-------------------------------------------------------------------------
+  public void test_builder_columnNameFromMeasure() {
+    ColumnName test = ColumnName.of("Test");
+    assertEquals(test.getName(), "Test");
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_serialization() {
+    ColumnName test = ColumnName.of("Test");
+    assertSerialization(test);
+    assertJodaConvert(ColumnName.class, test);
+  }
+
+}


### PR DESCRIPTION
Add factory method to create `ColumnName` from `Measure`
Fixes #1239