### PR TITLE
Support parameterized notional schedule

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueSchedule.java
@@ -29,6 +29,7 @@ import com.opengamma.strata.basics.schedule.RollConvention;
 import com.opengamma.strata.basics.schedule.RollConventions;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.array.DoubleArray;
 
 /**
@@ -169,10 +170,10 @@ public final class ValueSchedule
   // resolve the values
   private DoubleArray resolveValues(List<SchedulePeriod> periods, RollConvention rollConv) {
     // handle simple case where there are no steps
-    if (steps.size() > 0 || stepSequence != null) {
-      return resolveSteps(periods, rollConv);
+    if (steps.size() == 0 && stepSequence == null) {
+      return DoubleArray.filled(periods.size(), initialValue);
     }
-    return DoubleArray.filled(periods.size(), initialValue);
+    return resolveSteps(periods, rollConv);
   }
 
   // resolve the steps, broken into a separate method to aid inlining
@@ -186,7 +187,9 @@ public final class ValueSchedule
     for (ValueStep step : resolvedSteps) {
       int index = step.findIndex(periods);
       if (expandedSteps[index] != null && !expandedSteps[index].equals(step.getValue())) {
-        throw new IllegalArgumentException("Two ValueStep instances resolve to the same schedule period");
+        throw new IllegalArgumentException(Messages.format(
+            "Invalid ValueSchedule, two steps resolved to the same schedule period starting on {}, schedule defined as {}",
+            periods.get(index).getUnadjustedStartDate(), this));
       }
       expandedSteps[index] = step.getValue();
     }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueSchedule.java
@@ -6,10 +6,10 @@
 package com.opengamma.strata.basics.value;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import org.joda.beans.Bean;
@@ -25,14 +25,26 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Doubles;
+import com.opengamma.strata.basics.schedule.RollConvention;
+import com.opengamma.strata.basics.schedule.RollConventions;
+import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
+import com.opengamma.strata.collect.array.DoubleArray;
 
 /**
  * A value that can vary over time.
  * <p>
  * This represents a single initial value and any adjustments over the lifetime of a trade.
  * Adjustments may be specified in absolute or relative terms.
+ * <p>
+ * The adjustments may be specified as individual steps or as a sequence of steps.
+ * An individual step is a change that occurs at a specific date, identified either by
+ * the date or the index within the schedule. A sequence of steps consists of a start date,
+ * end date and frequency, with the same change applying many times.
+ * All changes must occur on dates that are period boundaries in the specified schedule.
+ * <p>
+ * It is possible to specify both individual steps and a sequence, however this is not recommended.
+ * It it is done, then the individual steps and sequence steps must resolve to different dates.
  * <p>
  * The value is specified as a {@code double} with the context adding additional meaning.
  * If the value represents an amount of money then the currency is specified separately.
@@ -65,6 +77,14 @@ public final class ValueSchedule
    */
   @PropertyDefinition(validate = "notNull")
   private final List<ValueStep> steps;
+  /**
+   * The sequence of steps changing the value.
+   * <p>
+   * This allows a regular pattern of steps to be encoded.
+   * All step dates must be unique, thus the list of steps must not contain any date implied by this sequence.
+   */
+  @PropertyDefinition(get = "optional")
+  private final ValueStepSequence stepSequence;
 
   //-------------------------------------------------------------------------
   /**
@@ -74,7 +94,7 @@ public final class ValueSchedule
    * @return the value schedule
    */
   public static ValueSchedule of(double value) {
-    return new ValueSchedule(value, ImmutableList.of());
+    return new ValueSchedule(value, ImmutableList.of(), null);
   }
 
   /**
@@ -88,7 +108,7 @@ public final class ValueSchedule
    * @return the value schedule
    */
   public static ValueSchedule of(double initialValue, ValueStep... steps) {
-    return new ValueSchedule(initialValue, ImmutableList.copyOf(steps));
+    return new ValueSchedule(initialValue, ImmutableList.copyOf(steps), null);
   }
 
   /**
@@ -102,7 +122,21 @@ public final class ValueSchedule
    * @return the value schedule
    */
   public static ValueSchedule of(double initialValue, List<ValueStep> steps) {
-    return new ValueSchedule(initialValue, ImmutableList.copyOf(steps));
+    return new ValueSchedule(initialValue, ImmutableList.copyOf(steps), null);
+  }
+
+  /**
+   * Obtains an instance from an initial value and a sequence of steps.
+   * <p>
+   * The sequence defines changes from one date to another date using a frequency.
+   * For example, the value might change every year from 2011-06-01 to 2015-06-01.
+   * 
+   * @param initialValue  the initial value used for the first period
+   * @param stepSequence  the full definition of how the value changes over time
+   * @return the value schedule
+   */
+  public static ValueSchedule of(double initialValue, ValueStepSequence stepSequence) {
+    return new ValueSchedule(initialValue, ImmutableList.of(), stepSequence);
   }
 
   //-------------------------------------------------------------------------
@@ -110,42 +144,61 @@ public final class ValueSchedule
    * Resolves the value and adjustments against a specific schedule.
    * <p>
    * This converts a schedule into a list of values, one for each schedule period.
-   * <p>
-   * The output list is immutable and matches the input list.
-   * Use {@link Doubles#toArray} to efficiently access the list as a {@code double[]}
-   * (without breaking encapsulation or immutability).
    * 
    * @param periods  the list of schedule periods
    * @return the values, one for each schedule period
+   * @deprecated Use {@link #resolveValues(Schedule)}
    */
+  @Deprecated
   public List<Double> resolveValues(List<SchedulePeriod> periods) {
+    return resolveValues(periods, RollConventions.NONE).toList();
+  }
+
+  /**
+   * Resolves the value and adjustments against a specific schedule.
+   * <p>
+   * This converts a schedule into a list of values, one for each schedule period.
+   * 
+   * @param schedule  the schedule
+   * @return the values, one for each schedule period
+   */
+  public DoubleArray resolveValues(Schedule schedule) {
+    return resolveValues(schedule.getPeriods(), schedule.getRollConvention());
+  }
+
+  // resolve the values
+  private DoubleArray resolveValues(List<SchedulePeriod> periods, RollConvention rollConv) {
+    // handle simple case where there are no steps
+    if (steps.size() > 0 || stepSequence != null) {
+      return resolveSteps(periods, rollConv);
+    }
+    return DoubleArray.filled(periods.size(), initialValue);
+  }
+
+  // resolve the steps, broken into a separate method to aid inlining
+  private DoubleArray resolveSteps(List<SchedulePeriod> periods, RollConvention rollConv) {
     int size = periods.size();
     double[] result = new double[size];
-    // handle simple case
-    if (steps.size() == 0) {
-      Arrays.fill(result, initialValue);
-    } else {
-      // expand ValueStep to array of adjustments matching the periods
-      // the steps are not sorted, so use fixed size array to absorb incoming data
-      ValueAdjustment[] expandedSteps = new ValueAdjustment[size];
-      for (ValueStep step : steps) {
-        int index = step.findIndex(periods);
-        if (expandedSteps[index] != null && !expandedSteps[index].equals(step.getValue())) {
-          throw new IllegalArgumentException("Two ValueStep instances resolve to the same schedule period");
-        }
-        expandedSteps[index] = step.getValue();
+    List<ValueStep> resolvedSteps = getStepSequence().map(seq -> seq.resolve(steps, rollConv)).orElse(steps);
+    // expand ValueStep to array of adjustments matching the periods
+    // the steps are not sorted, so use fixed size array to absorb incoming data
+    ValueAdjustment[] expandedSteps = new ValueAdjustment[size];
+    for (ValueStep step : resolvedSteps) {
+      int index = step.findIndex(periods);
+      if (expandedSteps[index] != null && !expandedSteps[index].equals(step.getValue())) {
+        throw new IllegalArgumentException("Two ValueStep instances resolve to the same schedule period");
       }
-      // apply each adjustment
-      double value = initialValue;
-      for (int i = 0; i < size; i++) {
-        if (expandedSteps[i] != null) {
-          value = expandedSteps[i].adjust(value);
-        }
-        result[i] = value;
-      }
+      expandedSteps[index] = step.getValue();
     }
-    // result array is wrapped, not copied, which is OK as scope of result ends here
-    return Doubles.asList(result);
+    // apply each adjustment
+    double value = initialValue;
+    for (int i = 0; i < size; i++) {
+      if (expandedSteps[i] != null) {
+        value = expandedSteps[i].adjust(value);
+      }
+      result[i] = value;
+    }
+    return DoubleArray.ofUnsafe(result);
   }
 
   //------------------------- AUTOGENERATED START -------------------------
@@ -177,10 +230,12 @@ public final class ValueSchedule
 
   private ValueSchedule(
       double initialValue,
-      List<ValueStep> steps) {
+      List<ValueStep> steps,
+      ValueStepSequence stepSequence) {
     JodaBeanUtils.notNull(steps, "steps");
     this.initialValue = initialValue;
     this.steps = ImmutableList.copyOf(steps);
+    this.stepSequence = stepSequence;
   }
 
   @Override
@@ -222,6 +277,18 @@ public final class ValueSchedule
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the sequence of steps changing the value.
+   * <p>
+   * This allows a regular pattern of steps to be encoded.
+   * All step dates must be unique, thus the list of steps must not contain any date implied by this sequence.
+   * @return the optional value of the property, not null
+   */
+  public Optional<ValueStepSequence> getStepSequence() {
+    return Optional.ofNullable(stepSequence);
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Returns a builder that allows this bean to be mutated.
    * @return the mutable builder, not null
    */
@@ -237,7 +304,8 @@ public final class ValueSchedule
     if (obj != null && obj.getClass() == this.getClass()) {
       ValueSchedule other = (ValueSchedule) obj;
       return JodaBeanUtils.equal(initialValue, other.initialValue) &&
-          JodaBeanUtils.equal(steps, other.steps);
+          JodaBeanUtils.equal(steps, other.steps) &&
+          JodaBeanUtils.equal(stepSequence, other.stepSequence);
     }
     return false;
   }
@@ -247,15 +315,17 @@ public final class ValueSchedule
     int hash = getClass().hashCode();
     hash = hash * 31 + JodaBeanUtils.hashCode(initialValue);
     hash = hash * 31 + JodaBeanUtils.hashCode(steps);
+    hash = hash * 31 + JodaBeanUtils.hashCode(stepSequence);
     return hash;
   }
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(96);
+    StringBuilder buf = new StringBuilder(128);
     buf.append("ValueSchedule{");
     buf.append("initialValue").append('=').append(initialValue).append(',').append(' ');
-    buf.append("steps").append('=').append(JodaBeanUtils.toString(steps));
+    buf.append("steps").append('=').append(steps).append(',').append(' ');
+    buf.append("stepSequence").append('=').append(JodaBeanUtils.toString(stepSequence));
     buf.append('}');
     return buf.toString();
   }
@@ -282,12 +352,18 @@ public final class ValueSchedule
     private final MetaProperty<List<ValueStep>> steps = DirectMetaProperty.ofImmutable(
         this, "steps", ValueSchedule.class, (Class) List.class);
     /**
+     * The meta-property for the {@code stepSequence} property.
+     */
+    private final MetaProperty<ValueStepSequence> stepSequence = DirectMetaProperty.ofImmutable(
+        this, "stepSequence", ValueSchedule.class, ValueStepSequence.class);
+    /**
      * The meta-properties.
      */
     private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
         this, null,
         "initialValue",
-        "steps");
+        "steps",
+        "stepSequence");
 
     /**
      * Restricted constructor.
@@ -302,6 +378,8 @@ public final class ValueSchedule
           return initialValue;
         case 109761319:  // steps
           return steps;
+        case 2141410989:  // stepSequence
+          return stepSequence;
       }
       return super.metaPropertyGet(propertyName);
     }
@@ -338,6 +416,14 @@ public final class ValueSchedule
       return steps;
     }
 
+    /**
+     * The meta-property for the {@code stepSequence} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ValueStepSequence> stepSequence() {
+      return stepSequence;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
@@ -346,6 +432,8 @@ public final class ValueSchedule
           return ((ValueSchedule) bean).getInitialValue();
         case 109761319:  // steps
           return ((ValueSchedule) bean).getSteps();
+        case 2141410989:  // stepSequence
+          return ((ValueSchedule) bean).stepSequence;
       }
       return super.propertyGet(bean, propertyName, quiet);
     }
@@ -369,6 +457,7 @@ public final class ValueSchedule
 
     private double initialValue;
     private List<ValueStep> steps = ImmutableList.of();
+    private ValueStepSequence stepSequence;
 
     /**
      * Restricted constructor.
@@ -383,6 +472,7 @@ public final class ValueSchedule
     private Builder(ValueSchedule beanToCopy) {
       this.initialValue = beanToCopy.getInitialValue();
       this.steps = ImmutableList.copyOf(beanToCopy.getSteps());
+      this.stepSequence = beanToCopy.stepSequence;
     }
 
     //-----------------------------------------------------------------------
@@ -393,6 +483,8 @@ public final class ValueSchedule
           return initialValue;
         case 109761319:  // steps
           return steps;
+        case 2141410989:  // stepSequence
+          return stepSequence;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
       }
@@ -407,6 +499,9 @@ public final class ValueSchedule
           break;
         case 109761319:  // steps
           this.steps = (List<ValueStep>) newValue;
+          break;
+        case 2141410989:  // stepSequence
+          this.stepSequence = (ValueStepSequence) newValue;
           break;
         default:
           throw new NoSuchElementException("Unknown property: " + propertyName);
@@ -442,7 +537,8 @@ public final class ValueSchedule
     public ValueSchedule build() {
       return new ValueSchedule(
           initialValue,
-          steps);
+          steps,
+          stepSequence);
     }
 
     //-----------------------------------------------------------------------
@@ -481,13 +577,27 @@ public final class ValueSchedule
       return steps(ImmutableList.copyOf(steps));
     }
 
+    /**
+     * Sets the sequence of steps changing the value.
+     * <p>
+     * This allows a regular pattern of steps to be encoded.
+     * All step dates must be unique, thus the list of steps must not contain any date implied by this sequence.
+     * @param stepSequence  the new value
+     * @return this, for chaining, not null
+     */
+    public Builder stepSequence(ValueStepSequence stepSequence) {
+      this.stepSequence = stepSequence;
+      return this;
+    }
+
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(96);
+      StringBuilder buf = new StringBuilder(128);
       buf.append("ValueSchedule.Builder{");
       buf.append("initialValue").append('=').append(JodaBeanUtils.toString(initialValue)).append(',').append(' ');
-      buf.append("steps").append('=').append(JodaBeanUtils.toString(steps));
+      buf.append("steps").append('=').append(JodaBeanUtils.toString(steps)).append(',').append(' ');
+      buf.append("stepSequence").append('=').append(JodaBeanUtils.toString(stepSequence));
       buf.append('}');
       return buf.toString();
     }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueStepSequence.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueStepSequence.java
@@ -1,0 +1,522 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.value;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanBuilder;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableValidator;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.RollConvention;
+import com.opengamma.strata.basics.schedule.Schedule;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.Messages;
+
+/**
+ * A sequence of steps that vary a value over time.
+ * <p>
+ * A financial value, such as the notional or interest rate, may vary over time.
+ * This class represents a sequence of changes in the value within {@link ValueSchedule}.
+ * <p>
+ * The sequence is defined by a start date, end date and frequency.
+ * The adjustment at each step is defined using {@link ValueAdjustment}.
+ */
+@BeanDefinition(builderScope = "private")
+public final class ValueStepSequence
+    implements ImmutableBean, Serializable {
+
+  /**
+   * The first date in the sequence.
+   * <p>
+   * This sequence will change the value on this date, but not before.
+   * This must be one of the unadjusted dates in the schedule period schedule.
+   * <p>
+   * For example, consider a 5 year swap from 2012-02-01 to 2017-02-01 with 6 month frequency.
+   * The date '2013-02-01' is an unadjusted schedule period boundary, and so may be specified here.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final LocalDate firstStepDate;
+  /**
+   * The last date in the sequence.
+   * <p>
+   * This sequence will change the value on this date, but not after.
+   * This must be one of the unadjusted dates in the schedule period schedule.
+   * <p>
+   * For example, consider a 5 year swap from 2012-02-01 to 2017-02-01 with 6 month frequency.
+   * The date '2015-02-01' is an unadjusted schedule period boundary, and so may be specified here.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final LocalDate lastStepDate;
+  /**
+   * The frequency of the sequence.
+   * <p>
+   * This sequence will change the value on each date between the start and end defined by this frequency.
+   * The frequency is interpreted relative to the frequency of a {@link Schedule}.
+   * It must be equal or greater than the related schedule.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final Frequency frequency;
+  /**
+   * The adjustment representing the change that occurs at each step.
+   * <p>
+   * The adjustment type must not be 'Replace'.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final ValueAdjustment adjustment;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains an instance from the dates, frequency and change.
+   * 
+   * @param firstStepDate  the first date of the sequence
+   * @param lastStepDate  the last date of the sequence
+   * @param frequency  the frequency of changes
+   * @param adjustment  the adjustment at each step
+   * @return the varying step
+   */
+  public static ValueStepSequence of(
+      LocalDate firstStepDate,
+      LocalDate lastStepDate,
+      Frequency frequency,
+      ValueAdjustment adjustment) {
+
+    return new ValueStepSequence(firstStepDate, lastStepDate, frequency, adjustment);
+  }
+
+  @ImmutableValidator
+  private void validate() {
+    ArgChecker.inOrderOrEqual(firstStepDate, lastStepDate, "firstStepDate", "lastStepDate");
+    ArgChecker.isTrue(adjustment.getType() != ValueAdjustmentType.REPLACE, "ValueAdjustmentType must not be 'Replace'");
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Resolves the sequence to a list of steps.
+   * 
+   * @param existingSteps  the existing list of steps
+   * @param rollConv  the roll convention
+   * @return the steps
+   */
+  List<ValueStep> resolve(List<ValueStep> existingSteps, RollConvention rollConv) {
+    ImmutableList.Builder<ValueStep> steps = ImmutableList.builder();
+    steps.addAll(existingSteps);
+    LocalDate prev = firstStepDate;
+    LocalDate date = firstStepDate;
+    while (!date.isAfter(lastStepDate)) {
+      steps.add(ValueStep.of(date, adjustment));
+      prev = date;
+      date = rollConv.next(date, frequency);
+    }
+    if (!prev.equals(lastStepDate)) {
+      throw new IllegalArgumentException(Messages.format(
+          "ValueStepSequence lastStepDate did not match frequency '{}' using roll convention '{}', {} != {}",
+          frequency, rollConv, lastStepDate, prev));
+    }
+    return steps.build();
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code ValueStepSequence}.
+   * @return the meta-bean, not null
+   */
+  public static ValueStepSequence.Meta meta() {
+    return ValueStepSequence.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(ValueStepSequence.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  private ValueStepSequence(
+      LocalDate firstStepDate,
+      LocalDate lastStepDate,
+      Frequency frequency,
+      ValueAdjustment adjustment) {
+    JodaBeanUtils.notNull(firstStepDate, "firstStepDate");
+    JodaBeanUtils.notNull(lastStepDate, "lastStepDate");
+    JodaBeanUtils.notNull(frequency, "frequency");
+    JodaBeanUtils.notNull(adjustment, "adjustment");
+    this.firstStepDate = firstStepDate;
+    this.lastStepDate = lastStepDate;
+    this.frequency = frequency;
+    this.adjustment = adjustment;
+    validate();
+  }
+
+  @Override
+  public ValueStepSequence.Meta metaBean() {
+    return ValueStepSequence.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the first date in the sequence.
+   * <p>
+   * This sequence will change the value on this date, but not before.
+   * This must be one of the unadjusted dates in the schedule period schedule.
+   * <p>
+   * For example, consider a 5 year swap from 2012-02-01 to 2017-02-01 with 6 month frequency.
+   * The date '2013-02-01' is an unadjusted schedule period boundary, and so may be specified here.
+   * @return the value of the property, not null
+   */
+  public LocalDate getFirstStepDate() {
+    return firstStepDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the last date in the sequence.
+   * <p>
+   * This sequence will change the value on this date, but not after.
+   * This must be one of the unadjusted dates in the schedule period schedule.
+   * <p>
+   * For example, consider a 5 year swap from 2012-02-01 to 2017-02-01 with 6 month frequency.
+   * The date '2015-02-01' is an unadjusted schedule period boundary, and so may be specified here.
+   * @return the value of the property, not null
+   */
+  public LocalDate getLastStepDate() {
+    return lastStepDate;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the frequency of the sequence.
+   * <p>
+   * This sequence will change the value on each date between the start and end defined by this frequency.
+   * The frequency is interpreted relative to the frequency of a {@link Schedule}.
+   * It must be equal or greater than the related schedule.
+   * @return the value of the property, not null
+   */
+  public Frequency getFrequency() {
+    return frequency;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the adjustment representing the change that occurs at each step.
+   * <p>
+   * The adjustment type must not be 'Replace'.
+   * @return the value of the property, not null
+   */
+  public ValueAdjustment getAdjustment() {
+    return adjustment;
+  }
+
+  //-----------------------------------------------------------------------
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      ValueStepSequence other = (ValueStepSequence) obj;
+      return JodaBeanUtils.equal(firstStepDate, other.firstStepDate) &&
+          JodaBeanUtils.equal(lastStepDate, other.lastStepDate) &&
+          JodaBeanUtils.equal(frequency, other.frequency) &&
+          JodaBeanUtils.equal(adjustment, other.adjustment);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(firstStepDate);
+    hash = hash * 31 + JodaBeanUtils.hashCode(lastStepDate);
+    hash = hash * 31 + JodaBeanUtils.hashCode(frequency);
+    hash = hash * 31 + JodaBeanUtils.hashCode(adjustment);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(160);
+    buf.append("ValueStepSequence{");
+    buf.append("firstStepDate").append('=').append(firstStepDate).append(',').append(' ');
+    buf.append("lastStepDate").append('=').append(lastStepDate).append(',').append(' ');
+    buf.append("frequency").append('=').append(frequency).append(',').append(' ');
+    buf.append("adjustment").append('=').append(JodaBeanUtils.toString(adjustment));
+    buf.append('}');
+    return buf.toString();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code ValueStepSequence}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code firstStepDate} property.
+     */
+    private final MetaProperty<LocalDate> firstStepDate = DirectMetaProperty.ofImmutable(
+        this, "firstStepDate", ValueStepSequence.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code lastStepDate} property.
+     */
+    private final MetaProperty<LocalDate> lastStepDate = DirectMetaProperty.ofImmutable(
+        this, "lastStepDate", ValueStepSequence.class, LocalDate.class);
+    /**
+     * The meta-property for the {@code frequency} property.
+     */
+    private final MetaProperty<Frequency> frequency = DirectMetaProperty.ofImmutable(
+        this, "frequency", ValueStepSequence.class, Frequency.class);
+    /**
+     * The meta-property for the {@code adjustment} property.
+     */
+    private final MetaProperty<ValueAdjustment> adjustment = DirectMetaProperty.ofImmutable(
+        this, "adjustment", ValueStepSequence.class, ValueAdjustment.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "firstStepDate",
+        "lastStepDate",
+        "frequency",
+        "adjustment");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -1025397910:  // firstStepDate
+          return firstStepDate;
+        case -292412080:  // lastStepDate
+          return lastStepDate;
+        case -70023844:  // frequency
+          return frequency;
+        case 1977085293:  // adjustment
+          return adjustment;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public BeanBuilder<? extends ValueStepSequence> builder() {
+      return new ValueStepSequence.Builder();
+    }
+
+    @Override
+    public Class<? extends ValueStepSequence> beanType() {
+      return ValueStepSequence.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code firstStepDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> firstStepDate() {
+      return firstStepDate;
+    }
+
+    /**
+     * The meta-property for the {@code lastStepDate} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<LocalDate> lastStepDate() {
+      return lastStepDate;
+    }
+
+    /**
+     * The meta-property for the {@code frequency} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Frequency> frequency() {
+      return frequency;
+    }
+
+    /**
+     * The meta-property for the {@code adjustment} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<ValueAdjustment> adjustment() {
+      return adjustment;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case -1025397910:  // firstStepDate
+          return ((ValueStepSequence) bean).getFirstStepDate();
+        case -292412080:  // lastStepDate
+          return ((ValueStepSequence) bean).getLastStepDate();
+        case -70023844:  // frequency
+          return ((ValueStepSequence) bean).getFrequency();
+        case 1977085293:  // adjustment
+          return ((ValueStepSequence) bean).getAdjustment();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code ValueStepSequence}.
+   */
+  private static final class Builder extends DirectFieldsBeanBuilder<ValueStepSequence> {
+
+    private LocalDate firstStepDate;
+    private LocalDate lastStepDate;
+    private Frequency frequency;
+    private ValueAdjustment adjustment;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -1025397910:  // firstStepDate
+          return firstStepDate;
+        case -292412080:  // lastStepDate
+          return lastStepDate;
+        case -70023844:  // frequency
+          return frequency;
+        case 1977085293:  // adjustment
+          return adjustment;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case -1025397910:  // firstStepDate
+          this.firstStepDate = (LocalDate) newValue;
+          break;
+        case -292412080:  // lastStepDate
+          this.lastStepDate = (LocalDate) newValue;
+          break;
+        case -70023844:  // frequency
+          this.frequency = (Frequency) newValue;
+          break;
+        case 1977085293:  // adjustment
+          this.adjustment = (ValueAdjustment) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public ValueStepSequence build() {
+      return new ValueStepSequence(
+          firstStepDate,
+          lastStepDate,
+          frequency,
+          adjustment);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(160);
+      buf.append("ValueStepSequence.Builder{");
+      buf.append("firstStepDate").append('=').append(JodaBeanUtils.toString(firstStepDate)).append(',').append(' ');
+      buf.append("lastStepDate").append('=').append(JodaBeanUtils.toString(lastStepDate)).append(',').append(' ');
+      buf.append("frequency").append('=').append(JodaBeanUtils.toString(frequency)).append(',').append(' ');
+      buf.append("adjustment").append('=').append(JodaBeanUtils.toString(adjustment));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueScheduleTest.java
@@ -7,15 +7,22 @@ package com.opengamma.strata.basics.value;
 
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
 
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.RollConventions;
+import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
+import com.opengamma.strata.collect.array.DoubleArray;
 
 /**
  * Test {@link ValueSchedule}.
@@ -32,6 +39,11 @@ public class ValueScheduleTest {
   private static SchedulePeriod PERIOD3 = SchedulePeriod.of(
       date(2014, 3, 1), date(2014, 4, 1), date(2014, 3, 2), date(2014, 4, 1));
   private static ImmutableList<SchedulePeriod> PERIODS = ImmutableList.of(PERIOD1, PERIOD2, PERIOD3);
+  private static Schedule SCHEDULE = Schedule.builder()
+      .periods(PERIODS)
+      .frequency(Frequency.P1M)
+      .rollConvention(RollConventions.DAY_1)
+      .build();
 
   //-------------------------------------------------------------------------
   public void test_constant_ALWAYS_0() {
@@ -77,6 +89,15 @@ public class ValueScheduleTest {
     assertEquals(test.getSteps(), ImmutableList.of());
   }
 
+  public void test_of_sequence() {
+    ValueStepSequence seq = ValueStepSequence.of(
+        date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ValueAdjustment.ofDeltaAmount(-100));
+    ValueSchedule test = ValueSchedule.of(10000d, seq);
+    assertEquals(test.getInitialValue(), 10000d, TOLERANCE);
+    assertEquals(test.getSteps(), ImmutableList.of());
+    assertEquals(test.getStepSequence(), Optional.of(seq));
+  }
+
   public void test_builder_validEmpty() {
     ValueSchedule test = ValueSchedule.builder().build();
     assertEquals(test.getInitialValue(), 0d, TOLERANCE);
@@ -84,13 +105,21 @@ public class ValueScheduleTest {
   }
 
   public void test_builder_validFull() {
-    ValueSchedule test = ValueSchedule.builder().initialValue(2000d).steps(ImmutableList.of(STEP1, STEP2)).build();
+    ValueStepSequence seq = ValueStepSequence.of(
+        date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ValueAdjustment.ofDeltaAmount(-100));
+    ValueSchedule test = ValueSchedule.builder()
+        .initialValue(2000d)
+        .steps(STEP1, STEP2)
+        .stepSequence(seq)
+        .build();
     assertEquals(test.getInitialValue(), 2000d, TOLERANCE);
     assertEquals(test.getSteps(), ImmutableList.of(STEP1, STEP2));
+    assertEquals(test.getStepSequence(), Optional.of(seq));
   }
 
   //-------------------------------------------------------------------------
-  public void test_resolveValues_dateBased() {
+  @SuppressWarnings("deprecation")
+  public void test_resolveValues_dateBased_deprecated() {
     ValueStep step1 = ValueStep.of(date(2014, 2, 1), ValueAdjustment.ofReplace(300d));
     ValueStep step2 = ValueStep.of(date(2014, 3, 1), ValueAdjustment.ofReplace(400d));
     // no steps
@@ -107,21 +136,39 @@ public class ValueScheduleTest {
     assertEquals(test2.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 400d));
   }
 
+  //-------------------------------------------------------------------------
+  public void test_resolveValues_dateBased() {
+    ValueStep step1 = ValueStep.of(date(2014, 2, 1), ValueAdjustment.ofReplace(300d));
+    ValueStep step2 = ValueStep.of(date(2014, 3, 1), ValueAdjustment.ofReplace(400d));
+    // no steps
+    ValueSchedule test0 = ValueSchedule.of(200d, ImmutableList.of());
+    assertEquals(test0.resolveValues(SCHEDULE), DoubleArray.of(200d, 200d, 200d));
+    // step1
+    ValueSchedule test1a = ValueSchedule.of(200d, ImmutableList.of(step1));
+    assertEquals(test1a.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 300d));
+    // step2
+    ValueSchedule test1b = ValueSchedule.of(200d, ImmutableList.of(step2));
+    assertEquals(test1b.resolveValues(SCHEDULE), DoubleArray.of(200d, 200d, 400d));
+    // step1 and step2
+    ValueSchedule test2 = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
+    assertEquals(test2.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 400d));
+  }
+
   public void test_resolveValues_dateBased_matchAdjusted() {
     ValueStep step1 = ValueStep.of(date(2014, 2, 1), ValueAdjustment.ofReplace(300d));
     ValueStep step2 = ValueStep.of(date(2014, 3, 2), ValueAdjustment.ofReplace(400d));
     // no steps
     ValueSchedule test0 = ValueSchedule.of(200d, ImmutableList.of());
-    assertEquals(test0.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 200d));
+    assertEquals(test0.resolveValues(SCHEDULE), DoubleArray.of(200d, 200d, 200d));
     // step1
     ValueSchedule test1a = ValueSchedule.of(200d, ImmutableList.of(step1));
-    assertEquals(test1a.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 300d));
+    assertEquals(test1a.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 300d));
     // step2
     ValueSchedule test1b = ValueSchedule.of(200d, ImmutableList.of(step2));
-    assertEquals(test1b.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 400d));
+    assertEquals(test1b.resolveValues(SCHEDULE), DoubleArray.of(200d, 200d, 400d));
     // step1 and step2
     ValueSchedule test2 = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
-    assertEquals(test2.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 400d));
+    assertEquals(test2.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 400d));
   }
 
   public void test_resolveValues_indexBased() {
@@ -129,48 +176,72 @@ public class ValueScheduleTest {
     ValueStep step2 = ValueStep.of(2, ValueAdjustment.ofReplace(400d));
     // no steps
     ValueSchedule test0 = ValueSchedule.of(200d, ImmutableList.of());
-    assertEquals(test0.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 200d));
+    assertEquals(test0.resolveValues(SCHEDULE), DoubleArray.of(200d, 200d, 200d));
     // step1
     ValueSchedule test1a = ValueSchedule.of(200d, ImmutableList.of(step1));
-    assertEquals(test1a.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 300d));
+    assertEquals(test1a.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 300d));
     // step2
     ValueSchedule test1b = ValueSchedule.of(200d, ImmutableList.of(step2));
-    assertEquals(test1b.resolveValues(PERIODS), ImmutableList.of(200d, 200d, 400d));
+    assertEquals(test1b.resolveValues(SCHEDULE), DoubleArray.of(200d, 200d, 400d));
     // step1 and step2
     ValueSchedule test2 = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
-    assertEquals(test2.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 400d));
+    assertEquals(test2.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 400d));
   }
 
   public void test_resolveValues_indexBased_duplicateDefinitionValid() {
     ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
     ValueStep step2 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
-    assertEquals(test.resolveValues(PERIODS), ImmutableList.of(200d, 300d, 300d));
+    assertEquals(test.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 300d));
   }
 
   public void test_resolveValues_indexBased_duplicateDefinitionInvalid() {
     ValueStep step1 = ValueStep.of(1, ValueAdjustment.ofReplace(300d));
     ValueStep step2 = ValueStep.of(1, ValueAdjustment.ofReplace(400d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step1, step2));
-    assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
+    assertThrowsIllegalArg(() -> test.resolveValues(SCHEDULE));
   }
 
   public void test_resolveValues_dateBased_indexZeroValid() {
     ValueStep step = ValueStep.of(date(2014, 1, 1), ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
-    assertEquals(test.resolveValues(PERIODS), ImmutableList.of(300d, 300d, 300d));
+    assertEquals(test.resolveValues(SCHEDULE), DoubleArray.of(300d, 300d, 300d));
   }
 
   public void test_resolveValues_indexBased_indexTooBig() {
     ValueStep step = ValueStep.of(3, ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
-    assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
+    assertThrowsIllegalArg(() -> test.resolveValues(SCHEDULE));
   }
 
   public void test_resolveValues_dateBased_dateInvalid() {
     ValueStep step = ValueStep.of(date(2014, 4, 1), ValueAdjustment.ofReplace(300d));
     ValueSchedule test = ValueSchedule.of(200d, ImmutableList.of(step));
-    assertThrowsIllegalArg(() -> test.resolveValues(PERIODS));
+    assertThrowsIllegalArg(() -> test.resolveValues(SCHEDULE));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_resolveValues_sequence() {
+    ValueStepSequence seq = ValueStepSequence.of(
+        date(2014, 2, 1), date(2014, 3, 1), Frequency.P1M, ValueAdjustment.ofDeltaAmount(100));
+    ValueSchedule test = ValueSchedule.of(200d, seq);
+    assertEquals(test.resolveValues(SCHEDULE), DoubleArray.of(200d, 300d, 400d));
+  }
+
+  public void test_resolveValues_sequenceAndSteps() {
+    ValueStepSequence seq = ValueStepSequence.of(
+        date(2014, 2, 1), date(2014, 3, 1), Frequency.P1M, ValueAdjustment.ofDeltaAmount(100));
+    ValueStep step1 = ValueStep.of(date(2014, 1, 1), ValueAdjustment.ofReplace(350d));
+    ValueSchedule test = ValueSchedule.builder().initialValue(200d).steps(step1).stepSequence(seq).build();
+    assertEquals(test.resolveValues(SCHEDULE), DoubleArray.of(350d, 450d, 550d));
+  }
+
+  public void test_resolveValues_sequenceAndStepClash() {
+    ValueStepSequence seq = ValueStepSequence.of(
+        date(2014, 2, 1), date(2014, 3, 1), Frequency.P1M, ValueAdjustment.ofDeltaAmount(100));
+    ValueStep step1 = ValueStep.of(date(2014, 2, 1), ValueAdjustment.ofReplace(350d));
+    ValueSchedule test = ValueSchedule.builder().initialValue(200d).steps(step1).stepSequence(seq).build();
+    assertThrowsIllegalArg(() -> test.resolveValues(SCHEDULE));
   }
 
   //-------------------------------------------------------------------------
@@ -186,7 +257,12 @@ public class ValueScheduleTest {
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    coverImmutableBean(ValueSchedule.of(10000d, Lists.newArrayList(STEP1, STEP2)));
+    ValueStepSequence seq = ValueStepSequence.of(
+        date(2014, 2, 1), date(2014, 3, 1), Frequency.P1M, ValueAdjustment.ofDeltaAmount(100));
+
+    ValueSchedule test = ValueSchedule.of(10000d, Lists.newArrayList(STEP1, STEP2));
+    coverImmutableBean(test);
+    coverBeanEquals(test, ValueSchedule.of(20000d, seq));
   }
 
   public void test_serialization() {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueStepSequenceTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueStepSequenceTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.value;
+
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.RollConventions;
+
+/**
+ * Test {@link ValueStepSequence}.
+ */
+@Test
+public class ValueStepSequenceTest {
+
+  private static final ValueAdjustment ADJ = ValueAdjustment.ofDeltaAmount(-100);
+  private static final ValueAdjustment ADJ2 = ValueAdjustment.ofDeltaAmount(-200);
+  private static final ValueAdjustment ADJ_BAD = ValueAdjustment.ofReplace(100);
+
+  //-------------------------------------------------------------------------
+  public void test_of() {
+    ValueStepSequence test = ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ADJ);
+    assertEquals(test.getFirstStepDate(), date(2016, 4, 20));
+    assertEquals(test.getLastStepDate(), date(2016, 10, 20));
+    assertEquals(test.getFrequency(), Frequency.P3M);
+    assertEquals(test.getAdjustment(), ADJ);
+  }
+
+  public void test_of_invalid() {
+    assertThrowsIllegalArg(() -> ValueStepSequence.of(date(2016, 4, 20), date(2016, 4, 19), Frequency.P3M, ADJ));
+    assertThrowsIllegalArg(() -> ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ADJ_BAD));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_resolve() {
+    ValueStepSequence test = ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ADJ);
+    ValueStep baseStep = ValueStep.of(date(2016, 1, 20), ValueAdjustment.ofReplace(500d));
+    List<ValueStep> steps = test.resolve(ImmutableList.of(baseStep), RollConventions.NONE);
+    assertEquals(steps.size(), 4);
+    assertEquals(steps.get(0), baseStep);
+    assertEquals(steps.get(1), ValueStep.of(date(2016, 4, 20), ADJ));
+    assertEquals(steps.get(2), ValueStep.of(date(2016, 7, 20), ADJ));
+    assertEquals(steps.get(3), ValueStep.of(date(2016, 10, 20), ADJ));
+  }
+
+  public void test_resolve_invalid() {
+    ValueStepSequence test = ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P12M, ADJ);
+    ValueStep baseStep = ValueStep.of(date(2016, 1, 20), ValueAdjustment.ofReplace(500d));
+    assertThrowsIllegalArg(() -> test.resolve(ImmutableList.of(baseStep), RollConventions.NONE));
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    ValueStepSequence test = ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ADJ);
+    coverImmutableBean(test);
+    ValueStepSequence test2 = ValueStepSequence.of(date(2016, 4, 1), date(2016, 10, 1), Frequency.P1M, ADJ2);
+    coverImmutableBean(test2);
+  }
+
+  public void test_serialization() {
+    ValueStepSequence test = ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P3M, ADJ);
+    assertSerialization(test);
+  }
+
+}

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/ird-ex02-stub-amort-swap2.xml
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/ird-ex02-stub-amort-swap2.xml
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--View is confirmation-->
+<!--Version is 5-8-->
+<!--NS is http://www.fpml.org/FpML-5/confirmation-->
+<!--
+  == Copyright (c) 2014-2015 All rights reserved.
+  == Financial Products Markup Language is subject to the FpML public license.
+  == A copy of this license is available at http://www.fpml.org/license/license.html
+  -->
+<!-- Altered to use notionalStepParameters -->
+<dataDocument xmlns="http://www.fpml.org/FpML-5/confirmation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" fpmlVersion="5-8" xsi:schemaLocation="http://www.fpml.org/FpML-5/confirmation ../../fpml-main-5-8.xsd http://www.w3.org/2000/09/xmldsig# ../../xmldsig-core-schema.xsd">
+  <trade>
+    <tradeHeader>
+      <partyTradeIdentifier>
+        <partyReference href="party1" />
+        <tradeId tradeIdScheme="http://www.partyA.com/swaps/trade-id">TW9235</tradeId>
+      </partyTradeIdentifier>
+      <partyTradeIdentifier>
+        <partyReference href="party2" />
+        <tradeId tradeIdScheme="http://www.barclays.com/swaps/trade-id">SW2000</tradeId>
+      </partyTradeIdentifier>
+      <tradeDate>1994-12-12</tradeDate>
+    </tradeHeader>
+    <swap>
+<!-- PArty A pays the floating rate every 6 months, based on 6M EUR-LIBOR-BBA,
+            on ACT/360 basis -->
+      <swapStream>
+        <payerPartyReference href="party1" />
+        <receiverPartyReference href="party2" />
+        <calculationPeriodDates id="floatingCalcPeriodDates">
+          <effectiveDate>
+            <unadjustedDate>1995-01-16</unadjustedDate>
+            <dateAdjustments>
+              <businessDayConvention>NONE</businessDayConvention>
+            </dateAdjustments>
+          </effectiveDate>
+          <terminationDate>
+            <unadjustedDate>1999-12-14</unadjustedDate>
+            <dateAdjustments>
+              <businessDayConvention>MODFOLLOWING</businessDayConvention>
+              <businessCenters id="primaryBusinessCenters">
+                <businessCenter>EUTA</businessCenter>
+              </businessCenters>
+            </dateAdjustments>
+          </terminationDate>
+          <calculationPeriodDatesAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCentersReference href="primaryBusinessCenters" />
+          </calculationPeriodDatesAdjustments>
+          <firstRegularPeriodStartDate>1995-06-14</firstRegularPeriodStartDate>
+          <calculationPeriodFrequency>
+            <periodMultiplier>6</periodMultiplier>
+            <period>M</period>
+            <rollConvention>14</rollConvention>
+          </calculationPeriodFrequency>
+        </calculationPeriodDates>
+        <paymentDates>
+          <calculationPeriodDatesReference href="floatingCalcPeriodDates" />
+          <paymentFrequency>
+            <periodMultiplier>6</periodMultiplier>
+            <period>M</period>
+          </paymentFrequency>
+          <firstPaymentDate>1995-06-14</firstPaymentDate>
+          <payRelativeTo>CalculationPeriodEndDate</payRelativeTo>
+          <paymentDatesAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCentersReference href="primaryBusinessCenters" />
+          </paymentDatesAdjustments>
+        </paymentDates>
+        <resetDates id="resetDates">
+          <calculationPeriodDatesReference href="floatingCalcPeriodDates" />
+          <resetRelativeTo>CalculationPeriodStartDate</resetRelativeTo>
+          <fixingDates>
+            <periodMultiplier>-2</periodMultiplier>
+            <period>D</period>
+            <dayType>Business</dayType>
+            <businessDayConvention>NONE</businessDayConvention>
+            <businessCenters>
+              <businessCenter>GBLO</businessCenter>
+            </businessCenters>
+            <dateRelativeTo href="resetDates" />
+          </fixingDates>
+          <resetFrequency>
+            <periodMultiplier>6</periodMultiplier>
+            <period>M</period>
+          </resetFrequency>
+          <resetDatesAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCentersReference href="primaryBusinessCenters" />
+          </resetDatesAdjustments>
+        </resetDates>
+        <calculationPeriodAmount>
+          <calculation>
+            <notionalSchedule>
+              <notionalStepSchedule>
+                <initialValue>50000000.00</initialValue>
+                <currency currencyScheme="http://www.fpml.org/coding-scheme/external/iso4217">EUR</currency>
+              </notionalStepSchedule>
+              <notionalStepParameters>
+                <calculationPeriodDatesReference href="floatingCalcPeriodDates" />
+                <stepFrequency>
+                  <periodMultiplier>1</periodMultiplier>
+                  <period>Y</period>
+                </stepFrequency>
+                <firstNotionalStepDate>1995-12-14</firstNotionalStepDate>
+                <lastNotionalStepDate>1998-12-14</lastNotionalStepDate>
+                <notionalStepAmount>-10000000.00</notionalStepAmount>
+              </notionalStepParameters>
+            </notionalSchedule>
+            <floatingRateCalculation>
+              <floatingRateIndex>EUR-LIBOR-BBA</floatingRateIndex>
+              <indexTenor>
+                <periodMultiplier>6</periodMultiplier>
+                <period>M</period>
+              </indexTenor>
+            </floatingRateCalculation>
+            <dayCountFraction>ACT/360</dayCountFraction>
+          </calculation>
+        </calculationPeriodAmount>
+        <stubCalculationPeriodAmount>
+          <calculationPeriodDatesReference href="floatingCalcPeriodDates" />
+          <initialStub>
+            <floatingRate>
+              <floatingRateIndex>EUR-LIBOR-BBA</floatingRateIndex>
+              <indexTenor>
+                <periodMultiplier>3</periodMultiplier>
+                <period>M</period>
+              </indexTenor>
+            </floatingRate>
+            <floatingRate>
+              <floatingRateIndex>EUR-LIBOR-BBA</floatingRateIndex>
+              <indexTenor>
+                <periodMultiplier>6</periodMultiplier>
+                <period>M</period>
+              </indexTenor>
+            </floatingRate>
+          </initialStub>
+        </stubCalculationPeriodAmount>
+        <cashflows>
+          <cashflowsMatchParameters>true</cashflowsMatchParameters>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1995-06-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1995-01-16</adjustedStartDate>
+              <adjustedEndDate>1995-06-14</adjustedEndDate>
+              <notionalAmount>50000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1995-01-12</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1995-12-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1995-06-14</adjustedStartDate>
+              <adjustedEndDate>1995-12-14</adjustedEndDate>
+              <notionalAmount>50000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1995-06-12</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1996-06-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1995-12-14</adjustedStartDate>
+              <adjustedEndDate>1996-06-14</adjustedEndDate>
+              <notionalAmount>40000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1995-12-12</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1996-12-16</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1996-06-14</adjustedStartDate>
+              <adjustedEndDate>1996-12-16</adjustedEndDate>
+              <notionalAmount>40000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1996-06-12</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1997-06-16</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1996-12-16</adjustedStartDate>
+              <adjustedEndDate>1997-06-16</adjustedEndDate>
+              <notionalAmount>30000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1996-12-12</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1997-12-15</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1997-06-16</adjustedStartDate>
+              <adjustedEndDate>1997-12-15</adjustedEndDate>
+              <notionalAmount>30000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1997-06-12</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1998-06-15</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1997-12-15</adjustedStartDate>
+              <adjustedEndDate>1998-06-15</adjustedEndDate>
+              <notionalAmount>20000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1997-12-11</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1998-12-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1998-06-15</adjustedStartDate>
+              <adjustedEndDate>1998-12-14</adjustedEndDate>
+              <notionalAmount>20000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1998-06-11</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1999-06-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1998-12-14</adjustedStartDate>
+              <adjustedEndDate>1999-06-14</adjustedEndDate>
+              <notionalAmount>10000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1998-12-10</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1999-12-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1999-06-14</adjustedStartDate>
+              <adjustedEndDate>1999-12-14</adjustedEndDate>
+              <notionalAmount>10000000.00</notionalAmount>
+              <floatingRateDefinition>
+                <rateObservation>
+                  <adjustedFixingDate>1999-06-10</adjustedFixingDate>
+                  <observationWeight>1</observationWeight>
+                </rateObservation>
+              </floatingRateDefinition>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+        </cashflows>
+      </swapStream>
+<!-- Barclays pays the 6% fixed rate every year on
+            a 30E/360 basis -->
+      <swapStream>
+        <payerPartyReference href="party2" />
+        <receiverPartyReference href="party1" />
+        <calculationPeriodDates id="fixedCalcPeriodDates">
+          <effectiveDate>
+            <unadjustedDate>1995-01-16</unadjustedDate>
+            <dateAdjustments>
+              <businessDayConvention>NONE</businessDayConvention>
+            </dateAdjustments>
+          </effectiveDate>
+          <terminationDate>
+            <unadjustedDate>1999-12-14</unadjustedDate>
+            <dateAdjustments>
+              <businessDayConvention>MODFOLLOWING</businessDayConvention>
+              <businessCentersReference href="primaryBusinessCenters" />
+            </dateAdjustments>
+          </terminationDate>
+          <calculationPeriodDatesAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCentersReference href="primaryBusinessCenters" />
+          </calculationPeriodDatesAdjustments>
+          <firstRegularPeriodStartDate>1995-12-14</firstRegularPeriodStartDate>
+          <calculationPeriodFrequency>
+            <periodMultiplier>1</periodMultiplier>
+            <period>Y</period>
+            <rollConvention>14</rollConvention>
+          </calculationPeriodFrequency>
+        </calculationPeriodDates>
+        <paymentDates>
+          <calculationPeriodDatesReference href="fixedCalcPeriodDates" />
+          <paymentFrequency>
+            <periodMultiplier>1</periodMultiplier>
+            <period>Y</period>
+          </paymentFrequency>
+          <firstPaymentDate>1995-12-14</firstPaymentDate>
+          <payRelativeTo>CalculationPeriodEndDate</payRelativeTo>
+          <paymentDatesAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCentersReference href="primaryBusinessCenters" />
+          </paymentDatesAdjustments>
+        </paymentDates>
+        <calculationPeriodAmount>
+          <calculation>
+            <notionalSchedule>
+              <notionalStepSchedule>
+                <initialValue>50000000.00</initialValue>
+                <currency currencyScheme="http://www.fpml.org/coding-scheme/external/iso4217">EUR</currency>
+              </notionalStepSchedule>
+              <notionalStepParameters>
+                <calculationPeriodDatesReference href="floatingCalcPeriodDates" />
+                <stepFrequency>
+                  <periodMultiplier>1</periodMultiplier>
+                  <period>Y</period>
+                </stepFrequency>
+                <firstNotionalStepDate>1995-12-14</firstNotionalStepDate>
+                <lastNotionalStepDate>1998-12-14</lastNotionalStepDate>
+                <notionalStepRate>-0.2</notionalStepRate>
+                <stepRelativeTo>Initial</stepRelativeTo>
+              </notionalStepParameters>
+            </notionalSchedule>
+            <fixedRateSchedule>
+              <initialValue>0.06</initialValue>
+            </fixedRateSchedule>
+            <dayCountFraction>30E/360</dayCountFraction>
+          </calculation>
+        </calculationPeriodAmount>
+        <cashflows>
+          <cashflowsMatchParameters>true</cashflowsMatchParameters>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1995-12-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1995-01-16</adjustedStartDate>
+              <adjustedEndDate>1995-12-14</adjustedEndDate>
+              <notionalAmount>50000000.00</notionalAmount>
+              <fixedRate>0.06</fixedRate>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1996-12-16</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1995-12-14</adjustedStartDate>
+              <adjustedEndDate>1996-12-16</adjustedEndDate>
+              <notionalAmount>40000000.00</notionalAmount>
+              <fixedRate>0.06</fixedRate>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1997-12-15</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1996-12-16</adjustedStartDate>
+              <adjustedEndDate>1997-12-15</adjustedEndDate>
+              <notionalAmount>30000000.00</notionalAmount>
+              <fixedRate>0.06</fixedRate>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1998-12-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1997-12-15</adjustedStartDate>
+              <adjustedEndDate>1998-12-14</adjustedEndDate>
+              <notionalAmount>20000000.00</notionalAmount>
+              <fixedRate>0.06</fixedRate>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+          <paymentCalculationPeriod>
+            <adjustedPaymentDate>1999-12-14</adjustedPaymentDate>
+            <calculationPeriod>
+              <adjustedStartDate>1998-12-14</adjustedStartDate>
+              <adjustedEndDate>1999-12-14</adjustedEndDate>
+              <notionalAmount>10000000.00</notionalAmount>
+              <fixedRate>0.06</fixedRate>
+            </calculationPeriod>
+          </paymentCalculationPeriod>
+        </cashflows>
+      </swapStream>
+    </swap>
+  </trade>
+  <party id="party1">
+    <partyId>Party1</partyId>
+  </party>
+  <party id="party2">
+    <partyId>Party2</partyId>
+  </party>
+</dataDocument>
+

--- a/modules/product/src/main/java/com/opengamma/strata/product/bond/CapitalIndexedBond.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/bond/CapitalIndexedBond.java
@@ -8,7 +8,6 @@ package com.opengamma.strata.product.bond;
 import static com.opengamma.strata.basics.value.ValueSchedule.ALWAYS_1;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -39,6 +38,7 @@ import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.SecuritizedProduct;
 import com.opengamma.strata.product.SecurityId;
 import com.opengamma.strata.product.rate.RateComputation;
@@ -181,8 +181,8 @@ public final class CapitalIndexedBond
   public ResolvedCapitalIndexedBond resolve(ReferenceData refData) {
     Schedule adjustedSchedule = accrualSchedule.createSchedule(refData);
     DateAdjuster exCouponPeriodAdjuster = exCouponPeriod.resolve(refData);
-    List<Double> resolvedGearings =
-        rateCalculation.getGearing().orElse(ALWAYS_1).resolveValues(adjustedSchedule.getPeriods());
+    DoubleArray resolvedGearings =
+        rateCalculation.getGearing().orElse(ALWAYS_1).resolveValues(adjustedSchedule);
     ImmutableList.Builder<CapitalIndexedBondPaymentPeriod> bondPeriodsBuilder = ImmutableList.builder();
     // coupon payments
     for (int i = 0; i < adjustedSchedule.size(); i++) {

--- a/modules/product/src/main/java/com/opengamma/strata/product/capfloor/IborCapFloorLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/capfloor/IborCapFloorLeg.java
@@ -7,7 +7,6 @@ package com.opengamma.strata.product.capfloor;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -42,6 +41,7 @@ import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.common.PayReceive;
 import com.opengamma.strata.product.rate.IborRateComputation;
 import com.opengamma.strata.product.swap.FixingRelativeTo;
@@ -192,9 +192,9 @@ public final class IborCapFloorLeg
   @Override
   public ResolvedIborCapFloorLeg resolve(ReferenceData refData) {
     Schedule adjustedSchedule = paymentSchedule.createSchedule(refData);
-    List<Double> cap = getCapSchedule().isPresent() ? capSchedule.resolveValues(adjustedSchedule.getPeriods()) : null;
-    List<Double> floor = getFloorSchedule().isPresent() ? floorSchedule.resolveValues(adjustedSchedule.getPeriods()) : null;
-    List<Double> notionals = notional.resolveValues(adjustedSchedule.getPeriods());
+    DoubleArray cap = getCapSchedule().isPresent() ? capSchedule.resolveValues(adjustedSchedule) : null;
+    DoubleArray floor = getFloorSchedule().isPresent() ? floorSchedule.resolveValues(adjustedSchedule) : null;
+    DoubleArray notionals = notional.resolveValues(adjustedSchedule);
     DateAdjuster fixingDateAdjuster = calculation.getFixingDateOffset().resolve(refData);
     DateAdjuster paymentDateAdjuster = paymentDateOffset.resolve(refData);
     Function<LocalDate, IborIndexObservation> obsFn = calculation.getIndex().resolve(refData);

--- a/modules/product/src/main/java/com/opengamma/strata/product/cms/CmsLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/cms/CmsLeg.java
@@ -7,7 +7,6 @@ package com.opengamma.strata.product.cms;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -43,6 +42,7 @@ import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.common.PayReceive;
 import com.opengamma.strata.product.swap.FixingRelativeTo;
@@ -264,9 +264,9 @@ public final class CmsLeg
   @Override
   public ResolvedCmsLeg resolve(ReferenceData refData) {
     Schedule adjustedSchedule = paymentSchedule.createSchedule(refData);
-    List<Double> cap = getCapSchedule().isPresent() ? capSchedule.resolveValues(adjustedSchedule.getPeriods()) : null;
-    List<Double> floor = getFloorSchedule().isPresent() ? floorSchedule.resolveValues(adjustedSchedule.getPeriods()) : null;
-    List<Double> notionals = notional.resolveValues(adjustedSchedule.getPeriods());
+    DoubleArray cap = getCapSchedule().isPresent() ? capSchedule.resolveValues(adjustedSchedule) : null;
+    DoubleArray floor = getFloorSchedule().isPresent() ? floorSchedule.resolveValues(adjustedSchedule) : null;
+    DoubleArray notionals = notional.resolveValues(adjustedSchedule);
     DateAdjuster fixingDateAdjuster = fixingDateOffset.resolve(refData);
     DateAdjuster paymentDateAdjuster = paymentDateOffset.resolve(refData);
     ImmutableList.Builder<CmsPeriod> cmsPeriodsBuild = ImmutableList.builder();

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/FixedRateCalculation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/FixedRateCalculation.java
@@ -8,7 +8,6 @@ package com.opengamma.strata.product.swap;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -34,6 +33,7 @@ import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.value.ValueSchedule;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 
 /**
@@ -124,7 +124,7 @@ public final class FixedRateCalculation
     Optional<SchedulePeriod> scheduleInitialStub = accrualSchedule.getInitialStub();
     Optional<SchedulePeriod> scheduleFinalStub = accrualSchedule.getFinalStub();
     // resolve data by schedule
-    List<Double> resolvedRates = rate.resolveValues(accrualSchedule.getPeriods());
+    DoubleArray resolvedRates = rate.resolveValues(accrualSchedule);
     // build accrual periods
     ImmutableList.Builder<RateAccrualPeriod> accrualPeriods = ImmutableList.builder();
     for (int i = 0; i < accrualSchedule.size(); i++) {

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateCalculation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/IborRateCalculation.java
@@ -47,6 +47,7 @@ import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.value.ValueSchedule;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 import com.opengamma.strata.product.rate.IborAveragedFixing;
 import com.opengamma.strata.product.rate.IborAveragedRateComputation;
@@ -285,8 +286,8 @@ public final class IborRateCalculation
           .createAccrualPeriods(accrualSchedule, paymentSchedule, refData);
     }
     // resolve data by schedule
-    List<Double> resolvedGearings = firstNonNull(gearing, ALWAYS_1).resolveValues(accrualSchedule.getPeriods());
-    List<Double> resolvedSpreads = firstNonNull(spread, ALWAYS_0).resolveValues(accrualSchedule.getPeriods());
+    DoubleArray resolvedGearings = firstNonNull(gearing, ALWAYS_1).resolveValues(accrualSchedule);
+    DoubleArray resolvedSpreads = firstNonNull(spread, ALWAYS_0).resolveValues(accrualSchedule);
     // resolve against reference data once
     DateAdjuster fixingDateAdjuster = fixingDateOffset.resolve(refData);
     Function<SchedulePeriod, Schedule> resetScheduleFn =

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/InflationRateCalculation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/InflationRateCalculation.java
@@ -12,7 +12,6 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.YearMonth;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -44,6 +43,7 @@ import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.rate.InflationEndInterpolatedRateComputation;
 import com.opengamma.strata.product.rate.InflationEndMonthRateComputation;
 import com.opengamma.strata.product.rate.InflationInterpolatedRateComputation;
@@ -208,7 +208,7 @@ public final class InflationRateCalculation
       ReferenceData refData) {
 
     // resolve data by schedule
-    List<Double> resolvedGearings = firstNonNull(gearing, ALWAYS_1).resolveValues(accrualSchedule.getPeriods());
+    DoubleArray resolvedGearings = firstNonNull(gearing, ALWAYS_1).resolveValues(accrualSchedule);
     // build accrual periods
     ImmutableList.Builder<RateAccrualPeriod> accrualPeriods = ImmutableList.builder();
     for (int i = 0; i < accrualSchedule.size(); i++) {

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/KnownAmountSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/KnownAmountSwapLeg.java
@@ -39,6 +39,7 @@ import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.value.ValueSchedule;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.common.PayReceive;
 
 /**
@@ -163,7 +164,7 @@ public final class KnownAmountSwapLeg
   // create the payment period
   private List<SwapPaymentPeriod> createPaymentPeriods(Schedule resolvedPayments, ReferenceData refData) {
     // resolve amount schedule against payment schedule
-    List<Double> amounts = amount.resolveValues(resolvedPayments.getPeriods());
+    DoubleArray amounts = amount.resolveValues(resolvedPayments);
     // resolve against reference data once
     DateAdjuster paymentDateAdjuster = paymentSchedule.getPaymentDateOffset().resolve(refData);
     // build up payment periods using schedule

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/OvernightRateCalculation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/OvernightRateCalculation.java
@@ -10,7 +10,6 @@ import static com.opengamma.strata.basics.value.ValueSchedule.ALWAYS_0;
 import static com.opengamma.strata.basics.value.ValueSchedule.ALWAYS_1;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -40,6 +39,7 @@ import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.rate.OvernightAveragedRateComputation;
 import com.opengamma.strata.product.rate.OvernightCompoundedRateComputation;
 import com.opengamma.strata.product.rate.RateComputation;
@@ -197,8 +197,8 @@ public final class OvernightRateCalculation
       ReferenceData refData) {
 
     // resolve data by schedule
-    List<Double> resolvedGearings = firstNonNull(gearing, ALWAYS_1).resolveValues(accrualSchedule.getPeriods());
-    List<Double> resolvedSpreads = firstNonNull(spread, ALWAYS_0).resolveValues(accrualSchedule.getPeriods());
+    DoubleArray resolvedGearings = firstNonNull(gearing, ALWAYS_1).resolveValues(accrualSchedule);
+    DoubleArray resolvedSpreads = firstNonNull(spread, ALWAYS_0).resolveValues(accrualSchedule);
     // build accrual periods
     ImmutableList.Builder<RateAccrualPeriod> accrualPeriods = ImmutableList.builder();
     for (int i = 0; i < accrualSchedule.size(); i++) {

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/PaymentSchedule.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/PaymentSchedule.java
@@ -40,6 +40,7 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.schedule.Frequency;
 import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.product.common.PayReceive;
 
 /**
@@ -186,7 +187,7 @@ public final class PaymentSchedule
       PayReceive payReceive,
       ReferenceData refData) {
 
-    List<Double> notionals = notionalSchedule.getAmount().resolveValues(paymentSchedule.getPeriods());
+    DoubleArray notionals = notionalSchedule.getAmount().resolveValues(paymentSchedule);
     // resolve against reference data once
     DateAdjuster paymentDateAdjuster = paymentDateOffset.resolve(refData);
     Function<SchedulePeriod, FxReset> fxResetFn =


### PR DESCRIPTION
Extend `ValueSchedule` to support a sequence of step changes
Alter `resolvevalues()` to take `Schedule` and return `DoubleArray`
Deprecate old `resolveValues()`
Enhance FpML parsing to handle parameterized notional schedules