### PR TITLE
Created DiscountFactorsDecoratedForward. 

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/DiscountFactorsDecoratedForward.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/DiscountFactorsDecoratedForward.java
@@ -1,0 +1,470 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.ImmutableConstructor;
+import org.joda.beans.PropertyDefinition;
+
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.data.MarketDataName;
+import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
+import com.opengamma.strata.market.param.ParameterMetadata;
+import com.opengamma.strata.market.param.ParameterPerturbation;
+import com.opengamma.strata.pricer.DiscountFactors;
+import com.opengamma.strata.pricer.ZeroRateSensitivity;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.joda.beans.Bean;
+import org.joda.beans.BeanBuilder;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+/**
+ * Discount factors based on an underlying discount factors and a forward date. 
+ * The new discount factors acts as the implied forward discount factor.
+ * <p>
+ * Only the methods used for direct valuation are implemented. The methods with spread and the methods related
+ * to sensitivities are not implemented.
+ */
+@BeanDefinition(builderScope = "private")
+public class DiscountFactorsDecoratedForward 
+    implements DiscountFactors, ImmutableBean, Serializable {
+
+  /**
+   * Year fraction used as an effective zero.
+   */
+  private static final double EFFECTIVE_ZERO = 1e-10;
+  
+  /** Underlying provider. */
+  @PropertyDefinition(validate = "notNull")
+  private final DiscountFactors underlying;
+  /** The forward rate. */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final LocalDate valuationDate;
+  /** The discount factor at the forward date. */
+  private final double discountFactorForwardDate;  // cached, not a property
+  /** The relative year fraction to the forward date. */
+  private final double yearFractionForwardDate;  // cached, not a property
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates a new {@link DiscountFactors} from an existing one and a forward date. 
+   * <p>
+   * The provider created as a valuation date at the forward date. The discount factors at a given date are the 
+   * forward discount factors, i.e the ratio of the original discount factor at the date and the discount 
+   * factor at the forward date.
+   * 
+   * @param underlying  the underlying discount factors
+   * @param valuationDate  the valuation date for which the curve is valid
+   * @return the discount factors
+   */
+  public static DiscountFactorsDecoratedForward of(DiscountFactors underlying, LocalDate valuationDate) {
+    return new DiscountFactorsDecoratedForward(underlying, valuationDate);
+  }
+
+  @ImmutableConstructor
+  private DiscountFactorsDecoratedForward(DiscountFactors underlying, LocalDate valuationDate) {
+    this.underlying = ArgChecker.notNull(underlying, "underlying");
+    this.valuationDate = ArgChecker.notNull(valuationDate, "valuation date");
+    this.discountFactorForwardDate = underlying.discountFactor(valuationDate);
+    this.yearFractionForwardDate = underlying.relativeYearFraction(valuationDate);
+  }
+
+  @Override
+  public Currency getCurrency() {
+    return underlying.getCurrency();
+  }
+
+  @Override
+  public int getParameterCount() {
+    return underlying.getParameterCount();
+  }
+
+  @Override
+  public double discountFactor(LocalDate date) {
+    return underlying.discountFactor(date) / discountFactorForwardDate;
+  }
+
+  @Override
+  public double getParameter(int parameterIndex) {
+    return underlying.getParameter(parameterIndex);
+  }
+
+  @Override
+  public ParameterMetadata getParameterMetadata(int parameterIndex) {
+    return underlying.getParameterMetadata(parameterIndex);
+  }
+
+  @Override
+  public double relativeYearFraction(LocalDate date) {
+    return underlying.relativeYearFraction(date) - yearFractionForwardDate; 
+    // Rely on additive relative year fraction
+  }
+
+  @Override
+  public double discountFactor(double yearFraction) {
+    return underlying.discountFactor(yearFraction + yearFractionForwardDate) 
+        / discountFactorForwardDate;
+  }
+
+  @Override
+  public double zeroRate(double yearFraction) {
+    double yearFractionMod = Math.max(EFFECTIVE_ZERO, yearFraction);
+    double discountFactor = discountFactor(yearFractionMod);
+    return -Math.log(discountFactor) / yearFractionMod;
+  }
+
+  @Override
+  public DiscountFactors withParameter(int parameterIndex, double newValue) {
+    return DiscountFactorsDecoratedForward.of(underlying.withParameter(parameterIndex, newValue), valuationDate);
+  }
+
+  @Override
+  public DiscountFactors withPerturbation(ParameterPerturbation perturbation) {
+    return DiscountFactorsDecoratedForward.of(underlying.withPerturbation(perturbation), valuationDate);
+  }
+
+  @Override
+  public ZeroRateSensitivity zeroRatePointSensitivity(double yearFraction, Currency sensitivityCurrency) {
+    double discountFactor = discountFactor(yearFraction);
+    return ZeroRateSensitivity
+        .of(underlying.getCurrency(), yearFraction, sensitivityCurrency, -discountFactor * yearFraction);
+  }
+
+  @Override
+  public CurrencyParameterSensitivities parameterSensitivity(ZeroRateSensitivity pointSensitivity) {
+    double yearFraction = pointSensitivity.getYearFraction();
+    if (Math.abs(yearFraction) < EFFECTIVE_ZERO) {
+      return CurrencyParameterSensitivities.empty(); // Discount factor in 0 is always 1, no sensitivity.
+    }
+    double dfForward = discountFactor(yearFraction);
+    double n = pointSensitivity.getSensitivity() / (-yearFraction * dfForward);
+    ZeroRateSensitivity ptsTimeShifted =
+        ZeroRateSensitivity.of(pointSensitivity.getCurveCurrency(), pointSensitivity.getYearFraction() + yearFractionForwardDate,
+            pointSensitivity.getCurrency(), -(yearFraction + yearFractionForwardDate) * dfForward);
+    ZeroRateSensitivity ptsForward =
+        ZeroRateSensitivity.of(pointSensitivity.getCurveCurrency(), yearFractionForwardDate,
+            pointSensitivity.getCurrency(), yearFractionForwardDate * dfForward);
+    return  (underlying.parameterSensitivity(ptsTimeShifted)
+        .combinedWith(underlying.parameterSensitivity(ptsForward))).multipliedBy(n);
+  }
+
+  @Override
+  public CurrencyParameterSensitivities createParameterSensitivity(Currency currency, DoubleArray sensitivities) {
+    return underlying.createParameterSensitivity(currency, sensitivities);
+  }
+
+  @Override
+  public <T> Optional<T> findData(MarketDataName<T> name) {
+    return underlying.findData(name);
+  }
+    
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code DiscountFactorsDecoratedForward}.
+   * @return the meta-bean, not null
+   */
+  public static DiscountFactorsDecoratedForward.Meta meta() {
+    return DiscountFactorsDecoratedForward.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(DiscountFactorsDecoratedForward.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public DiscountFactorsDecoratedForward.Meta metaBean() {
+    return DiscountFactorsDecoratedForward.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets underlying provider.
+   * @return the value of the property, not null
+   */
+  public DiscountFactors getUnderlying() {
+    return underlying;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the forward rate.
+   * @return the value of the property, not null
+   */
+  @Override
+  public LocalDate getValuationDate() {
+    return valuationDate;
+  }
+
+  //-----------------------------------------------------------------------
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      DiscountFactorsDecoratedForward other = (DiscountFactorsDecoratedForward) obj;
+      return JodaBeanUtils.equal(underlying, other.underlying) &&
+          JodaBeanUtils.equal(valuationDate, other.valuationDate);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(underlying);
+    hash = hash * 31 + JodaBeanUtils.hashCode(valuationDate);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder(96);
+    buf.append("DiscountFactorsDecoratedForward{");
+    int len = buf.length();
+    toString(buf);
+    if (buf.length() > len) {
+      buf.setLength(buf.length() - 2);
+    }
+    buf.append('}');
+    return buf.toString();
+  }
+
+  protected void toString(StringBuilder buf) {
+    buf.append("underlying").append('=').append(JodaBeanUtils.toString(underlying)).append(',').append(' ');
+    buf.append("valuationDate").append('=').append(JodaBeanUtils.toString(valuationDate)).append(',').append(' ');
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code DiscountFactorsDecoratedForward}.
+   */
+  public static class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code underlying} property.
+     */
+    private final MetaProperty<DiscountFactors> underlying = DirectMetaProperty.ofImmutable(
+        this, "underlying", DiscountFactorsDecoratedForward.class, DiscountFactors.class);
+    /**
+     * The meta-property for the {@code valuationDate} property.
+     */
+    private final MetaProperty<LocalDate> valuationDate = DirectMetaProperty.ofImmutable(
+        this, "valuationDate", DiscountFactorsDecoratedForward.class, LocalDate.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "underlying",
+        "valuationDate");
+
+    /**
+     * Restricted constructor.
+     */
+    protected Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -1770633379:  // underlying
+          return underlying;
+        case 113107279:  // valuationDate
+          return valuationDate;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public BeanBuilder<? extends DiscountFactorsDecoratedForward> builder() {
+      return new DiscountFactorsDecoratedForward.Builder();
+    }
+
+    @Override
+    public Class<? extends DiscountFactorsDecoratedForward> beanType() {
+      return DiscountFactorsDecoratedForward.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code underlying} property.
+     * @return the meta-property, not null
+     */
+    public final MetaProperty<DiscountFactors> underlying() {
+      return underlying;
+    }
+
+    /**
+     * The meta-property for the {@code valuationDate} property.
+     * @return the meta-property, not null
+     */
+    public final MetaProperty<LocalDate> valuationDate() {
+      return valuationDate;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case -1770633379:  // underlying
+          return ((DiscountFactorsDecoratedForward) bean).getUnderlying();
+        case 113107279:  // valuationDate
+          return ((DiscountFactorsDecoratedForward) bean).getValuationDate();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code DiscountFactorsDecoratedForward}.
+   */
+  private static class Builder extends DirectFieldsBeanBuilder<DiscountFactorsDecoratedForward> {
+
+    private DiscountFactors underlying;
+    private LocalDate valuationDate;
+
+    /**
+     * Restricted constructor.
+     */
+    protected Builder() {
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case -1770633379:  // underlying
+          return underlying;
+        case 113107279:  // valuationDate
+          return valuationDate;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case -1770633379:  // underlying
+          this.underlying = (DiscountFactors) newValue;
+          break;
+        case 113107279:  // valuationDate
+          this.valuationDate = (LocalDate) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public DiscountFactorsDecoratedForward build() {
+      return new DiscountFactorsDecoratedForward(
+          underlying,
+          valuationDate);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(96);
+      buf.append("DiscountFactorsDecoratedForward.Builder{");
+      int len = buf.length();
+      toString(buf);
+      if (buf.length() > len) {
+        buf.setLength(buf.length() - 2);
+      }
+      buf.append('}');
+      return buf.toString();
+    }
+
+    protected void toString(StringBuilder buf) {
+      buf.append("underlying").append('=').append(JodaBeanUtils.toString(underlying)).append(',').append(' ');
+      buf.append("valuationDate").append('=').append(JodaBeanUtils.toString(valuationDate)).append(',').append(' ');
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/DiscountFactorsDecoratedForwardTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/DiscountFactorsDecoratedForwardTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.currency.Currency.USD;
+import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.market.curve.CurveName;
+import com.opengamma.strata.market.curve.Curves;
+import com.opengamma.strata.market.curve.InterpolatedNodalCurve;
+import com.opengamma.strata.market.curve.interpolator.CurveExtrapolator;
+import com.opengamma.strata.market.curve.interpolator.CurveExtrapolators;
+import com.opengamma.strata.market.curve.interpolator.CurveInterpolator;
+import com.opengamma.strata.market.curve.interpolator.CurveInterpolators;
+import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
+
+/**
+ * Tests {@link DiscountFactorsDecoratedForward}.
+ */
+@Test
+public class DiscountFactorsDecoratedForwardTest {
+
+  private static final LocalDate DATE_VAL = LocalDate.of(2015, 6, 4);
+  private static final LocalDate DATE_FWD = LocalDate.of(2015, 6, 5);
+
+  private static final CurveInterpolator INTERPOLATOR = CurveInterpolators.LINEAR;
+  private static final CurveExtrapolator EXTRAPOLATOR_FLAT = CurveExtrapolators.FLAT;
+  private static final CurveName NAME = CurveName.of("TestCurve");
+  private static final DoubleArray TIMES = DoubleArray.of(0, 0.25, 0.50, 1.0, 2.0, 10);
+  private static final DoubleArray ZC = DoubleArray.of(0.01, 0.02, 0.01, 0.02, 0.01, 0.02);
+  private static final InterpolatedNodalCurve CURVE_ZERO = InterpolatedNodalCurve.of(
+      Curves.zeroRates(NAME, ACT_365F), TIMES, ZC,
+      INTERPOLATOR, EXTRAPOLATOR_FLAT, EXTRAPOLATOR_FLAT);
+  private static final DiscountFactors DF_START = DiscountFactors.of(GBP, DATE_VAL, CURVE_ZERO);
+  private static final DiscountFactorsDecoratedForward DF_FWD = DiscountFactorsDecoratedForward.of(DF_START, DATE_FWD);
+
+  private static final double TOLERANCE = 1.0E-8;
+  private static final double TOLERANCE_DELTA = 1.0E-6;
+
+  public void date_ccy_param() {
+    assertEquals(DF_FWD.getValuationDate(), DATE_FWD);
+    assertEquals(DF_FWD.getCurrency(), GBP);
+    assertEquals(DF_FWD.getParameterCount(), DF_START.getParameterCount());
+    assertEquals(DF_FWD.getParameter(2), DF_START.getParameter(2));
+    assertEquals(DF_FWD.getParameterMetadata(2), DF_START.getParameterMetadata(2));
+  }
+
+  public void discount_factor() {
+    int nbDate = 10;
+    Period step = Period.ofMonths(5);
+    double dfFwd = DF_START.discountFactor(DATE_FWD);
+    for (int i = 0; i < nbDate; i++) {
+      LocalDate testDate = DATE_FWD.plus(step.multipliedBy(i));
+      double dfComputed = DF_FWD.discountFactor(testDate);
+      double dfExpected = DF_START.discountFactor(testDate) / dfFwd;
+      assertEquals(dfComputed, dfExpected, TOLERANCE);
+      double yf = DF_FWD.relativeYearFraction(testDate);
+      double dfComputedYf = DF_FWD.discountFactor(yf);
+      assertEquals(dfComputedYf, dfExpected, TOLERANCE);
+      assertEquals(yf, DF_START.relativeYearFraction(testDate) - DF_START.relativeYearFraction(DATE_FWD), TOLERANCE);
+    }
+  }
+
+  public void zero_rate() {
+    int nbDate = 10;
+    Period step = Period.ofMonths(5);
+    for (int i = 0; i < nbDate; i++) {
+      LocalDate testDate = DATE_FWD.plus(step.multipliedBy(i));
+      double zrComputed = DF_FWD.zeroRate(testDate);
+      double yf = DF_FWD.relativeYearFraction(testDate);
+      double yfEffective = Math.max(1.0E-10, yf);
+      double zrExpected = -1.0 / yfEffective * Math.log(DF_FWD.discountFactor(yfEffective));
+      assertEquals(zrComputed, zrExpected, TOLERANCE);
+      double zrComputedYf = DF_FWD.zeroRate(yf);
+      assertEquals(zrComputedYf, zrExpected, TOLERANCE);
+    }
+  }  
+
+  public void with_param() {
+    double newParam = 0.12345;
+    int paramIndex = 2;
+    DiscountFactors dfWithParam = DF_FWD.withParameter(paramIndex, newParam);
+    assertEquals(dfWithParam.getParameter(paramIndex), newParam, TOLERANCE);
+  }
+
+  public void zero_rate_sensitivity() {
+    int nbDate = 10;
+    Period step = Period.ofMonths(5);
+    for (int i = 0; i < nbDate; i++) {
+      LocalDate testDate = DATE_FWD.plus(step.multipliedBy(i));
+      ZeroRateSensitivity zrsComputed = DF_FWD.zeroRatePointSensitivity(testDate);
+      double t = DF_FWD.relativeYearFraction(testDate);
+      double df = DF_FWD.discountFactor(testDate);
+      assertEquals(zrsComputed.getSensitivity(), -t * df, TOLERANCE);
+      assertEquals(zrsComputed.getYearFraction(), t, TOLERANCE);
+    }
+  }
+
+  // Compare parameter sensitivity to a finite difference computation.
+  public void parameter_sensitivity() {
+    double sensiFactor = 123.456;
+    final double shift = 1.0E-4;
+    int nbDate = 10;
+    Period step = Period.ofMonths(5);
+    for (int i = 0; i < nbDate; i++) {
+      LocalDate testDate = DATE_FWD.plus(step.multipliedBy(i));
+      ZeroRateSensitivity zrsComputed = DF_FWD.zeroRatePointSensitivity(testDate, USD).multipliedBy(sensiFactor);
+      CurrencyParameterSensitivities psComputed = DF_FWD.parameterSensitivity(zrsComputed);
+      if (i == 0) {
+        assertEquals(psComputed.size(), 0); // No sensitivity at valuation date
+      } else {
+        DoubleArray psComputedArray = psComputed.getSensitivities().get(0).getSensitivity();
+        for (int loopparam = 0; loopparam < ZC.size(); loopparam++) {
+          double[] dfMP = new double[2];
+          for (int j = 0; j < 2; j++) {
+            final int loopparam2 = loopparam;
+            final int j2 = j;
+            DiscountFactors dfShifted = DF_FWD
+                .withPerturbation((idx, value, meta) -> (idx == loopparam2) ? value + (-1 + 2 * j2) * shift : value);
+            DiscountFactorsDecoratedForward dfFwd = DiscountFactorsDecoratedForward.of(dfShifted, DATE_FWD);
+            dfMP[j] = dfFwd.discountFactor(testDate);
+          }
+          double sensiExpected = sensiFactor * (dfMP[1] - dfMP[0]) / (2 * shift);
+          assertEquals(psComputedArray.get(loopparam), sensiExpected, Math.abs(TOLERANCE_DELTA * sensiExpected));
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This is the first part of a multi-leg development. The final goal is to create tools to compute generic "theta" values, i.e. impact of time, for interest rate books.
This require to be able to reprice books with curves at a later date (usually T+1). Their are several ways to create the curves at a later date; this implementation uses a forward approach.
Within that approach we need to move the discount factors (this PR), ibor values, overnight values, and FX rates (forthcoming PRs) at the future date.
While working on discount factors, I moved some methods implemented by copy and past at the class level to the interface level as default implementation.
