### PR TITLE
Generic security enhancements

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/StandardComponents.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/StandardComponents.java
@@ -31,11 +31,13 @@ import com.opengamma.strata.measure.fxopt.FxSingleBarrierOptionTradeCalculationF
 import com.opengamma.strata.measure.fxopt.FxVanillaOptionTradeCalculationFunction;
 import com.opengamma.strata.measure.index.IborFutureTradeCalculationFunction;
 import com.opengamma.strata.measure.payment.BulletPaymentTradeCalculationFunction;
+import com.opengamma.strata.measure.security.GenericSecurityPositionCalculationFunction;
 import com.opengamma.strata.measure.security.GenericSecurityTradeCalculationFunction;
 import com.opengamma.strata.measure.security.SecurityPositionCalculationFunction;
 import com.opengamma.strata.measure.security.SecurityTradeCalculationFunction;
 import com.opengamma.strata.measure.swap.SwapTradeCalculationFunction;
 import com.opengamma.strata.measure.swaption.SwaptionTradeCalculationFunction;
+import com.opengamma.strata.product.GenericSecurityPosition;
 import com.opengamma.strata.product.GenericSecurityTrade;
 import com.opengamma.strata.product.SecurityPosition;
 import com.opengamma.strata.product.SecurityTrade;
@@ -83,6 +85,7 @@ public final class StandardComponents {
       new FxSingleTradeCalculationFunction(),
       new FxSwapTradeCalculationFunction(),
       new FxVanillaOptionTradeCalculationFunction(),
+      new GenericSecurityPositionCalculationFunction(),
       new GenericSecurityTradeCalculationFunction(),
       new IborCapFloorTradeCalculationFunction(),
       new IborFutureTradeCalculationFunction(),
@@ -169,7 +172,7 @@ public final class StandardComponents {
    *  <li>FX swap - {@link FxSwapTrade}
    *  <li>FX vanilla option - {@link FxVanillaOptionTrade}
    *  <li>FX single barrier option - {@link FxSingleBarrierOptionTrade}
-   *  <li>Generic Security - {@link GenericSecurityTrade}
+   *  <li>Generic Security - {@link GenericSecurityTrade} and {@link GenericSecurityPosition}
    *  <li>Rate Swap - {@link SwapTrade}
    *  <li>Swaption - {@link SwaptionTrade}
    *  <li>Security - {@link SecurityTrade} and {@link SecurityPosition}

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/security/GenericSecurityPositionCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/security/GenericSecurityPositionCalculationFunction.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.measure.security;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.calc.Measure;
+import com.opengamma.strata.calc.runner.CalculationFunction;
+import com.opengamma.strata.calc.runner.CalculationParameters;
+import com.opengamma.strata.calc.runner.FunctionRequirements;
+import com.opengamma.strata.collect.result.FailureReason;
+import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.data.scenario.ScenarioArray;
+import com.opengamma.strata.data.scenario.ScenarioMarketData;
+import com.opengamma.strata.market.observable.QuoteId;
+import com.opengamma.strata.measure.Measures;
+import com.opengamma.strata.product.GenericSecurityPosition;
+import com.opengamma.strata.product.Security;
+
+/**
+ * Perform calculations on a single {@code GenericSecurityPosition} for each of a set of scenarios.
+ * <p>
+ * The supported built-in measures are:
+ * <ul>
+ *   <li>{@linkplain Measures#PRESENT_VALUE Present value}
+ * </ul>
+ */
+public class GenericSecurityPositionCalculationFunction
+    implements CalculationFunction<GenericSecurityPosition> {
+
+  /**
+   * The calculations by measure.
+   */
+  private static final ImmutableMap<Measure, SingleMeasureCalculation> CALCULATORS =
+      ImmutableMap.<Measure, SingleMeasureCalculation>builder()
+          .put(Measures.PRESENT_VALUE, SecurityMeasureCalculations::presentValue)
+          .build();
+
+  private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
+
+  /**
+   * Creates an instance.
+   */
+  public GenericSecurityPositionCalculationFunction() {
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Class<GenericSecurityPosition> targetType() {
+    return GenericSecurityPosition.class;
+  }
+
+  @Override
+  public Set<Measure> supportedMeasures() {
+    return MEASURES;
+  }
+
+  @Override
+  public Optional<String> identifier(GenericSecurityPosition target) {
+    return target.getInfo().getId().map(id -> id.toString());
+  }
+
+  @Override
+  public Currency naturalCurrency(GenericSecurityPosition position, ReferenceData refData) {
+    return position.getCurrency();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public FunctionRequirements requirements(
+      GenericSecurityPosition position,
+      Set<Measure> measures,
+      CalculationParameters parameters,
+      ReferenceData refData) {
+
+    QuoteId id = QuoteId.of(position.getSecurityId().getStandardId());
+
+    return FunctionRequirements.builder()
+        .valueRequirements(ImmutableSet.of(id))
+        .outputCurrencies(position.getCurrency())
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Map<Measure, Result<?>> calculate(
+      GenericSecurityPosition position,
+      Set<Measure> measures,
+      CalculationParameters parameters,
+      ScenarioMarketData scenarioMarketData,
+      ReferenceData refData) {
+
+    // loop around measures, calculating all scenarios for one measure
+    Map<Measure, Result<?>> results = new HashMap<>();
+    for (Measure measure : measures) {
+      results.put(measure, calculate(measure, position, scenarioMarketData));
+    }
+    return results;
+  }
+
+  // calculate one measure
+  private Result<?> calculate(
+      Measure measure,
+      GenericSecurityPosition position,
+      ScenarioMarketData scenarioMarketData) {
+
+    SingleMeasureCalculation calculator = CALCULATORS.get(measure);
+    if (calculator == null) {
+      return Result.failure(FailureReason.UNSUPPORTED, "Unsupported measure for GenericSecurityPosition: {}", measure);
+    }
+    return Result.of(() -> calculator.calculate(position.getSecurity(), position.getQuantity(), scenarioMarketData));
+  }
+
+  //-------------------------------------------------------------------------
+  @FunctionalInterface
+  interface SingleMeasureCalculation {
+    public abstract ScenarioArray<?> calculate(
+        Security security,
+        double quantity,
+        ScenarioMarketData marketData);
+  }
+
+}

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/security/GenericSecurityPositionCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/security/GenericSecurityPositionCalculationFunctionTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.measure.security;
+
+import static com.opengamma.strata.basics.currency.Currency.EUR;
+import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyAmount;
+import com.opengamma.strata.calc.Measure;
+import com.opengamma.strata.calc.runner.CalculationParameters;
+import com.opengamma.strata.calc.runner.FunctionRequirements;
+import com.opengamma.strata.collect.result.Result;
+import com.opengamma.strata.data.scenario.CurrencyScenarioArray;
+import com.opengamma.strata.data.scenario.ScenarioMarketData;
+import com.opengamma.strata.market.observable.QuoteId;
+import com.opengamma.strata.measure.Measures;
+import com.opengamma.strata.measure.curve.TestMarketDataMap;
+import com.opengamma.strata.product.GenericSecurity;
+import com.opengamma.strata.product.GenericSecurityPosition;
+import com.opengamma.strata.product.PositionInfo;
+import com.opengamma.strata.product.SecurityId;
+import com.opengamma.strata.product.SecurityInfo;
+
+/**
+ * Test {@link GenericSecurityPositionCalculationFunction}.
+ */
+@Test
+public class GenericSecurityPositionCalculationFunctionTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final CalculationParameters PARAMS = CalculationParameters.empty();
+  private static final double MARKET_PRICE = 99.42;
+  private static final double TICK_SIZE = 0.01;
+  private static final int TICK_VALUE = 10;
+  private static final int QUANTITY = 20;
+  private static final SecurityId SEC_ID = SecurityId.of("OG-Future", "Foo-Womble-Mar14");
+  private static final GenericSecurity FUTURE = GenericSecurity.of(
+      SecurityInfo.of(SEC_ID, TICK_SIZE, CurrencyAmount.of(EUR, TICK_VALUE)));
+  public static final GenericSecurityPosition TRADE = GenericSecurityPosition.builder()
+      .info(PositionInfo.empty())
+      .security(FUTURE)
+      .longQuantity(QUANTITY)
+      .build();
+  private static final Currency CURRENCY = TRADE.getCurrency();
+  private static final LocalDate VAL_DATE = LocalDate.of(2013, 12, 8);
+
+  //-------------------------------------------------------------------------
+  public void test_requirementsAndCurrency() {
+    GenericSecurityPositionCalculationFunction function = new GenericSecurityPositionCalculationFunction();
+    Set<Measure> measures = function.supportedMeasures();
+    FunctionRequirements reqs = function.requirements(TRADE, measures, PARAMS, REF_DATA);
+    assertThat(reqs.getOutputCurrencies()).containsOnly(CURRENCY);
+    assertThat(reqs.getValueRequirements()).isEqualTo(ImmutableSet.of(QuoteId.of(SEC_ID.getStandardId())));
+    assertThat(reqs.getTimeSeriesRequirements()).isEmpty();
+    assertThat(function.naturalCurrency(TRADE, REF_DATA)).isEqualTo(CURRENCY);
+  }
+
+  public void test_presentValue() {
+    GenericSecurityPositionCalculationFunction function = new GenericSecurityPositionCalculationFunction();
+    ScenarioMarketData md = marketData();
+
+    double unitPv = (MARKET_PRICE / TICK_SIZE) * TICK_VALUE;
+    CurrencyAmount expectedPv = CurrencyAmount.of(CURRENCY, unitPv * QUANTITY);
+
+    Set<Measure> measures = ImmutableSet.of(Measures.PRESENT_VALUE);
+    assertThat(function.calculate(TRADE, measures, PARAMS, md, REF_DATA))
+        .containsEntry(
+            Measures.PRESENT_VALUE, Result.success(CurrencyScenarioArray.of(ImmutableList.of(expectedPv))));
+  }
+
+  //-------------------------------------------------------------------------
+  private ScenarioMarketData marketData() {
+    TestMarketDataMap md = new TestMarketDataMap(
+        VAL_DATE,
+        ImmutableMap.of(QuoteId.of(SEC_ID.getStandardId()), MARKET_PRICE),
+        ImmutableMap.of());
+    return md;
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverPrivateConstructor(SecurityMeasureCalculations.class);
+  }
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/GenericSecurity.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/GenericSecurity.java
@@ -25,6 +25,7 @@ import org.joda.beans.impl.direct.DirectPrivateBeanBuilder;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.product.bond.BondFutureOptionSecurity;
 import com.opengamma.strata.product.bond.FixedCouponBondSecurity;
 import com.opengamma.strata.product.index.IborFutureSecurity;
@@ -40,7 +41,7 @@ import com.opengamma.strata.product.index.IborFutureSecurity;
  */
 @BeanDefinition(builderScope = "private")
 public final class GenericSecurity
-    implements Security, ImmutableBean, Serializable {
+    implements Security, SecuritizedProduct, ImmutableBean, Serializable {
 
   /**
    * The standard security information.
@@ -63,14 +64,34 @@ public final class GenericSecurity
 
   //-------------------------------------------------------------------------
   @Override
+  public SecurityId getSecurityId() {
+    return Security.super.getSecurityId();
+  }
+
+  @Override
+  public Currency getCurrency() {
+    return Security.super.getCurrency();
+  }
+
+  @Override
   public ImmutableSet<SecurityId> getUnderlyingIds() {
     return ImmutableSet.of();
   }
 
   //-------------------------------------------------------------------------
+  /**
+   * Creates the associated product, which simply returns {@code this}.
+   * <p>
+   * The product associated with a security normally returns the financial model used for pricing.
+   * In the case of a {@code GenericSecurity}, no underlying financial model is available.
+   * As such, the {@code GenericSecurity} is the product.
+   * 
+   * @param refData  the reference data to use
+   * @return this security
+   */
   @Override
-  public SecuritizedProduct createProduct(ReferenceData refData) {
-    throw new UnsupportedOperationException("Unable to create product, GenericSecurity does not have a product model");
+  public GenericSecurity createProduct(ReferenceData refData) {
+    return this;
   }
 
   @Override

--- a/modules/product/src/test/java/com/opengamma/strata/product/GenericSecurityTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/GenericSecurityTest.java
@@ -7,7 +7,6 @@ package com.opengamma.strata.product;
 
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
-import static com.opengamma.strata.collect.TestHelper.assertThrows;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.testng.Assert.assertEquals;
@@ -36,7 +35,7 @@ public class GenericSecurityTest {
     assertEquals(test.getCurrency(), INFO.getPriceInfo().getCurrency());
     assertEquals(test.getUnderlyingIds(), ImmutableSet.of());
     assertEquals(test, GenericSecurity.of(INFO));
-    assertThrows(() -> test.createProduct(ReferenceData.empty()), UnsupportedOperationException.class);
+    assertEquals(test.createProduct(ReferenceData.empty()), test);
     assertEquals(
         test.createTrade(TradeInfo.empty(), 1, 2, ReferenceData.empty()),
         GenericSecurityTrade.of(TradeInfo.empty(), GenericSecurity.of(INFO), 1, 2));


### PR DESCRIPTION
Add generic security position calc functions. This appears to have simply been missed previously.

Add a product for `GenericSecurity`. Making `GenericSecurity` implement `SecuritizedProduct` is not ideal, but adding another class feels worse. The justification is that `GenericSecurity` has no modelled product, so the security is as good as it gets.