### PR TITLE
Add license to jar file

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,4 @@
+Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+
+Strata is licensed under The Apache Software License, Version 2.0
+http://strata.opengamma.io/

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,6 +19,39 @@
   <description>Example code to demonstrate use of Strata</description>
 
   <!-- ==================================================================== -->
+  <!-- standard build setup -->
+  <build>
+    <!-- Include LICENSE/NOTICE in jar files -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${root.dir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
+      </resource>
+    </resources>
+    <!-- Include LICENSE/NOTICE in test jar files -->
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+      <testResource>
+        <directory>${root.dir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
+      </testResource>
+    </testResources>
+  </build>
+
+  <!-- ==================================================================== -->
   <dependencies>
     <!-- OpenGamma, relying on transitive dependencies -->
     <dependency>
@@ -124,6 +157,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/..</root.dir>
     <!-- Versions -->
     <assertj.version>3.6.2</assertj.version>
     <jcommander.version>1.58</jcommander.version>

--- a/modules/basics/pom.xml
+++ b/modules/basics/pom.xml
@@ -40,6 +40,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Basics</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Basics API</h1>]]></doctitle>

--- a/modules/calc/pom.xml
+++ b/modules/calc/pom.xml
@@ -72,6 +72,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-surefire-plugin -->
     <tests.testng.threads>1</tests.testng.threads>
     <!-- Properties for maven-javadoc-plugin -->

--- a/modules/collect/pom.xml
+++ b/modules/collect/pom.xml
@@ -42,6 +42,14 @@
   <!-- ==================================================================== -->
   <build>
     <resources>
+      <!-- Include all standard resources -->
+      <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+          <exclude>com/opengamma/strata/collect/version.properties</exclude>
+        </excludes>
+      </resource>
+      <!-- Include filtered version.properties -->
       <resource>
         <directory>src/main/resources</directory>
         <includes>
@@ -49,11 +57,22 @@
         </includes>
         <filtering>true</filtering>
       </resource>
+      <!-- Include LICENSE/NOTICE in jar files -->
+      <resource>
+        <directory>${root.dir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
+      </resource>
     </resources>
   </build>
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Collect</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Collect API</h1>]]></doctitle>

--- a/modules/data/pom.xml
+++ b/modules/data/pom.xml
@@ -50,6 +50,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Data</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Data</h1>]]></doctitle>

--- a/modules/loader/pom.xml
+++ b/modules/loader/pom.xml
@@ -62,6 +62,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Loader</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Loader</h1>]]></doctitle>

--- a/modules/market/pom.xml
+++ b/modules/market/pom.xml
@@ -62,6 +62,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Market</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Market</h1>]]></doctitle>

--- a/modules/math/pom.xml
+++ b/modules/math/pom.xml
@@ -60,6 +60,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <colt.version>1.2.0</colt.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <!-- Properties for maven-javadoc-plugin -->

--- a/modules/measure/pom.xml
+++ b/modules/measure/pom.xml
@@ -76,6 +76,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-surefire-plugin -->
     <tests.testng.threads>1</tests.testng.threads>
     <!-- Properties for maven-javadoc-plugin -->

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -64,13 +64,33 @@
   <!-- standard build setup -->
   <build>
     <resources>
+      <!-- Include all standard resources -->
       <resource>
         <directory>src/main/resources</directory>
       </resource>
+      <!-- Include LICENSE/NOTICE in jar files -->
+      <resource>
+        <directory>${root.dir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
+      </resource>
     </resources>
     <testResources>
+      <!-- Include all standard resources -->
       <testResource>
         <directory>src/test/resources</directory>
+      </testResource>
+      <!-- Include LICENSE/NOTICE in test jar files -->
+      <testResource>
+        <directory>${root.dir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+          <include>NOTICE.txt</include>
+        </includes>
       </testResource>
     </testResources>
     <plugins>
@@ -597,6 +617,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/..</root.dir>
     <!-- Versions -->
     <assertj.version>3.6.2</assertj.version>
     <guava.version>20.0</guava.version>

--- a/modules/pricer/pom.xml
+++ b/modules/pricer/pom.xml
@@ -67,6 +67,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Pricer API</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Pricer API</h1>]]></doctitle>

--- a/modules/product/pom.xml
+++ b/modules/product/pom.xml
@@ -44,6 +44,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Product</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Product API</h1>]]></doctitle>

--- a/modules/report/pom.xml
+++ b/modules/report/pom.xml
@@ -77,6 +77,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}/../..</root.dir>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Pricer</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Pricer</h1>]]></doctitle>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,8 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Locate the root directory of the multi-module build -->
+    <root.dir>${project.basedir}</root.dir>
     <!-- Not installed/deployed -->
     <maven.install.skip>true</maven.install.skip>
     <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
Add notice file.
This is a poor approach to adding licenses as it uses relative paths outside the project, but it is a quick solution that works.