### PR TITLE
Enhance FRA conventions

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/fra/type/FraConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fra/type/FraConvention.java
@@ -101,11 +101,51 @@ public interface FraConvention
 
   //-------------------------------------------------------------------------
   /**
-   * Creates a trade based on this convention.
+   * Creates a trade based on this convention, using the index tenor to define the end of the FRA.
+   * <p>
+   * This returns a trade based on the specified period to start.
+   * For example, a '2 x 5' FRA has a period to the start date of 2 months.
+   * The period to the end, 5 months, is implied by adding the tenor of the index,
+   * 3 months, to the period to start.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the FRA, the floating rate is received from the counterparty, with the fixed rate being paid.
+   * If selling the FRA, the floating rate is paid to the counterparty, with the fixed rate being received.
+   * <p>
+   * The start date will be the trade date, plus spot offset, plus period to start, adjusted to a valid business day.
+   * The end date will be the trade date, plus spot offset, plus period to start, plus index tenor, adjusted to a valid business day.
+   * The adjustment of the start and end date occurs at trade creation.
+   * The payment date offset is also applied at trade creation.
+   * When the Fra is {@linkplain Fra#resolve(ReferenceData) resolved}, the start and end date
+   * are not adjusted again but the payment date is.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param periodToStart  the period between the spot date and the start date
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount, in the payment currency of the template
+   * @param fixedRate  the fixed rate, typically derived from the market
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  public default FraTrade createTrade(
+      LocalDate tradeDate,
+      Period periodToStart,
+      BuySell buySell,
+      double notional,
+      double fixedRate,
+      ReferenceData refData) {
+    
+    Period periodToEnd = periodToStart.plus(getIndex().getTenor());
+    return createTrade(tradeDate, periodToStart, periodToEnd , buySell, notional, fixedRate, refData);
+  }
+
+  /**
+   * Creates a trade based on this convention, specifying the end of the FRA.
    * <p>
    * This returns a trade based on the specified periods.
    * For example, a '2 x 5' FRA has a period to the start date of 2 months and
-   * a period to the end date of 5 months
+   * a period to the end date of 5 months.
    * <p>
    * The notional is unsigned, with buy/sell determining the direction of the trade.
    * If buying the FRA, the floating rate is received from the counterparty, with the fixed rate being paid.

--- a/modules/product/src/main/java/com/opengamma/strata/product/fra/type/FraConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fra/type/FraConventions.java
@@ -5,18 +5,40 @@
  */
 package com.opengamma.strata.product.fra.type;
 
+import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.collect.named.ExtendedEnum;
 
 /**
- * Helper for conventions.
+ * Market standard FRA conventions.
+ * <p>
+ * FRA conventions are based on the details held within the {@link IborIndex}.
+ * As such, there is a factory method rather than constants for the conventions.
+ * <p>
+ * http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
  */
-final class FraConventions {
+public final class FraConventions {
 
   /**
    * The extended enum lookup from name to instance.
    */
   static final ExtendedEnum<FraConvention> ENUM_LOOKUP = ExtendedEnum.of(FraConvention.class);
 
+  /**
+   * Obtains a convention based on the specified index.
+   * <p>
+   * This uses the index name to find the matching convention.
+   * By default, this will always return a convention, however configuration may be added
+   * to restrict the conventions that are registered.
+   * 
+   * @param index  the index, from which the index name is used to find the matching convention
+   * @return the convention
+   * @throws IllegalArgumentException if no convention is registered for the index
+   */
+  public static FraConvention of(IborIndex index) {
+    return FraConvention.of(index);
+  }
+
+  //-------------------------------------------------------------------------
   /**
    * Restricted constructor.
    */

--- a/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraConventionTest.java
@@ -99,6 +99,9 @@ public class FraConventionTest {
     assertEquals(test.getFixingDateOffset(), GBP_LIBOR_3M.getFixingDateOffset());
     assertEquals(test.getDayCount(), ACT_365F);
     assertEquals(test.getDiscounting(), ISDA);
+    // ensure other factories match
+    assertEquals(FraConvention.of(GBP_LIBOR_3M), test);
+    assertEquals(FraConventions.of(GBP_LIBOR_3M), test);
   }
 
   //-------------------------------------------------------------------------
@@ -157,6 +160,26 @@ public class FraConventionTest {
     ImmutableFraConvention test = ImmutableFraConvention.of(NZD_INDEX);
     assertEquals(test.getIndex(), NZD_INDEX);
     assertEquals(test.getDiscounting(), AFMA);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_createTrade_period() {
+    FraConvention base = ImmutableFraConvention.builder()
+        .index(GBP_LIBOR_3M)
+        .spotDateOffset(NEXT_SAME_BUS_DAY)
+        .build();
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    FraTrade test = base.createTrade(tradeDate, Period.ofMonths(3), BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    Fra expected = Fra.builder()
+        .buySell(BUY)
+        .notional(NOTIONAL_2M)
+        .startDate(date(2015, 8, 5))
+        .endDate(date(2015, 11, 5))
+        .fixedRate(0.25d)
+        .index(GBP_LIBOR_3M)
+        .build();
+    assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
+    assertEquals(test.getProduct(), expected);
   }
 
   //-------------------------------------------------------------------------
@@ -267,6 +290,10 @@ public class FraConventionTest {
         .build();
     assertEquals(test.getInfo().getTradeDate(), Optional.of(tradeDate));
     assertEquals(test.getProduct(), expected);
+  }
+
+  public void test_unknownIndex() {
+    assertThrowsIllegalArg(() -> FraConvention.of("Rubbish"));
   }
 
   public void test_toTemplate_badDateOrder() {


### PR DESCRIPTION
Make `FraConventions` public for consistency with other conventions
Add `createTrade` method that implies the period to end from index tenor
Fixes #1332