### PR TITLE
Propagate CalculationListener.calculationsStarted()

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultCalculationTaskRunner.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultCalculationTaskRunner.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 
 import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.calc.Column;
 import com.opengamma.strata.calc.Results;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Messages;
@@ -215,6 +216,11 @@ final class DefaultCalculationTaskRunner implements CalculationTaskRunner {
 
     private UnwrappingListener(CalculationListener delegate) {
       this.delegate = delegate;
+    }
+
+    @Override
+    public void calculationsStarted(List<CalculationTarget> targets, List<Column> columns) {
+      delegate.calculationsStarted(targets, columns);
     }
 
     @Override


### PR DESCRIPTION
Propagate `CalculationListener.calculationsStarted()` to the delegate listener in `UnwrappingListener` and add a test.

This is a fix for a bug introduced with `CalculationListener.calculationsStarted()`. The calculations would never complete if the calculations were requested via `CalculationRunner.calculateAsync()`. That code path wasn't covered by the existing tests and was the only one affected by the issue.