### PR TITLE
Added first order derivative for discount factors with respect to time.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/DiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/DiscountFactors.java
@@ -120,6 +120,17 @@ public interface DiscountFactors
    * @throws RuntimeException if the value cannot be obtained
    */
   public abstract double discountFactor(double yearFraction);
+  
+  /**
+   * Returns the discount factor derivative with respect to the year fraction or time.
+   * <p>
+   * The year fraction must be based on {@code #relativeYearFraction(LocalDate)}.
+   * 
+   * @param yearFraction  the year fraction 
+   * @return the discount factor derivative
+   * @throws RuntimeException if the value cannot be obtained
+   */
+  public abstract double discountFactorTimeDerivative(double yearFraction);
 
   /**
    * Gets the discount factor for the specified date with z-spread.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/SimpleDiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/SimpleDiscountFactors.java
@@ -166,6 +166,11 @@ public final class SimpleDiscountFactors
   }
 
   @Override
+  public double discountFactorTimeDerivative(double yearFraction) {
+    return curve.firstDerivative(yearFraction);
+  }
+
+  @Override
   public double zeroRate(double yearFraction) {
     double yearFractionMod = Math.max(EFFECTIVE_ZERO, yearFraction);
     double discountFactor = discountFactor(yearFractionMod);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRateDiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRateDiscountFactors.java
@@ -162,6 +162,13 @@ public final class ZeroRateDiscountFactors
   }
 
   @Override
+  public double discountFactorTimeDerivative(double yearFraction) {
+    double zr = curve.yValue(yearFraction);    
+    return - Math.exp(-yearFraction * curve.yValue(yearFraction)) 
+        * (zr + curve.firstDerivative(yearFraction) * yearFraction);
+  }
+
+  @Override
   public double zeroRate(double yearFraction) {
     return curve.yValue(yearFraction);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRatePeriodicDiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRatePeriodicDiscountFactors.java
@@ -174,6 +174,15 @@ public final class ZeroRatePeriodicDiscountFactors
   }
 
   @Override
+  public double discountFactorTimeDerivative(double yearFraction) {
+    double zr = curve.yValue(yearFraction);
+    double periodIF = 1d + zr / frequency;
+    double df = Math.pow(periodIF, -yearFraction * frequency);
+    return - frequency * df * 
+        (Math.log(periodIF) + yearFraction / periodIF * curve.firstDerivative(yearFraction) / frequency);
+  }
+
+  @Override
   public double zeroRate(double yearFraction) {
     double ratePeriod = curve.yValue(yearFraction);
     return frequency * Math.log(1d + ratePeriod / frequency);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/SimpleDiscountFactorsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/SimpleDiscountFactorsTest.java
@@ -52,6 +52,7 @@ public class SimpleDiscountFactorsTest {
 
   private static final double SPREAD = 0.05;
   private static final double TOL = 1.0e-12;
+  private static final double TOL_FD = 1.0e-8;
   private static final double EPS = 1.0e-6;
 
   //-------------------------------------------------------------------------
@@ -92,6 +93,14 @@ public class SimpleDiscountFactorsTest {
     double relativeYearFraction = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
     double expected = CURVE.yValue(relativeYearFraction);
     assertEquals(test.discountFactor(DATE_AFTER), expected);
+  }
+  
+  public void test_discountFactorTimeDerivative() {
+    DiscountFactors test = DiscountFactors.of(GBP, DATE_VAL, CURVE);
+    double relativeYearFraction = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
+    double expectedP = test.discountFactor(relativeYearFraction + EPS);
+    double expectedM = test.discountFactor(relativeYearFraction - EPS);
+    assertEquals(test.discountFactorTimeDerivative(relativeYearFraction), (expectedP - expectedM) / (2 * EPS), TOL_FD);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/ZeroRateDiscountFactorsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/ZeroRateDiscountFactorsTest.java
@@ -52,6 +52,7 @@ public class ZeroRateDiscountFactorsTest {
 
   private static final double SPREAD = 0.05;
   private static final double TOL = 1.0e-12;
+  private static final double TOL_FD = 1.0e-8;
   private static final double EPS = 1.0e-6;
 
   //-------------------------------------------------------------------------
@@ -92,6 +93,14 @@ public class ZeroRateDiscountFactorsTest {
     double relativeYearFraction = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
     double expected = Math.exp(-relativeYearFraction * CURVE.yValue(relativeYearFraction));
     assertEquals(test.discountFactor(DATE_AFTER), expected);
+  }
+  
+  public void test_discountFactorTimeDerivative() {
+    DiscountFactors test = DiscountFactors.of(GBP, DATE_VAL, CURVE);
+    double relativeYearFraction = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
+    double expectedP = test.discountFactor(relativeYearFraction + EPS);
+    double expectedM = test.discountFactor(relativeYearFraction - EPS);
+    assertEquals(test.discountFactorTimeDerivative(relativeYearFraction), (expectedP - expectedM) / (2 * EPS), TOL_FD);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/ZeroRatePeriodicDiscountFactorsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/ZeroRatePeriodicDiscountFactorsTest.java
@@ -66,6 +66,7 @@ public class ZeroRatePeriodicDiscountFactorsTest {
   private static final double TOLERANCE_DF = 1.0e-12;
   private static final double TOLERANCE_DELTA = 1.0e-10;
   private static final double TOLERANCE_DELTA_FD = 1.0e-8;
+  private static final double EPS = 1.0e-6;
 
   //-------------------------------------------------------------------------
   public void test_of() {
@@ -126,6 +127,15 @@ public class ZeroRatePeriodicDiscountFactorsTest {
     double expected = Math.pow(1.0d + CURVE.yValue(relativeYearFraction) / CMP_PERIOD,
         -CMP_PERIOD * relativeYearFraction);
     assertEquals(test.discountFactor(DATE_AFTER), expected);
+  }
+  
+  public void test_discountFactorTimeDerivative() {
+    DiscountFactors test = DiscountFactors.of(GBP, DATE_VAL, CURVE);
+    double relativeYearFraction = ACT_365F.relativeYearFraction(DATE_VAL, DATE_AFTER);
+    double expectedP = test.discountFactor(relativeYearFraction + EPS);
+    double expectedM = test.discountFactor(relativeYearFraction - EPS);
+    assertEquals(test.discountFactorTimeDerivative(relativeYearFraction), (expectedP - expectedM) / (2 * EPS),
+        TOLERANCE_DELTA_FD);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
DiscountFactors currently returns the discount factor for a given year fraction/time. The method is a function from double to double; it is natural in some circumstances to compute its derivative.
This PR add the time derivative in the interface methods and implement it for the 3 current DiscountFactors implementations.
The same method need to be implemented in other modules which implement this interface.