### PR TITLE
Add CalculationListener.calculationsStarted

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationListener.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationListener.java
@@ -5,21 +5,42 @@
  */
 package com.opengamma.strata.calc.runner;
 
+import java.util.List;
+
 import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.calc.CalculationRunner;
+import com.opengamma.strata.calc.Column;
 
 /**
  * Listener that is notified when calculations are performed by a {@link CalculationRunner}.
  * <p>
  * It is guaranteed that the methods of a listener will only be invoked by a single thread at any
- * time. Therefore listener implementations are not necessarily required to be thread safe.
+ * time. It is not guaranteed to be the same thread invoking a listener each time. The calling
+ * code is synchronized to ensure that any changes in the listener state will be
+ * visible to every thread used to invoke the listener. Therefore listener implementations
+ * are not required to be thread safe.
  * <p>
- * It is not guaranteed to be the same thread invoking a listener each time.
+ * A listener instance should not be used for multiple sets of calculations.
  */
 public interface CalculationListener {
 
   /**
-   * Invoked when a calculation completes.
+   * Invoked when the calculations start; guaranteed to be invoked
+   * before {@link #resultReceived(CalculationTarget, CalculationResult)} and
+   * {@link #calculationsComplete()}.
+   *
+   * @param columns the columns for which values are being calculated
+   */
+  public default void calculationsStarted(List<Column> columns) {
+    // Default implementation does nothing, required for backwards compatibility
+  }
+
+  /**
+   * Invoked when a calculation completes; it is guaranteed that {@link {@link #calculationsStarted(List)}} will
+   * be called before this method and that this method will never be called after {@link #calculationsComplete()}.
+   * <p>
+   * It is possible that this method will never be called. This can happen if an empty list of targets
+   * is passed to the calculation runner.
    *
    * @param target  the calculation target, such as a trade
    * @param result  the result of the calculation
@@ -30,6 +51,10 @@ public interface CalculationListener {
    * Invoked when all calculations have completed.
    * <p>
    * This is guaranteed to be called after all results have been passed to {@link #resultReceived}.
+   * <p>
+   * This method will be called immediately after {@link #calculationsStarted(List)} and without any calls
+   * to {@link #resultReceived(CalculationTarget, CalculationResult)} if there are no calculations to be performed.
+   * This can happen if an empty list of targets is passed to the calculation runner.
    */
   public abstract void calculationsComplete();
 

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationListener.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationListener.java
@@ -29,14 +29,15 @@ public interface CalculationListener {
    * before {@link #resultReceived(CalculationTarget, CalculationResult)} and
    * {@link #calculationsComplete()}.
    *
+   * @param targets the targets for which values are being calculated; these are often trades
    * @param columns the columns for which values are being calculated
    */
-  public default void calculationsStarted(List<Column> columns) {
+  public default void calculationsStarted(List<CalculationTarget> targets, List<Column> columns) {
     // Default implementation does nothing, required for backwards compatibility
   }
 
   /**
-   * Invoked when a calculation completes; it is guaranteed that {@link {@link #calculationsStarted(List)}} will
+   * Invoked when a calculation completes; it is guaranteed that {@link {@link #calculationsStarted(List, List) }} will
    * be called before this method and that this method will never be called after {@link #calculationsComplete()}.
    * <p>
    * It is possible that this method will never be called. This can happen if an empty list of targets
@@ -52,7 +53,7 @@ public interface CalculationListener {
    * <p>
    * This is guaranteed to be called after all results have been passed to {@link #resultReceived}.
    * <p>
-   * This method will be called immediately after {@link #calculationsStarted(List)} and without any calls
+   * This method will be called immediately after {@link #calculationsStarted(List, List)} and without any calls
    * to {@link #resultReceived(CalculationTarget, CalculationResult)} if there are no calculations to be performed.
    * This can happen if an empty list of targets is passed to the calculation runner.
    */

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultCalculationTaskRunner.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultCalculationTaskRunner.java
@@ -49,7 +49,7 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
    *    // use the runner
    *  }
    * </pre>
-   * 
+   *
    * @return the calculation task runner
    */
   static DefaultCalculationTaskRunner ofMultiThreaded() {
@@ -60,7 +60,7 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
    * Creates a calculation task runner capable of performing calculations, specifying the executor.
    * <p>
    * It is the callers responsibility to manage the life-cycle of the executor.
-   * 
+   *
    * @param executor  the executor to use
    * @return the calculation task runner
    */
@@ -83,7 +83,7 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
   //-------------------------------------------------------------------------
   /**
    * Creates an instance specifying the executor to use.
-   * 
+   *
    * @param executor  the executor that is used to perform the calculations
    */
   private DefaultCalculationTaskRunner(ExecutorService executor) {
@@ -175,7 +175,9 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
     // the listener is invoked via this wrapper
     // the wrapper ensures thread-safety for the listener
     // it also calls the listener with single CalculationResult cells, not CalculationResults
-    Consumer<CalculationResults> consumer = new ListenerWrapper(listener, taskList.size(), tasks.getColumns());
+    Consumer<CalculationResults> consumer =
+        new ListenerWrapper(listener, taskList.size(), tasks.getTargets(), tasks.getColumns());
+
     // run each task using the executor
     taskList.forEach(task -> runTask(task, marketData, refData, consumer));
   }

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultCalculationTaskRunner.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultCalculationTaskRunner.java
@@ -159,7 +159,7 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
       ScenarioMarketData marketData,
       ReferenceData refData) {
 
-    ResultsListener listener = new ResultsListener(tasks.getColumns());
+    ResultsListener listener = new ResultsListener();
     calculateMultiScenarioAsync(tasks, marketData, refData, listener);
     return listener.result();
   }
@@ -175,9 +175,9 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
     // the listener is invoked via this wrapper
     // the wrapper ensures thread-safety for the listener
     // it also calls the listener with single CalculationResult cells, not CalculationResults
-    Consumer<CalculationResults> consumer = new ListenerWrapper(listener, taskList.size());
+    Consumer<CalculationResults> consumer = new ListenerWrapper(listener, taskList.size(), tasks.getColumns());
     // run each task using the executor
-    taskList.stream().forEach(task -> runTask(task, marketData, refData, consumer));
+    taskList.forEach(task -> runTask(task, marketData, refData, consumer));
   }
 
   // submits a task to the executor to be run

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ListenerWrapper.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ListenerWrapper.java
@@ -15,6 +15,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.calc.Column;
 import com.opengamma.strata.collect.ArgChecker;
 
@@ -64,18 +65,17 @@ final class ListenerWrapper implements Consumer<CalculationResults> {
   //-------------------------------------------------------------------------
   /**
    * Creates an instance wrapping the specified listener.
-   * 
-   * @param listener  the underlying listener wrapped by this object
+   *  @param listener  the underlying listener wrapped by this object
    * @param tasksExpected  the number of tasks to be executed
    * @param columns  the columns for which values are being calculated
    */
-  ListenerWrapper(CalculationListener listener, int tasksExpected, List<Column> columns) {
+  ListenerWrapper(CalculationListener listener, int tasksExpected, List<CalculationTarget> targets, List<Column> columns) {
     this.listener = ArgChecker.notNull(listener, "listener");
     this.tasksExpected = ArgChecker.notNegative(tasksExpected, "tasksExpected");
 
     listenerLock.lock();
     try {
-      listener.calculationsStarted(columns);
+      listener.calculationsStarted(targets, columns);
 
       if (tasksExpected == 0) {
         listener.calculationsComplete();

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ListenerWrapper.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ListenerWrapper.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.calc.runner;
 
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -14,6 +15,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.opengamma.strata.calc.Column;
 import com.opengamma.strata.collect.ArgChecker;
 
 /**
@@ -65,13 +67,21 @@ final class ListenerWrapper implements Consumer<CalculationResults> {
    * 
    * @param listener  the underlying listener wrapped by this object
    * @param tasksExpected  the number of tasks to be executed
+   * @param columns  the columns for which values are being calculated
    */
-  ListenerWrapper(CalculationListener listener, int tasksExpected) {
+  ListenerWrapper(CalculationListener listener, int tasksExpected, List<Column> columns) {
     this.listener = ArgChecker.notNull(listener, "listener");
     this.tasksExpected = ArgChecker.notNegative(tasksExpected, "tasksExpected");
 
-    if (tasksExpected == 0) {
-      listener.calculationsComplete();
+    listenerLock.lock();
+    try {
+      listener.calculationsStarted(columns);
+
+      if (tasksExpected == 0) {
+        listener.calculationsComplete();
+      }
+    } finally {
+      listenerLock.unlock();
     }
   }
 

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ResultsListener.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ResultsListener.java
@@ -32,16 +32,16 @@ public final class ResultsListener extends AggregatingCalculationListener<Result
   private final List<CalculationResult> results = new ArrayList<>();
 
   /** The columns that define what values are calculated. */
-  private final List<Column> columns;
+  private List<Column> columns;
 
   /**
-   * Creates a listener that builds a set of results for the specified columns.
-   * <p>
-   * The columns must be the same columns passed to the calculation runner.
-   *
-   * @param columns the columns defining the calculated values
+   * Creates a new instance.
    */
-  public ResultsListener(List<Column> columns) {
+  public ResultsListener() {
+  }
+
+  @Override
+  public void calculationsStarted(List<Column> columns) {
     this.columns = ImmutableList.copyOf(columns);
   }
 

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ResultsListener.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/ResultsListener.java
@@ -41,7 +41,7 @@ public final class ResultsListener extends AggregatingCalculationListener<Result
   }
 
   @Override
-  public void calculationsStarted(List<Column> columns) {
+  public void calculationsStarted(List<CalculationTarget> targets, List<Column> columns) {
     this.columns = ImmutableList.copyOf(columns);
   }
 

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/ListenerWrapperTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/ListenerWrapperTest.java
@@ -35,7 +35,7 @@ public class ListenerWrapperTest {
     CountDownLatch latch = new CountDownLatch(1);
     int expectedResultCount = nThreads * resultsPerThread;
     Listener listener = new Listener(errors, latch);
-    Consumer<CalculationResults> wrapper = new ListenerWrapper(listener, expectedResultCount);
+    Consumer<CalculationResults> wrapper = new ListenerWrapper(listener, expectedResultCount, ImmutableList.of());
     ExecutorService executor = Executors.newFixedThreadPool(nThreads);
     CalculationResult result = CalculationResult.of(0, 0, Result.failure(FailureReason.ERROR, "foo"));
     CalculationTarget target = new CalculationTarget() {};

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/ListenerWrapperTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/ListenerWrapperTest.java
@@ -35,7 +35,8 @@ public class ListenerWrapperTest {
     CountDownLatch latch = new CountDownLatch(1);
     int expectedResultCount = nThreads * resultsPerThread;
     Listener listener = new Listener(errors, latch);
-    Consumer<CalculationResults> wrapper = new ListenerWrapper(listener, expectedResultCount, ImmutableList.of());
+    Consumer<CalculationResults> wrapper =
+        new ListenerWrapper(listener, expectedResultCount, ImmutableList.of(), ImmutableList.of());
     ExecutorService executor = Executors.newFixedThreadPool(nThreads);
     CalculationResult result = CalculationResult.of(0, 0, Result.failure(FailureReason.ERROR, "foo"));
     CalculationTarget target = new CalculationTarget() {};


### PR DESCRIPTION
Adds a method to `CalculationListener` that is invoked before any results are calculated. This allows the listener to know about the columns without the user having to pass the columns to both the listener and the calculation runner.