### PR TITLE
Enhance schedule generation

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/DayRollConventions.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/DayRollConventions.java
@@ -85,6 +85,11 @@ final class DayRollConventions implements NamedLookup<RollConvention> {
     }
 
     @Override
+    public int getDayOfMonth() {
+      return day;
+    }
+
+    @Override
     public LocalDate adjust(LocalDate date) {
       ArgChecker.notNull(date, "date");
       if (day >= 29 && date.getMonthValue() == 2) {

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/RollConvention.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/RollConvention.java
@@ -181,6 +181,20 @@ public interface RollConvention
 
   //-------------------------------------------------------------------------
   /**
+   * Gets the day-of-month that the roll convention implies.
+   * <p>
+   * This extracts the day-of-month for simple roll conventions.
+   * The numeric roll conventions will return their day-of-month.
+   * The 'EOM' convention will return 31.
+   * All other conventions will return zero.
+   * 
+   * @return the day-of-month that the roll convention implies, zero if not applicable
+   */
+  public default int getDayOfMonth() {
+    return 0;
+  }
+
+  /**
    * Gets the name that uniquely identifies this convention.
    * <p>
    * This name is used in serialization and can be parsed using {@link #of(String)}.

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StandardRollConventions.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StandardRollConventions.java
@@ -33,6 +33,11 @@ enum StandardRollConventions implements RollConvention {
       ArgChecker.notNull(date, "date");
       return date.withDayOfMonth(date.lengthOfMonth());
     }
+
+    @Override
+    public int getDayOfMonth() {
+      return 31;
+    }
   },
 
   // 3rd Wednesday

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StandardRollConventions.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StandardRollConventions.java
@@ -36,6 +36,8 @@ enum StandardRollConventions implements RollConvention {
 
     @Override
     public int getDayOfMonth() {
+      // EOM is equivalent to 31 in FpML in most cases
+      // because roll conventions 30 and 29 also have to adjust to end of February
       return 31;
     }
   },

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -361,6 +361,15 @@ public class PeriodicScheduleTest {
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_31, AUG_31, NOV_30),
             ImmutableList.of(NOV_29_2013, FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), EOM},
 
+        // pre-adjusted start date, no change needed
+        {JUL_17, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,
+            ImmutableList.of(JUL_17, AUG_17, SEP_17, OCT_17),
+            ImmutableList.of(JUL_17, AUG_18, SEP_17, OCT_17), DAY_17},
+        // pre-adjusted start date, change needed
+        {AUG_18, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,
+            ImmutableList.of(AUG_17, SEP_17, OCT_17),
+            ImmutableList.of(AUG_18, SEP_17, OCT_17), DAY_17},
+
         // TERM period
         {JUN_04, SEP_17, TERM, STUB_NONE, null, null, null, null,
             ImmutableList.of(JUN_04, SEP_17),


### PR DESCRIPTION
Allow non-EOM roll conventions to behave like EOM ones based on pre-adjusted dates.
See [FpML clarification](http://www.fpml.org/forums/topic/can-a-roll-convention-imply-a-stub/#post-7659).