### PR TITLE
Ensure order of properties is retained

### DIFF
--- a/modules/basics/src/main/resources/com/opengamma/strata/config/base/HolidayCalendar.ini
+++ b/modules/basics/src/main/resources/com/opengamma/strata/config/base/HolidayCalendar.ini
@@ -8,8 +8,8 @@
 #  'instance', the class has a static field named INSTANCE that is of type NamedLookup
 [providers]
 com.opengamma.strata.basics.date.HolidayCalendars = constants
-com.opengamma.strata.basics.date.GlobalHolidayCalendars = constants
 com.opengamma.strata.basics.date.HolidayCalendarIniLookup = instance
+com.opengamma.strata.basics.date.GlobalHolidayCalendars = constants
 
 
 # The set of alternate names

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/IniFile.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/IniFile.java
@@ -9,13 +9,13 @@ import java.io.UncheckedIOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.google.common.io.CharSource;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.collect.Unchecked;
 
 /**
@@ -79,7 +79,7 @@ public final class IniFile {
   public static IniFile of(CharSource source) {
     ArgChecker.notNull(source, "source");
     ImmutableList<String> lines = Unchecked.wrap(() -> source.readLines());
-    Map<String, Multimap<String, String>> parsedIni = parse(lines);
+    ImmutableMap<String, ImmutableListMultimap<String, String>> parsedIni = parse(lines);
     ImmutableMap.Builder<String, PropertySet> builder = ImmutableMap.builder();
     parsedIni.forEach((sectionName, sectionData) -> builder.put(sectionName, PropertySet.of(sectionData)));
     return new IniFile(builder.build());
@@ -87,9 +87,11 @@ public final class IniFile {
 
   //-------------------------------------------------------------------------
   // parses the INI file format
-  private static Map<String, Multimap<String, String>> parse(ImmutableList<String> lines) {
-    Map<String, Multimap<String, String>> ini = new LinkedHashMap<>();
-    Multimap<String, String> currentSection = null;
+  private static ImmutableMap<String, ImmutableListMultimap<String, String>> parse(ImmutableList<String> lines) {
+    // cannot use ArrayListMultiMap as it does not retain the order of the keys
+    // whereas ImmutableListMultimap does retain the order of the keys
+    Map<String, ImmutableListMultimap.Builder<String, String>> ini = new LinkedHashMap<>();
+    ImmutableListMultimap.Builder<String, String> currentSection = null;
     int lineNum = 0;
     for (String line : lines) {
       lineNum++;
@@ -102,7 +104,7 @@ public final class IniFile {
         if (ini.containsKey(sectionName)) {
           throw new IllegalArgumentException("Invalid INI file, duplicate section not allowed, line " + lineNum);
         }
-        currentSection = ArrayListMultimap.create();
+        currentSection = ImmutableListMultimap.builder();
         ini.put(sectionName, currentSection);
 
       } else if (currentSection == null) {
@@ -118,7 +120,7 @@ public final class IniFile {
         currentSection.put(key, value);
       }
     }
-    return ini;
+    return MapStream.of(ini).mapValues(b -> b.build()).toMap();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/PropertiesFile.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/PropertiesFile.java
@@ -9,9 +9,8 @@ import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.io.CharSource;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Unchecked;
@@ -75,7 +74,9 @@ public final class PropertiesFile {
 
   // parses the properties file format
   private static PropertySet parse(ImmutableList<String> lines) {
-    Multimap<String, String> parsed = ArrayListMultimap.create();
+    // cannot use ArrayListMultiMap as it does not retain the order of the keys
+    // whereas ImmutableListMultimap does retain the order of the keys
+    ImmutableListMultimap.Builder<String, String> parsed = ImmutableListMultimap.builder();
     int lineNum = 0;
     for (String line : lines) {
       lineNum++;
@@ -91,7 +92,7 @@ public final class PropertiesFile {
       }
       parsed.put(key, value);
     }
-    return PropertySet.of(parsed);
+    return PropertySet.of(parsed.build());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceConfig.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceConfig.java
@@ -214,7 +214,7 @@ public final class ResourceConfig {
       // add entries, replacing existing data
       for (String sectionName : file.asMap().keySet()) {
         if (!sectionName.equals(CHAIN_SECTION)) {
-          sectionMap.merge(sectionName, file.section(sectionName), PropertySet::combinedWith);
+          sectionMap.merge(sectionName, file.section(sectionName), PropertySet::overrideWith);
         }
       }
     }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertiesFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertiesFileTest.java
@@ -30,6 +30,7 @@ public class PropertiesFileTest {
       "a = x\n" +
       " \n" +
       "; comment\n" +
+      "c = z\n" +
       "b = y\n";
   private final String FILE2 = "" +
       "a = x\n" +
@@ -37,9 +38,9 @@ public class PropertiesFileTest {
 
   public void test_of_noLists() {
     PropertiesFile test = PropertiesFile.of(CharSource.wrap(FILE1));
-    Multimap<String, String> keyValues = ImmutableListMultimap.of("a", "x", "b", "y");
+    Multimap<String, String> keyValues = ImmutableListMultimap.of("a", "x", "c", "z", "b", "y");
     assertEquals(test.getProperties(), PropertySet.of(keyValues));
-    assertEquals(test.toString(), "{a=[x], b=[y]}");
+    assertEquals(test.toString(), "{a=[x], c=[z], b=[y]}");
   }
 
   public void test_of_list() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertySetTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertySetTest.java
@@ -79,9 +79,9 @@ public class PropertySetTest {
 
   //-------------------------------------------------------------------------
   public void test_combinedWith() {
-    PropertySet base = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "b", "y", "c", "z"));
-    PropertySet other = PropertySet.of(ImmutableListMultimap.of("a", "aa", "b", "bb"));
-    PropertySet expected = PropertySet.of(ImmutableListMultimap.of("a", "aa", "b", "bb", "c", "z"));
+    PropertySet base = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "c", "z"));
+    PropertySet other = PropertySet.of(ImmutableListMultimap.of("a", "aa", "b", "bb", "d", "dd"));
+    PropertySet expected = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "c", "z", "b", "bb", "d", "dd"));
     assertEquals(base.combinedWith(other), expected);
   }
 
@@ -93,6 +93,24 @@ public class PropertySetTest {
   public void test_combinedWith_emptyOther() {
     PropertySet base = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "b", "y", "c", "z"));
     assertEquals(PropertySet.empty().combinedWith(base), base);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_overrideWith() {
+    PropertySet base = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "b", "y", "c", "z"));
+    PropertySet other = PropertySet.of(ImmutableListMultimap.of("a", "aa", "c", "cc", "d", "dd", "e", "ee"));
+    PropertySet expected = PropertySet.of(ImmutableListMultimap.of("a", "aa", "b", "y", "c", "cc", "d", "dd", "e", "ee"));
+    assertEquals(base.overrideWith(other), expected);
+  }
+
+  public void test_overrideWith_emptyBase() {
+    PropertySet base = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "b", "y", "c", "z"));
+    assertEquals(base.overrideWith(PropertySet.empty()), base);
+  }
+
+  public void test_overrideWith_emptyOther() {
+    PropertySet base = PropertySet.of(ImmutableListMultimap.of("a", "x", "a", "y", "b", "y", "c", "z"));
+    assertEquals(PropertySet.empty().overrideWith(base), base);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
ArrayListMultimap does not retain the order of inserted keys
Fix IniFile, PropertiesFile and PropertySet
Fix combinedWith() to match correct Strata behaviour
Add overrideWith() to compensate
Adjust order of files in HolidayCalendar.ini to allow overrides
HolidayCalendarIniLookup should be before GlobalHolidayCalendars
Fixes #1430