### PR TITLE
Fix FRA date conventions

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/fra/Fra.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fra/Fra.java
@@ -63,6 +63,12 @@ import com.opengamma.strata.product.rate.RateComputation;
  * <li>Fixing date, the date on which the index is to be observed, typically 2 business days before the start date
  * <li>Payment date, the date on which payment is made, typically the same as the start date
  * </ul>
+ * <p>
+ * The start date, end date and payment date are determined when the trade if created,
+ * adjusting to valid business days based on the holiday calendar dates known on the trade trade.
+ * The payment date may be further adjusted when the FRA is resolved if an additional holiday has been added.
+ * The data model does allow for the start and end dates to be adjusted when the FRA is resolved,
+ * but this is typically not used.
  */
 @BeanDefinition
 public final class Fra
@@ -235,8 +241,9 @@ public final class Fra
     DateAdjuster bda = getBusinessDayAdjustment().orElse(BusinessDayAdjustment.NONE).resolve(refData);
     LocalDate start = bda.adjust(startDate);
     LocalDate end = bda.adjust(endDate);
+    LocalDate pay = paymentDate.adjusted(refData);
     return ResolvedFra.builder()
-        .paymentDate(getPaymentDate().adjusted(refData))
+        .paymentDate(pay)
         .startDate(start)
         .endDate(end)
         .yearFraction(dayCount.yearFraction(start, end))

--- a/modules/product/src/main/java/com/opengamma/strata/product/fra/type/FraConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fra/type/FraConvention.java
@@ -21,6 +21,7 @@ import com.opengamma.strata.collect.named.Named;
 import com.opengamma.strata.product.TradeConvention;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.fra.Fra;
 import com.opengamma.strata.product.fra.FraTrade;
 
 /**
@@ -109,6 +110,13 @@ public interface FraConvention
    * The notional is unsigned, with buy/sell determining the direction of the trade.
    * If buying the FRA, the floating rate is received from the counterparty, with the fixed rate being paid.
    * If selling the FRA, the floating rate is paid to the counterparty, with the fixed rate being received.
+   * <p>
+   * The start date will be the trade date, plus spot offset, plus period to start, adjusted to a valid business day.
+   * The end date will be the trade date, plus spot offset, plus period to end, adjusted to a valid business day.
+   * The adjustment of the start and end date occurs at trade creation.
+   * The payment date offset is also applied at trade creation.
+   * When the Fra is {@linkplain Fra#resolve(ReferenceData) resolved}, the start and end date
+   * are not adjusted again but the payment date is.
    * 
    * @param tradeDate  the date of the trade
    * @param periodToStart  the period between the spot date and the start date
@@ -129,6 +137,7 @@ public interface FraConvention
       double fixedRate,
       ReferenceData refData);
 
+  //-------------------------------------------------------------------------
   /**
    * Creates a trade based on this convention.
    * <p>
@@ -138,9 +147,9 @@ public interface FraConvention
    * If selling the FRA, the floating rate is paid to the counterparty, with the fixed rate being received.
    * 
    * @param tradeDate  the date of the trade
-   * @param startDate  the start date
-   * @param endDate  the end date
-   * @param paymentDate  the payment date
+   * @param startDate  the start date, which should be adjusted to be a valid business day
+   * @param endDate  the end date, which should be adjusted to be a valid business day
+   * @param paymentDate  the payment date, which should be adjusted to be a valid business day
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount, in the payment currency of the template
    * @param fixedRate  the fixed rate, typically derived from the market
@@ -168,9 +177,9 @@ public interface FraConvention
    * If selling the FRA, the floating rate is paid to the counterparty, with the fixed rate being received.
    * 
    * @param tradeInfo  additional information about the trade
-   * @param startDate  the start date
-   * @param endDate  the end date
-   * @param paymentDate  the payment date
+   * @param startDate  the start date, which should be adjusted to be a valid business day
+   * @param endDate  the end date, which should be adjusted to be a valid business day
+   * @param paymentDate  the payment date, which should be adjusted to be a valid business day
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount, in the payment currency of the template
    * @param fixedRate  the fixed rate, typically derived from the market

--- a/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraConventionTest.java
@@ -160,7 +160,7 @@ public class FraConventionTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_toTrade_periods() {
+  public void test_createTrade_periods() {
     FraConvention base = ImmutableFraConvention.builder()
         .index(GBP_LIBOR_3M)
         .spotDateOffset(NEXT_SAME_BUS_DAY)
@@ -172,7 +172,6 @@ public class FraConventionTest {
         .notional(NOTIONAL_2M)
         .startDate(date(2015, 8, 5))
         .endDate(date(2015, 11, 5))
-        .businessDayAdjustment(BDA_MOD_FOLLOW)
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
         .build();
@@ -180,6 +179,49 @@ public class FraConventionTest {
     assertEquals(test.getProduct(), expected);
   }
 
+  public void test_createTrade_periods_adjust() {
+    FraConvention base = ImmutableFraConvention.builder()
+        .index(GBP_LIBOR_3M)
+        .spotDateOffset(NEXT_SAME_BUS_DAY)
+        .paymentDateOffset(DaysAdjustment.ofCalendarDays(0, BDA_FOLLOW))
+        .build();
+    LocalDate tradeDate = LocalDate.of(2016, 8, 11);
+    FraTrade test = base.createTrade(tradeDate, Period.ofMonths(1), Period.ofMonths(4), BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    Fra expected = Fra.builder()
+        .buySell(BUY)
+        .notional(NOTIONAL_2M)
+        .startDate(date(2016, 9, 12))
+        .endDate(date(2016, 12, 12))
+        .paymentDate(AdjustableDate.of(date(2016, 9, 12), BDA_FOLLOW))
+        .fixedRate(0.25d)
+        .index(GBP_LIBOR_3M)
+        .build();
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
+  }
+
+  public void test_createTrade_periods_adjust_payOffset() {
+    FraConvention base = ImmutableFraConvention.builder()
+        .index(GBP_LIBOR_3M)
+        .spotDateOffset(NEXT_SAME_BUS_DAY)
+        .paymentDateOffset(PLUS_TWO_DAYS)
+        .build();
+    LocalDate tradeDate = LocalDate.of(2016, 8, 11);
+    FraTrade test = base.createTrade(tradeDate, Period.ofMonths(1), Period.ofMonths(4), BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    Fra expected = Fra.builder()
+        .buySell(BUY)
+        .notional(NOTIONAL_2M)
+        .startDate(date(2016, 9, 12))
+        .endDate(date(2016, 12, 12))
+        .paymentDate(AdjustableDate.of(date(2016, 9, 14), PLUS_TWO_DAYS.getAdjustment()))
+        .fixedRate(0.25d)
+        .index(GBP_LIBOR_3M)
+        .build();
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
+  }
+
+  //-------------------------------------------------------------------------
   public void test_toTrade_dates() {
     FraConvention base = ImmutableFraConvention.builder()
         .index(GBP_LIBOR_3M)
@@ -195,7 +237,6 @@ public class FraConventionTest {
         .notional(NOTIONAL_2M)
         .startDate(startDate)
         .endDate(endDate)
-        .businessDayAdjustment(BDA_MOD_FOLLOW)
         .paymentDate(AdjustableDate.of(paymentDate))
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
@@ -220,7 +261,6 @@ public class FraConventionTest {
         .notional(NOTIONAL_2M)
         .startDate(date(2015, 8, 5))
         .endDate(date(2015, 11, 5))
-        .businessDayAdjustment(BDA_MOD_FOLLOW)
         .paymentDate(AdjustableDate.of(paymentDate, PLUS_TWO_DAYS.getAdjustment()))
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)

--- a/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraTemplateTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraTemplateTest.java
@@ -5,7 +5,6 @@
  */
 package com.opengamma.strata.product.fra.type;
 
-import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
@@ -25,7 +24,6 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.AdjustableDate;
-import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.product.fra.Fra;
 import com.opengamma.strata.product.fra.FraTrade;
@@ -39,7 +37,6 @@ public class FraTemplateTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
   private static final FraConvention FRA_GBP_LIBOR_3M = FraConvention.of(GBP_LIBOR_3M);
   private static final double NOTIONAL_2M = 2_000_000d;
-  private static final BusinessDayAdjustment BDA_MOD_FOLLOW = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO);
   private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
 
   //-------------------------------------------------------------------------
@@ -82,7 +79,6 @@ public class FraTemplateTest {
         .notional(NOTIONAL_2M)
         .startDate(date(2015, 8, 5))
         .endDate(date(2015, 11, 5))
-        .businessDayAdjustment(BDA_MOD_FOLLOW)
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)
         .build();
@@ -102,7 +98,6 @@ public class FraTemplateTest {
         .notional(NOTIONAL_2M)
         .startDate(date(2015, 8, 5))
         .endDate(date(2015, 11, 5))
-        .businessDayAdjustment(BDA_MOD_FOLLOW)
         .paymentDate(AdjustableDate.of(date(2015, 8, 7), PLUS_TWO_DAYS.getAdjustment()))
         .fixedRate(0.25d)
         .index(GBP_LIBOR_3M)


### PR DESCRIPTION
Start and end date should be adjusted when trade is created, not later
Payment date should be offset and adjusted when trade is created
Payment date should be re-adjusted when resolved
Fixes #1301