### PR TITLE
Ensure derived fields are transient for serialization

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendar.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendar.java
@@ -83,13 +83,13 @@ public final class ImmutableHolidayCalendar
    * The start year.
    * Used as the base year for the lookup table.
    */
-  private final int startYear;
+  private final transient int startYear;  // not a property
   /**
    * The lookup table, where each item represents a month from January of startYear onwards.
    * Bits 0 to 31 are used for each day-of-month, where 0 is a holiday and 1 is a business day.
    * Trailing bits are set to 0 so they act as holidays, avoiding month length logic.
    */
-  private final int[] lookup;
+  private final transient int[] lookup;  // not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -213,6 +213,11 @@ public final class ImmutableHolidayCalendar
       array[index] &= ~(1 << (date.getDayOfMonth() - 1));
     }
     return array;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ImmutableHolidayCalendar(id, holidays, weekendDays);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/ImmutableIborIndex.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/ImmutableIborIndex.java
@@ -130,7 +130,7 @@ public final class ImmutableIborIndex
   /**
    * The floating rate name, such as 'GBP-LIBOR'.
    */
-  private final String floatingRateName;  // derived
+  private final transient String floatingRateName;  // derived
 
   //-------------------------------------------------------------------------
   // creates an instance
@@ -168,6 +168,21 @@ public final class ImmutableIborIndex
   @ImmutableDefaults
   private static void applyDefaults(Builder builder) {
     builder.active = true;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ImmutableIborIndex(
+        name,
+        currency,
+        active,
+        fixingCalendar,
+        fixingTime,
+        fixingZone,
+        fixingDateOffset,
+        effectiveDateOffset,
+        maturityDateOffset,
+        dayCount);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/Results.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/Results.java
@@ -65,11 +65,11 @@ public final class Results implements ImmutableBean {
   /**
    * The number of rows.
    */
-  private final int rowCount;  // derived, not a property
+  private final transient int rowCount;  // derived, not a property
   /**
    * The number of columns.
    */
-  private final int columnCount;  // derived, not a property
+  private final transient int columnCount;  // derived, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -102,6 +102,11 @@ public final class Results implements ImmutableBean {
               this.rowCount,
               this.columnCount));
     }
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new Results(columns, cells);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/array/DoubleMatrix.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/array/DoubleMatrix.java
@@ -64,15 +64,15 @@ public final class DoubleMatrix
   /**
    * The number of rows.
    */
-  private final int rows;  // derived, not a property
+  private final transient int rows;  // derived, not a property
   /**
    * The number of columns.
    */
-  private final int columns;  // derived, not a property
+  private final transient int columns;  // derived, not a property
   /**
    * The number of elements.
    */
-  private final int elements;  // derived, not a property
+  private final transient int elements;  // derived, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -340,6 +340,11 @@ public final class DoubleMatrix
       cloned[i] = input[i].clone();
     }
     return cloned;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DoubleMatrix(array);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveGroupDefinition.java
@@ -98,11 +98,11 @@ public final class CurveGroupDefinition
   /**
    * Entries for the curves, keyed by the curve name.
    */
-  private final ImmutableMap<CurveName, CurveGroupEntry> entriesByName;
+  private final transient ImmutableMap<CurveName, CurveGroupEntry> entriesByName;  // not a property
   /**
    * Definitions for the curves, keyed by the curve name.
    */
-  private final ImmutableMap<CurveName, NodalCurveDefinition> curveDefinitionsByName;
+  private final transient ImmutableMap<CurveName, NodalCurveDefinition> curveDefinitionsByName;  // not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -193,6 +193,12 @@ public final class CurveGroupDefinition
     if (builder.computePvSensitivityToMarketQuote) {
       builder.computeJacobian = true;
     }
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new CurveGroupDefinition(
+        name, entries, curveDefinitions, seasonalityDefinitions, computeJacobian, computePvSensitivityToMarketQuote);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/InflationNodalCurve.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/InflationNodalCurve.java
@@ -65,9 +65,14 @@ public final class InflationNodalCurve
    */
   @PropertyDefinition(validate = "notNull")
   private final ShiftType adjustmentType;
-
-  private final double xFixing;  // cached, not a property
-  private final double yFixing;  // cached, not a property
+  /**
+   * The first x-value, from the curve.
+   */
+  private final transient double xFixing;  // cached, not a property
+  /**
+   * The first y-value from the curve.
+   */
+  private final transient double yFixing;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -152,6 +157,12 @@ public final class InflationNodalCurve
     this.adjustmentType = adjustmentType;
   }
 
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new InflationNodalCurve(underlying, seasonality, adjustmentType);
+  }
+
+  //-------------------------------------------------------------------------
   @Override
   public CurveMetadata getMetadata() {
     return underlying.getMetadata();

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultBondFutureOptionScenarioMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultBondFutureOptionScenarioMarketData.java
@@ -43,7 +43,7 @@ final class DefaultBondFutureOptionScenarioMarketData
   /**
    * The cache of single scenario instances.
    */
-  private final AtomicReferenceArray<BondFutureOptionMarketData> cache;  // derived
+  private final transient AtomicReferenceArray<BondFutureOptionMarketData> cache;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -71,6 +71,11 @@ final class DefaultBondFutureOptionScenarioMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.cache = new AtomicReferenceArray<>(marketData.getScenarioCount());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultBondFutureOptionScenarioMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLegalEntityDiscountingMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLegalEntityDiscountingMarketData.java
@@ -43,7 +43,7 @@ final class DefaultLegalEntityDiscountingMarketData
   /**
    * The discounting provider.
    */
-  private final LegalEntityDiscountingProvider discountingProvider;  // derived
+  private final transient LegalEntityDiscountingProvider discountingProvider;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -65,6 +65,11 @@ final class DefaultLegalEntityDiscountingMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.discountingProvider = lookup.discountingProvider(marketData);
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultLegalEntityDiscountingMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLegalEntityDiscountingScenarioMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLegalEntityDiscountingScenarioMarketData.java
@@ -43,7 +43,7 @@ final class DefaultLegalEntityDiscountingScenarioMarketData
   /**
    * The cache of single scenario instances.
    */
-  private final AtomicReferenceArray<LegalEntityDiscountingMarketData> cache;  // derived
+  private final transient AtomicReferenceArray<LegalEntityDiscountingMarketData> cache;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -71,6 +71,11 @@ final class DefaultLegalEntityDiscountingScenarioMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.cache = new AtomicReferenceArray<>(marketData.getScenarioCount());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultLegalEntityDiscountingScenarioMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/capfloor/DefaultIborCapFloorScenarioMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/capfloor/DefaultIborCapFloorScenarioMarketData.java
@@ -43,7 +43,7 @@ final class DefaultIborCapFloorScenarioMarketData
   /**
    * The cache of single scenario instances.
    */
-  private final AtomicReferenceArray<IborCapFloorMarketData> cache;  // derived
+  private final transient AtomicReferenceArray<IborCapFloorMarketData> cache;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -71,6 +71,11 @@ final class DefaultIborCapFloorScenarioMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.cache = new AtomicReferenceArray<>(marketData.getScenarioCount());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultIborCapFloorScenarioMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/fxopt/DefaultFxOptionScenarioMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/fxopt/DefaultFxOptionScenarioMarketData.java
@@ -43,7 +43,7 @@ final class DefaultFxOptionScenarioMarketData
   /**
    * The cache of single scenario instances.
    */
-  private final AtomicReferenceArray<FxOptionMarketData> cache;  // derived
+  private final transient AtomicReferenceArray<FxOptionMarketData> cache;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -71,6 +71,11 @@ final class DefaultFxOptionScenarioMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.cache = new AtomicReferenceArray<>(marketData.getScenarioCount());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultFxOptionScenarioMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
@@ -77,7 +77,7 @@ final class DefaultLookupRatesProvider
   /**
    * The FX rate provider.
    */
-  private final FxRateProvider fxRateProvider;  // derived
+  private final transient FxRateProvider fxRateProvider;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -99,6 +99,11 @@ final class DefaultLookupRatesProvider
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.fxRateProvider = lookup.fxRateProvider(marketData);
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultLookupRatesProvider(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultRatesMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultRatesMarketData.java
@@ -43,7 +43,7 @@ final class DefaultRatesMarketData
   /**
    * The rates provider.
    */
-  private final RatesProvider ratesProvider;  // derived
+  private final transient RatesProvider ratesProvider;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -65,6 +65,11 @@ final class DefaultRatesMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.ratesProvider = lookup.ratesProvider(marketData);
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultRatesMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultRatesScenarioMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultRatesScenarioMarketData.java
@@ -43,7 +43,7 @@ final class DefaultRatesScenarioMarketData
   /**
    * The cache of single scenario instances.
    */
-  private final AtomicReferenceArray<RatesMarketData> cache;  // derived
+  private final transient AtomicReferenceArray<RatesMarketData> cache;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -65,6 +65,11 @@ final class DefaultRatesScenarioMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.cache = new AtomicReferenceArray<>(marketData.getScenarioCount());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultRatesScenarioMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/swaption/DefaultSwaptionScenarioMarketData.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/swaption/DefaultSwaptionScenarioMarketData.java
@@ -43,7 +43,7 @@ final class DefaultSwaptionScenarioMarketData
   /**
    * The cache of single scenario instances.
    */
-  private final AtomicReferenceArray<SwaptionMarketData> cache;  // derived
+  private final transient AtomicReferenceArray<SwaptionMarketData> cache;  // derived
 
   //-------------------------------------------------------------------------
   /**
@@ -71,6 +71,11 @@ final class DefaultSwaptionScenarioMarketData
     this.lookup = ArgChecker.notNull(lookup, "lookup");
     this.marketData = ArgChecker.notNull(marketData, "marketData");
     this.cache = new AtomicReferenceArray<>(marketData.getScenarioCount());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DefaultSwaptionScenarioMarketData(lookup, marketData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/SimpleDiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/SimpleDiscountFactors.java
@@ -77,7 +77,7 @@ public final class SimpleDiscountFactors
   /**
    * The day count convention of the curve.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -117,6 +117,11 @@ public final class SimpleDiscountFactors
     this.valuationDate = valuationDate;
     this.curve = curve;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new SimpleDiscountFactors(currency, valuationDate, curve);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRateDiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRateDiscountFactors.java
@@ -73,7 +73,7 @@ public final class ZeroRateDiscountFactors
   /**
    * The day count convention of the curve.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -113,6 +113,11 @@ public final class ZeroRateDiscountFactors
     this.valuationDate = valuationDate;
     this.curve = curve;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ZeroRateDiscountFactors(currency, valuationDate, curve);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRatePeriodicDiscountFactors.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/ZeroRatePeriodicDiscountFactors.java
@@ -77,11 +77,11 @@ public final class ZeroRatePeriodicDiscountFactors
   /**
    * The number of compounding periods per year of the zero-coupon rate.
    */
-  private final int frequency;  // cached, not a property
+  private final transient int frequency;  // cached, not a property
   /**
    * The day count convention of the curve.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -125,6 +125,11 @@ public final class ZeroRatePeriodicDiscountFactors
     this.curve = curve;
     this.dayCount = dayCount;
     this.frequency = frequencyOpt.get();
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ZeroRatePeriodicDiscountFactors(currency, valuationDate, curve);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/BlackBondFutureExpiryLogMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/BlackBondFutureExpiryLogMoneynessVolatilities.java
@@ -70,7 +70,7 @@ public final class BlackBondFutureExpiryLogMoneynessVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -117,6 +117,11 @@ public final class BlackBondFutureExpiryLogMoneynessVolatilities
     this.valuationDateTime = valuationDateTime;
     this.surface = surface;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new BlackBondFutureExpiryLogMoneynessVolatilities(valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/BlackIborCapletFloorletExpiryStrikeVolatilities.java
@@ -80,7 +80,7 @@ public final class BlackIborCapletFloorletExpiryStrikeVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -132,6 +132,11 @@ public final class BlackIborCapletFloorletExpiryStrikeVolatilities
     this.valuationDateTime = valuationDateTime;
     this.surface = surface;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new BlackIborCapletFloorletExpiryStrikeVolatilities(index, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/NormalIborCapletFloorletExpiryStrikeVolatilities.java
@@ -80,7 +80,7 @@ public final class NormalIborCapletFloorletExpiryStrikeVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -132,6 +132,11 @@ public final class NormalIborCapletFloorletExpiryStrikeVolatilities
     this.valuationDateTime = valuationDateTime;
     this.surface = surface;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new NormalIborCapletFloorletExpiryStrikeVolatilities(index, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/ShiftedBlackIborCapletFloorletExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/capfloor/ShiftedBlackIborCapletFloorletExpiryStrikeVolatilities.java
@@ -94,7 +94,7 @@ public final class ShiftedBlackIborCapletFloorletExpiryStrikeVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -158,6 +158,11 @@ public final class ShiftedBlackIborCapletFloorletExpiryStrikeVolatilities
     if (!curve.getMetadata().findInfo(CurveInfoType.DAY_COUNT).orElse(dayCount).equals(dayCount)) {
       throw new IllegalArgumentException("shift curve must have the same day count as surface");
     }
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ShiftedBlackIborCapletFloorletExpiryStrikeVolatilities(index, valuationDateTime, surface, shiftCurve);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/DiscountFxForwardRates.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/DiscountFxForwardRates.java
@@ -77,11 +77,11 @@ public final class DiscountFxForwardRates
   /**
    * The valuation date.
    */
-  private final LocalDate valuationDate;  // not a property, derived and cached from input data
+  private final transient LocalDate valuationDate;  // not a property, derived and cached from input data
   /**
    * The parameter combiner.
    */
-  private final ParameterizedDataCombiner paramCombiner;  // not a property
+  private final transient ParameterizedDataCombiner paramCombiner;  // not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -136,6 +136,11 @@ public final class DiscountFxForwardRates
     this.counterCurrencyDiscountFactors = counterCurrencyDiscountFactors;
     this.valuationDate = baseCurrencyDiscountFactors.getValuationDate();
     this.paramCombiner = ParameterizedDataCombiner.of(baseCurrencyDiscountFactors, counterCurrencyDiscountFactors);
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new DiscountFxForwardRates(currencyPair, fxRateProvider, baseCurrencyDiscountFactors, counterCurrencyDiscountFactors);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionFlatVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionFlatVolatilities.java
@@ -77,7 +77,7 @@ public final class BlackFxOptionFlatVolatilities
   /**
    * The day count convention of the curve.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -126,6 +126,11 @@ public final class BlackFxOptionFlatVolatilities
     this.valuationDateTime = valuationDateTime;
     this.curve = curve;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new BlackFxOptionFlatVolatilities(currencyPair, valuationDateTime, curve);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionSurfaceVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fxopt/BlackFxOptionSurfaceVolatilities.java
@@ -77,7 +77,7 @@ public final class BlackFxOptionSurfaceVolatilities
   /**
    * The day count convention of the curve.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -129,6 +129,11 @@ public final class BlackFxOptionSurfaceVolatilities
     this.valuationDateTime = valuationDateTime;
     this.surface = surface;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new BlackFxOptionSurfaceVolatilities(currencyPair, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/index/NormalIborFutureOptionExpirySimpleMoneynessVolatilities.java
@@ -78,11 +78,11 @@ public final class NormalIborFutureOptionExpirySimpleMoneynessVolatilities
   /**
    * Whether the moneyness is on the price (true) or on the rate (false).
    */
-  private final boolean moneynessOnPrice;  // cached, not a property
+  private final transient boolean moneynessOnPrice;  // cached, not a property
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -137,6 +137,11 @@ public final class NormalIborFutureOptionExpirySimpleMoneynessVolatilities
     this.surface = surface;
     this.moneynessOnPrice = moneynessType == MoneynessType.PRICE;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new NormalIborFutureOptionExpirySimpleMoneynessVolatilities(index, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/model/SabrInterestRateParameters.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/model/SabrInterestRateParameters.java
@@ -93,11 +93,11 @@ public final class SabrInterestRateParameters
   /**
    * The day count convention of the surfaces.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
   /**
    * The parameter combiner.
    */
-  private final ParameterizedDataCombiner paramCombiner;  // cached, not a property
+  private final transient ParameterizedDataCombiner paramCombiner;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -223,6 +223,11 @@ public final class SabrInterestRateParameters
     if (!surface.getMetadata().findInfo(SurfaceInfoType.DAY_COUNT).orElse(dayCount).equals(dayCount)) {
       throw new IllegalArgumentException("SABR surfaces must have the same day count");
     }
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new SabrInterestRateParameters(alphaSurface, betaSurface, rhoSurface, nuSurface, shiftSurface, sabrVolatilityFormula);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/model/SabrParameters.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/model/SabrParameters.java
@@ -93,11 +93,11 @@ public final class SabrParameters
   /**
    * The day count convention of the curves.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
   /**
    * The parameter combiner.
    */
-  private final ParameterizedDataCombiner paramCombiner;  // cached, not a property
+  private final transient ParameterizedDataCombiner paramCombiner;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -216,6 +216,11 @@ public final class SabrParameters
     if (!curve.getMetadata().findInfo(CurveInfoType.DAY_COUNT).orElse(dayCount).equals(dayCount)) {
       throw new IllegalArgumentException("SABR curves must have the same day count");
     }
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new SabrParameters(alphaCurve, betaCurve, rhoCurve, nuCurve, shiftCurve, sabrVolatilityFormula);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/SimpleIborIndexRates.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/SimpleIborIndexRates.java
@@ -83,7 +83,7 @@ public final class SimpleIborIndexRates
   /**
    * The day count convention of the curve.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   /**
    * Obtains an instance from a curve, with an empty time-series of fixings.
@@ -151,6 +151,11 @@ public final class SimpleIborIndexRates
     this.curve = curve;
     this.fixings = fixings;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new SimpleIborIndexRates(index, valuationDate, curve, fixings);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionExpiryTenorVolatilities.java
@@ -78,7 +78,7 @@ public final class BlackSwaptionExpiryTenorVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -130,6 +130,11 @@ public final class BlackSwaptionExpiryTenorVolatilities
     this.surface = surface;
     this.convention = convention;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new BlackSwaptionExpiryTenorVolatilities(convention, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpirySimpleMoneynessVolatilities.java
@@ -79,7 +79,7 @@ public final class NormalSwaptionExpirySimpleMoneynessVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -131,6 +131,11 @@ public final class NormalSwaptionExpirySimpleMoneynessVolatilities
     this.surface = surface;
     this.convention = convention;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new NormalSwaptionExpirySimpleMoneynessVolatilities(convention, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryStrikeVolatilities.java
@@ -78,7 +78,7 @@ public final class NormalSwaptionExpiryStrikeVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -130,6 +130,11 @@ public final class NormalSwaptionExpiryStrikeVolatilities
     this.surface = surface;
     this.convention = convention;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new NormalSwaptionExpiryStrikeVolatilities(convention, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilities.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionExpiryTenorVolatilities.java
@@ -78,7 +78,7 @@ public final class NormalSwaptionExpiryTenorVolatilities
   /**
    * The day count convention of the surface.
    */
-  private final DayCount dayCount;  // cached, not a property
+  private final transient DayCount dayCount;  // cached, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -130,6 +130,11 @@ public final class NormalSwaptionExpiryTenorVolatilities
     this.surface = surface;
     this.convention = convention;
     this.dayCount = dayCount;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new NormalSwaptionExpiryTenorVolatilities(convention, valuationDateTime, surface);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/SecurityPriceInfo.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/SecurityPriceInfo.java
@@ -70,7 +70,7 @@ public final class SecurityPriceInfo
   /**
    * Multiplier to apply to the price.
    */
-  private final double tradeUnitValue;  // derived, not a property
+  private final transient double tradeUnitValue;  // derived, not a property
 
   //-------------------------------------------------------------------------
   /**
@@ -137,6 +137,11 @@ public final class SecurityPriceInfo
     this.tickValue = tickValue;
     this.contractSize = contractSize;
     this.tradeUnitValue = (tickValue.getAmount() * contractSize) / tickSize;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new SecurityPriceInfo(tickSize, tickValue, contractSize);
   }
 
   //-----------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/capfloor/ResolvedIborCapFloor.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/capfloor/ResolvedIborCapFloor.java
@@ -66,11 +66,11 @@ public final class ResolvedIborCapFloor
   /**
    * The set of currencies.
    */
-  private final ImmutableSet<Currency> currencies;  // not a property, derived and cached from input data
+  private final transient ImmutableSet<Currency> currencies;  // not a property, derived and cached from input data
   /**
    * The set of indices.
    */
-  private final ImmutableSet<Index> indices;  // not a property, derived and cached from input data
+  private final transient ImmutableSet<Index> indices;  // not a property, derived and cached from input data
 
   //-------------------------------------------------------------------------
   /**
@@ -132,6 +132,11 @@ public final class ResolvedIborCapFloor
       payLeg.collectIndices(builder);
     }
     return builder.build();
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ResolvedIborCapFloor(capFloorLeg, payLeg);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/deposit/ResolvedTermDeposit.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/deposit/ResolvedTermDeposit.java
@@ -15,7 +15,6 @@ import org.joda.beans.Bean;
 import org.joda.beans.BeanDefinition;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.ImmutableConstructor;
-import org.joda.beans.ImmutableValidator;
 import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.MetaProperty;
 import org.joda.beans.Property;
@@ -104,29 +103,34 @@ public final class ResolvedTermDeposit
    * When the rate is positive, a 'buy' term deposit has a positive signed interest amount 
    * and a 'sell' term deposit has a negative signed interest amount.
    */
-  private final double interest;  // not a property
+  private final transient double interest;  // not a property
 
   //-------------------------------------------------------------------------
   @ImmutableConstructor
-  private ResolvedTermDeposit(ResolvedTermDeposit.Builder builder) {
-    JodaBeanUtils.notNull(builder.startDate, "startDate");
-    JodaBeanUtils.notNull(builder.endDate, "endDate");
-    ArgChecker.inOrderNotEqual(builder.startDate, builder.endDate, "startDate", "endDate");
-    ArgChecker.notNegative(builder.yearFraction, "yearFraction");
-    JodaBeanUtils.notNull(builder.rate, "rate");
-    this.startDate = builder.startDate;
-    this.endDate = builder.endDate;
-    this.yearFraction = builder.yearFraction;
-    this.currency = builder.currency;
-    this.notional = builder.notional;
-    this.rate = builder.rate;
-    interest = (rate * notional * yearFraction);
-    validate();
+  private ResolvedTermDeposit(
+      Currency currency,
+      double notional,
+      LocalDate startDate,
+      LocalDate endDate,
+      double yearFraction,
+      double rate) {
+    JodaBeanUtils.notNull(currency, "currency");
+    JodaBeanUtils.notNull(startDate, "startDate");
+    JodaBeanUtils.notNull(endDate, "endDate");
+    ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
+    ArgChecker.notNegative(yearFraction, "yearFraction");
+    this.currency = currency;
+    this.notional = notional;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.yearFraction = yearFraction;
+    this.rate = rate;
+    this.interest = (rate * notional * yearFraction);
   }
 
-  @ImmutableValidator
-  private void validate() {
-    ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ResolvedTermDeposit(currency, notional, startDate, endDate, yearFraction, rate);
   }
 
   //-------------------------------------------------------------------------
@@ -588,7 +592,13 @@ public final class ResolvedTermDeposit
 
     @Override
     public ResolvedTermDeposit build() {
-      return new ResolvedTermDeposit(this);
+      return new ResolvedTermDeposit(
+          currency,
+          notional,
+          startDate,
+          endDate,
+          yearFraction,
+          rate);
     }
 
     //-----------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/fra/ResolvedFra.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fra/ResolvedFra.java
@@ -130,7 +130,7 @@ public final class ResolvedFra
   /**
    * The set of indices.
    */
-  private final ImmutableSet<IborIndex> indices;  // not a property, derived and cached from input data
+  private final transient ImmutableSet<IborIndex> indices;  // not a property, derived and cached from input data
 
   //-------------------------------------------------------------------------
   @ImmutableConstructor
@@ -165,6 +165,12 @@ public final class ResolvedFra
     return builder.build().stream()
         .map(index -> IborIndex.class.cast(index))
         .collect(toImmutableSet());
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ResolvedFra(
+        currency, notional, paymentDate, startDate, endDate, yearFraction, fixedRate, floatingRate, discounting);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/rate/IborAveragedRateComputation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/rate/IborAveragedRateComputation.java
@@ -54,7 +54,7 @@ public final class IborAveragedRateComputation
   /**
    * The total weight of all the fixings in this computation.
    */
-  private final double totalWeight;  // not a property, derived and cached from input data
+  private final transient double totalWeight;  // not a property, derived and cached from input data
 
   //-------------------------------------------------------------------------
   /**
@@ -80,6 +80,11 @@ public final class IborAveragedRateComputation
     this.totalWeight = fixings.stream()
         .mapToDouble(f -> f.getWeight())
         .sum();
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new IborAveragedRateComputation(fixings);
   }
 
   //-----------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/RatePeriodSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/RatePeriodSwapLeg.java
@@ -160,7 +160,7 @@ public final class RatePeriodSwapLeg
   /**
    * The currency of the leg.
    */
-  private final Currency currency;  // not a property, derived and cached from input data
+  private final transient Currency currency;  // not a property, derived and cached from input data
 
   //-------------------------------------------------------------------------
   @ImmutableConstructor
@@ -194,6 +194,19 @@ public final class RatePeriodSwapLeg
       throw new IllegalArgumentException("Swap leg must have a single currency, found: " + currencies);
     }
     this.currency = Iterables.getOnlyElement(currencies);
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new RatePeriodSwapLeg(
+        type,
+        payReceive,
+        paymentPeriods,
+        initialExchange,
+        intermediateExchange,
+        finalExchange,
+        paymentEvents,
+        paymentBusinessDayAdjustment);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/ResolvedSwap.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/ResolvedSwap.java
@@ -79,11 +79,11 @@ public final class ResolvedSwap
   /**
    * The set of currencies.
    */
-  private final ImmutableSet<Currency> currencies;  // not a property, derived and cached from input data
+  private final transient ImmutableSet<Currency> currencies;  // not a property, derived and cached from input data
   /**
    * The set of indices.
    */
-  private final ImmutableSet<Index> indices;  // not a property, derived and cached from input data
+  private final transient ImmutableSet<Index> indices;  // not a property, derived and cached from input data
 
   //-------------------------------------------------------------------------
   /**
@@ -133,6 +133,11 @@ public final class ResolvedSwap
       leg.collectIndices(builder);
     }
     return builder.build();
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ResolvedSwap(legs);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/ResolvedSwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/ResolvedSwapLeg.java
@@ -101,7 +101,7 @@ public final class ResolvedSwapLeg
   /**
    * The currency of the leg.
    */
-  private final Currency currency;  // not a property, derived and cached from input data
+  private final transient Currency currency;  // not a property, derived and cached from input data
 
   //-------------------------------------------------------------------------
   @ImmutableConstructor
@@ -138,6 +138,11 @@ public final class ResolvedSwapLeg
     this.paymentPeriods = ImmutableList.copyOf(paymentPeriods);
     this.paymentEvents = ImmutableList.copyOf(paymentEvents);
     this.currency = currency;
+  }
+
+  // ensure standard constructor is invoked
+  private Object readResolve() {
+    return new ResolvedSwapLeg(type, payReceive, paymentPeriods, paymentEvents);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Fields that are derived should be marked as `transient`, with `readResolve()` added to ensure the derived state is recreated.

Removing elements from the serialized form is compatible in that a later version can read data from an earlier version, but not vice versa.