### PR TITLE
Extend de-adjustments

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -394,9 +394,9 @@ public final class PeriodicSchedule
    *  yields the specified start date
    * </ul>
    * <p>
-   * There is additional special handling for pre-adjusted first/last regular dates.
-   * If the following conditions hold true, then the unadjusted first/last regular date is treated
-   * as being the day-of-month implied by the roll convention (the adjusted date is unaffected).
+   * There is additional special handling for pre-adjusted first/last regular dates and the end date.
+   * If the following conditions hold true, then the unadjusted date is treated as being the
+   * day-of-month implied by the roll convention (the adjusted date is unaffected).
    * <ul>
    * <li>the roll convention is numeric or 'EOM'
    * <li>applying {@code businessDayAdjustment} to the day-of-month implied by the roll convention
@@ -493,9 +493,9 @@ public final class PeriodicSchedule
    *  yields the specified start date
    * </ul>
    * <p>
-   * There is additional special handling for pre-adjusted first/last regular dates.
-   * If the following conditions hold true, then the unadjusted first/last regular date is treated
-   * as being the day-of-month implied by the roll convention (the adjusted date is unaffected).
+   * There is additional special handling for pre-adjusted first/last regular dates and the end date.
+   * If the following conditions hold true, then the unadjusted date is treated as being the
+   * day-of-month implied by the roll convention (the adjusted date is unaffected).
    * <ul>
    * <li>the roll convention is numeric or 'EOM'
    * <li>applying {@code businessDayAdjustment} to the day-of-month implied by the roll convention
@@ -715,9 +715,9 @@ public final class PeriodicSchedule
    *  yields the specified start date
    * </ul>
    * <p>
-   * There is additional special handling for pre-adjusted first/last regular dates.
-   * If the following conditions hold true, then the unadjusted first/last regular date is treated
-   * as being the day-of-month implied by the roll convention (the adjusted date is unaffected).
+   * There is additional special handling for pre-adjusted first/last regular dates and the end date.
+   * If the following conditions hold true, then the unadjusted date is treated as being the
+   * day-of-month implied by the roll convention (the adjusted date is unaffected).
    * <ul>
    * <li>the roll convention is numeric or 'EOM'
    * <li>applying {@code businessDayAdjustment} to the day-of-month implied by the roll convention
@@ -805,12 +805,12 @@ public final class PeriodicSchedule
     // change date if numeric roll convention
     // and day-of-month actually differs
     // and reference data is available
-    // and if EOM then the adjustment must be NONE (for backwards compatibility)
+    // and explicit start adjustment must be NONE (not ideal, but meets backwards compatibility)
     int rollDom = rollConvention != null ? rollConvention.getDayOfMonth() : 0;
     if (rollDom > 0 &&
         startDate.getDayOfMonth() != rollDom &&
         refData != null &&
-        (rollDom < 31 || BusinessDayAdjustment.NONE.equals(startDateBusinessDayAdjustment))) {
+        BusinessDayAdjustment.NONE.equals(startDateBusinessDayAdjustment)) {
 
       return calculatedUnadjustedDateFromAdjusted(startDate, rollDom, businessDayAdjustment, refData);
     }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -390,10 +390,6 @@ public class PeriodicScheduleTest {
         {AUG_18, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,
             ImmutableList.of(AUG_17, SEP_17, OCT_17),
             ImmutableList.of(AUG_18, SEP_17, OCT_17), DAY_17},
-        // pre-adjusted start date, change needed, with adjustment
-        {AUG_18, OCT_17, P1M, null, DAY_17, null, null, BDA,
-            ImmutableList.of(AUG_17, SEP_17, OCT_17),
-            ImmutableList.of(AUG_18, SEP_17, OCT_17), DAY_17},
         // pre-adjusted first regular, change needed
         {JUL_11, OCT_17, P1M, null, DAY_17, AUG_18, null, BDA_NONE,
             ImmutableList.of(JUL_11, AUG_17, SEP_17, OCT_17),

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -390,6 +390,10 @@ public class PeriodicScheduleTest {
         {AUG_18, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,
             ImmutableList.of(AUG_17, SEP_17, OCT_17),
             ImmutableList.of(AUG_18, SEP_17, OCT_17), DAY_17},
+        // pre-adjusted start date, change needed, with adjustment
+        {AUG_18, OCT_17, P1M, null, DAY_17, null, null, BDA,
+            ImmutableList.of(AUG_17, SEP_17, OCT_17),
+            ImmutableList.of(AUG_18, SEP_17, OCT_17), DAY_17},
         // pre-adjusted first regular, change needed
         {JUL_11, OCT_17, P1M, null, DAY_17, AUG_18, null, BDA_NONE,
             ImmutableList.of(JUL_11, AUG_17, SEP_17, OCT_17),
@@ -402,6 +406,14 @@ public class PeriodicScheduleTest {
         {APR_01, OCT_17, P1M, null, DAY_17, MAY_19, AUG_18, BDA_NONE,
             ImmutableList.of(APR_01, MAY_17, JUN_17, JUL_17, AUG_17, OCT_17),
             ImmutableList.of(APR_01, MAY_19, JUN_17, JUL_17, AUG_18, OCT_17), DAY_17},
+        // pre-adjusted end date, change needed
+        {JUL_17, AUG_18, P1M, null, DAY_17, null, null, BDA_NONE,
+            ImmutableList.of(JUL_17, AUG_17),
+            ImmutableList.of(JUL_17, AUG_18), DAY_17},
+        // pre-adjusted end date, change needed, with adjustment
+        {JUL_17, AUG_18, P1M, null, DAY_17, null, null, BDA,
+            ImmutableList.of(JUL_17, AUG_17),
+            ImmutableList.of(JUL_17, AUG_18), DAY_17},
 
         // TERM period
         {JUN_04, SEP_17, TERM, STUB_NONE, null, null, null, null,


### PR DESCRIPTION
Start date:
Bring checks more in line with other dates

End date:
De-adjust using the roll convention as per other dates