### PR TITLE
Ensure consistent readResolve for transient fields

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/StandardId.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/StandardId.java
@@ -175,7 +175,7 @@ public final class StandardId
 
   // resolve after deserialization
   private Object readResolve() {
-    return of(scheme, value);
+    return new StandardId(scheme, value);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/ConstantNodalCurve.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/ConstantNodalCurve.java
@@ -39,9 +39,11 @@ import com.opengamma.strata.market.param.UnitParameterSensitivity;
  * This class defines a curve in terms of a single node point. 
  * The resulting curve is a constant curve with the y-value of the node point.
  * When queried, {@link #yValue(double)} always returns the constant value.
+ * The x-value is not significant in most use cases.
+ * See {@link ConstantCurve} for an alternative that does not have an x-value.
  * <p>
- * The {@link #getXValues()} method returns a single x-value of the node.
- * The {@link #getYValues()} method returns a single y-value of the node.
+ * The {@link #getXValues()} method returns the single x-value of the node.
+ * The {@link #getYValues()} method returns the single y-value of the node.
  * The sensitivity is 1 and the first derivative is 0.
  */
 @BeanDefinition
@@ -65,12 +67,16 @@ public final class ConstantNodalCurve
    */
   @PropertyDefinition(validate = "notNull")
   private final double yValue;
-
+  /**
+   * The parameter metadata.
+   */
   private transient final List<ParameterMetadata> parameterMetadata;  // derived, not a property
 
   //-------------------------------------------------------------------------
   /**
    * Creates a constant nodal curve with metadata.
+   * <p>
+   * The curve is defined by a single x and y value.
    * 
    * @param metadata  the curve metadata
    * @param xValue  the x-value
@@ -83,13 +89,20 @@ public final class ConstantNodalCurve
 
   /**
    * Creates a constant nodal curve with metadata.
+   * <p>
+   * The curve is defined by a single x and y value.
    * 
    * @param metadata  the curve metadata
    * @param xValue  the x-value
    * @param yValue  the y-value
    * @return the curve
+   * @deprecated Use {@link #of(CurveMetadata, double, double)}
    */
+  @Deprecated
   public static ConstantNodalCurve of(CurveMetadata metadata, DoubleArray xValue, DoubleArray yValue) {
+    if (xValue.size() != 1 || yValue.size() != 1) {
+      throw new IllegalArgumentException("Length of x-values and y-values must be 1");
+    }
     return new ConstantNodalCurve(metadata, xValue.get(0), yValue.get(0));
   }
 
@@ -110,6 +123,11 @@ public final class ConstantNodalCurve
     this.xValue = xValue;
     this.yValue = yValue;
     this.parameterMetadata = ImmutableList.of(getParameterMetadata(0));
+  }
+
+  // resolve after deserialization
+  private Object readResolve() {
+    return new ConstantNodalCurve(metadata, xValue, yValue);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/ConstantNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/ConstantNodalCurveTest.java
@@ -33,45 +33,47 @@ public class ConstantNodalCurveTest {
   private static final CurveMetadata METADATA_ENTRIES2 =
       Curves.zeroRates(CURVE_NAME, ACT_365F, ParameterMetadata.listOfEmpty(SIZE + 2));
   private static final CurveMetadata METADATA_NOPARAM = Curves.zeroRates(CURVE_NAME, ACT_365F);
-  private static final DoubleArray XVALUE = DoubleArray.of(2d);
-  private static final DoubleArray YVALUE = DoubleArray.of(7d);
-  private static final DoubleArray XVALUE_NEW = DoubleArray.of(3d);
-  private static final DoubleArray YVALUE_BUMPED = DoubleArray.of(5d);
+  private static final double XVALUE = 2d;
+  private static final DoubleArray XVALUE_ARRAY = DoubleArray.of(XVALUE);
+  private static final double YVALUE = 7d;
+  private static final DoubleArray YVALUE_ARRAY = DoubleArray.of(YVALUE);
+  private static final DoubleArray XVALUE_ARRAY_NEW = DoubleArray.of(3d);
+  private static final double YVALUE_BUMPED = 5d;
+  private static final DoubleArray YVALUE_BUMPED_ARRAY = DoubleArray.of(YVALUE_BUMPED);
 
   //-------------------------------------------------------------------------
   public void test_of_CurveMetadata() {
     ConstantNodalCurve test = ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE, YVALUE);
-    ConstantNodalCurve testRe = ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE.get(0), YVALUE.get(0));
+    ConstantNodalCurve testRe = ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE, YVALUE);
     assertThat(test).isEqualTo(testRe);
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(SIZE);
-    assertThat(test.getParameter(0)).isEqualTo(YVALUE.get(0));
+    assertThat(test.getParameter(0)).isEqualTo(YVALUE);
     assertThrowsIllegalArg(() -> test.getParameter(1));
     assertThat(test.getParameterMetadata(0)).isSameAs(METADATA_ENTRIES.getParameterMetadata().get().get(0));
-    assertThat(test.withParameter(0, 2d)).isEqualTo(
-        ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE, YVALUE.with(0, 2d)));
+    assertThat(test.withParameter(0, 2d)).isEqualTo(ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE, 2d));
     assertThrowsIllegalArg(() -> test.withParameter(1, 2d));
     assertThat(test.withPerturbation((i, v, m) -> v - 2d)).isEqualTo(
         ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE, YVALUE_BUMPED));
     assertThat(test.getMetadata()).isEqualTo(METADATA_ENTRIES);
-    assertThat(test.getXValues()).isEqualTo(XVALUE);
-    assertThat(test.getYValues()).isEqualTo(YVALUE);
+    assertThat(test.getXValues()).isEqualTo(XVALUE_ARRAY);
+    assertThat(test.getYValues()).isEqualTo(YVALUE_ARRAY);
   }
 
   public void test_of_noCurveMetadata() {
     ConstantNodalCurve test = ConstantNodalCurve.of(METADATA_NOPARAM, XVALUE, YVALUE);
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(SIZE);
-    assertThat(test.getParameter(0)).isEqualTo(YVALUE.get(0));
-    assertThat(test.getParameterMetadata(0)).isEqualTo(SimpleCurveParameterMetadata.of(ValueType.YEAR_FRACTION, XVALUE.get(0)));
+    assertThat(test.getParameter(0)).isEqualTo(YVALUE);
+    assertThat(test.getParameterMetadata(0)).isEqualTo(SimpleCurveParameterMetadata.of(ValueType.YEAR_FRACTION, XVALUE));
   }
 
   //-------------------------------------------------------------------------
   public void test_withNode() {
     ConstantNodalCurve base = ConstantNodalCurve.of(METADATA_ENTRIES, XVALUE, YVALUE);
-    SimpleCurveParameterMetadata param = SimpleCurveParameterMetadata.of(ValueType.YEAR_FRACTION, XVALUE.get(0));
-    ConstantNodalCurve test = base.withNode(XVALUE.get(0), 2d, param);
-    assertThat(test.getXValue()).isEqualTo(XVALUE.get(0));
+    SimpleCurveParameterMetadata param = SimpleCurveParameterMetadata.of(ValueType.YEAR_FRACTION, XVALUE);
+    ConstantNodalCurve test = base.withNode(XVALUE, 2d, param);
+    assertThat(test.getXValue()).isEqualTo(XVALUE);
     assertThat(test.getYValue()).isEqualTo(2d);
     assertThat(test.getParameterMetadata(0)).isEqualTo(param);
   }
@@ -84,7 +86,7 @@ public class ConstantNodalCurveTest {
   //-------------------------------------------------------------------------
   public void test_values() {
     ConstantNodalCurve test = ConstantNodalCurve.of(METADATA, XVALUE, YVALUE);
-    assertThat(test.yValue(10.2421)).isEqualTo(YVALUE.get(0));
+    assertThat(test.yValue(10.2421)).isEqualTo(YVALUE);
     assertThat(test.yValueParameterSensitivity(10.2421).getMarketDataName()).isEqualTo(CURVE_NAME);
     assertThat(test.yValueParameterSensitivity(10.2421).getSensitivity()).isEqualTo(DoubleArray.of(1d));
     assertThat(test.firstDerivative(10.2421)).isEqualTo(0d);
@@ -97,8 +99,8 @@ public class ConstantNodalCurveTest {
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(SIZE);
     assertThat(test.getMetadata()).isEqualTo(METADATA_ENTRIES);
-    assertThat(test.getXValues()).isEqualTo(XVALUE);
-    assertThat(test.getYValues()).isEqualTo(YVALUE);
+    assertThat(test.getXValues()).isEqualTo(XVALUE_ARRAY);
+    assertThat(test.getYValues()).isEqualTo(YVALUE_ARRAY);
   }
 
   public void test_withMetadata_badSize() {
@@ -109,12 +111,12 @@ public class ConstantNodalCurveTest {
   //-------------------------------------------------------------------------
   public void test_withValues() {
     ConstantNodalCurve base = ConstantNodalCurve.of(METADATA, XVALUE, YVALUE);
-    ConstantNodalCurve test = base.withYValues(YVALUE_BUMPED);
+    ConstantNodalCurve test = base.withYValues(YVALUE_BUMPED_ARRAY);
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(SIZE);
     assertThat(test.getMetadata()).isEqualTo(METADATA);
-    assertThat(test.getXValues()).isEqualTo(XVALUE);
-    assertThat(test.getYValues()).isEqualTo(YVALUE_BUMPED);
+    assertThat(test.getXValues()).isEqualTo(XVALUE_ARRAY);
+    assertThat(test.getYValues()).isEqualTo(YVALUE_BUMPED_ARRAY);
   }
 
   public void test_withValues_badSize() {
@@ -126,12 +128,12 @@ public class ConstantNodalCurveTest {
   //-------------------------------------------------------------------------
   public void test_withValuesXy() {
     ConstantNodalCurve base = ConstantNodalCurve.of(METADATA, XVALUE, YVALUE);
-    ConstantNodalCurve test = base.withValues(XVALUE_NEW, YVALUE_BUMPED);
+    ConstantNodalCurve test = base.withValues(XVALUE_ARRAY_NEW, YVALUE_BUMPED_ARRAY);
     assertThat(test.getName()).isEqualTo(CURVE_NAME);
     assertThat(test.getParameterCount()).isEqualTo(SIZE);
     assertThat(test.getMetadata()).isEqualTo(METADATA);
-    assertThat(test.getXValues()).isEqualTo(XVALUE_NEW);
-    assertThat(test.getYValues()).isEqualTo(YVALUE_BUMPED);
+    assertThat(test.getXValues()).isEqualTo(XVALUE_ARRAY_NEW);
+    assertThat(test.getYValues()).isEqualTo(YVALUE_BUMPED_ARRAY);
   }
 
   public void test_withValuesXy_badSize() {


### PR DESCRIPTION
Transient fields always need a readResolve method
Remove array factry method on ConstantNodalCurve
See #1322