### PR TITLE
Copy code from Cern Colt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,3 +2,13 @@ Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of compan
 
 Strata is licensed under The Apache Software License, Version 2.0
 http://strata.opengamma.io/
+
+
+Strata includes modified code from CERN licensed as follows:
+
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/AbstractContinousDistribution.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/AbstractContinousDistribution.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * Abstract base class for all continous distributions.
+ *
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ */
+abstract class AbstractContinousDistribution extends AbstractDistribution {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+  * Makes this class non instantiable, but still let's others inherit from it.
+  */
+  protected AbstractContinousDistribution() {
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/AbstractDistribution.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/AbstractDistribution.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - use Java 8 function interfaces
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.IntUnaryOperator;
+
+//CSOFF: ALL
+/**
+ * Abstract base class for all random distributions.
+ *
+ * A subclass of this class need to override method <tt>nextDouble()</tt> and, in rare cases, also <tt>nextInt()</tt>.
+ * <p>
+ * Currently all subclasses use a uniform pseudo-random number generation engine and transform its results to the target distribution.
+ * Thus, they expect such a uniform engine upon instance construction.
+ * <p>
+ * {@link MersenneTwister} is recommended as uniform pseudo-random number generation engine, since it is very strong and at the same time quick.
+ * {@link #makeDefaultGenerator()} will conveniently construct and return such a magic thing.
+ * You can also, for example, use {@code DRand}, a quicker (but much weaker) uniform random number generation engine.
+ * Of course, you can also use other strong uniform random number generation engines. 
+ *
+ * <p>
+ * <b>Ressources on the Web:</b>
+ * <dt>Check the Web version of the <A HREF="http://www.cern.ch/RD11/rkb/AN16pp/node1.html"> CERN Data Analysis Briefbook </A>. This will clarify the definitions of most distributions.
+ * <dt>Also consult the <A HREF="http://www.statsoftinc.com/textbook/stathome.html"> StatSoft Electronic Textbook</A> - the definite web book.
+ * <p>
+ * <b>Other useful ressources:</b>
+ * <dt><A HREF="http://www.stats.gla.ac.uk/steps/glossary/probability_distributions.html"> Another site </A> and <A HREF="http://www.statlets.com/usermanual/glossary.htm"> yet another site </A>describing the definitions of several distributions.
+ * <dt>You may want to check out a <A HREF="http://www.stat.berkeley.edu/users/stark/SticiGui/Text/gloss.htm"> Glossary of Statistical Terms</A>.
+ * <dt>The GNU Scientific Library contains an extensive (but hardly readable) <A HREF="http://sourceware.cygnus.com/gsl/html/gsl-ref_toc.html#TOC26"> list of definition of distributions</A>.
+ * <dt>Use this Web interface to <A HREF="http://www.stat.ucla.edu/calculators/cdf"> plot all sort of distributions</A>.
+ * <dt>Even more ressources: <A HREF="http://www.animatedsoftware.com/statglos/statglos.htm"> Internet glossary of Statistical Terms</A>,
+ * <A HREF="http://www.ruf.rice.edu/~lane/hyperstat/index.html"> a text book</A>,
+ * <A HREF="http://www.stat.umn.edu/~jkuhn/courses/stat3091f/stat3091f.html"> another text book</A>.
+ * <dt>Finally, a good link list <A HREF="http://www.execpc.com/~helberg/statistics.html"> Statistics on the Web</A>.
+ * <p>
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ */
+abstract class AbstractDistribution
+    extends PersistentObject
+    implements DoubleUnaryOperator, IntUnaryOperator {
+
+  private static final long serialVersionUID = 1L;
+
+  protected RandomEngine randomGenerator;
+
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected AbstractDistribution() {
+  }
+
+  /**
+  Equivalent to <tt>nextDouble()</tt>.
+  This has the effect that distributions can now be used as function objects, returning a random number upon function evaluation.
+  */
+  @Override
+  public double applyAsDouble(double dummy) {
+    return nextDouble();
+  }
+
+  /**
+  Equivalent to <tt>nextInt()</tt>.
+  This has the effect that distributions can now be used as function objects, returning a random number upon function evaluation.
+  */
+  @Override
+  public int applyAsInt(int dummy) {
+    return nextInt();
+  }
+
+  /**
+   * Returns a deep copy of the receiver; the copy will produce identical sequences.
+   * After this call has returned, the copy and the receiver have equal but separate state.
+   *
+   * @return a copy of the receiver.
+   */
+  @Override
+  public Object clone() {
+    AbstractDistribution copy = (AbstractDistribution) super.clone();
+    if (this.randomGenerator != null)
+      copy.randomGenerator = (RandomEngine) this.randomGenerator.clone();
+    return copy;
+  }
+
+  /**
+   * Returns the used uniform random number generator;
+   * @return result
+   */
+  protected RandomEngine getRandomGenerator() {
+    return randomGenerator;
+  }
+
+  /**
+   * Constructs and returns a new uniform random number generation engine seeded with the current time.
+   * Currently this is {@link MersenneTwister}.
+   * @return result
+   */
+  public static RandomEngine makeDefaultGenerator() {
+    return RandomEngine.makeDefault();
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   * @return result
+   */
+  public abstract double nextDouble();
+
+  /**
+   * Returns a random number from the distribution; returns <tt>(int) Math.round(nextDouble())</tt>.
+   * Override this method if necessary.
+   * @return result
+   */
+  public int nextInt() {
+    return (int) Math.round(nextDouble());
+  }
+
+  /**
+   * Sets the uniform random generator internally used.
+   * @param randomGenerator input
+   */
+  protected void setRandomGenerator(RandomEngine randomGenerator) {
+    this.randomGenerator = randomGenerator;
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Arithmetic.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Arithmetic.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.math` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - remove unused methods
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * Arithmetic functions.
+ */
+class Arithmetic extends Constants {
+
+  // for method stirlingCorrection(...)
+  private static final double[] stirlingCorrection = {
+      0.0,
+      8.106146679532726e-02, 4.134069595540929e-02,
+      2.767792568499834e-02, 2.079067210376509e-02,
+      1.664469118982119e-02, 1.387612882307075e-02,
+      1.189670994589177e-02, 1.041126526197209e-02,
+      9.255462182712733e-03, 8.330563433362871e-03,
+      7.573675487951841e-03, 6.942840107209530e-03,
+      6.408994188004207e-03, 5.951370112758848e-03,
+      5.554733551962801e-03, 5.207655919609640e-03,
+      4.901395948434738e-03, 4.629153749334029e-03,
+      4.385560249232324e-03, 4.166319691996922e-03,
+      3.967954218640860e-03, 3.787618068444430e-03,
+      3.622960224683090e-03, 3.472021382978770e-03,
+      3.333155636728090e-03, 3.204970228055040e-03,
+      3.086278682608780e-03, 2.976063983550410e-03,
+      2.873449362352470e-03, 2.777674929752690e-03,
+  };
+
+  // for method logFactorial(...)
+  // log(k!) for k = 0, ..., 29
+  protected static final double[] logFactorials = {
+      0.00000000000000000, 0.00000000000000000, 0.69314718055994531,
+      1.79175946922805500, 3.17805383034794562, 4.78749174278204599,
+      6.57925121201010100, 8.52516136106541430, 10.60460290274525023,
+      12.80182748008146961, 15.10441257307551530, 17.50230784587388584,
+      19.98721449566188615, 22.55216385312342289, 25.19122118273868150,
+      27.89927138384089157, 30.67186010608067280, 33.50507345013688888,
+      36.39544520803305358, 39.33988418719949404, 42.33561646075348503,
+      45.38013889847690803, 48.47118135183522388, 51.60667556776437357,
+      54.78472939811231919, 58.00360522298051994, 61.26170176100200198,
+      64.55753862700633106, 67.88974313718153498, 71.25703896716800901
+  };
+
+  // k! for k = 0, ..., 20
+  protected static final long[] longFactorials = {
+      1L,
+      1L,
+      2L,
+      6L,
+      24L,
+      120L,
+      720L,
+      5040L,
+      40320L,
+      362880L,
+      3628800L,
+      39916800L,
+      479001600L,
+      6227020800L,
+      87178291200L,
+      1307674368000L,
+      20922789888000L,
+      355687428096000L,
+      6402373705728000L,
+      121645100408832000L,
+      2432902008176640000L
+  };
+
+  // k! for k = 21, ..., 170
+  protected static final double[] doubleFactorials = {
+      5.109094217170944E19,
+      1.1240007277776077E21,
+      2.585201673888498E22,
+      6.204484017332394E23,
+      1.5511210043330984E25,
+      4.032914611266057E26,
+      1.0888869450418352E28,
+      3.048883446117138E29,
+      8.841761993739701E30,
+      2.652528598121911E32,
+      8.222838654177924E33,
+      2.6313083693369355E35,
+      8.68331761881189E36,
+      2.952327990396041E38,
+      1.0333147966386144E40,
+      3.719933267899013E41,
+      1.3763753091226346E43,
+      5.23022617466601E44,
+      2.0397882081197447E46,
+      8.15915283247898E47,
+      3.34525266131638E49,
+      1.4050061177528801E51,
+      6.041526306337384E52,
+      2.6582715747884495E54,
+      1.196222208654802E56,
+      5.502622159812089E57,
+      2.5862324151116827E59,
+      1.2413915592536068E61,
+      6.082818640342679E62,
+      3.0414093201713376E64,
+      1.5511187532873816E66,
+      8.06581751709439E67,
+      4.274883284060024E69,
+      2.308436973392413E71,
+      1.2696403353658264E73,
+      7.109985878048632E74,
+      4.052691950487723E76,
+      2.350561331282879E78,
+      1.386831185456898E80,
+      8.32098711274139E81,
+      5.075802138772246E83,
+      3.146997326038794E85,
+      1.9826083154044396E87,
+      1.2688693218588414E89,
+      8.247650592082472E90,
+      5.443449390774432E92,
+      3.6471110918188705E94,
+      2.48003554243683E96,
+      1.7112245242814127E98,
+      1.1978571669969892E100,
+      8.504785885678624E101,
+      6.123445837688612E103,
+      4.470115461512686E105,
+      3.307885441519387E107,
+      2.4809140811395404E109,
+      1.8854947016660506E111,
+      1.451830920282859E113,
+      1.1324281178206295E115,
+      8.94618213078298E116,
+      7.15694570462638E118,
+      5.797126020747369E120,
+      4.7536433370128435E122,
+      3.94552396972066E124,
+      3.314240134565354E126,
+      2.8171041143805494E128,
+      2.4227095383672744E130,
+      2.107757298379527E132,
+      1.854826422573984E134,
+      1.6507955160908465E136,
+      1.4857159644817605E138,
+      1.3520015276784033E140,
+      1.2438414054641305E142,
+      1.156772507081641E144,
+      1.0873661566567426E146,
+      1.0329978488239061E148,
+      9.916779348709491E149,
+      9.619275968248216E151,
+      9.426890448883248E153,
+      9.332621544394415E155,
+      9.332621544394418E157,
+      9.42594775983836E159,
+      9.614466715035125E161,
+      9.902900716486178E163,
+      1.0299016745145631E166,
+      1.0813967582402912E168,
+      1.1462805637347086E170,
+      1.2265202031961373E172,
+      1.324641819451829E174,
+      1.4438595832024942E176,
+      1.5882455415227423E178,
+      1.7629525510902457E180,
+      1.974506857221075E182,
+      2.2311927486598138E184,
+      2.543559733472186E186,
+      2.925093693493014E188,
+      3.393108684451899E190,
+      3.96993716080872E192,
+      4.6845258497542896E194,
+      5.574585761207606E196,
+      6.689502913449135E198,
+      8.094298525273444E200,
+      9.875044200833601E202,
+      1.2146304367025332E205,
+      1.506141741511141E207,
+      1.882677176888926E209,
+      2.3721732428800483E211,
+      3.0126600184576624E213,
+      3.856204823625808E215,
+      4.974504222477287E217,
+      6.466855489220473E219,
+      8.471580690878813E221,
+      1.1182486511960037E224,
+      1.4872707060906847E226,
+      1.99294274616152E228,
+      2.690472707318049E230,
+      3.6590428819525483E232,
+      5.0128887482749884E234,
+      6.917786472619482E236,
+      9.615723196941089E238,
+      1.3462012475717523E241,
+      1.8981437590761713E243,
+      2.6953641378881633E245,
+      3.8543707171800694E247,
+      5.550293832739308E249,
+      8.047926057471989E251,
+      1.1749972043909107E254,
+      1.72724589045464E256,
+      2.5563239178728637E258,
+      3.8089226376305687E260,
+      5.7133839564458575E262,
+      8.627209774233244E264,
+      1.3113358856834527E267,
+      2.0063439050956838E269,
+      3.0897696138473515E271,
+      4.789142901463393E273,
+      7.471062926282892E275,
+      1.1729568794264134E278,
+      1.8532718694937346E280,
+      2.946702272495036E282,
+      4.714723635992061E284,
+      7.590705053947223E286,
+      1.2296942187394494E289,
+      2.0044015765453032E291,
+      3.287218585534299E293,
+      5.423910666131583E295,
+      9.003691705778434E297,
+      1.5036165148649983E300,
+      2.5260757449731988E302,
+      4.2690680090047056E304,
+      7.257415615308004E306
+  };
+
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected Arithmetic() {
+  }
+
+  /**
+   * Efficiently returns the binomial coefficient, often also referred to as "n over k" or "n choose k".
+   * The binomial coefficient is defined as <tt>(n * n-1 * ... * n-k+1 ) / ( 1 * 2 * ... * k )</tt>.
+   * <ul>
+   * <li>k<0<tt>: <tt>0</tt>.
+   * <li>k==0<tt>: <tt>1</tt>.
+   * <li>k==1<tt>: <tt>n</tt>.
+   * <li>else: <tt>(n * n-1 * ... * n-k+1 ) / ( 1 * 2 * ... * k )</tt>.
+   * </ul>
+   * @param n n
+   * @param k k
+   * @return the binomial coefficient.
+   */
+  public static double binomial(double n, long k) {
+    if (k < 0)
+      return 0;
+    if (k == 0)
+      return 1;
+    if (k == 1)
+      return n;
+
+    // binomial(n,k) = (n * n-1 * ... * n-k+1 ) / ( 1 * 2 * ... * k )
+    double a = n - k + 1;
+    double b = 1;
+    double binomial = 1;
+    for (long i = k; i-- > 0;) {
+      binomial *= (a++) / (b++);
+    }
+    return binomial;
+  }
+
+  /**
+   * Efficiently returns the binomial coefficient, often also referred to as "n over k" or "n choose k".
+   * The binomial coefficient is defined as
+   * <ul>
+   * <li>k<0<tt>: <tt>0</tt>.
+   * <li>k==0 || k==n<tt>: <tt>1</tt>.
+   * <li>k==1 || k==n-1<tt>: <tt>n</tt>.
+   * <li>else: <tt>(n * n-1 * ... * n-k+1 ) / ( 1 * 2 * ... * k )</tt>.
+   * </ul>
+   * @param n n
+   * @param inK k
+   * @return the binomial coefficient.
+   */
+  public static double binomial(long n, long inK) {
+    long k = inK;
+    if (k < 0)
+      return 0;
+    if (k == 0 || k == n)
+      return 1;
+    if (k == 1 || k == n - 1)
+      return n;
+
+    // try quick version and see whether we get numeric overflows.
+    // factorial(..) is O(1); requires no loop; only a table lookup.
+    if (n > k) {
+      int max = longFactorials.length + doubleFactorials.length;
+      if (n < max) { // if (n! < inf && k! < inf)
+        double n_fac = factorial((int) n);
+        double k_fac = factorial((int) k);
+        double n_minus_k_fac = factorial((int) (n - k));
+        double nk = n_minus_k_fac * k_fac;
+        if (nk != Double.POSITIVE_INFINITY) { // no numeric overflow?
+          // now this is completely safe and accurate
+          return n_fac / nk;
+        }
+      }
+      if (k > n / 2)
+        k = n - k; // quicker
+    }
+
+    // binomial(n,k) = (n * n-1 * ... * n-k+1 ) / ( 1 * 2 * ... * k )
+    long a = n - k + 1;
+    long b = 1;
+    double binomial = 1;
+    for (long i = k; i-- > 0;) {
+      binomial *= ((double) (a++)) / (b++);
+    }
+    return binomial;
+  }
+
+  /**
+   * Returns the smallest <code>long &gt;= value</code>.
+   * <dt>Examples: <code>1.0 -> 1, 1.2 -> 2, 1.9 -> 2</code>.
+   * This method is safer than using (long) Math.ceil(value), because of possible rounding error.
+   * @param value v
+   * @return result
+   */
+  public static long ceil(double value) {
+    return Math.round(Math.ceil(value));
+  }
+
+  /**
+   * Evaluates the series of Chebyshev polynomials Ti at argument x/2.
+   * The series is given by
+   * <pre>
+   *        N-1
+   *         - '
+   *  y  =   >   coef[i] T (x/2)
+   *         -            i
+   *        i=0
+   * </pre>
+   * Coefficients are stored in reverse order, i.e. the zero
+   * order term is last in the array.  Note N is the number of
+   * coefficients, not the order.
+   * <p>
+   * If coefficients are for the interval a to b, x must
+   * have been transformed to x -> 2(2x - b - a)/(b-a) before
+   * entering the routine.  This maps x from (a, b) to (-1, 1),
+   * over which the Chebyshev polynomials are defined.
+   * <p>
+   * If the coefficients are for the inverted interval, in
+   * which (a, b) is mapped to (1/b, 1/a), the transformation
+   * required is x -> 2(2ab/x - b - a)/(b-a).  If b is infinity,
+   * this becomes x -> 4a/x - 1.
+   * <p>
+   * SPEED:
+   * <p>
+   * Taking advantage of the recurrence properties of the
+   * Chebyshev polynomials, the routine requires one more
+   * addition per loop than evaluating a nested polynomial of
+   * the same degree.
+   *
+   * @param x argument to the polynomial.
+   * @param coef the coefficients of the polynomial.
+   * @param N the number of coefficients.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  public static double chbevl(double x, double coef[], int N) throws ArithmeticException {
+    double b0, b1, b2;
+
+    int p = 0;
+    int i;
+
+    b0 = coef[p++];
+    b1 = 0.0;
+    i = N - 1;
+
+    do {
+      b2 = b1;
+      b1 = b0;
+      b0 = x * b1 - b2 + coef[p++];
+    } while (--i > 0);
+
+    return (0.5 * (b0 - b2));
+  }
+
+  /**
+   * Instantly returns the factorial <tt>k!</tt>.
+   * @param k must hold <tt>k &gt;= 0</tt>.
+   * @return result
+   */
+  static public double factorial(int k) {
+    if (k < 0)
+      throw new IllegalArgumentException();
+
+    int length1 = longFactorials.length;
+    if (k < length1)
+      return longFactorials[k];
+
+    int length2 = doubleFactorials.length;
+    if (k < length1 + length2)
+      return doubleFactorials[k - length1];
+    else
+      return Double.POSITIVE_INFINITY;
+  }
+
+  /**
+   * Returns the largest <code>long &lt;= value</code>.
+   * <dt>Examples: <code>
+   * 1.0 -> 1, 1.2 -> 1, 1.9 -> 1 <dt>
+   * 2.0 -> 2, 2.2 -> 2, 2.9 -> 2 </code><dt>
+   * This method is safer than using (long) Math.floor(value), because of possible rounding error.
+   * @param value v
+   * @return result
+   */
+  public static long floor(double value) {
+    return Math.round(Math.floor(value));
+  }
+
+  /**
+   * Returns <tt>log<sub>base</sub>value</tt>.
+   * @param base base
+   * @param value v
+   * @return result
+   */
+  public static double log(double base, double value) {
+    return Math.log(value) / Math.log(base);
+  }
+
+  /**
+   * Returns <tt>log<sub>10</sub>value</tt>.
+   * @param value v
+   * @return result
+   */
+  static public double log10(double value) {
+    // 1.0 / Math.log(10) == 0.43429448190325176
+    return Math.log(value) * 0.43429448190325176;
+  }
+
+  /**
+   * Returns <tt>log<sub>2</sub>value</tt>.
+   * @param value v
+   * @return result
+   */
+  static public double log2(double value) {
+    // 1.0 / Math.log(2) == 1.4426950408889634
+    return Math.log(value) * 1.4426950408889634;
+  }
+
+  /**
+   * Returns <tt>log(k!)</tt>.
+   * Tries to avoid overflows.
+   * For <tt>k<30</tt> simply looks up a table in O(1).
+   * For <tt>k>=30</tt> uses stirlings approximation.
+   * @param k must hold <tt>k &gt;= 0</tt>.
+   * @return result
+   */
+  public static double logFactorial(int k) {
+    if (k >= 30) {
+      double r, rr;
+      final double C0 = 9.18938533204672742e-01;
+      final double C1 = 8.33333333333333333e-02;
+      final double C3 = -2.77777777777777778e-03;
+      final double C5 = 7.93650793650793651e-04;
+      final double C7 = -5.95238095238095238e-04;
+
+      r = 1.0 / (double) k;
+      rr = r * r;
+      return (k + 0.5) * Math.log(k) - k + C0 + r * (C1 + rr * (C3 + rr * (C5 + rr * C7)));
+    } else
+      return logFactorials[k];
+  }
+
+  /**
+   * Instantly returns the factorial <tt>k!</tt>.
+   * @param k must hold <tt>k &gt;= 0 && k &lt; 21</tt>.
+   * @return result
+   * @throws IllegalArgumentException error
+   */
+  static public long longFactorial(int k) throws IllegalArgumentException {
+    if (k < 0)
+      throw new IllegalArgumentException("Negative k");
+
+    if (k < longFactorials.length)
+      return longFactorials[k];
+    throw new IllegalArgumentException("Overflow");
+  }
+
+  /**
+   * Returns the StirlingCorrection.                 
+   * <p>                                                                      
+   * Correction term of the Stirling approximation for <tt>log(k!)</tt>
+   * (series in 1/k, or table values for small k)                         
+   * with int parameter k.                                            
+   * <p>                                                                                                                              
+   * <tt>
+   * log k! = (k + 1/2)log(k + 1) - (k + 1) + (1/2)log(2Pi) +
+   *          stirlingCorrection(k + 1)                                    
+   * <p>                                                                      
+   * log k! = (k + 1/2)log(k)     -  k      + (1/2)log(2Pi) +              
+   *          stirlingCorrection(k)
+   * </tt>
+   * @param k k
+   * @return result
+   */
+  public static double stirlingCorrection(int k) {
+    final double C1 = 8.33333333333333333e-02;     //  +1/12 
+    final double C3 = -2.77777777777777778e-03;     //  -1/360
+    final double C5 = 7.93650793650793651e-04;     //  +1/1260
+    final double C7 = -5.95238095238095238e-04;     //  -1/1680
+
+    double r, rr;
+
+    if (k > 30) {
+      r = 1.0 / (double) k;
+      rr = r * r;
+      return r * (C1 + rr * (C3 + rr * (C5 + rr * C7)));
+    } else
+      return stirlingCorrection[k];
+  }
+
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/ChiSquare.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/ChiSquare.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random.engine` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - remove unused method
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * ChiSquare distribution; See the <A HREF="http://www.cern.ch/RD11/rkb/AN16pp/node31.html#SECTION000310000000000000000"> math definition</A>
+ * and <A HREF="http://www.statsoft.com/textbook/glosc.html#Chi-square Distribution"> animated definition</A>.
+ * <dt>A special case of the Gamma distribution.
+ * <p>
+ * <tt>p(x) = (1/g(f/2)) * (x/2)^(f/2-1) * exp(-x/2)</tt> with <tt>g(a)</tt> being the gamma function and <tt>f</tt> being the degrees of freedom.
+ * <p>
+ * Valid parameter ranges: <tt>freedom &gt; 0</tt>.
+ * <p> 
+ * Instance methods operate on a user supplied uniform random number generator; they are unsynchronized.
+ * <dt>
+ * Static methods operate on a default uniform random number generator; they are synchronized.
+ * <p>
+ * <b>Implementation:</b> 
+ * <dt>
+ * Method: Ratio of Uniforms with shift.
+ * <dt>
+ * High performance implementation. This is a port of <A HREF="http://wwwinfo.cern.ch/asd/lhc++/clhep/manual/RefGuide/Random/RandChiSquare.html">RandChiSquare</A> used in <A HREF="http://wwwinfo.cern.ch/asd/lhc++/clhep">CLHEP 1.4.0</A> (C++).
+ * CLHEP's implementation, in turn, is based on <tt>chru.c</tt> from the <A HREF="http://www.cis.tu-graz.ac.at/stat/stadl/random.html">C-RAND / WIN-RAND</A> library.
+ * C-RAND's implementation, in turn, is based upon
+ * <p>J.F. Monahan (1987): An algorithm for generating chi random variables, ACM Trans. Math. Software 13, 168-172.
+ *
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ */
+public class ChiSquare extends AbstractContinousDistribution {
+
+  private static final long serialVersionUID = 1L;
+
+  protected double freedom;
+
+  // cached vars for method nextDouble(a) (for performance only)
+  private double freedom_in = -1.0, b, vm, vp, vd;
+
+  // The uniform random number generated shared by all <b>static</b> methods.
+  protected static ChiSquare shared = new ChiSquare(1.0, makeDefaultGenerator());
+
+  /**
+   * Constructs a ChiSquare distribution.
+   * Example: freedom=1.0.
+   * @param freedom degrees of freedom.
+   * @param randomGenerator generator
+   * @throws IllegalArgumentException if <tt>freedom &lt; 1.0</tt>.
+   */
+  public ChiSquare(double freedom, RandomEngine randomGenerator) {
+    setRandomGenerator(randomGenerator);
+    setState(freedom);
+  }
+
+  /**
+   * Returns the cumulative distribution function.
+   * @param x x
+   * @return result
+   */
+  public double cdf(double x) {
+    return Probability.chiSquare(freedom, x);
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   */
+  @Override
+  public double nextDouble() {
+    return nextDouble(this.freedom);
+  }
+
+  /**
+   * Returns a random number from the distribution; bypasses the internal state.
+   * @param freedom degrees of freedom.
+   * It should hold <tt>freedom &lt; 1.0</tt>.
+   * @return result
+   */
+  public double nextDouble(double freedom) {
+    /******************************************************************
+     *                                                                *
+     *        Chi Distribution - Ratio of Uniforms  with shift        *
+     *                                                                *
+     ******************************************************************
+     *                                                                *
+     * FUNCTION :   - chru samples a random number from the Chi       *
+     *                distribution with parameter  a > 1.             *
+     * REFERENCE :  - J.F. Monahan (1987): An algorithm for           *
+     *                generating chi random variables, ACM Trans.     *
+     *                Math. Software 13, 168-172.                     *
+     * SUBPROGRAM : - anEngine  ... pointer to a (0,1)-Uniform        *
+     *                engine                                          *
+     *                                                                *
+     * Implemented by R. Kremer, 1990                                 *
+     ******************************************************************/
+
+    double u, v, z, zz, r;
+
+    //if( a < 1 )  return (-1.0); // Check for invalid input value
+
+    if (freedom == 1.0) {
+      for (;;) {
+        u = randomGenerator.raw();
+        v = randomGenerator.raw() * 0.857763884960707;
+        z = v / u;
+        if (z < 0)
+          continue;
+        zz = z * z;
+        r = 2.5 - zz;
+        if (z < 0.0)
+          r = r + zz * z / (3.0 * z);
+        if (u < r * 0.3894003915)
+          return (z * z);
+        if (zz > (1.036961043 / u + 1.4))
+          continue;
+        if (2.0 * Math.log(u) < (-zz * 0.5))
+          return (z * z);
+      }
+    } else {
+      if (freedom != freedom_in) {
+        b = Math.sqrt(freedom - 1.0);
+        vm = -0.6065306597 * (1.0 - 0.25 / (b * b + 1.0));
+        vm = (-b > vm) ? -b : vm;
+        vp = 0.6065306597 * (0.7071067812 + b) / (0.5 + b);
+        vd = vp - vm;
+        freedom_in = freedom;
+      }
+      for (;;) {
+        u = randomGenerator.raw();
+        v = randomGenerator.raw() * vd + vm;
+        z = v / u;
+        if (z < -b)
+          continue;
+        zz = z * z;
+        r = 2.5 - zz;
+        if (z < 0.0)
+          r = r + zz * z / (3.0 * (z + b));
+        if (u < r * 0.3894003915)
+          return ((z + b) * (z + b));
+        if (zz > (1.036961043 / u + 1.4))
+          continue;
+        if (2.0 * Math.log(u) < (Math.log(1.0 + z / b) * b * b - zz * 0.5 - z * b))
+          return ((z + b) * (z + b));
+      }
+    }
+  }
+
+  /**
+   * Returns the probability distribution function.
+   * @param x x
+   * @return result
+   */
+  public double pdf(double x) {
+    if (x <= 0.0)
+      throw new IllegalArgumentException();
+    double logGamma = Fun.logGamma(freedom / 2.0);
+    return Math.exp((freedom / 2.0 - 1.0) * Math.log(x / 2.0) - x / 2.0 - logGamma) / 2.0;
+  }
+
+  /**
+   * Sets the distribution parameter.
+   * @param freedom degrees of freedom.
+   * @throws IllegalArgumentException if <tt>freedom &lt; 1.0</tt>.
+   */
+  public void setState(double freedom) {
+    if (freedom < 1.0)
+      throw new IllegalArgumentException();
+    this.freedom = freedom;
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   * @param freedom degrees of freedom.
+   * @return result
+   * @throws IllegalArgumentException if <tt>freedom &lt; 1.0</tt>.
+   */
+  public static double staticNextDouble(double freedom) {
+    synchronized (shared) {
+      return shared.nextDouble(freedom);
+    }
+  }
+
+  /**
+   * Returns a String representation of the receiver.
+   */
+  @Override
+  public String toString() {
+    return this.getClass().getName() + "(" + freedom + ")";
+  }
+
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Constants.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Constants.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.math` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * Defines some useful constants.
+ */
+class Constants {
+  /*
+   * machine constants
+   */
+  protected static final double MACHEP = 1.11022302462515654042E-16;
+  protected static final double MAXLOG = 7.09782712893383996732E2;
+  protected static final double MINLOG = -7.451332191019412076235E2;
+  protected static final double MAXGAM = 171.624376956302725;
+  protected static final double SQTPI = 2.50662827463100050242E0;
+  protected static final double SQRTH = 7.07106781186547524401E-1;
+  protected static final double LOGPI = 1.14472988584940017414;
+
+  protected static final double big = 4.503599627370496e15;
+  protected static final double biginv = 2.22044604925031308085e-16;
+
+  /*
+  * MACHEP =  1.38777878078144567553E-17       2**-56
+  * MAXLOG =  8.8029691931113054295988E1       log(2**127)
+  * MINLOG = -8.872283911167299960540E1        log(2**-128)
+  * MAXNUM =  1.701411834604692317316873e38    2**127
+  *
+  * For IEEE arithmetic (IBMPC):
+  * MACHEP =  1.11022302462515654042E-16       2**-53
+  * MAXLOG =  7.09782712893383996843E2         log(2**1024)
+  * MINLOG = -7.08396418532264106224E2         log(2**-1022)
+  * MAXNUM =  1.7976931348623158E308           2**1024
+  *
+  * The global symbols for mathematical constants are
+  * PI     =  3.14159265358979323846           pi
+  * PIO2   =  1.57079632679489661923           pi/2
+  * PIO4   =  7.85398163397448309616E-1        pi/4
+  * SQRT2  =  1.41421356237309504880           sqrt(2)
+  * SQRTH  =  7.07106781186547524401E-1        sqrt(2)/2
+  * LOG2E  =  1.4426950408889634073599         1/log(2)
+  * SQ2OPI =  7.9788456080286535587989E-1      sqrt( 2/pi )
+  * LOGE2  =  6.93147180559945309417E-1        log(2)
+  * LOGSQ2 =  3.46573590279972654709E-1        log(2)/2
+  * THPIO4 =  2.35619449019234492885           3*pi/4
+  * TWOOPI =  6.36619772367581343075535E-1     2/pi
+  */
+
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected Constants() {
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Fun.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Fun.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * Contains various mathematical helper methods.
+ *
+ * <b>Implementation:</b> High performance implementation.
+ * <dt>This is a port of <tt>gen_fun.cpp</tt> from the <A HREF="http://www.cis.tu-graz.ac.at/stat/stadl/random.html">C-RAND / WIN-RAND</A> library.
+ *
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ */
+class Fun {
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected Fun() {
+    throw new RuntimeException("Non instantiable");
+  }
+
+  private static double _fkt_value(double lambda, double z1, double z2, double x_value) {
+    double y_value;
+
+    y_value = Math.cos(z1 * x_value) / (Math.pow((x_value * x_value + z2 * z2), (lambda + 0.5)));
+    return y_value;
+  }
+
+  public static double bessel2_fkt(double lambda, double beta) {
+    final double pi = Math.PI;
+    double sum, x, step, x1, first_value, new_value;
+    double epsilon = 0.01;
+    double y, fx, z1, z2, erg;
+    double period, border, first_sum, second_sum;
+    double my, c, prod = 0.0, diff, value;
+    int i, j, nr_per;
+
+    final double b0[] = {-1.5787132, -0.6130827, 0.1735823, 1.4793411,
+        2.6667307, 4.9086836, 8.1355339,
+    };
+    final double b05[] = {-1.9694802, -0.7642538, 0.0826017, 1.4276355,
+        2.6303682, 4.8857787, 8.1207968,
+    };
+    final double b1[] = {-2.9807345, -1.1969943, -0.1843161, 1.2739241,
+        2.5218256, 4.8172216, 8.0765633,
+    };
+    final double b2[] = {-5.9889676, -2.7145389, -1.1781269, 0.6782201,
+        2.0954009, 4.5452152, 7.9003173,
+    };
+    final double b3[] = {-9.6803440, -4.8211925, -2.6533185, -0.2583337,
+        1.4091915, 4.0993448, 7.6088310,
+    };
+    final double b5[] = {-18.1567152, -10.0939408, -6.5819139, -2.9371545,
+        -0.6289005, 2.7270412, 6.6936799,
+    };
+    final double b8[] = {-32.4910195, -19.6065943, -14.0347298, -8.3839439,
+        -4.9679730, -0.3567823, 4.5589697,
+    };
+
+    if (lambda == 0.0) {
+      if (beta == 0.1)
+        return (b0[0]);
+      if (beta == 0.5)
+        return (b0[1]);
+      if (beta == 1.0)
+        return (b0[2]);
+      if (beta == 2.0)
+        return (b0[3]);
+      if (beta == 3.0)
+        return (b0[4]);
+      if (beta == 5.0)
+        return (b0[5]);
+      if (beta == 8.0)
+        return (b0[6]);
+    }
+
+    if (lambda == 0.5) {
+      if (beta == 0.1)
+        return (b05[0]);
+      if (beta == 0.5)
+        return (b05[1]);
+      if (beta == 1.0)
+        return (b05[2]);
+      if (beta == 2.0)
+        return (b05[3]);
+      if (beta == 3.0)
+        return (b05[4]);
+      if (beta == 5.0)
+        return (b05[5]);
+      if (beta == 8.0)
+        return (b05[6]);
+    }
+
+    if (lambda == 1.0) {
+      if (beta == 0.1)
+        return (b1[0]);
+      if (beta == 0.5)
+        return (b1[1]);
+      if (beta == 1.0)
+        return (b1[2]);
+      if (beta == 2.0)
+        return (b1[3]);
+      if (beta == 3.0)
+        return (b1[4]);
+      if (beta == 5.0)
+        return (b1[5]);
+      if (beta == 8.0)
+        return (b1[6]);
+    }
+
+    if (lambda == 2.0) {
+      if (beta == 0.1)
+        return (b2[0]);
+      if (beta == 0.5)
+        return (b2[1]);
+      if (beta == 1.0)
+        return (b2[2]);
+      if (beta == 2.0)
+        return (b2[3]);
+      if (beta == 3.0)
+        return (b2[4]);
+      if (beta == 5.0)
+        return (b2[5]);
+      if (beta == 8.0)
+        return (b2[6]);
+    }
+
+    if (lambda == 3.0) {
+      if (beta == 0.1)
+        return (b3[0]);
+      if (beta == 0.5)
+        return (b3[1]);
+      if (beta == 1.0)
+        return (b3[2]);
+      if (beta == 2.0)
+        return (b3[3]);
+      if (beta == 3.0)
+        return (b3[4]);
+      if (beta == 5.0)
+        return (b3[5]);
+      if (beta == 8.0)
+        return (b3[6]);
+    }
+
+    if (lambda == 5.0) {
+      if (beta == 0.1)
+        return (b5[0]);
+      if (beta == 0.5)
+        return (b5[1]);
+      if (beta == 1.0)
+        return (b5[2]);
+      if (beta == 2.0)
+        return (b5[3]);
+      if (beta == 3.0)
+        return (b5[4]);
+      if (beta == 5.0)
+        return (b5[5]);
+      if (beta == 8.0)
+        return (b5[6]);
+    }
+
+    if (lambda == 8.0) {
+      if (beta == 0.1)
+        return (b8[0]);
+      if (beta == 0.5)
+        return (b8[1]);
+      if (beta == 1.0)
+        return (b8[2]);
+      if (beta == 2.0)
+        return (b8[3]);
+      if (beta == 3.0)
+        return (b8[4]);
+      if (beta == 5.0)
+        return (b8[5]);
+      if (beta == 8.0)
+        return (b8[6]);
+    }
+
+    if ((beta - 5.0 * lambda - 8.0) >= 0.0) {
+      my = 4.0 * lambda * lambda;
+      c = -0.9189385 + 0.5 * Math.log(beta) + beta;
+      sum = 1.0;
+      value = 1.0;
+      diff = 8.0;
+      i = 1;
+      for (;;) { //while (!NULL) {
+        if ((factorial(i) * Math.pow((8.0 * beta), i)) > 1.0e250)
+          break;
+        if (i > 10)
+          break;
+        if (i == 1)
+          prod = my - 1.0;
+        else {
+          value += diff;
+          prod = prod * (my - value);
+          diff *= 2.0;
+        }
+        sum = sum + prod / (factorial(i) * Math.pow((8.0 * beta), i));
+        i++;
+      }
+      erg = c - Math.log(sum);
+      return (erg);
+    }
+
+    if ((lambda > 0.0) && ((beta - 0.04 * lambda) <= 0.0)) {
+      if (lambda < 11.5) {
+        erg = -Math.log(gamma(lambda)) - lambda * Math.log(2.0) + lambda * Math.log(beta);
+        return (erg);
+      } else {
+        erg = -(lambda + 1.0) * Math.log(2.0) - (lambda - 0.5) * Math.log(lambda) + lambda + lambda * Math.log(beta) -
+            0.5 * Math.log(0.5 * pi);
+        return (erg);
+      }
+    }
+
+    // otherwise numerical integration of the function defined above 
+
+    x = 0.0;
+
+    if (beta < 1.57) {
+      fx = (fkt2_value(lambda, beta, x)) * 0.01;
+      y = 0.0;
+      for (;;) { //while (!NULL) {
+        y += 0.1;
+        if ((fkt2_value(lambda, beta, y)) < fx)
+          break;
+      }
+      step = y * 0.001;
+      x1 = step;
+      sum = (0.5 * (10.0 * step + fkt2_value(lambda, beta, x1))) * step;
+      first_value = sum;
+      for (;;) { //while (!NULL) {
+        x = x1;
+        x1 += step;
+        new_value = (0.5 * (fkt2_value(lambda, beta, x) + fkt2_value(lambda, beta, x1))) * step;
+        sum += new_value;
+        if ((new_value / first_value) < epsilon)
+          break;
+      }
+      erg = -Math.log(2.0 * sum);
+      return (erg);
+    } else {
+      z2 = 1.57;
+      z1 = beta / 1.57;
+      sum = 0.0;
+      period = pi / z1;
+      step = 0.1 * period;
+      border = 100.0 / ((lambda + 0.1) * (lambda + 0.1));
+      nr_per = (int) Math.ceil((border / period)) + 20;
+      x1 = step;
+      for (i = 1; i <= nr_per; i++) {
+        for (j = 1; j <= 10; j++) {
+          new_value = (0.5 * (_fkt_value(lambda, z1, z2, x) + _fkt_value(lambda, z1, z2, x1))) * step;
+          sum += new_value;
+          x = x1;
+          x1 += step;
+        }
+      }
+      for (j = 1; j <= 5; j++) {
+        new_value = (0.5 * (_fkt_value(lambda, z1, z2, x) + _fkt_value(lambda, z1, z2, x1))) * step;
+        sum += new_value;
+        x = x1;
+        x1 += step;
+      }
+      first_sum = sum;
+      for (j = 1; j <= 10; j++) {
+        new_value = (0.5 * (_fkt_value(lambda, z1, z2, x) + _fkt_value(lambda, z1, z2, x1))) * step;
+        sum += new_value;
+        x = x1;
+        x1 += step;
+      }
+      second_sum = sum;
+      sum = 0.5 * (first_sum + second_sum);
+      erg = gamma(lambda + 0.5) * Math.pow((2.0 * z2), lambda) / (Math.sqrt(pi) * Math.pow(z1, lambda)) * sum;
+      erg = -Math.log(2.0 * erg);
+      return (erg);
+    }
+  }
+
+  /**
+   * Modified Bessel Functions of First Kind - Order 0.
+   * @param x x
+   * @return result
+   */
+  public static double bessi0(double x) {
+    double ax, ans;
+    double y;
+
+    if ((ax = Math.abs(x)) < 3.75) {
+      y = x / 3.75;
+      y *= y;
+      ans = 1.0 + y * (3.5156229 + y * (3.0899424 + y * (1.2067492 + y * (0.2659732 + y * (0.360768e-1 + y * 0.45813e-2)))));
+    } else {
+      y = 3.75 / ax;
+      ans = (Math.exp(ax) / Math.sqrt(ax)) * (0.39894228 + y * (0.1328592e-1 + y * (0.225319e-2 + y * (-0.157565e-2 +
+          y * (0.916281e-2 + y * (-0.2057706e-1 + y * (0.2635537e-1 + y * (-0.1647633e-1 + y * 0.392377e-2))))))));
+    }
+    return ans;
+  }
+
+  /**
+   * Modified Bessel Functions of First Kind - Order 1.
+   * @param x x
+   * @return result
+   */
+  public static double bessi1(double x) {
+    double ax, ans;
+    double y;
+
+    if ((ax = Math.abs(x)) < 3.75) {
+      y = x / 3.75;
+      y *= y;
+      ans = ax * (0.5 +
+          y * (0.87890594 + y * (0.51498869 + y * (0.15084934 + y * (0.2658733e-1 + y * (0.301532e-2 + y * 0.32411e-3))))));
+    } else {
+      y = 3.75 / ax;
+      ans = 0.2282967e-1 + y * (-0.2895312e-1 + y * (0.1787654e-1 - y * 0.420059e-2));
+      ans = 0.39894228 + y * (-0.3988024e-1 + y * (-0.362018e-2 + y * (0.163801e-2 + y * (-0.1031555e-1 + y * ans))));
+      ans *= (Math.exp(ax) / Math.sqrt(ax));
+    }
+    return x < 0.0 ? -ans : ans;
+  }
+
+  /**
+   * Returns <tt>n!</tt>.
+   * @param n n
+   * @return result
+   */
+  public static long factorial(int n) {
+    return Arithmetic.longFactorial(n);
+    /*
+    long i,prod;
+    
+    prod = 1;
+    if (n != 0) {
+    	for (i = 2; i <= n; i++) prod *= i;
+    }
+    return prod;
+    */
+  }
+
+  private static double fkt2_value(double lambda, double beta, double x_value) {
+    double y_value;
+
+    y_value = cosh(lambda * x_value) * Math.exp(-beta * cosh(x_value));
+    return y_value;
+  }
+
+  private static double cosh(double x) {
+    return (Math.exp(x) + Math.exp(-x)) / 2.0;
+  }
+
+  /**
+   * Returns the gamma function <tt>gamma(x)</tt>.
+   * @param inX x
+   * @return result
+   */
+  public static double gamma(double inX) {
+    double x = logGamma(inX);
+    //if (x > Math.log(Double.MAX_VALUE)) return Double.MAX_VALUE;
+    return Math.exp(x);
+  }
+
+  /**
+   * Returns a quick approximation of <tt>log(gamma(x))</tt>.
+   * @param inX x
+   * @return result
+   */
+  public static double logGamma(double inX) {
+    double x = inX;
+    final double c0 = 9.1893853320467274e-01, c1 = 8.3333333333333333e-02,
+        c2 = -2.7777777777777777e-03, c3 = 7.9365079365079365e-04,
+        c4 = -5.9523809523809524e-04, c5 = 8.4175084175084175e-04,
+        c6 = -1.9175269175269175e-03;
+    double g, r, z;
+
+    if (x <= 0.0 /* || x > 1.3e19 */ )
+      return -999;
+
+    for (z = 1.0; x < 11.0; x++)
+      z *= x;
+
+    r = 1.0 / (x * x);
+    g = c1 + r * (c2 + r * (c3 + r * (c4 + r * (c5 + r + c6))));
+    g = (x - 0.5) * Math.log(x) - x + c0 + g / x;
+    if (z == 1.0)
+      return g;
+    return g - Math.log(z);
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Gamma.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Gamma.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - remove unused method
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * Gamma distribution; <A HREF="http://wwwinfo.cern.ch/asdoc/shortwrupsdir/g106/top.html"> math definition</A>,
+ * <A HREF="http://www.cern.ch/RD11/rkb/AN16pp/node96.html#SECTION000960000000000000000"> definition of gamma function</A>
+ * and <A HREF="http://www.statsoft.com/textbook/glosf.html#Gamma Distribution"> animated definition</A>. 
+ * <p>
+ * <tt>p(x) = k * x^(alpha-1) * e^(-x/beta)</tt> with <tt>k = 1/(g(alpha) * b^a))</tt> and <tt>g(a)</tt> being the gamma function.
+ * <p>
+ * Valid parameter ranges: <tt>alpha &gt; 0</tt>.
+ * <p>
+ * Note: For a Gamma distribution to have the mean <tt>mean</tt> and variance <tt>variance</tt>, set the parameters as follows:
+ * <pre>
+ * alpha = mean*mean / variance; lambda = 1 / (variance / mean); 
+ * </pre>
+ * <p>
+ * Instance methods operate on a user supplied uniform random number generator; they are unsynchronized.
+ * <dt>
+ * Static methods operate on a default uniform random number generator; they are synchronized.
+ * <p>
+ * <b>Implementation:</b> 
+ * <dt>
+ * Method: Acceptance Rejection combined with Acceptance Complement.
+ * <dt>
+ * High performance implementation. This is a port of <A HREF="http://wwwinfo.cern.ch/asd/lhc++/clhep/manual/RefGuide/Random/RandGamma.html">RandGamma</A> used in <A HREF="http://wwwinfo.cern.ch/asd/lhc++/clhep">CLHEP 1.4.0</A> (C++).
+ * CLHEP's implementation, in turn, is based on <tt>gds.c</tt> from the <A HREF="http://www.cis.tu-graz.ac.at/stat/stadl/random.html">C-RAND / WIN-RAND</A> library.
+ * C-RAND's implementation, in turn, is based upon
+ * <p>
+ * J.H. Ahrens, U. Dieter (1974): Computer methods for sampling from gamma, beta, Poisson and binomial distributions, 
+ * Computing 12, 223-246.
+ * <p>
+ * and
+ * <p>
+ * J.H. Ahrens, U. Dieter (1982): Generating gamma variates by a modified rejection technique,
+ * Communications of the ACM 25, 47-54.
+ *
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ */
+public class Gamma extends AbstractContinousDistribution {
+
+  private static final long serialVersionUID = 1L;
+
+  protected double alpha;
+  protected double lambda;
+
+  // The uniform random number generated shared by all <b>static</b> methods.
+  protected static Gamma shared = new Gamma(1.0, 1.0, makeDefaultGenerator());
+
+  /**
+   * Constructs a Gamma distribution.
+   * Example: alpha=1.0, lambda=1.0.
+   * @param alpha alpha
+   * @param lambda lambda
+   * @param randomGenerator generator
+   * @throws IllegalArgumentException if <tt>alpha &lt;= 0.0 || lambda &lt;= 0.0</tt>.
+   */
+  public Gamma(double alpha, double lambda, RandomEngine randomGenerator) {
+    setRandomGenerator(randomGenerator);
+    setState(alpha, lambda);
+  }
+
+  /**
+   * Returns the cumulative distribution function.
+   * @param x x
+   * @return result
+   */
+  public double cdf(double x) {
+    return Probability.gamma(alpha, lambda, x);
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   */
+  @Override
+  public double nextDouble() {
+    return nextDouble(alpha, lambda);
+  }
+
+  /**
+   * Returns a random number from the distribution; bypasses the internal state.
+   * @param alpha alpha
+   * @param lambda lambda
+   * @return result
+   */
+  public double nextDouble(double alpha, double lambda) {
+    /******************************************************************
+     *                                                                *
+     *    Gamma Distribution - Acceptance Rejection combined with     *
+     *                         Acceptance Complement                  *
+     *                                                                *
+     ******************************************************************
+     *                                                                *
+     * FUNCTION:    - gds samples a random number from the standard   *
+     *                gamma distribution with parameter  a > 0.       *
+     *                Acceptance Rejection  gs  for  a < 1 ,          *
+     *                Acceptance Complement gd  for  a >= 1 .         *
+     * REFERENCES:  - J.H. Ahrens, U. Dieter (1974): Computer methods *
+     *                for sampling from gamma, beta, Poisson and      *
+     *                binomial distributions, Computing 12, 223-246.  *
+     *              - J.H. Ahrens, U. Dieter (1982): Generating gamma *
+     *                variates by a modified rejection technique,     *
+     *                Communications of the ACM 25, 47-54.            *
+     * SUBPROGRAMS: - drand(seed) ... (0,1)-Uniform generator with    *
+     *                unsigned long integer *seed                     *
+     *              - NORMAL(seed) ... Normal generator N(0,1).       *
+     *                                                                *
+     ******************************************************************/
+    double a = alpha;
+    double aa = -1.0, aaa = -1.0,
+        b = 0.0, c = 0.0, d = 0.0, e, r, s = 0.0, si = 0.0, ss = 0.0, q0 = 0.0,
+        q1 = 0.0416666664, q2 = 0.0208333723, q3 = 0.0079849875,
+        q4 = 0.0015746717, q5 = -0.0003349403, q6 = 0.0003340332,
+        q7 = 0.0006053049, q8 = -0.0004701849, q9 = 0.0001710320,
+        a1 = 0.333333333, a2 = -0.249999949, a3 = 0.199999867,
+        a4 = -0.166677482, a5 = 0.142873973, a6 = -0.124385581,
+        a7 = 0.110368310, a8 = -0.112750886, a9 = 0.104089866,
+        e1 = 1.000000000, e2 = 0.499999994, e3 = 0.166666848,
+        e4 = 0.041664508, e5 = 0.008345522, e6 = 0.001353826,
+        e7 = 0.000247453;
+
+    double gds, p, q, t, sign_u, u, v, w, x;
+    double v1, v2, v12;
+
+    // Check for invalid input values
+
+    if (a <= 0.0)
+      throw new IllegalArgumentException();
+    if (lambda <= 0.0)
+      new IllegalArgumentException();
+
+    if (a < 1.0) { // CASE A: Acceptance rejection algorithm gs
+      b = 1.0 + 0.36788794412 * a;              // Step 1
+      for (;;) {
+        p = b * randomGenerator.raw();
+        if (p <= 1.0) {                       // Step 2. Case gds <= 1
+          gds = Math.exp(Math.log(p) / a);
+          if (Math.log(randomGenerator.raw()) <= -gds)
+            return (gds / lambda);
+        } else {                                // Step 3. Case gds > 1
+          gds = -Math.log((b - p) / a);
+          if (Math.log(randomGenerator.raw()) <= ((a - 1.0) * Math.log(gds)))
+            return (gds / lambda);
+        }
+      }
+    }
+
+    else {        // CASE B: Acceptance complement algorithm gd (gaussian distribution, box muller transformation)
+      if (a != aa) {                        // Step 1. Preparations
+        aa = a;
+        ss = a - 0.5;
+        s = Math.sqrt(ss);
+        d = 5.656854249 - 12.0 * s;
+      }
+      // Step 2. Normal deviate
+      do {
+        v1 = 2.0 * randomGenerator.raw() - 1.0;
+        v2 = 2.0 * randomGenerator.raw() - 1.0;
+        v12 = v1 * v1 + v2 * v2;
+      } while (v12 > 1.0);
+      t = v1 * Math.sqrt(-2.0 * Math.log(v12) / v12);
+      x = s + 0.5 * t;
+      gds = x * x;
+      if (t >= 0.0)
+        return (gds / lambda);         // Immediate acceptance
+
+      u = randomGenerator.raw();                // Step 3. Uniform random number
+      if (d * u <= t * t * t)
+        return (gds / lambda); // Squeeze acceptance
+
+      if (a != aaa) {                           // Step 4. Set-up for hat case
+        aaa = a;
+        r = 1.0 / a;
+        q0 = ((((((((q9 * r + q8) * r + q7) * r + q6) * r + q5) * r + q4) *
+            r + q3) * r + q2) * r + q1) * r;
+        if (a > 3.686) {
+          if (a > 13.022) {
+            b = 1.77;
+            si = 0.75;
+            c = 0.1515 / s;
+          } else {
+            b = 1.654 + 0.0076 * ss;
+            si = 1.68 / s + 0.275;
+            c = 0.062 / s + 0.024;
+          }
+        } else {
+          b = 0.463 + s - 0.178 * ss;
+          si = 1.235;
+          c = 0.195 / s - 0.079 + 0.016 * s;
+        }
+      }
+      if (x > 0.0) {                        // Step 5. Calculation of q
+        v = t / (s + s);                  // Step 6.
+        if (Math.abs(v) > 0.25) {
+          q = q0 - s * t + 0.25 * t * t + (ss + ss) * Math.log(1.0 + v);
+        } else {
+          q = q0 + 0.5 * t * t * ((((((((a9 * v + a8) * v + a7) * v + a6) *
+              v + a5) * v + a4) * v + a3) * v + a2) * v + a1) * v;
+        }								  // Step 7. Quotient acceptance
+        if (Math.log(1.0 - u) <= q)
+          return (gds / lambda);
+      }
+
+      for (;;) {              			      // Step 8. Double exponential deviate t
+        do {
+          e = -Math.log(randomGenerator.raw());
+          u = randomGenerator.raw();
+          u = u + u - 1.0;
+          sign_u = (u > 0) ? 1.0 : -1.0;
+          t = b + (e * si) * sign_u;
+        } while (t <= -0.71874483771719); // Step 9. Rejection of t
+        v = t / (s + s);                  // Step 10. New q(t)
+        if (Math.abs(v) > 0.25) {
+          q = q0 - s * t + 0.25 * t * t + (ss + ss) * Math.log(1.0 + v);
+        } else {
+          q = q0 + 0.5 * t * t * ((((((((a9 * v + a8) * v + a7) * v + a6) *
+              v + a5) * v + a4) * v + a3) * v + a2) * v + a1) * v;
+        }
+        if (q <= 0.0)
+          continue;           // Step 11.
+        if (q > 0.5) {
+          w = Math.exp(q) - 1.0;
+        } else {
+          w = ((((((e7 * q + e6) * q + e5) * q + e4) * q + e3) * q + e2) *
+              q + e1) * q;
+        }                    			  // Step 12. Hat acceptance
+        if (c * u * sign_u <= w * Math.exp(e - 0.5 * t * t)) {
+          x = s + 0.5 * t;
+          return (x * x / lambda);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the probability distribution function.
+   * @param x x
+   * @return result
+   */
+  public double pdf(double x) {
+    if (x < 0)
+      throw new IllegalArgumentException();
+    if (x == 0) {
+      if (alpha == 1.0)
+        return 1.0 / lambda;
+      else
+        return 0.0;
+    }
+    if (alpha == 1.0)
+      return Math.exp(-x / lambda) / lambda;
+
+    return Math.exp((alpha - 1.0) * Math.log(x / lambda) - x / lambda - Fun.logGamma(alpha)) / lambda;
+  }
+
+  /**
+   * Sets the mean and variance.
+   * @param alpha alpha
+   * @param lambda lambda
+   * @throws IllegalArgumentException if <tt>alpha &lt;= 0.0 || lambda &lt;= 0.0</tt>.
+   */
+  public void setState(double alpha, double lambda) {
+    if (alpha <= 0.0)
+      throw new IllegalArgumentException();
+    if (lambda <= 0.0)
+      throw new IllegalArgumentException();
+    this.alpha = alpha;
+    this.lambda = lambda;
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   * @param alpha alpha
+   * @param lambda lambda
+   * @return result
+   * @throws IllegalArgumentException if <tt>alpha &lt;= 0.0 || lambda &lt;= 0.0</tt>.
+   */
+  public static double staticNextDouble(double alpha, double lambda) {
+    synchronized (shared) {
+      return shared.nextDouble(alpha, lambda);
+    }
+  }
+
+  /**
+   * Returns a String representation of the receiver.
+   */
+  @Override
+  public String toString() {
+    return this.getClass().getName() + "(" + alpha + "," + lambda + ")";
+  }
+
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/GammaFunctions.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/GammaFunctions.java
@@ -1,0 +1,698 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.stat` package.
+ * Changes:
+ * - class name (was Gamma)
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+// CSOFF: ALL
+/**
+ * Gamma and Beta functions.
+ * <p>
+ * <b>Implementation:</b>
+ * <dt>
+ * Some code taken and adapted from the <A HREF="http://www.sci.usq.edu.au/staff/leighb/graph/Top.html">Java 2D Graph Package 2.4</A>,
+ * which in turn is a port from the <A HREF="http://people.ne.mediaone.net/moshier/index.html#Cephes">Cephes 2.2</A> Math Library (C).
+ * Most Cephes code (missing from the 2D Graph Package) directly ported.
+ *
+ * @author wolfgang.hoschek@cern.ch
+ * @version 0.9, 22-Jun-99
+ */
+class GammaFunctions extends Constants {
+
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected GammaFunctions() {
+  }
+
+  /**
+   * Returns the beta function of the arguments.
+   * <pre>
+   *                   -     -
+   *                  | (a) | (b)
+   * beta( a, b )  =  -----------.
+   *                     -
+   *                    | (a+b)
+   * </pre>
+   * 
+   * @param a a
+   * @param b b
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double beta(double a, double b) throws ArithmeticException {
+    double y;
+
+    y = a + b;
+    y = gamma(y);
+    if (y == 0.0)
+      return 1.0;
+
+    if (a > b) {
+      y = gamma(a) / y;
+      y *= gamma(b);
+    } else {
+      y = gamma(b) / y;
+      y *= gamma(a);
+    }
+
+    return (y);
+  }
+
+  /**
+   * Returns the Gamma function of the argument.
+   * 
+   * @param inX x
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double gamma(double inX) throws ArithmeticException {
+    double x = inX;
+
+    double P[] = {
+        1.60119522476751861407E-4,
+        1.19135147006586384913E-3,
+        1.04213797561761569935E-2,
+        4.76367800457137231464E-2,
+        2.07448227648435975150E-1,
+        4.94214826801497100753E-1,
+        9.99999999999999996796E-1
+    };
+    double Q[] = {
+        -2.31581873324120129819E-5,
+        5.39605580493303397842E-4,
+        -4.45641913851797240494E-3,
+        1.18139785222060435552E-2,
+        3.58236398605498653373E-2,
+        -2.34591795718243348568E-1,
+        7.14304917030273074085E-2,
+        1.00000000000000000320E0
+    };
+//double MAXGAM = 171.624376956302725;
+//double LOGPI  = 1.14472988584940017414;
+
+    double p, z;
+    @SuppressWarnings("unused")
+    int i;
+
+    double q = Math.abs(x);
+
+    if (q > 33.0) {
+      if (x < 0.0) {
+        p = Math.floor(q);
+        if (p == q)
+          throw new ArithmeticException("gamma: overflow");
+        i = (int) p;
+        z = q - p;
+        if (z > 0.5) {
+          p += 1.0;
+          z = q - p;
+        }
+        z = q * Math.sin(Math.PI * z);
+        if (z == 0.0)
+          throw new ArithmeticException("gamma: overflow");
+        z = Math.abs(z);
+        z = Math.PI / (z * stirlingFormula(q));
+
+        return -z;
+      } else {
+        return stirlingFormula(x);
+      }
+    }
+
+    z = 1.0;
+    while (x >= 3.0) {
+      x -= 1.0;
+      z *= x;
+    }
+
+    while (x < 0.0) {
+      if (x == 0.0) {
+        throw new ArithmeticException("gamma: singular");
+      } else if (x > -1.E-9) {
+        return (z / ((1.0 + 0.5772156649015329 * x) * x));
+      }
+      z /= x;
+      x += 1.0;
+    }
+
+    while (x < 2.0) {
+      if (x == 0.0) {
+        throw new ArithmeticException("gamma: singular");
+      } else if (x < 1.e-9) {
+        return (z / ((1.0 + 0.5772156649015329 * x) * x));
+      }
+      z /= x;
+      x += 1.0;
+    }
+
+    if ((x == 2.0) || (x == 3.0))
+      return z;
+
+    x -= 2.0;
+    p = Polynomial.polevl(x, P, 6);
+    q = Polynomial.polevl(x, Q, 7);
+    return z * p / q;
+
+  }
+
+  /**
+   * Returns the Incomplete Beta Function evaluated from zero to <tt>xx</tt>; formerly named <tt>ibeta</tt>.
+   *
+   * @param aa the alpha parameter of the beta distribution.
+   * @param bb the beta parameter of the beta distribution.
+   * @param xx the integration end point.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  public static double incompleteBeta(double aa, double bb, double xx) throws ArithmeticException {
+    double a, b, t, x, xc, w, y;
+    boolean flag;
+
+    if (aa <= 0.0 || bb <= 0.0)
+      throw new ArithmeticException("ibeta: Domain error!");
+
+    if ((xx <= 0.0) || (xx >= 1.0)) {
+      if (xx == 0.0)
+        return 0.0;
+      if (xx == 1.0)
+        return 1.0;
+      throw new ArithmeticException("ibeta: Domain error!");
+    }
+
+    flag = false;
+    if ((bb * xx) <= 1.0 && xx <= 0.95) {
+      t = powerSeries(aa, bb, xx);
+      return t;
+    }
+
+    w = 1.0 - xx;
+
+    /* Reverse a and b if x is greater than the mean. */
+    if (xx > (aa / (aa + bb))) {
+      flag = true;
+      a = bb;
+      b = aa;
+      xc = xx;
+      x = w;
+    } else {
+      a = aa;
+      b = bb;
+      xc = w;
+      x = xx;
+    }
+
+    if (flag && (b * x) <= 1.0 && x <= 0.95) {
+      t = powerSeries(a, b, x);
+      if (t <= MACHEP)
+        t = 1.0 - MACHEP;
+      else
+        t = 1.0 - t;
+      return t;
+    }
+
+    /* Choose expansion for better convergence. */
+    y = x * (a + b - 2.0) - (a - 1.0);
+    if (y < 0.0)
+      w = incompleteBetaFraction1(a, b, x);
+    else
+      w = incompleteBetaFraction2(a, b, x) / xc;
+
+    /* Multiply w by the factor
+       a      b   _             _     _
+      x  (1-x)   | (a+b) / ( a | (a) | (b) ) .   */
+
+    y = a * Math.log(x);
+    t = b * Math.log(xc);
+    if ((a + b) < MAXGAM && Math.abs(y) < MAXLOG && Math.abs(t) < MAXLOG) {
+      t = Math.pow(xc, b);
+      t *= Math.pow(x, a);
+      t /= a;
+      t *= w;
+      t *= gamma(a + b) / (gamma(a) * gamma(b));
+      if (flag) {
+        if (t <= MACHEP)
+          t = 1.0 - MACHEP;
+        else
+          t = 1.0 - t;
+      }
+      return t;
+    }
+    /* Resort to logarithms.  */
+    y += t + logGamma(a + b) - logGamma(a) - logGamma(b);
+    y += Math.log(w / a);
+    if (y < MINLOG)
+      t = 0.0;
+    else
+      t = Math.exp(y);
+
+    if (flag) {
+      if (t <= MACHEP)
+        t = 1.0 - MACHEP;
+      else
+        t = 1.0 - t;
+    }
+    return t;
+  }
+
+  /**
+   * Continued fraction expansion #1 for incomplete beta integral; formerly named <tt>incbcf</tt>.
+   */
+  static double incompleteBetaFraction1(double a, double b, double x) throws ArithmeticException {
+    double xk, pk, pkm1, pkm2, qk, qkm1, qkm2;
+    double k1, k2, k3, k4, k5, k6, k7, k8;
+    double r, t, ans, thresh;
+    int n;
+
+    k1 = a;
+    k2 = a + b;
+    k3 = a;
+    k4 = a + 1.0;
+    k5 = 1.0;
+    k6 = b - 1.0;
+    k7 = k4;
+    k8 = a + 2.0;
+
+    pkm2 = 0.0;
+    qkm2 = 1.0;
+    pkm1 = 1.0;
+    qkm1 = 1.0;
+    ans = 1.0;
+    r = 1.0;
+    n = 0;
+    thresh = 3.0 * MACHEP;
+    do {
+      xk = -(x * k1 * k2) / (k3 * k4);
+      pk = pkm1 + pkm2 * xk;
+      qk = qkm1 + qkm2 * xk;
+      pkm2 = pkm1;
+      pkm1 = pk;
+      qkm2 = qkm1;
+      qkm1 = qk;
+
+      xk = (x * k5 * k6) / (k7 * k8);
+      pk = pkm1 + pkm2 * xk;
+      qk = qkm1 + qkm2 * xk;
+      pkm2 = pkm1;
+      pkm1 = pk;
+      qkm2 = qkm1;
+      qkm1 = qk;
+
+      if (qk != 0)
+        r = pk / qk;
+      if (r != 0) {
+        t = Math.abs((ans - r) / r);
+        ans = r;
+      } else
+        t = 1.0;
+
+      if (t < thresh)
+        return ans;
+
+      k1 += 1.0;
+      k2 += 1.0;
+      k3 += 2.0;
+      k4 += 2.0;
+      k5 += 1.0;
+      k6 -= 1.0;
+      k7 += 2.0;
+      k8 += 2.0;
+
+      if ((Math.abs(qk) + Math.abs(pk)) > big) {
+        pkm2 *= biginv;
+        pkm1 *= biginv;
+        qkm2 *= biginv;
+        qkm1 *= biginv;
+      }
+      if ((Math.abs(qk) < biginv) || (Math.abs(pk) < biginv)) {
+        pkm2 *= big;
+        pkm1 *= big;
+        qkm2 *= big;
+        qkm1 *= big;
+      }
+    } while (++n < 300);
+
+    return ans;
+  }
+
+  /**
+   * Continued fraction expansion #2 for incomplete beta integral; formerly named <tt>incbd</tt>.
+   */
+  static double incompleteBetaFraction2(double a, double b, double x) throws ArithmeticException {
+    double xk, pk, pkm1, pkm2, qk, qkm1, qkm2;
+    double k1, k2, k3, k4, k5, k6, k7, k8;
+    double r, t, ans, z, thresh;
+    int n;
+
+    k1 = a;
+    k2 = b - 1.0;
+    k3 = a;
+    k4 = a + 1.0;
+    k5 = 1.0;
+    k6 = a + b;
+    k7 = a + 1.0;
+    ;
+    k8 = a + 2.0;
+
+    pkm2 = 0.0;
+    qkm2 = 1.0;
+    pkm1 = 1.0;
+    qkm1 = 1.0;
+    z = x / (1.0 - x);
+    ans = 1.0;
+    r = 1.0;
+    n = 0;
+    thresh = 3.0 * MACHEP;
+    do {
+      xk = -(z * k1 * k2) / (k3 * k4);
+      pk = pkm1 + pkm2 * xk;
+      qk = qkm1 + qkm2 * xk;
+      pkm2 = pkm1;
+      pkm1 = pk;
+      qkm2 = qkm1;
+      qkm1 = qk;
+
+      xk = (z * k5 * k6) / (k7 * k8);
+      pk = pkm1 + pkm2 * xk;
+      qk = qkm1 + qkm2 * xk;
+      pkm2 = pkm1;
+      pkm1 = pk;
+      qkm2 = qkm1;
+      qkm1 = qk;
+
+      if (qk != 0)
+        r = pk / qk;
+      if (r != 0) {
+        t = Math.abs((ans - r) / r);
+        ans = r;
+      } else
+        t = 1.0;
+
+      if (t < thresh)
+        return ans;
+
+      k1 += 1.0;
+      k2 -= 1.0;
+      k3 += 2.0;
+      k4 += 2.0;
+      k5 += 1.0;
+      k6 += 1.0;
+      k7 += 2.0;
+      k8 += 2.0;
+
+      if ((Math.abs(qk) + Math.abs(pk)) > big) {
+        pkm2 *= biginv;
+        pkm1 *= biginv;
+        qkm2 *= biginv;
+        qkm1 *= biginv;
+      }
+      if ((Math.abs(qk) < biginv) || (Math.abs(pk) < biginv)) {
+        pkm2 *= big;
+        pkm1 *= big;
+        qkm2 *= big;
+        qkm1 *= big;
+      }
+    } while (++n < 300);
+
+    return ans;
+  }
+
+  /**
+   * Returns the Incomplete Gamma function; formerly named <tt>igamma</tt>.
+   * @param a the parameter of the gamma distribution.
+   * @param x the integration end point.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double incompleteGamma(double a, double x)
+      throws ArithmeticException {
+
+    double ans, ax, c, r;
+
+    if (x <= 0 || a <= 0)
+      return 0.0;
+
+    if (x > 1.0 && x > a)
+      return 1.0 - incompleteGammaComplement(a, x);
+
+    /* Compute  x**a * exp(-x) / gamma(a)  */
+    ax = a * Math.log(x) - x - logGamma(a);
+    if (ax < -MAXLOG)
+      return (0.0);
+
+    ax = Math.exp(ax);
+
+    /* power series */
+    r = a;
+    c = 1.0;
+    ans = 1.0;
+
+    do {
+      r += 1.0;
+      c *= x / r;
+      ans += c;
+    } while (c / ans > MACHEP);
+
+    return (ans * ax / a);
+
+  }
+
+  /**
+   * Returns the Complemented Incomplete Gamma function; formerly named <tt>igamc</tt>.
+   * @param a the parameter of the gamma distribution.
+   * @param x the integration start point.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double incompleteGammaComplement(double a, double x) throws ArithmeticException {
+    double ans, ax, c, yc, r, t, y, z;
+    double pk, pkm1, pkm2, qk, qkm1, qkm2;
+
+    if (x <= 0 || a <= 0)
+      return 1.0;
+
+    if (x < 1.0 || x < a)
+      return 1.0 - incompleteGamma(a, x);
+
+    ax = a * Math.log(x) - x - logGamma(a);
+    if (ax < -MAXLOG)
+      return 0.0;
+
+    ax = Math.exp(ax);
+
+    /* continued fraction */
+    y = 1.0 - a;
+    z = x + y + 1.0;
+    c = 0.0;
+    pkm2 = 1.0;
+    qkm2 = x;
+    pkm1 = x + 1.0;
+    qkm1 = z * x;
+    ans = pkm1 / qkm1;
+
+    do {
+      c += 1.0;
+      y += 1.0;
+      z += 2.0;
+      yc = y * c;
+      pk = pkm1 * z - pkm2 * yc;
+      qk = qkm1 * z - qkm2 * yc;
+      if (qk != 0) {
+        r = pk / qk;
+        t = Math.abs((ans - r) / r);
+        ans = r;
+      } else
+        t = 1.0;
+
+      pkm2 = pkm1;
+      pkm1 = pk;
+      qkm2 = qkm1;
+      qkm1 = qk;
+      if (Math.abs(pk) > big) {
+        pkm2 *= biginv;
+        pkm1 *= biginv;
+        qkm2 *= biginv;
+        qkm1 *= biginv;
+      }
+    } while (t > MACHEP);
+
+    return ans * ax;
+  }
+
+  /**
+   * Returns the natural logarithm of the gamma function; formerly named <tt>lgamma</tt>.
+   * @param inX x
+   * @return result
+   * @throws ArithmeticException error
+   */
+  public static double logGamma(double inX) throws ArithmeticException {
+    double x = inX;
+    double p, q, w, z;
+
+    double A[] = {
+        8.11614167470508450300E-4,
+        -5.95061904284301438324E-4,
+        7.93650340457716943945E-4,
+        -2.77777777730099687205E-3,
+        8.33333333333331927722E-2
+    };
+    double B[] = {
+        -1.37825152569120859100E3,
+        -3.88016315134637840924E4,
+        -3.31612992738871184744E5,
+        -1.16237097492762307383E6,
+        -1.72173700820839662146E6,
+        -8.53555664245765465627E5
+    };
+    double C[] = {
+        /* 1.00000000000000000000E0, */
+        -3.51815701436523470549E2,
+        -1.70642106651881159223E4,
+        -2.20528590553854454839E5,
+        -1.13933444367982507207E6,
+        -2.53252307177582951285E6,
+        -2.01889141433532773231E6
+    };
+
+    if (x < -34.0) {
+      q = -x;
+      w = logGamma(q);
+      p = Math.floor(q);
+      if (p == q)
+        throw new ArithmeticException("lgam: Overflow");
+      z = q - p;
+      if (z > 0.5) {
+        p += 1.0;
+        z = p - q;
+      }
+      z = q * Math.sin(Math.PI * z);
+      if (z == 0.0)
+        throw new ArithmeticException("lgamma: Overflow");
+      z = LOGPI - Math.log(z) - w;
+      return z;
+    }
+
+    if (x < 13.0) {
+      z = 1.0;
+      while (x >= 3.0) {
+        x -= 1.0;
+        z *= x;
+      }
+      while (x < 2.0) {
+        if (x == 0.0)
+          throw new ArithmeticException("lgamma: Overflow");
+        z /= x;
+        x += 1.0;
+      }
+      if (z < 0.0)
+        z = -z;
+      if (x == 2.0)
+        return Math.log(z);
+      x -= 2.0;
+      p = x * Polynomial.polevl(x, B, 5) / Polynomial.p1evl(x, C, 6);
+      return (Math.log(z) + p);
+    }
+
+    if (x > 2.556348e305)
+      throw new ArithmeticException("lgamma: Overflow");
+
+    q = (x - 0.5) * Math.log(x) - x + 0.91893853320467274178;
+    //if( x > 1.0e8 ) return( q );
+    if (x > 1.0e8)
+      return (q);
+
+    p = 1.0 / (x * x);
+    if (x >= 1000.0)
+      q += ((7.9365079365079365079365e-4 * p - 2.7777777777777777777778e-3) * p + 0.0833333333333333333333) / x;
+    else
+      q += Polynomial.polevl(p, A, 4) / x;
+    return q;
+  }
+
+  /**
+   * Power series for incomplete beta integral; formerly named <tt>pseries</tt>.
+   * Use when b*x is small and x not too close to 1.  
+   */
+  static double powerSeries(double a, double b, double x) throws ArithmeticException {
+    double s, t, u, v, n, t1, z, ai;
+
+    ai = 1.0 / a;
+    u = (1.0 - b) * x;
+    v = u / (a + 1.0);
+    t1 = v;
+    t = u;
+    n = 2.0;
+    s = 0.0;
+    z = MACHEP * ai;
+    while (Math.abs(v) > z) {
+      u = (n - b) * x / n;
+      t *= u;
+      v = t / (a + n);
+      s += v;
+      n += 1.0;
+    }
+    s += t1;
+    s += ai;
+
+    u = a * Math.log(x);
+    if ((a + b) < MAXGAM && Math.abs(u) < MAXLOG) {
+      t = GammaFunctions.gamma(a + b) / (GammaFunctions.gamma(a) * GammaFunctions.gamma(b));
+      s = s * t * Math.pow(x, a);
+    } else {
+      t = GammaFunctions.logGamma(a + b) - GammaFunctions.logGamma(a) - GammaFunctions.logGamma(b) + u + Math.log(s);
+      if (t < MINLOG)
+        s = 0.0;
+      else
+        s = Math.exp(t);
+    }
+    return s;
+  }
+
+  /**
+   * Returns the Gamma function computed by Stirling's formula; formerly named <tt>stirf</tt>.
+   * The polynomial STIR is valid for 33 <= x <= 172.
+   */
+  static double stirlingFormula(double x) throws ArithmeticException {
+    double STIR[] = {
+        7.87311395793093628397E-4,
+        -2.29549961613378126380E-4,
+        -2.68132617805781232825E-3,
+        3.47222221605458667310E-3,
+        8.33333333333482257126E-2,
+    };
+    double MAXSTIR = 143.01608;
+
+    double w = 1.0 / x;
+    double y = Math.exp(x);
+
+    w = 1.0 + w * Polynomial.polevl(w, STIR, 4);
+
+    if (x > MAXSTIR) {
+      /* Avoid overflow in Math.pow() */
+      double v = Math.pow(x, 0.5 * x - 0.25);
+      y = v * (v / y);
+    } else {
+      y = Math.pow(x, x - 0.5) / y;
+    }
+    y = SQTPI * y * w;
+    return y;
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/MersenneTwister.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/MersenneTwister.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random.engine` package.
+ * Changes:
+ * - package name
+ * - added serialization version
+ * - missing Javadoc tags
+ * - reformat
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+import java.util.Date;
+
+// CSOFF: ALL
+/**
+MersenneTwister (MT19937) is one of the strongest uniform pseudo-random number generators known so far; at the same time it is quick.
+Produces uniformly distributed <tt>int</tt>'s and <tt>long</tt>'s in the closed intervals <tt>[Integer.MIN_VALUE,Integer.MAX_VALUE]</tt> and <tt>[Long.MIN_VALUE,Long.MAX_VALUE]</tt>, respectively, 
+as well as <tt>float</tt>'s and <tt>double</tt>'s in the open unit intervals <tt>(0.0f,1.0f)</tt> and <tt>(0.0,1.0)</tt>, respectively.
+The seed can be any 32-bit integer except <tt>0</tt>. Shawn J. Cokus commented that perhaps the seed should preferably be odd.
+<p>
+<b>Quality:</b> MersenneTwister is designed to pass the k-distribution test. It has an astronomically large period of 2<sup>19937</sup>-1 (=10<sup>6001</sup>) and 623-dimensional equidistribution up to 32-bit accuracy.
+It passes many stringent statistical tests, including the <A HREF="http://stat.fsu.edu/~geo/diehard.html">diehard</A> test of G. Marsaglia and the load test of P. Hellekalek and S. Wegenkittl.
+<p>
+<b>Performance:</b> Its speed is comparable to other modern generators (in particular, as fast as <tt>java.util.Random.nextFloat()</tt>).
+2.5 million calls to <tt>raw()</tt> per second (Pentium Pro 200 Mhz, JDK 1.2, NT).
+Be aware, however, that there is a non-negligible amount of overhead required to initialize the data
+structures used by a MersenneTwister. Code like
+<pre>
+  double sum = 0.0;
+  for (int i=0; i<100000; ++i) {
+     RandomElement twister = new MersenneTwister(new java.util.Date());
+     sum += twister.raw();
+  }
+</pre>
+will be wildly inefficient. Consider using
+<pre>
+  double sum = 0.0;
+  RandomElement twister = new MersenneTwister(new java.util.Date());
+  for (int i=0; i<100000; ++i) {
+     sum += twister.raw();
+  }
+</pre>
+instead.  This allows the cost of constructing the MersenneTwister object
+to be borne only once, rather than once for each iteration in the loop.
+<p>
+<b>Implementation:</b> After M. Matsumoto and T. Nishimura,                                  
+"Mersenne Twister: A 623-Dimensionally Equidistributed Uniform Pseudo-Random Number Generator",                                
+ACM Transactions on Modeling and Computer Simulation,           
+Vol. 8, No. 1, January 1998, pp 3--30.
+<dt>More info on <A HREF="http://www.math.keio.ac.jp/~matumoto/eindex.html"> Masumoto's homepage</A>.
+<dt>More info on <A HREF="http://www.ncsa.uiuc.edu/Apps/CMP/RNG/www-rng.html"> Pseudo-random number generators is on the Web</A>.
+<dt>Yet <A HREF="http://nhse.npac.syr.edu/random"> some more info</A>.
+<p>
+The correctness of this implementation has been verified against the published output sequence 
+<a href="http://www.math.keio.ac.jp/~nisimura/random/real2/mt19937-2.out">mt19937-2.out</a> of the C-implementation
+<a href="http://www.math.keio.ac.jp/~nisimura/random/real2/mt19937-2.c">mt19937-2.c</a>.
+(Call <tt>test(1000)</tt> to print the sequence).
+<dt>
+Note that this implementation is <b>not synchronized</b>.                                  
+<p>
+<b>Details:</b> MersenneTwister is designed with consideration of the flaws of various existing generators in mind.
+It is an improved version of TT800, a very successful generator.
+MersenneTwister is based on linear recurrences modulo 2.
+Such generators are very fast, have extremely long periods, and appear quite robust. 
+MersenneTwister produces 32-bit numbers, and every <tt>k</tt>-dimensional vector of such numbers appears the same number of times as <tt>k</tt> successive values over the
+period length, for each <tt>k &lt;= 623</tt> (except for the zero vector, which appears one time less).
+If one looks at only the first <tt>n &lt;= 16</tt> bits of each number, then the property holds for even larger <tt>k</tt>, as shown in the following table (taken from the publication cited above):
+<div align="center">
+<table width="75%" border="1" cellspacing="0" cellpadding="0">
+  <tr> 
+  <td width="2%"> <div align="center">n</div> </td>
+  <td width="6%"> <div align="center">1</div> </td>
+  <td width="5%"> <div align="center">2</div> </td>
+  <td width="5%"> <div align="center">3</div> </td>
+  <td width="5%"> <div align="center">4</div> </td>
+  <td width="5%"> <div align="center">5</div> </td>
+  <td width="5%"> <div align="center">6</div> </td>
+  <td width="5%"> <div align="center">7</div> </td>
+  <td width="5%"> <div align="center">8</div> </td>
+  <td width="5%"> <div align="center">9</div> </td>
+  <td width="5%"> <div align="center">10</div> </td>
+  <td width="5%"> <div align="center">11</div> </td>
+  <td width="10%"> <div align="center">12 .. 16</div> </td>
+  <td width="10%"> <div align="center">17 .. 32</div> </td>
+  </tr>
+  <tr> 
+  <td width="2%"> <div align="center">k</div> </td>
+  <td width="6%"> <div align="center">19937</div> </td>
+  <td width="5%"> <div align="center">9968</div> </td>
+  <td width="5%"> <div align="center">6240</div> </td>
+  <td width="5%"> <div align="center">4984</div> </td>
+  <td width="5%"> <div align="center">3738</div> </td>
+  <td width="5%"> <div align="center">3115</div> </td>
+  <td width="5%"> <div align="center">2493</div> </td>
+  <td width="5%"> <div align="center">2492</div> </td>
+  <td width="5%"> <div align="center">1869</div> </td>
+  <td width="5%"> <div align="center">1869</div> </td>
+  <td width="5%"> <div align="center">1248</div> </td>
+  <td width="10%"> <div align="center">1246</div> </td>
+  <td width="10%"> <div align="center">623</div> </td>
+  </tr>
+</table>
+</div>
+<p>
+MersenneTwister generates random numbers in batches of 624 numbers at a time, so the caching and pipelining of modern systems is exploited.
+The generator is implemented to generate the output by using the fastest arithmetic operations only: 32-bit additions and bit operations (no division, no multiplication, no mod).
+These operations generate sequences of 32 random bits (<tt>int</tt>'s).
+<tt>long</tt>'s are formed by concatenating two 32 bit <tt>int</tt>'s.
+<tt>float</tt>'s are formed by dividing the interval <tt>[0.0,1.0]</tt> into 2<sup>32</sup> sub intervals, then randomly choosing one subinterval.
+<tt>double</tt>'s are formed by dividing the interval <tt>[0.0,1.0]</tt> into 2<sup>64</sup> sub intervals, then randomly choosing one subinterval.
+<p>
+@author wolfgang.hoschek@cern.ch
+@version 1.0, 09/24/99
+@see java.util.Random
+*/
+public class MersenneTwister extends RandomEngine {
+  private static final long serialVersionUID = 1L;
+
+  private int mti;
+  private int[] mt = new int[N]; /* set initial seeds: N = 624 words */
+
+  /* Period parameters */
+  private static final int N = 624;
+  private static final int M = 397;
+  private static final int MATRIX_A = 0x9908b0df; /* constant vector a */
+  private static final int UPPER_MASK = 0x80000000; /* most significant w-r bits */
+  private static final int LOWER_MASK = 0x7fffffff; /* least significant r bits */
+
+  /* for tempering */
+  private static final int TEMPERING_MASK_B = 0x9d2c5680;
+  private static final int TEMPERING_MASK_C = 0xefc60000;
+
+  private static final int mag0 = 0x0;
+  private static final int mag1 = MATRIX_A;
+  //private static final int[] mag01=new int[] {0x0, MATRIX_A};
+  /* mag01[x] = x * MATRIX_A  for x=0,1 */
+
+  public static final int DEFAULT_SEED = 4357;
+
+  /**
+   * Constructs and returns a random number generator with a default seed, which is a <b>constant</b>.
+   * Thus using this constructor will yield generators that always produce exactly the same sequence.
+   * This method is mainly intended to ease testing and debugging.
+   */
+  public MersenneTwister() {
+    this(DEFAULT_SEED);
+  }
+
+  /**
+   * Constructs and returns a random number generator with the given seed.
+   * @param seed the seed
+   */
+  public MersenneTwister(int seed) {
+    setSeed(seed);
+  }
+
+  /**
+   * Constructs and returns a random number generator seeded with the given date.
+   *
+   * @param d typically <tt>new java.util.Date()</tt>
+   */
+  public MersenneTwister(Date d) {
+    this((int) d.getTime());
+  }
+
+  /**
+   * Returns a copy of the receiver; the copy will produce identical sequences.
+   * After this call has returned, the copy and the receiver have equal but separate state.
+   *
+   * @return a copy of the receiver.
+   */
+  @Override
+  public Object clone() {
+    MersenneTwister clone = (MersenneTwister) super.clone();
+    clone.mt = (int[]) this.mt.clone();
+    return clone;
+  }
+
+  /**
+   * Generates N words at one time.
+   */
+  protected void nextBlock() {
+    /*
+    // ******************** OPTIMIZED **********************
+    // only 5-10% faster ?
+    int y;
+    
+    int kk;
+    int[] cache = mt; // cached for speed
+    int kkM;
+    int limit = N-M;
+    for (kk=0,kkM=kk+M; kk<limit; kk++,kkM++) {
+    y = (cache[kk]&UPPER_MASK)|(cache[kk+1]&LOWER_MASK);
+    cache[kk] = cache[kkM] ^ (y >>> 1) ^ ((y & 0x1) == 0 ? mag0 : mag1);
+    }
+    limit = N-1;
+    for (kkM=kk+(M-N); kk<limit; kk++,kkM++) {
+    y = (cache[kk]&UPPER_MASK)|(cache[kk+1]&LOWER_MASK);
+    cache[kk] = cache[kkM] ^ (y >>> 1) ^ ((y & 0x1) == 0 ? mag0 : mag1);
+    }
+    y = (cache[N-1]&UPPER_MASK)|(cache[0]&LOWER_MASK);
+    cache[N-1] = cache[M-1] ^ (y >>> 1) ^ ((y & 0x1) == 0 ? mag0 : mag1);
+    
+    this.mt = cache;
+    this.mti = 0;
+    */
+
+    // ******************** UNOPTIMIZED **********************
+    int y;
+
+    int kk;
+
+    for (kk = 0; kk < N - M; kk++) {
+      y = (mt[kk] & UPPER_MASK) | (mt[kk + 1] & LOWER_MASK);
+      mt[kk] = mt[kk + M] ^ (y >>> 1) ^ ((y & 0x1) == 0 ? mag0 : mag1);
+    }
+    for (; kk < N - 1; kk++) {
+      y = (mt[kk] & UPPER_MASK) | (mt[kk + 1] & LOWER_MASK);
+      mt[kk] = mt[kk + (M - N)] ^ (y >>> 1) ^ ((y & 0x1) == 0 ? mag0 : mag1);
+    }
+    y = (mt[N - 1] & UPPER_MASK) | (mt[0] & LOWER_MASK);
+    mt[N - 1] = mt[M - 1] ^ (y >>> 1) ^ ((y & 0x1) == 0 ? mag0 : mag1);
+
+    this.mti = 0;
+
+  }
+
+  /**
+   * Returns a 32 bit uniformly distributed random number in the closed interval <tt>[Integer.MIN_VALUE,Integer.MAX_VALUE]</tt> (including <tt>Integer.MIN_VALUE</tt> and <tt>Integer.MAX_VALUE</tt>).
+   */
+  @Override
+  public int nextInt() {
+    /* Each single bit including the sign bit will be random */
+    if (mti == N)
+      nextBlock(); // generate N ints at one time
+
+    int y = mt[mti++];
+    y ^= y >>> 11; // y ^= TEMPERING_SHIFT_U(y );
+    y ^= (y << 7) & TEMPERING_MASK_B; // y ^= TEMPERING_SHIFT_S(y) & TEMPERING_MASK_B;
+    y ^= (y << 15) & TEMPERING_MASK_C; // y ^= TEMPERING_SHIFT_T(y) & TEMPERING_MASK_C; 
+    // y &= 0xffffffff; //you may delete this line if word size = 32 
+    y ^= y >>> 18; // y ^= TEMPERING_SHIFT_L(y);
+
+    return y;
+  }
+
+  /**
+   * Sets the receiver's seed. 
+   * This method resets the receiver's entire internal state.
+   * @param seed the seed
+   */
+  protected void setSeed(int seed) {
+    mt[0] = seed & 0xffffffff;
+    for (int i = 1; i < N; i++) {
+      mt[i] = (1812433253 * (mt[i - 1] ^ (mt[i - 1] >> 30)) + i);
+      /* See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. */
+      /* In the previous versions, MSBs of the seed affect   */
+      /* only MSBs of the array mt[].                        */
+      /* 2002/01/09 modified by Makoto Matsumoto             */
+      mt[i] &= 0xffffffff;
+      /* for >32 bit machines */
+    }
+    //System.out.println("init done");
+    mti = N;
+
+    /*
+    old version was:  
+    for (int i = 0; i < N; i++) {
+    mt[i] = seed & 0xffff0000;
+    seed = 69069 * seed + 1;
+    mt[i] |= (seed & 0xffff0000) >>> 16;
+    seed = 69069 * seed + 1;
+    }
+    //System.out.println("init done");
+    mti = N;
+    */
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/MersenneTwister64.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/MersenneTwister64.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random.engine` package.
+ * Changes:
+ * - package name
+ * - added serialization version
+ * - reformat
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+import java.util.Date;
+
+//CSOFF: ALL
+/**
+ * Same as <tt>MersenneTwister</tt> except that method <tt>raw()</tt> returns 64 bit random numbers instead of 32 bit random numbers.
+ * 
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ * @see MersenneTwister
+ */
+public class MersenneTwister64 extends MersenneTwister {
+  private static final long serialVersionUID = 1L;
+
+  /**
+  * Constructs and returns a random number generator with a default seed, which is a <b>constant</b>.
+  */
+  public MersenneTwister64() {
+    super();
+  }
+
+  /**
+   * Constructs and returns a random number generator with the given seed.
+   * @param seed should not be 0, in such a case <tt>MersenneTwister64.DEFAULT_SEED</tt> is silently substituted.
+   */
+  public MersenneTwister64(int seed) {
+    super(seed);
+  }
+
+  /**
+   * Constructs and returns a random number generator seeded with the given date.
+   *
+   * @param d typically <tt>new java.util.Date()</tt>
+   */
+  public MersenneTwister64(Date d) {
+    super(d);
+  }
+
+  /**
+   * Returns a 64 bit uniformly distributed random number in the open unit interval <code>(0.0,1.0)</code> (excluding 0.0 and 1.0).
+   */
+  @Override
+  public double raw() {
+    return nextDouble();
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Normal.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Normal.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - remove unused method
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+Normal (aka Gaussian) distribution; See the <A HREF="http://www.cern.ch/RD11/rkb/AN16pp/node188.html#SECTION0001880000000000000000"> math definition</A>
+and <A HREF="http://www.statsoft.com/textbook/glosn.html#Normal Distribution"> animated definition</A>.
+<pre>                       
+				   1                       2
+	  pdf(x) = ---------    exp( - (x-mean) / 2v ) 
+			   sqrt(2pi*v)
+
+							x
+							 -
+				   1        | |                 2
+	  cdf(x) = ---------    |    exp( - (t-mean) / 2v ) dt
+			   sqrt(2pi*v)| |
+						   -
+						  -inf.
+</pre>
+where <tt>v = variance = standardDeviation^2</tt>.
+<p>
+Instance methods operate on a user supplied uniform random number generator; they are unsynchronized.
+<dt>
+Static methods operate on a default uniform random number generator; they are synchronized.
+<p>
+<b>Implementation:</b> Polar Box-Muller transformation. See 
+G.E.P. Box, M.E. Muller (1958): A note on the generation of random normal deviates, Annals Math. Statist. 29, 610-611.
+<p>
+@author wolfgang.hoschek@cern.ch
+@version 1.0, 09/24/99
+*/
+public class Normal extends AbstractContinousDistribution {
+
+  private static final long serialVersionUID = 1L;
+
+  protected double mean;
+  protected double variance;
+  protected double standardDeviation;
+
+  protected double cache; // cache for Box-Mueller algorithm 
+  protected boolean cacheFilled; // Box-Mueller
+
+  protected double SQRT_INV; // performance cache
+
+  // The uniform random number generated shared by all <b>static</b> methods.
+  protected static Normal shared = new Normal(0.0, 1.0, makeDefaultGenerator());
+
+  /**
+   * Constructs a normal (gauss) distribution.
+   * Example: mean=0.0, standardDeviation=1.0.
+   * @param mean mean
+   * @param standardDeviation standard deviation
+   * @param randomGenerator generator
+   */
+  public Normal(double mean, double standardDeviation, RandomEngine randomGenerator) {
+    setRandomGenerator(randomGenerator);
+    setState(mean, standardDeviation);
+  }
+
+  /**
+   * Returns the cumulative distribution function.
+   * @param x x
+   * @return result
+   */
+  public double cdf(double x) {
+    return Probability.normal(mean, variance, x);
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   */
+  @Override
+  public double nextDouble() {
+    return nextDouble(this.mean, this.standardDeviation);
+  }
+
+  /**
+   * Returns a random number from the distribution; bypasses the internal state.
+   * @param mean mean
+   * @param standardDeviation standard deviation
+   * @return result
+   */
+  public double nextDouble(double mean, double standardDeviation) {
+    // Uses polar Box-Muller transformation.
+    if (cacheFilled && this.mean == mean && this.standardDeviation == standardDeviation) {
+      cacheFilled = false;
+      return cache;
+    }
+    ;
+
+    double x, y, r, z;
+    do {
+      x = 2.0 * randomGenerator.raw() - 1.0;
+      y = 2.0 * randomGenerator.raw() - 1.0;
+      r = x * x + y * y;
+    } while (r >= 1.0);
+
+    z = Math.sqrt(-2.0 * Math.log(r) / r);
+    cache = mean + standardDeviation * x * z;
+    cacheFilled = true;
+    return mean + standardDeviation * y * z;
+  }
+
+  /**
+   * Returns the probability distribution function.
+   * @param x x
+   * @return result
+   */
+  public double pdf(double x) {
+    double diff = x - mean;
+    return SQRT_INV * Math.exp(-(diff * diff) / (2.0 * variance));
+  }
+
+  /**
+   * Sets the uniform random generator internally used.
+   */
+  @Override
+  protected void setRandomGenerator(RandomEngine randomGenerator) {
+    super.setRandomGenerator(randomGenerator);
+    this.cacheFilled = false;
+  }
+
+  /**
+   * Sets the mean and variance.
+   * @param mean mean
+   * @param standardDeviation standard deviation
+   */
+  public void setState(double mean, double standardDeviation) {
+    if (mean != this.mean || standardDeviation != this.standardDeviation) {
+      this.mean = mean;
+      this.standardDeviation = standardDeviation;
+      this.variance = standardDeviation * standardDeviation;
+      this.cacheFilled = false;
+
+      this.SQRT_INV = 1.0 / Math.sqrt(2.0 * Math.PI * variance);
+    }
+  }
+
+  /**
+   * Returns a random number from the distribution with the given mean and standard deviation.
+   * @param mean mean
+   * @param standardDeviation standard deviation
+   * @return result
+   */
+  public static double staticNextDouble(double mean, double standardDeviation) {
+    synchronized (shared) {
+      return shared.nextDouble(mean, standardDeviation);
+    }
+  }
+
+  /**
+   * Returns a String representation of the receiver.
+   */
+  @Override
+  public String toString() {
+    return this.getClass().getName() + "(" + mean + "," + standardDeviation + ")";
+  }
+
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/PersistentObject.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/PersistentObject.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.colt` package.
+ * Changes:
+ * - package name
+ * - added serialization version
+ * - reformat
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * This empty class is the common root for all persistent capable classes.
+ * If this class inherits from <tt>java.lang.Object</tt> then all subclasses are serializable with the standard Java serialization mechanism.
+ * If this class inherits from <tt>com.objy.db.app.ooObj</tt> then all subclasses are <i>additionally</i> serializable with the Objectivity ODBMS persistance mechanism.
+ * Thus, by modifying the inheritance of this class the entire tree of subclasses can be switched to Objectivity compatibility (and back) with minimum effort.
+ */
+abstract class PersistentObject extends Object implements java.io.Serializable, Cloneable {
+  public static final long serialVersionUID = 1020L;
+
+  /**
+   * Not yet commented.
+   */
+  protected PersistentObject() {
+  }
+
+  /**
+   * Returns a copy of the receiver.
+   * This default implementation does not nothing except making the otherwise <tt>protected</tt> clone method <tt>public</tt>.
+   *
+   * @return a copy of the receiver.
+   */
+  @Override
+  public Object clone() {
+    try {
+      return super.clone();
+    } catch (CloneNotSupportedException exc) {
+      throw new InternalError(); //should never happen since we are cloneable
+    }
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Polynomial.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Polynomial.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.math` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ * - make package scoped
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * Polynomial functions.
+ */
+class Polynomial extends Constants {
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected Polynomial() {
+  }
+
+  /**
+   * Evaluates the given polynomial of degree <tt>N</tt> at <tt>x</tt>, assuming coefficient of N is 1.0.
+   * Otherwise same as <tt>polevl()</tt>.
+   * <pre>
+   *                     2          N
+   * y  =  C  + C x + C x  +...+ C x
+   *        0    1     2          N
+   *
+   * where C  = 1 and hence is omitted from the array.
+   *        N
+   *
+   * Coefficients are stored in reverse order:
+   *
+   * coef[0] = C  , ..., coef[N-1] = C  .
+   *            N-1                   0
+   *
+   * Calling arguments are otherwise the same as polevl().
+   * </pre>
+   * In the interest of speed, there are no checks for out of bounds arithmetic.
+   *
+   * @param x argument to the polynomial.
+   * @param coef the coefficients of the polynomial.
+   * @param N the degree of the polynomial.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  public static double p1evl(double x, double coef[], int N) throws ArithmeticException {
+    double ans;
+
+    ans = x + coef[0];
+
+    for (int i = 1; i < N; i++) {
+      ans = ans * x + coef[i];
+    }
+
+    return ans;
+  }
+
+  /**
+   * Evaluates the given polynomial of degree <tt>N</tt> at <tt>x</tt>.
+   * <pre>
+   *                     2          N
+   * y  =  C  + C x + C x  +...+ C x
+   *        0    1     2          N
+   *
+   * Coefficients are stored in reverse order:
+   *
+   * coef[0] = C  , ..., coef[N] = C  .
+   *            N                   0
+   * </pre>
+   * In the interest of speed, there are no checks for out of bounds arithmetic.
+   *
+   * @param x argument to the polynomial.
+   * @param coef the coefficients of the polynomial.
+   * @param N the degree of the polynomial.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  public static double polevl(double x, double coef[], int N) throws ArithmeticException {
+    double ans;
+    ans = coef[0];
+
+    for (int i = 1; i <= N; i++)
+      ans = ans * x + coef[i];
+
+    return ans;
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Probability.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/Probability.java
@@ -1,0 +1,882 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.stat` package.
+ * Changes:
+ * - package name
+ * - added serialization version
+ * - missing Javadoc tags
+ * - reformat
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+// CSOFF: ALL
+/**
+ * Custom tailored numerical integration of certain probability distributions.
+ * <p>
+ * <b>Implementation:</b>
+ * <dt>
+ * Some code taken and adapted from the <A HREF="http://www.sci.usq.edu.au/staff/leighb/graph/Top.html">Java 2D Graph Package 2.4</A>,
+ * which in turn is a port from the <A HREF="http://people.ne.mediaone.net/moshier/index.html#Cephes">Cephes 2.2</A> Math Library (C).
+ * Most Cephes code (missing from the 2D Graph Package) directly ported.
+ *
+ * @author peter.gedeck@pharma.Novartis.com
+ * @author wolfgang.hoschek@cern.ch
+ * @version 0.91, 08-Dec-99
+ */
+public class Probability extends Constants {
+  /*************************************************
+   *    COEFFICIENTS FOR METHOD  normalInverse()   *
+   *************************************************/
+  /* approximation for 0 <= |y - 0.5| <= 3/8 */
+  protected static final double P0[] = {
+      -5.99633501014107895267E1,
+      9.80010754185999661536E1,
+      -5.66762857469070293439E1,
+      1.39312609387279679503E1,
+      -1.23916583867381258016E0,
+  };
+  protected static final double Q0[] = {
+      /* 1.00000000000000000000E0,*/
+      1.95448858338141759834E0,
+      4.67627912898881538453E0,
+      8.63602421390890590575E1,
+      -2.25462687854119370527E2,
+      2.00260212380060660359E2,
+      -8.20372256168333339912E1,
+      1.59056225126211695515E1,
+      -1.18331621121330003142E0,
+  };
+
+  /* Approximation for interval z = sqrt(-2 log y ) between 2 and 8
+   * i.e., y between exp(-2) = .135 and exp(-32) = 1.27e-14.
+   */
+  protected static final double P1[] = {
+      4.05544892305962419923E0,
+      3.15251094599893866154E1,
+      5.71628192246421288162E1,
+      4.40805073893200834700E1,
+      1.46849561928858024014E1,
+      2.18663306850790267539E0,
+      -1.40256079171354495875E-1,
+      -3.50424626827848203418E-2,
+      -8.57456785154685413611E-4,
+  };
+  protected static final double Q1[] = {
+      /*  1.00000000000000000000E0,*/
+      1.57799883256466749731E1,
+      4.53907635128879210584E1,
+      4.13172038254672030440E1,
+      1.50425385692907503408E1,
+      2.50464946208309415979E0,
+      -1.42182922854787788574E-1,
+      -3.80806407691578277194E-2,
+      -9.33259480895457427372E-4,
+  };
+
+  /* Approximation for interval z = sqrt(-2 log y ) between 8 and 64
+   * i.e., y between exp(-32) = 1.27e-14 and exp(-2048) = 3.67e-890.
+   */
+  protected static final double P2[] = {
+      3.23774891776946035970E0,
+      6.91522889068984211695E0,
+      3.93881025292474443415E0,
+      1.33303460815807542389E0,
+      2.01485389549179081538E-1,
+      1.23716634817820021358E-2,
+      3.01581553508235416007E-4,
+      2.65806974686737550832E-6,
+      6.23974539184983293730E-9,
+  };
+  protected static final double Q2[] = {
+      /*  1.00000000000000000000E0,*/
+      6.02427039364742014255E0,
+      3.67983563856160859403E0,
+      1.37702099489081330271E0,
+      2.16236993594496635890E-1,
+      1.34204006088543189037E-2,
+      3.28014464682127739104E-4,
+      2.89247864745380683936E-6,
+      6.79019408009981274425E-9,
+  };
+
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected Probability() {
+  }
+
+  /**
+   * Returns the area from zero to <tt>x</tt> under the beta density
+   * function.
+   * <pre>
+   *                          x
+   *            -             -
+   *           | (a+b)       | |  a-1      b-1
+   * P(x)  =  ----------     |   t    (1-t)    dt
+   *           -     -     | |
+   *          | (a) | (b)   -
+   *                         0
+   * </pre>
+   * This function is identical to the incomplete beta
+   * integral function <tt>Gamma.incompleteBeta(a, b, x)</tt>.
+   *
+   * The complemented function is
+   *
+   * <tt>1 - P(1-x)  =  Gamma.incompleteBeta( b, a, x )</tt>;
+   *
+   * @param a a
+   * @param b b
+   * @param x x
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double beta(double a, double b, double x) {
+    return GammaFunctions.incompleteBeta(a, b, x);
+  }
+
+  /**
+   * Returns the area under the right hand tail (from <tt>x</tt> to
+   * infinity) of the beta density function.
+   * 
+   * This function is identical to the incomplete beta
+   * integral function <tt>Gamma.incompleteBeta(b, a, x)</tt>.
+   * 
+   * @param a a
+   * @param b b
+   * @param x x
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double betaComplemented(double a, double b, double x) {
+    return GammaFunctions.incompleteBeta(b, a, x);
+  }
+
+  /**
+   * Returns the sum of the terms <tt>0</tt> through <tt>k</tt> of the Binomial
+   * probability density.
+   * <pre>
+   *   k
+   *   --  ( n )   j      n-j
+   *   >   (   )  p  (1-p)
+   *   --  ( j )
+   *  j=0
+   * </pre>
+   * The terms are not summed directly; instead the incomplete
+   * beta integral is employed, according to the formula
+   * <p>
+   * <tt>y = binomial( k, n, p ) = Gamma.incompleteBeta( n-k, k+1, 1-p )</tt>.
+   * <p>
+   * All arguments must be positive, 
+   * @param k end term.
+   * @param n the number of trials.
+   * @param p the probability of success (must be in <tt>(0.0,1.0)</tt>).
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double binomial(int k, int n, double p) {
+    if ((p < 0.0) || (p > 1.0))
+      throw new IllegalArgumentException();
+    if ((k < 0) || (n < k))
+      throw new IllegalArgumentException();
+
+    if (k == n)
+      return (1.0);
+    if (k == 0)
+      return Math.pow(1.0 - p, n - k);
+
+    return GammaFunctions.incompleteBeta(n - k, k + 1, 1.0 - p);
+  }
+
+  /**
+   * Returns the sum of the terms <tt>k+1</tt> through <tt>n</tt> of the Binomial
+   * probability density.
+   * <pre>
+   *   n
+   *   --  ( n )   j      n-j
+   *   >   (   )  p  (1-p)
+   *   --  ( j )
+   *  j=k+1
+   * </pre>
+   * The terms are not summed directly; instead the incomplete
+   * beta integral is employed, according to the formula
+   * <p>
+   * <tt>y = binomialComplemented( k, n, p ) = Gamma.incompleteBeta( k+1, n-k, p )</tt>.
+   * <p>
+   * All arguments must be positive, 
+   * @param k end term.
+   * @param n the number of trials.
+   * @param p the probability of success (must be in <tt>(0.0,1.0)</tt>).
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double binomialComplemented(int k, int n, double p) {
+    if ((p < 0.0) || (p > 1.0))
+      throw new IllegalArgumentException();
+    if ((k < 0) || (n < k))
+      throw new IllegalArgumentException();
+
+    if (k == n)
+      return (0.0);
+    if (k == 0)
+      return 1.0 - Math.pow(1.0 - p, n - k);
+
+    return GammaFunctions.incompleteBeta(k + 1, n - k, p);
+  }
+
+  /**
+   * Returns the area under the left hand tail (from 0 to <tt>x</tt>)
+   * of the Chi square probability density function with
+   * <tt>v</tt> degrees of freedom.
+   * <pre>
+   *                                  inf.
+   *                                    -
+   *                        1          | |  v/2-1  -t/2
+   *  P( x | v )   =   -----------     |   t      e     dt
+   *                    v/2  -       | |
+   *                   2    | (v/2)   -
+   *                                   x
+   * </pre>
+   * where <tt>x</tt> is the Chi-square variable.
+   * <p>
+   * The incomplete gamma integral is used, according to the
+   * formula
+   * <p>
+   * <tt>y = chiSquare( v, x ) = incompleteGamma( v/2.0, x/2.0 )</tt>.
+   * <p>
+   * The arguments must both be positive.
+   *
+   * @param v degrees of freedom.
+   * @param x integration end point.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double chiSquare(double v, double x) throws ArithmeticException {
+    if (x < 0.0 || v < 1.0)
+      return 0.0;
+    return GammaFunctions.incompleteGamma(v / 2.0, x / 2.0);
+  }
+
+  /**
+   * Returns the area under the right hand tail (from <tt>x</tt> to
+   * infinity) of the Chi square probability density function
+   * with <tt>v</tt> degrees of freedom.
+   * <pre>
+   *                                  inf.
+   *                                    -
+   *                        1          | |  v/2-1  -t/2
+   *  P( x | v )   =   -----------     |   t      e     dt
+   *                    v/2  -       | |
+   *                   2    | (v/2)   -
+   *                                   x
+   * </pre>
+   * where <tt>x</tt> is the Chi-square variable.
+   *
+   * The incomplete gamma integral is used, according to the
+   * formula
+   *
+   * <tt>y = chiSquareComplemented( v, x ) = incompleteGammaComplement( v/2.0, x/2.0 )</tt>.
+   *
+   *
+   * The arguments must both be positive.
+   *
+   * @param v degrees of freedom.
+   * @param x x
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double chiSquareComplemented(double v, double x) throws ArithmeticException {
+    if (x < 0.0 || v < 1.0)
+      return 0.0;
+    return GammaFunctions.incompleteGammaComplement(v / 2.0, x / 2.0);
+  }
+
+  /**
+   * Returns the error function of the normal distribution; formerly named <tt>erf</tt>.
+   * The integral is
+   * <pre>
+   *                           x 
+   *                            -
+   *                 2         | |          2
+   *   erf(x)  =  --------     |    exp( - t  ) dt.
+   *              sqrt(pi)   | |
+   *                          -
+   *                           0
+   * </pre>
+   * <b>Implementation:</b>
+   * For <tt>0 <= |x| < 1, erf(x) = x * P4(x**2)/Q5(x**2)</tt>; otherwise
+   * <tt>erf(x) = 1 - erfc(x)</tt>.
+   * <p>
+   * Code adapted from the <A HREF="http://www.sci.usq.edu.au/staff/leighb/graph/Top.html">Java 2D Graph Package 2.4</A>,
+   * which in turn is a port from the <A HREF="http://people.ne.mediaone.net/moshier/index.html#Cephes">Cephes 2.2</A> Math Library (C).
+   *
+   * @param x the argument to the function.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double errorFunction(double x) throws ArithmeticException {
+    double y, z;
+    final double T[] = {
+        9.60497373987051638749E0,
+        9.00260197203842689217E1,
+        2.23200534594684319226E3,
+        7.00332514112805075473E3,
+        5.55923013010394962768E4
+    };
+    final double U[] = {
+        //1.00000000000000000000E0,
+        3.35617141647503099647E1,
+        5.21357949780152679795E2,
+        4.59432382970980127987E3,
+        2.26290000613890934246E4,
+        4.92673942608635921086E4
+    };
+
+    if (Math.abs(x) > 1.0)
+      return (1.0 - errorFunctionComplemented(x));
+    z = x * x;
+    y = x * Polynomial.polevl(z, T, 4) / Polynomial.p1evl(z, U, 5);
+    return y;
+  }
+
+  /**
+   * Returns the complementary Error function of the normal distribution; formerly named <tt>erfc</tt>.
+   * <pre>
+   *  1 - erf(x) =
+   *
+   *                           inf. 
+   *                             -
+   *                  2         | |          2
+   *   erfc(x)  =  --------     |    exp( - t  ) dt
+   *               sqrt(pi)   | |
+   *                           -
+   *                            x
+   * </pre>
+   * <b>Implementation:</b>
+   * For small x, <tt>erfc(x) = 1 - erf(x)</tt>; otherwise rational
+   * approximations are computed.
+   * <p>
+   * Code adapted from the <A HREF="http://www.sci.usq.edu.au/staff/leighb/graph/Top.html">Java 2D Graph Package 2.4</A>,
+   * which in turn is a port from the <A HREF="http://people.ne.mediaone.net/moshier/index.html#Cephes">Cephes 2.2</A> Math Library (C).
+   *
+   * @param a the argument to the function.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double errorFunctionComplemented(double a) throws ArithmeticException {
+    double x, y, z, p, q;
+
+    double P[] = {
+        2.46196981473530512524E-10,
+        5.64189564831068821977E-1,
+        7.46321056442269912687E0,
+        4.86371970985681366614E1,
+        1.96520832956077098242E2,
+        5.26445194995477358631E2,
+        9.34528527171957607540E2,
+        1.02755188689515710272E3,
+        5.57535335369399327526E2
+    };
+    double Q[] = {
+        //1.0
+        1.32281951154744992508E1,
+        8.67072140885989742329E1,
+        3.54937778887819891062E2,
+        9.75708501743205489753E2,
+        1.82390916687909736289E3,
+        2.24633760818710981792E3,
+        1.65666309194161350182E3,
+        5.57535340817727675546E2
+    };
+
+    double R[] = {
+        5.64189583547755073984E-1,
+        1.27536670759978104416E0,
+        5.01905042251180477414E0,
+        6.16021097993053585195E0,
+        7.40974269950448939160E0,
+        2.97886665372100240670E0
+    };
+    double S[] = {
+        //1.00000000000000000000E0, 
+        2.26052863220117276590E0,
+        9.39603524938001434673E0,
+        1.20489539808096656605E1,
+        1.70814450747565897222E1,
+        9.60896809063285878198E0,
+        3.36907645100081516050E0
+    };
+
+    if (a < 0.0)
+      x = -a;
+    else
+      x = a;
+
+    if (x < 1.0)
+      return 1.0 - errorFunction(a);
+
+    z = -a * a;
+
+    if (z < -MAXLOG) {
+      if (a < 0)
+        return (2.0);
+      else
+        return (0.0);
+    }
+
+    z = Math.exp(z);
+
+    if (x < 8.0) {
+      p = Polynomial.polevl(x, P, 8);
+      q = Polynomial.p1evl(x, Q, 8);
+    } else {
+      p = Polynomial.polevl(x, R, 5);
+      q = Polynomial.p1evl(x, S, 6);
+    }
+
+    y = (z * p) / q;
+
+    if (a < 0)
+      y = 2.0 - y;
+
+    if (y == 0.0) {
+      if (a < 0)
+        return 2.0;
+      else
+        return (0.0);
+    }
+
+    return y;
+  }
+
+  /**
+   * Returns the integral from zero to <tt>x</tt> of the gamma probability
+   * density function.
+   * <pre>
+   *                x
+   *        b       -
+   *       a       | |   b-1  -at
+   * y =  -----    |    t    e    dt
+   *       -     | |
+   *      | (b)   -
+   *               0
+   * </pre>
+   * The incomplete gamma integral is used, according to the
+   * relation
+   *
+   * <tt>y = Gamma.incompleteGamma( b, a*x )</tt>.
+   *
+   * @param a the paramater a (alpha) of the gamma distribution.
+   * @param b the paramater b (beta, lambda) of the gamma distribution.
+   * @param x integration end point.
+   * @return result
+   */
+  static public double gamma(double a, double b, double x) {
+    if (x < 0.0)
+      return 0.0;
+    return GammaFunctions.incompleteGamma(b, a * x);
+  }
+
+  /**
+   * Returns the integral from <tt>x</tt> to infinity of the gamma
+   * probability density function:
+   * <pre>
+   *               inf.
+   *        b       -
+   *       a       | |   b-1  -at
+   * y =  -----    |    t    e    dt
+   *       -     | |
+   *      | (b)   -
+   *               x
+   * </pre>
+   * The incomplete gamma integral is used, according to the
+   * relation
+   * <p>
+   * y = Gamma.incompleteGammaComplement( b, a*x ).
+   *
+   * @param a the paramater a (alpha) of the gamma distribution.
+   * @param b the paramater b (beta, lambda) of the gamma distribution.
+   * @param x integration end point.
+   * @return result
+   */
+  static public double gammaComplemented(double a, double b, double x) {
+    if (x < 0.0)
+      return 0.0;
+    return GammaFunctions.incompleteGammaComplement(b, a * x);
+  }
+
+  /**
+   * Returns the sum of the terms <tt>0</tt> through <tt>k</tt> of the Negative Binomial Distribution.
+   * <pre>
+   *   k
+   *   --  ( n+j-1 )   n      j
+   *   >   (       )  p  (1-p)
+   *   --  (   j   )
+   *  j=0
+   * </pre>
+   * In a sequence of Bernoulli trials, this is the probability
+   * that <tt>k</tt> or fewer failures precede the <tt>n</tt>-th success.
+   * <p>
+   * The terms are not computed individually; instead the incomplete
+   * beta integral is employed, according to the formula
+   * <p>
+   * <tt>y = negativeBinomial( k, n, p ) = Gamma.incompleteBeta( n, k+1, p )</tt>.
+   *
+   * All arguments must be positive, 
+   * @param k end term.
+   * @param n the number of trials.
+   * @param p the probability of success (must be in <tt>(0.0,1.0)</tt>).
+   * @return result
+   */
+  static public double negativeBinomial(int k, int n, double p) {
+    if ((p < 0.0) || (p > 1.0))
+      throw new IllegalArgumentException();
+    if (k < 0)
+      return 0.0;
+
+    return GammaFunctions.incompleteBeta(n, k + 1, p);
+  }
+
+  /**
+   * Returns the sum of the terms <tt>k+1</tt> to infinity of the Negative
+   * Binomial distribution.
+   * <pre>
+   *   inf
+   *   --  ( n+j-1 )   n      j
+   *   >   (       )  p  (1-p)
+   *   --  (   j   )
+   *  j=k+1
+   * </pre>
+   * The terms are not computed individually; instead the incomplete
+   * beta integral is employed, according to the formula
+   * <p>
+   * y = negativeBinomialComplemented( k, n, p ) = Gamma.incompleteBeta( k+1, n, 1-p ).
+   *
+   * All arguments must be positive, 
+   * @param k end term.
+   * @param n the number of trials.
+   * @param p the probability of success (must be in <tt>(0.0,1.0)</tt>).
+   * @return result
+   */
+  static public double negativeBinomialComplemented(int k, int n, double p) {
+    if ((p < 0.0) || (p > 1.0))
+      throw new IllegalArgumentException();
+    if (k < 0)
+      return 0.0;
+
+    return GammaFunctions.incompleteBeta(k + 1, n, 1.0 - p);
+  }
+
+  /**
+   * Returns the area under the Normal (Gaussian) probability density
+   * function, integrated from minus infinity to <tt>x</tt> (assumes mean is zero, variance is one).
+   * <pre>
+   *                            x
+   *                             -
+   *                   1        | |          2
+   *  normal(x)  = ---------    |    exp( - t /2 ) dt
+   *               sqrt(2pi)  | |
+   *                           -
+   *                          -inf.
+   *
+   *             =  ( 1 + erf(z) ) / 2
+   *             =  erfc(z) / 2
+   * </pre>
+   * where <tt>z = x/sqrt(2)</tt>.
+   * Computation is via the functions <tt>errorFunction</tt> and <tt>errorFunctionComplement</tt>.
+   * 
+   * @param a a
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double normal(double a) throws ArithmeticException {
+    double x, y, z;
+
+    x = a * SQRTH;
+    z = Math.abs(x);
+
+    if (z < SQRTH)
+      y = 0.5 + 0.5 * errorFunction(x);
+    else {
+      y = 0.5 * errorFunctionComplemented(z);
+      if (x > 0)
+        y = 1.0 - y;
+    }
+
+    return y;
+  }
+
+  /**
+   * Returns the area under the Normal (Gaussian) probability density
+   * function, integrated from minus infinity to <tt>x</tt>.
+   * <pre>
+   *                            x
+   *                             -
+   *                   1        | |                 2
+   *  normal(x)  = ---------    |    exp( - (t-mean) / 2v ) dt
+   *               sqrt(2pi*v)| |
+   *                           -
+   *                          -inf.
+   *
+   * </pre>
+   * where <tt>v = variance</tt>.
+   * Computation is via the functions <tt>errorFunction</tt>.
+   *
+   * @param mean the mean of the normal distribution.
+   * @param variance the variance of the normal distribution.
+   * @param x the integration limit.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double normal(double mean, double variance, double x) throws ArithmeticException {
+    if (x > 0)
+      return 0.5 + 0.5 * errorFunction((x - mean) / Math.sqrt(2.0 * variance));
+    else
+      return 0.5 - 0.5 * errorFunction((-(x - mean)) / Math.sqrt(2.0 * variance));
+  }
+
+  /**
+   * Returns the value, <tt>x</tt>, for which the area under the
+   * Normal (Gaussian) probability density function (integrated from
+   * minus infinity to <tt>x</tt>) is equal to the argument <tt>y</tt> (assumes mean is zero, variance is one); formerly named <tt>ndtri</tt>.
+   * <p>
+   * For small arguments <tt>0 < y < exp(-2)</tt>, the program computes
+   * <tt>z = sqrt( -2.0 * log(y) )</tt>;  then the approximation is
+   * <tt>x = z - log(z)/z  - (1/z) P(1/z) / Q(1/z)</tt>.
+   * There are two rational functions P/Q, one for <tt>0 < y < exp(-32)</tt>
+   * and the other for <tt>y</tt> up to <tt>exp(-2)</tt>. 
+   * For larger arguments,
+   * <tt>w = y - 0.5</tt>, and  <tt>x/sqrt(2pi) = w + w**3 R(w**2)/S(w**2))</tt>.
+   *
+   * @param y0 y
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double normalInverse(double y0) throws ArithmeticException {
+    double x, y, z, y2, x0, x1;
+    int code;
+
+    final double s2pi = Math.sqrt(2.0 * Math.PI);
+
+    if (y0 <= 0.0)
+      throw new IllegalArgumentException();
+    if (y0 >= 1.0)
+      throw new IllegalArgumentException();
+    code = 1;
+    y = y0;
+    if (y > (1.0 - 0.13533528323661269189)) { /* 0.135... = exp(-2) */
+      y = 1.0 - y;
+      code = 0;
+    }
+
+    if (y > 0.13533528323661269189) {
+      y = y - 0.5;
+      y2 = y * y;
+      x = y + y * (y2 * Polynomial.polevl(y2, P0, 4) / Polynomial.p1evl(y2, Q0, 8));
+      x = x * s2pi;
+      return (x);
+    }
+
+    x = Math.sqrt(-2.0 * Math.log(y));
+    x0 = x - Math.log(x) / x;
+
+    z = 1.0 / x;
+    if (x < 8.0) /* y > exp(-32) = 1.2664165549e-14 */
+      x1 = z * Polynomial.polevl(z, P1, 8) / Polynomial.p1evl(z, Q1, 8);
+    else
+      x1 = z * Polynomial.polevl(z, P2, 8) / Polynomial.p1evl(z, Q2, 8);
+    x = x0 - x1;
+    if (code != 0)
+      x = -x;
+    return (x);
+  }
+
+  /**
+   * Returns the sum of the first <tt>k</tt> terms of the Poisson distribution.
+   * <pre>
+   *   k         j
+   *   --   -m  m
+   *   >   e    --
+   *   --       j!
+   *  j=0
+   * </pre>
+   * The terms are not summed directly; instead the incomplete
+   * gamma integral is employed, according to the relation
+   * <p>
+   * <tt>y = poisson( k, m ) = Gamma.incompleteGammaComplement( k+1, m )</tt>.
+   *
+   * The arguments must both be positive.
+   *
+   * @param k number of terms.
+   * @param mean the mean of the poisson distribution.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double poisson(int k, double mean) throws ArithmeticException {
+    if (mean < 0)
+      throw new IllegalArgumentException();
+    if (k < 0)
+      return 0.0;
+    return GammaFunctions.incompleteGammaComplement((double) (k + 1), mean);
+  }
+
+  /**
+   * Returns the sum of the terms <tt>k+1</tt> to <tt>Infinity</tt> of the Poisson distribution.
+   * <pre>
+   *  inf.       j
+   *   --   -m  m
+   *   >   e    --
+   *   --       j!
+   *  j=k+1
+   * </pre>
+   * The terms are not summed directly; instead the incomplete
+   * gamma integral is employed, according to the formula
+   * <p>
+   * <tt>y = poissonComplemented( k, m ) = Gamma.incompleteGamma( k+1, m )</tt>.
+   *
+   * The arguments must both be positive.
+   *
+   * @param k start term.
+   * @param mean the mean of the poisson distribution.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double poissonComplemented(int k, double mean) throws ArithmeticException {
+    if (mean < 0)
+      throw new IllegalArgumentException();
+    if (k < -1)
+      return 0.0;
+    return GammaFunctions.incompleteGamma((double) (k + 1), mean);
+  }
+
+  /**
+   * Returns the integral from minus infinity to <tt>t</tt> of the Student-t 
+   * distribution with <tt>k &gt; 0</tt> degrees of freedom.
+   * <pre>
+   *                                      t
+   *                                      -
+   *                                     | |
+   *              -                      |         2   -(k+1)/2
+   *             | ( (k+1)/2 )           |  (     x   )
+   *       ----------------------        |  ( 1 + --- )        dx
+   *                     -               |  (      k  )
+   *       sqrt( k pi ) | ( k/2 )        |
+   *                                   | |
+   *                                    -
+   *                                   -inf.
+   * </pre>
+   * Relation to incomplete beta integral:
+   * <p>
+   * <tt>1 - studentT(k,t) = 0.5 * Gamma.incompleteBeta( k/2, 1/2, z )</tt>
+   * where <tt>z = k/(k + t**2)</tt>.
+   * <p>
+   * Since the function is symmetric about <tt>t=0</tt>, the area under the
+   * right tail of the density is found by calling the function
+   * with <tt>-t</tt> instead of <tt>t</tt>.
+   *
+   * @param k degrees of freedom.
+   * @param t integration end point.
+   * @return result
+   * @throws ArithmeticException error
+   */
+  static public double studentT(double k, double t) throws ArithmeticException {
+    if (k <= 0)
+      throw new IllegalArgumentException();
+    if (t == 0)
+      return (0.5);
+
+    double cdf = 0.5 * GammaFunctions.incompleteBeta(0.5 * k, 0.5, k / (k + t * t));
+
+    if (t >= 0)
+      cdf = 1.0 - cdf; // fixes bug reported by stefan.bentink@molgen.mpg.de
+
+    return cdf;
+  }
+
+  /**
+   * Returns the value, <tt>t</tt>, for which the area under the
+   * Student-t probability density function (integrated from
+   * minus infinity to <tt>t</tt>) is equal to <tt>1-alpha/2</tt>.
+   * The value returned corresponds to usual Student t-distribution lookup
+   * table for <tt>t<sub>alpha[size]</sub></tt>.
+   * <p>
+   * The function uses the studentT function to determine the return
+   * value iteratively.
+   *
+   * @param alpha probability
+   * @param size size of data set
+   * @return result
+   * @throws ArithmeticException error
+   */
+  public static double studentTInverse(double alpha, int size) {
+    double cumProb = 1 - alpha / 2; // Cumulative probability
+    double f1, f2, f3;
+    double x1, x2, x3;
+    double g, s12;
+
+    cumProb = 1 - alpha / 2; // Cumulative probability
+    x1 = normalInverse(cumProb);
+
+    // Return inverse of normal for large size
+    if (size > 200) {
+      return x1;
+    }
+
+    // Find a pair of x1,x2 that braket zero
+    f1 = studentT(size, x1) - cumProb;
+    x2 = x1;
+    f2 = f1;
+    do {
+      if (f1 > 0) {
+        x2 = x2 / 2;
+      } else {
+        x2 = x2 + x1;
+      }
+      f2 = studentT(size, x2) - cumProb;
+    } while (f1 * f2 > 0);
+
+    // Find better approximation
+    // Pegasus-method
+    do {
+      // Calculate slope of secant and t value for which it is 0.
+      s12 = (f2 - f1) / (x2 - x1);
+      x3 = x2 - f2 / s12;
+
+      // Calculate function value at x3
+      f3 = studentT(size, x3) - cumProb;
+      if (Math.abs(f3) < 1e-8) { // This criteria needs to be very tight!
+        // We found a perfect value -> return
+        return x3;
+      }
+
+      if (f3 * f2 < 0) {
+        x1 = x2;
+        f1 = f2;
+        x2 = x3;
+        f2 = f3;
+      } else {
+        g = f2 / (f2 + f3);
+        f1 = g * f1;
+        x2 = x3;
+        f2 = f3;
+      }
+    } while (Math.abs(x2 - x1) > 0.001);
+
+    if (Math.abs(f2) <= Math.abs(f1)) {
+      return x2;
+    } else {
+      return x1;
+    }
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/RandomEngine.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/RandomEngine.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random.engine` package.
+ * Changes:
+ * - package name
+ * - added serialization version
+ * - missing Javadoc tags
+ * - reformat
+ * - use Java 8 function interfaces
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.IntUnaryOperator;
+
+//CSOFF: ALL
+/**
+ * Abstract base class for uniform pseudo-random number generating engines.
+ * <p>
+ * Most probability distributions are obtained by using a <b>uniform</b> pseudo-random number generation engine 
+ * followed by a transformation to the desired distribution.
+ * Thus, subclasses of this class are at the core of computational statistics, simulations, Monte Carlo methods, etc.
+ * <p>
+ * Subclasses produce uniformly distributed <tt>int</tt>'s and <tt>long</tt>'s in the closed intervals <tt>[Integer.MIN_VALUE,Integer.MAX_VALUE]</tt> and <tt>[Long.MIN_VALUE,Long.MAX_VALUE]</tt>, respectively, 
+ * as well as <tt>float</tt>'s and <tt>double</tt>'s in the open unit intervals <tt>(0.0f,1.0f)</tt> and <tt>(0.0,1.0)</tt>, respectively.
+ * <p>
+ * Subclasses need to override one single method only: <tt>nextInt()</tt>.
+ * All other methods generating different data types or ranges are usually layered upon <tt>nextInt()</tt>.
+ * <tt>long</tt>'s are formed by concatenating two 32 bit <tt>int</tt>'s.
+ * <tt>float</tt>'s are formed by dividing the interval <tt>[0.0f,1.0f]</tt> into 2<sup>32</sup> sub intervals, then randomly choosing one subinterval.
+ * <tt>double</tt>'s are formed by dividing the interval <tt>[0.0,1.0]</tt> into 2<sup>64</sup> sub intervals, then randomly choosing one subinterval.
+ * <p>
+ * Note that this implementation is <b>not synchronized</b>.
+ * 
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ * @see MersenneTwister
+ * @see MersenneTwister64
+ * @see java.util.Random
+ */
+//public abstract class RandomEngine extends edu.cornell.lassp.houle.RngPack.RandomSeedable implements cern.colt.function.DoubleFunction, cern.colt.function.IntFunction {
+public abstract class RandomEngine extends PersistentObject
+    implements DoubleUnaryOperator, IntUnaryOperator {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Makes this class non instantiable, but still let's others inherit from it.
+   */
+  protected RandomEngine() {
+  }
+
+  /**
+   * Equivalent to <tt>raw()</tt>.
+   * This has the effect that random engines can now be used as function objects, returning a random number upon function evaluation.
+   */
+  @Override
+  public double applyAsDouble(double dummy) {
+    return raw();
+  }
+
+  /**
+   * Equivalent to <tt>nextInt()</tt>.
+   * This has the effect that random engines can now be used as function objects, returning a random number upon function evaluation.
+   */
+  @Override
+  public int applyAsInt(int dummy) {
+    return nextInt();
+  }
+
+  /**
+   * Constructs and returns a new uniform random number engine seeded with the current time.
+   * Currently this is {@link MersenneTwister}.
+   * @return the engine
+   */
+  public static RandomEngine makeDefault() {
+    return new MersenneTwister((int) System.currentTimeMillis());
+  }
+
+  /**
+   * Returns a 64 bit uniformly distributed random number in the open unit interval <code>(0.0,1.0)</code> (excluding 0.0 and 1.0).
+   * @return the random number
+   */
+  public double nextDouble() {
+    double nextDouble;
+
+    do {
+      // -9.223372036854776E18 == (double) Long.MIN_VALUE
+      // 5.421010862427522E-20 == 1 / Math.pow(2,64) == 1 / ((double) Long.MAX_VALUE - (double) Long.MIN_VALUE);
+      nextDouble = ((double) nextLong() - -9.223372036854776E18) * 5.421010862427522E-20;
+    }
+    // catch loss of precision of long --> double conversion
+    while (!(nextDouble > 0.0 && nextDouble < 1.0));
+
+    // --> in (0.0,1.0)
+    return nextDouble;
+
+    /*
+    	nextLong == Long.MAX_VALUE         --> 1.0
+    	nextLong == Long.MIN_VALUE         --> 0.0
+    	nextLong == Long.MAX_VALUE-1       --> 1.0
+    	nextLong == Long.MAX_VALUE-100000L --> 0.9999999999999946
+    	nextLong == Long.MIN_VALUE+1       --> 0.0
+    	nextLong == Long.MIN_VALUE-100000L --> 0.9999999999999946
+    	nextLong == 1L                     --> 0.5
+    	nextLong == -1L                    --> 0.5
+    	nextLong == 2L                     --> 0.5
+    	nextLong == -2L                    --> 0.5
+    	nextLong == 2L+100000L             --> 0.5000000000000054
+    	nextLong == -2L-100000L            --> 0.49999999999999456
+    */
+  }
+
+  /**
+   * Returns a 32 bit uniformly distributed random number in the open unit interval <code>(0.0f,1.0f)</code> (excluding 0.0f and 1.0f).
+   * @return the random number
+   */
+  public float nextFloat() {
+    // catch loss of precision of double --> float conversion
+    float nextFloat;
+    do {
+      nextFloat = (float) raw();
+    } while (nextFloat >= 1.0f);
+
+    // --> in (0.0f,1.0f)
+    return nextFloat;
+  }
+
+  /**
+   * Returns a 32 bit uniformly distributed random number in the closed interval <tt>[Integer.MIN_VALUE,Integer.MAX_VALUE]</tt> (including <tt>Integer.MIN_VALUE</tt> and <tt>Integer.MAX_VALUE</tt>);
+   * @return the random number
+   */
+  public abstract int nextInt();
+
+  /**
+   * Returns a 64 bit uniformly distributed random number in the closed interval <tt>[Long.MIN_VALUE,Long.MAX_VALUE]</tt> (including <tt>Long.MIN_VALUE</tt> and <tt>Long.MAX_VALUE</tt>).
+   * @return the random number
+   */
+  public long nextLong() {
+    // concatenate two 32-bit strings into one 64-bit string
+    return ((nextInt() & 0xFFFFFFFFL) << 32) | ((nextInt() & 0xFFFFFFFFL));
+  }
+
+  /**
+   * Returns a 32 bit uniformly distributed random number in the open unit interval <code>(0.0,1.0)</code> (excluding 0.0 and 1.0).
+   * @return the random number
+   */
+  public double raw() {
+    int nextInt;
+    do { // accept anything but zero
+      nextInt = nextInt(); // in [Integer.MIN_VALUE,Integer.MAX_VALUE]-interval
+    } while (nextInt == 0);
+
+    // transform to (0.0,1.0)-interval
+    // 2.3283064365386963E-10 == 1.0 / Math.pow(2,32)
+    return (double) (nextInt & 0xFFFFFFFFL) * 2.3283064365386963E-10;
+
+    /*
+    	nextInt == Integer.MAX_VALUE   --> 0.49999999976716936
+    	nextInt == Integer.MIN_VALUE   --> 0.5
+    	nextInt == Integer.MAX_VALUE-1 --> 0.4999999995343387
+    	nextInt == Integer.MIN_VALUE+1 --> 0.5000000002328306
+    	nextInt == 1                   --> 2.3283064365386963E-10
+    	nextInt == -1                  --> 0.9999999997671694
+    	nextInt == 2                   --> 4.6566128730773926E-10
+    	nextInt == -2                  --> 0.9999999995343387
+    */
+  }
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/StudentT.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/cern/StudentT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2009 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+/*
+ * This code is copied from the original library from the `cern.jet.random` package.
+ * Changes:
+ * - package name
+ * - missing Javadoc param tags
+ * - reformat
+ */
+/*
+Copyright � 1999 CERN - European Organization for Nuclear Research.
+Permission to use, copy, modify, distribute and sell this software and its documentation for any purpose 
+is hereby granted without fee, provided that the above copyright notice appear in all copies and 
+that both that copyright notice and this permission notice appear in supporting documentation. 
+CERN makes no representations about the suitability of this software for any purpose. 
+It is provided "as is" without expressed or implied warranty.
+*/
+package com.opengamma.strata.math.impl.cern;
+
+//CSOFF: ALL
+/**
+ * StudentT distribution (aka T-distribution); See the <A HREF="http://www.cern.ch/RD11/rkb/AN16pp/node279.html#SECTION0002790000000000000000"> math definition</A>
+ * and <A HREF="http://www.statsoft.com/textbook/gloss.html#Student's t Distribution"> animated definition</A>.
+ * <p>
+ * <tt>p(x) = k  *  (1+x^2/f) ^ -(f+1)/2</tt> where <tt>k = g((f+1)/2) / (sqrt(pi*f) * g(f/2))</tt> and <tt>g(a)</tt> being the gamma function and <tt>f</tt> being the degrees of freedom.
+ * <p>
+ * Valid parameter ranges: <tt>freedom &gt; 0</tt>.
+ * <p>
+ * Instance methods operate on a user supplied uniform random number generator; they are unsynchronized.
+ * <dt>
+ * Static methods operate on a default uniform random number generator; they are synchronized.
+ * <p>
+ * <b>Implementation:</b>
+ * <dt>
+ * Method: Adapted Polar Box-Muller transformation.
+ * <dt>
+ * This is a port of <A HREF="http://wwwinfo.cern.ch/asd/lhc++/clhep/manual/RefGuide/Random/RandStudentT.html">RandStudentT</A> used in <A HREF="http://wwwinfo.cern.ch/asd/lhc++/clhep">CLHEP 1.4.0</A> (C++).
+ * CLHEP's implementation, in turn, is based on <tt>tpol.c</tt> from the <A HREF="http://www.cis.tu-graz.ac.at/stat/stadl/random.html">C-RAND / WIN-RAND</A> library.
+ * C-RAND's implementation, in turn, is based upon
+ * <p>R.W. Bailey (1994): Polar generation of random variates with the t-distribution, Mathematics of Computation 62, 779-781.
+ *
+ * @author wolfgang.hoschek@cern.ch
+ * @version 1.0, 09/24/99
+ */
+public class StudentT extends AbstractContinousDistribution {
+
+  private static final long serialVersionUID = 1L;
+
+  protected double freedom;
+
+  protected double TERM; // performance cache for pdf()
+  // The uniform random number generated shared by all <b>static</b> methods. 
+  protected static StudentT shared = new StudentT(1.0, makeDefaultGenerator());
+
+  /**
+   * Constructs a StudentT distribution.
+   * Example: freedom=1.0.
+   * @param freedom degrees of freedom.
+   * @param randomGenerator input
+   * @throws IllegalArgumentException if <tt>freedom &lt;= 0.0</tt>.
+   */
+  public StudentT(double freedom, RandomEngine randomGenerator) {
+    setRandomGenerator(randomGenerator);
+    setState(freedom);
+  }
+
+  /**
+   * Returns the cumulative distribution function.
+   * @param x input
+   * @return result
+   */
+  public double cdf(double x) {
+    return Probability.studentT(freedom, x);
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   */
+  @Override
+  public double nextDouble() {
+    return nextDouble(this.freedom);
+  }
+
+  /**
+   * Returns a random number from the distribution; bypasses the internal state.
+   * @param degreesOfFreedom degrees of freedom.
+   * @return result
+   * @throws IllegalArgumentException if <tt>a &lt;= 0.0</tt>.
+   */
+  public double nextDouble(double degreesOfFreedom) {
+    /*
+     * The polar method of Box/Muller for generating Normal variates 
+     * is adapted to the Student-t distribution. The two generated   
+     * variates are not independent and the expected no. of uniforms 
+     * per variate is 2.5464.
+     *
+     * REFERENCE :  - R.W. Bailey (1994): Polar generation of random  
+     *                variates with the t-distribution, Mathematics   
+     *                of Computation 62, 779-781.
+     */
+    if (degreesOfFreedom <= 0.0)
+      throw new IllegalArgumentException();
+    double u, v, w;
+
+    do {
+      u = 2.0 * randomGenerator.raw() - 1.0;
+      v = 2.0 * randomGenerator.raw() - 1.0;
+    } while ((w = u * u + v * v) > 1.0);
+
+    return (u * Math.sqrt(degreesOfFreedom * (Math.exp(-2.0 / degreesOfFreedom * Math.log(w)) - 1.0) / w));
+  }
+
+  /**
+   * Returns the probability distribution function.
+   * @param x input
+   * @return result
+   */
+  public double pdf(double x) {
+    return this.TERM * Math.pow((1 + x * x / freedom), -(freedom + 1) * 0.5);
+  }
+
+  /**
+   * Sets the distribution parameter.
+   * @param freedom degrees of freedom.
+   * @throws IllegalArgumentException if <tt>freedom &lt;= 0.0</tt>.
+   */
+  public void setState(double freedom) {
+    if (freedom <= 0.0)
+      throw new IllegalArgumentException();
+    this.freedom = freedom;
+
+    double val = Fun.logGamma((freedom + 1) / 2) - Fun.logGamma(freedom / 2);
+    this.TERM = Math.exp(val) / Math.sqrt(Math.PI * freedom);
+  }
+
+  /**
+   * Returns a random number from the distribution.
+   * @param freedom degrees of freedom.
+   * @return result
+   * @throws IllegalArgumentException if <tt>freedom &lt;= 0.0</tt>.
+   */
+  public static double staticNextDouble(double freedom) {
+    synchronized (shared) {
+      return shared.nextDouble(freedom);
+    }
+  }
+
+  /**
+   * Returns a String representation of the receiver.
+   */
+  @Override
+  public String toString() {
+    return this.getClass().getName() + "(" + freedom + ")";
+  }
+
+}


### PR DESCRIPTION
Avoid an unsupported external dependency. This will be beneficial when moving to Java 9.

The code was copied from the original source. It was then altered in minimal way to fit Strata conventions.