### PR TITLE
Don't create negative zero when negating currency amounts

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -263,14 +263,15 @@ public final class CurrencyAmount
   /**
    * Returns a copy of this {@code CurrencyAmount} with the amount negated.
    * <p>
-   * This takes this amount and negates it.
+   * This takes this amount and negates it. If the amount is 0.0 or -0.0 the negated amount is 0.0.
    * <p>
    * This instance is immutable and unaffected by this method.
    * 
    * @return an amount based on this with the amount negated
    */
   public CurrencyAmount negated() {
-    return new CurrencyAmount(currency, -amount);
+    // Zero is treated as a special case to avoid creating -0.0 which produces surprising equality behaviour
+    return new CurrencyAmount(currency, amount == 0d ? 0d : -amount);
   }
 
   /**

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/MultiCurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/MultiCurrencyAmount.java
@@ -405,14 +405,15 @@ public final class MultiCurrencyAmount
   /**
    * Returns a copy of this {@code CurrencyAmount} with the amount negated.
    * <p>
-   * This takes this amount and negates it.
+   * This takes this amount and negates it. If any amount is 0.0 or -0.0 the negated amount is 0.0.
    * <p>
    * This instance is immutable and unaffected by this method.
    * 
    * @return an amount based on this with the amount negated
    */
   public MultiCurrencyAmount negated() {
-    return mapAmounts(a -> -a);
+    // Zero is treated as a special case to avoid creating -0.0 which produces surprising equality behaviour
+    return mapAmounts(a -> a == 0d ? 0d : -a);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyAmountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyAmountTest.java
@@ -160,6 +160,8 @@ public class CurrencyAmountTest {
   public void test_negated() {
     assertEquals(CCY_AMOUNT.negated(), CCY_AMOUNT_NEGATIVE);
     assertEquals(CCY_AMOUNT_NEGATIVE.negated(), CCY_AMOUNT);
+    assertEquals(CurrencyAmount.zero(Currency.USD), CurrencyAmount.zero(Currency.USD).negated());
+    assertEquals(CurrencyAmount.of(Currency.USD, -0d).negated(), CurrencyAmount.zero(Currency.USD));
   }
 
   public void test_negative() {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/MultiCurrencyAmountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/MultiCurrencyAmountTest.java
@@ -330,6 +330,12 @@ public class MultiCurrencyAmountTest {
     MultiCurrencyAmount base = MultiCurrencyAmount.of(CA1, CA2);
     MultiCurrencyAmount test = base.negated();
     assertMCA(test, CA1.negated(), CA2.negated());
+    assertEquals(
+        MultiCurrencyAmount.of(CurrencyAmount.zero(Currency.USD), CurrencyAmount.zero(Currency.EUR)).negated(),
+        MultiCurrencyAmount.of(CurrencyAmount.zero(Currency.USD), CurrencyAmount.zero(Currency.EUR)));
+    assertEquals(
+        MultiCurrencyAmount.of(CurrencyAmount.of(Currency.USD, -0d), CurrencyAmount.of(Currency.EUR, -0d)).negated(),
+        MultiCurrencyAmount.of(CurrencyAmount.zero(Currency.USD), CurrencyAmount.zero(Currency.EUR)));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/FxSingleTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/FxSingleTest.java
@@ -121,7 +121,7 @@ public class FxSingleTest {
     assertEquals(test.getCounterCurrencyAmount().getAmount(), CurrencyAmount.zero(USD).getAmount(), 1e-12);
     assertEquals(test.getPaymentDate(), DATE_2015_06_30);
     assertEquals(test.getCurrencyPair(), CurrencyPair.of(GBP, USD));
-    assertEquals(test.getReceiveCurrencyAmount(), CurrencyAmount.of(USD, -0d));
+    assertEquals(test.getReceiveCurrencyAmount(), CurrencyAmount.of(USD, 0d));
   }
 
   public void test_of_rate_wrongCurrency() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/ResolvedFxSingleTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/ResolvedFxSingleTest.java
@@ -129,7 +129,7 @@ public class ResolvedFxSingleTest {
     assertEquals(test.getCounterCurrencyPayment().getValue().getAmount(), CurrencyAmount.zero(USD).getAmount(), 1e-12);
     assertEquals(test.getPaymentDate(), DATE_2015_06_30);
     assertEquals(test.getCurrencyPair(), CurrencyPair.of(GBP, USD));
-    assertEquals(test.getReceiveCurrencyAmount(), CurrencyAmount.of(USD, -0d));
+    assertEquals(test.getReceiveCurrencyAmount(), CurrencyAmount.of(USD, 0d));
   }
 
   public void test_of_rate_wrongCurrency() {


### PR DESCRIPTION
Changes `CurrencyAmount.negated()` and `MultiCurrencyAmount.negated()` so they never produce amounts containing negative zero.

Fixes #1369 