### PR TITLE
Enhance schedule generation

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
@@ -244,16 +244,26 @@ public enum StubConvention {
     ArgChecker.notNull(end, "end");
     ArgChecker.notNull(frequency, "frequency");
     if (isCalculateBackwards()) {
-      return toRollConvention(end, frequency, preferEndOfMonth);
+      return impliedRollConvention(end, start, frequency, preferEndOfMonth);
     } else {
-      return toRollConvention(start, frequency, preferEndOfMonth);
+      return impliedRollConvention(start, end, frequency, preferEndOfMonth);
     }
   }
 
   // helper for converting to roll convention
-  private static RollConvention toRollConvention(LocalDate date, Frequency frequency, boolean preferEndOfMonth) {
+  private static RollConvention impliedRollConvention(
+      LocalDate date,
+      LocalDate otherDate,
+      Frequency frequency,
+      boolean preferEndOfMonth) {
+
     if (frequency.isMonthBased()) {
       if (preferEndOfMonth && date.getDayOfMonth() == date.lengthOfMonth()) {
+        return RollConventions.EOM;
+      }
+      if (date.getDayOfMonth() != otherDate.getDayOfMonth() &&
+          date.getDayOfMonth() == date.lengthOfMonth() &&
+          otherDate.getDayOfMonth() == otherDate.lengthOfMonth()) {
         return RollConventions.EOM;
       }
       return RollConvention.ofDayOfMonth(date.getDayOfMonth());

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -372,6 +372,11 @@ public class PeriodicScheduleTest {
         {date(2011, 7, 31), date(2011, 10, 10), P1M, null, null, null, date(2011, 9, 30), null,
             ImmutableList.of(date(2011, 7, 31), date(2011, 8, 31), date(2011, 9, 30), date(2011, 10, 10)),
             ImmutableList.of(date(2011, 7, 29), date(2011, 8, 31), date(2011, 9, 30), date(2011, 10, 10)), EOM},
+        // EOM flag false, explicit stub, implies EOM true
+        {date(2011, 2, 2), date(2011, 5, 30), P1M, null, null, date(2011, 2, 28), null, null,
+            ImmutableList.of(date(2011, 2, 2), date(2011, 2, 28), date(2011, 3, 30), date(2011, 4, 30), date(2011, 5, 30)),
+            ImmutableList.of(date(2011, 2, 2), date(2011, 2, 28), date(2011, 3, 30), date(2011, 4, 29), date(2011, 5, 30)),
+            DAY_30},
 
         // pre-adjusted start date, no change needed
         {JUL_17, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -360,6 +360,18 @@ public class PeriodicScheduleTest {
         {NOV_29_2013, NOV_30, P3M, null, EOM, null, null, BDA_NONE,
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_31, AUG_31, NOV_30),
             ImmutableList.of(NOV_29_2013, FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), EOM},
+        // EOM flag false, short initial, implies EOM true
+        {date(2011, 6, 2), date(2011, 8, 31), P1M, SHORT_INITIAL, null, null, null, null,
+            ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 31), date(2011, 8, 31)),
+            ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 29), date(2011, 8, 31)), EOM},
+        // EOM flag false, explicit stub, implies EOM true
+        {date(2011, 6, 2), date(2011, 8, 31), P1M, null, null, date(2011, 6, 30), null, null,
+            ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 31), date(2011, 8, 31)),
+            ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 29), date(2011, 8, 31)), EOM},
+        // EOM flag false, explicit stub, implies EOM true
+        {date(2011, 7, 31), date(2011, 10, 10), P1M, null, null, null, date(2011, 9, 30), null,
+            ImmutableList.of(date(2011, 7, 31), date(2011, 8, 31), date(2011, 9, 30), date(2011, 10, 10)),
+            ImmutableList.of(date(2011, 7, 29), date(2011, 8, 31), date(2011, 9, 30), date(2011, 10, 10)), EOM},
 
         // pre-adjusted start date, no change needed
         {JUL_17, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
@@ -25,6 +25,7 @@ import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverEnum;
 import static com.opengamma.strata.collect.TestHelper.date;
+import static java.time.Month.APRIL;
 import static java.time.Month.AUGUST;
 import static java.time.Month.JANUARY;
 import static java.time.Month.JULY;
@@ -72,6 +73,8 @@ public class StubConventionTest {
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P2W, true, DAY_TUE},
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), TERM, false, RollConventions.NONE},
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), TERM, true, RollConventions.NONE},
+        {NONE, date(2014, JANUARY, 31), date(2014, APRIL, 30), P1M, true, RollConventions.EOM},
+        {NONE, date(2014, APRIL, 30), date(2014, AUGUST, 31), P1M, true, RollConventions.EOM},
 
         {SHORT_INITIAL, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, false, DAY_16},
         {SHORT_INITIAL, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, true, DAY_16},


### PR DESCRIPTION
Handle the case where a first regular start date is present and where the day of month differs from that of the end date due to end of month effects. Same also handled for an explicit last regular end date.