### PR TITLE
Use valid tenors for FloatingRateName when computing fixing days offset.

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/FloatingRateName.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/FloatingRateName.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
 
+import com.google.common.collect.Iterables;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
@@ -157,7 +158,7 @@ public interface FloatingRateName
    * @throws IllegalStateException if the type is not an Ibor index type
    */
   public default DaysAdjustment toIborIndexFixingOffset() {
-    return toIborIndex(Tenor.TENOR_3M).getFixingDateOffset();
+    return toIborIndex(Iterables.getFirst(getTenors(), Tenor.TENOR_3M)).getFixingDateOffset();
   }
 
   /**

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNameTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNameTest.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.basics.index;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.PRECEDING;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.DKCO;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.MXMC;
 import static com.opengamma.strata.collect.TestHelper.assertJodaConvert;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.assertThrows;
@@ -179,6 +180,12 @@ public class FloatingRateNameTest {
         FloatingRateName.of("DKK-CIBOR2-DKNA13").toIborIndexFixingOffset(),
         DaysAdjustment.ofBusinessDays(-2, DKCO));
   }
+
+  public void test_toIborInde_tiee() {
+    assertEquals(FloatingRateName.of("MXN-TIIE").toIborIndex(Tenor.TENOR_4W), IborIndices.MXN_TIIE_4W);
+    assertEquals(FloatingRateName.of("MXN-TIIE").toIborIndexFixingOffset(), DaysAdjustment.ofBusinessDays(-1, MXMC));
+  }
+
 
   //-------------------------------------------------------------------------
   public void coverage() {


### PR DESCRIPTION
Previously using "3M" which is not applicable for MXN and hence caused exception to be thrown.

toIborIndexFixingOffset() can now be called on any ibor instance of FloatingRateName