### PR TITLE
Abstract swap conventions

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -71,21 +71,46 @@ public final class Guavate {
   /**
    * Uses a number of suppliers to create a single optional result.
    * <p>
+   * This invokes each supplier in turn until a non empty optional is returned.
+   * As such, not all suppliers are necessarily invoked.
+   * <p>
    * The Java 8 {@link Optional} class does not have an {@code or} method,
    * so this provides an alternative.
    * 
-   * @param <T>  the type of element in the iterable
+   * @param <T>  the type of element in the optional
    * @param suppliers  the suppliers to combine
-   * @return the list that combines the inputs
+   * @return the first non empty optional
    */
   @SuppressWarnings("unchecked")
   @SafeVarargs
-  public static <T> Optional<T> firstNotEmpty(Supplier<Optional<? extends T>>... suppliers) {
+  public static <T> Optional<T> firstNonEmpty(Supplier<Optional<? extends T>>... suppliers) {
     for (Supplier<Optional<? extends T>> supplier : suppliers) {
       Optional<? extends T> result = supplier.get();
       if (result.isPresent()) {
         // safe, because Optional is read-only
         return (Optional<T>) result;
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Chooses the first optional that is not empty.
+   * <p>
+   * The Java 8 {@link Optional} class does not have an {@code or} method,
+   * so this provides an alternative.
+   * 
+   * @param <T>  the type of element in the optional
+   * @param optionals  the optionals to combine
+   * @return the first non empty optional
+   */
+  @SuppressWarnings("unchecked")
+  @SafeVarargs
+  public static <T> Optional<T> firstNonEmpty(Optional<? extends T>... optionals) {
+    for (Optional<? extends T> optional : optionals) {
+      if (optional.isPresent()) {
+        // safe, because Optional is read-only
+        return (Optional<T>) optional;
       }
     }
     return Optional.empty();

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -69,6 +69,30 @@ public final class Guavate {
 
   //-------------------------------------------------------------------------
   /**
+   * Uses a number of suppliers to create a single optional result.
+   * <p>
+   * The Java 8 {@link Optional} class does not have an {@code or} method,
+   * so this provides an alternative.
+   * 
+   * @param <T>  the type of element in the iterable
+   * @param suppliers  the suppliers to combine
+   * @return the list that combines the inputs
+   */
+  @SuppressWarnings("unchecked")
+  @SafeVarargs
+  public static <T> Optional<T> firstNotEmpty(Supplier<Optional<? extends T>>... suppliers) {
+    for (Supplier<Optional<? extends T>> supplier : suppliers) {
+      Optional<? extends T> result = supplier.get();
+      if (result.isPresent()) {
+        // safe, because Optional is read-only
+        return (Optional<T>) result;
+      }
+    }
+    return Optional.empty();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Converts an iterable to a serial stream.
    * <p>
    * This is harder than it should be, a method {@code Stream.of(Iterable)}

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -48,24 +48,40 @@ public class GuavateTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_firstNotEmpty_match1() {
-    Optional<Number> test = Guavate.firstNotEmpty(
+  public void test_firstNonEmpty_supplierMatch1() {
+    Optional<Number> test = Guavate.firstNonEmpty(
         () -> Optional.of(Integer.valueOf(1)),
         () -> Optional.of(Double.valueOf(2d)));
     assertEquals(test, Optional.of(Integer.valueOf(1)));
   }
 
-  public void test_firstNotEmpty_match2() {
-    Optional<Number> test = Guavate.firstNotEmpty(
+  public void test_firstNonEmpty_supplierMatch2() {
+    Optional<Number> test = Guavate.firstNonEmpty(
         () -> Optional.empty(),
         () -> Optional.of(Double.valueOf(2d)));
     assertEquals(test, Optional.of(Double.valueOf(2d)));
   }
 
-  public void test_firstNotEmpty_matchNone() {
-    Optional<Number> test = Guavate.firstNotEmpty(
+  public void test_firstNonEmpty_supplierMatchNone() {
+    Optional<Number> test = Guavate.firstNonEmpty(
         () -> Optional.empty(),
         () -> Optional.empty());
+    assertEquals(test, Optional.empty());
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_firstNonEmpty_optionalMatch1() {
+    Optional<Number> test = Guavate.firstNonEmpty(Optional.of(Integer.valueOf(1)), Optional.of(Double.valueOf(2d)));
+    assertEquals(test, Optional.of(Integer.valueOf(1)));
+  }
+
+  public void test_firstNonEmpty_optionalMatch2() {
+    Optional<Number> test = Guavate.firstNonEmpty(Optional.empty(), Optional.of(Double.valueOf(2d)));
+    assertEquals(test, Optional.of(Double.valueOf(2d)));
+  }
+
+  public void test_firstNonEmpty_optionalMatchNone() {
+    Optional<Number> test = Guavate.firstNonEmpty(Optional.empty(), Optional.empty());
     assertEquals(test, Optional.empty());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -48,6 +48,28 @@ public class GuavateTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_firstNotEmpty_match1() {
+    Optional<Number> test = Guavate.firstNotEmpty(
+        () -> Optional.of(Integer.valueOf(1)),
+        () -> Optional.of(Double.valueOf(2d)));
+    assertEquals(test, Optional.of(Integer.valueOf(1)));
+  }
+
+  public void test_firstNotEmpty_match2() {
+    Optional<Number> test = Guavate.firstNotEmpty(
+        () -> Optional.empty(),
+        () -> Optional.of(Double.valueOf(2d)));
+    assertEquals(test, Optional.of(Double.valueOf(2d)));
+  }
+
+  public void test_firstNotEmpty_matchNone() {
+    Optional<Number> test = Guavate.firstNotEmpty(
+        () -> Optional.empty(),
+        () -> Optional.empty());
+    assertEquals(test, Optional.empty());
+  }
+
+  //-------------------------------------------------------------------------
   public void test_stream_Iterable() {
     Iterable<String> iterable = Arrays.asList("a", "b", "c");
     List<String> test = Guavate.stream(iterable)

--- a/modules/product/src/main/java/com/opengamma/strata/product/deposit/type/ImmutableTermDepositConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/deposit/type/ImmutableTermDepositConvention.java
@@ -7,7 +7,6 @@ package com.opengamma.strata.product.deposit.type;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -25,7 +24,6 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
-import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DayCount;
@@ -119,20 +117,6 @@ public final class ImmutableTermDepositConvention
   }
 
   //-------------------------------------------------------------------------
-  @Override
-  public TermDepositTrade createTrade(
-      LocalDate tradeDate,
-      Period depositPeriod,
-      BuySell buySell,
-      double notional,
-      double rate,
-      ReferenceData refData) {
-
-    LocalDate startDate = calculateSpotDateFromTradeDate(tradeDate, refData);
-    LocalDate endDate = startDate.plus(depositPeriod);
-    return toTrade(tradeDate, startDate, endDate, buySell, notional, rate);
-  }
-
   @Override
   public TermDepositTrade toTrade(
       TradeInfo tradeInfo,

--- a/modules/product/src/main/java/com/opengamma/strata/product/deposit/type/TermDepositConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/deposit/type/TermDepositConvention.java
@@ -100,13 +100,18 @@ public interface TermDepositConvention
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
-  public abstract TermDepositTrade createTrade(
+  public default TermDepositTrade createTrade(
       LocalDate tradeDate,
       Period depositPeriod,
       BuySell buySell,
       double notional,
       double rate,
-      ReferenceData refData);
+      ReferenceData refData) {
+
+    LocalDate startDate = calculateSpotDateFromTradeDate(tradeDate, refData);
+    LocalDate endDate = startDate.plus(depositPeriod);
+    return toTrade(tradeDate, startDate, endDate, buySell, notional, rate);
+  }
 
   /**
    * Creates a trade based on this convention.

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedIborSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedIborSwapConvention.java
@@ -13,12 +13,10 @@ import org.joda.convert.ToString;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
-import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.named.ExtendedEnum;
 import com.opengamma.strata.collect.named.Named;
-import com.opengamma.strata.product.TradeConvention;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.swap.SwapTrade;
@@ -34,7 +32,7 @@ import com.opengamma.strata.product.swap.SwapTrade;
  * To register a specific convention, see {@code FixedIborSwapConvention.ini}.
  */
 public interface FixedIborSwapConvention
-    extends TradeConvention, Named {
+    extends SingleCurrencySwapConvention, Named {
 
   /**
    * Obtains an instance from the specified unique name.
@@ -76,16 +74,6 @@ public interface FixedIborSwapConvention
    */
   public abstract IborRateSwapLegConvention getFloatingLeg();
 
-  /**
-   * Gets the offset of the spot value date from the trade date.
-   * <p>
-   * The offset is applied to the trade date to find the start date.
-   * A typical value is "plus 2 business days".
-   * 
-   * @return the spot date offset, not null
-   */
-  public abstract DaysAdjustment getSpotDateOffset();
-
   //-------------------------------------------------------------------------
   /**
    * Creates a spot-starting trade based on this convention.
@@ -106,6 +94,7 @@ public interface FixedIborSwapConvention
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
+  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Tenor tenor,
@@ -114,7 +103,7 @@ public interface FixedIborSwapConvention
       double fixedRate,
       ReferenceData refData) {
 
-    return createTrade(tradeDate, Period.ZERO, tenor, buySell, notional, fixedRate, refData);
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, tenor, buySell, notional, fixedRate, refData);
   }
 
   /**
@@ -138,6 +127,7 @@ public interface FixedIborSwapConvention
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
+  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Period periodToStart,
@@ -147,10 +137,7 @@ public interface FixedIborSwapConvention
       double fixedRate,
       ReferenceData refData) {
 
-    LocalDate spotValue = calculateSpotDateFromTradeDate(tradeDate, refData);
-    LocalDate startDate = spotValue.plus(periodToStart);
-    LocalDate endDate = startDate.plus(tenor.getPeriod());
-    return toTrade(tradeDate, startDate, endDate, buySell, notional, fixedRate);
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, periodToStart, tenor, buySell, notional, fixedRate, refData);
   }
 
   /**
@@ -170,6 +157,7 @@ public interface FixedIborSwapConvention
    * @param fixedRate  the fixed rate, typically derived from the market
    * @return the trade
    */
+  @Override
   public default SwapTrade toTrade(
       LocalDate tradeDate,
       LocalDate startDate,
@@ -178,8 +166,7 @@ public interface FixedIborSwapConvention
       double notional,
       double fixedRate) {
 
-    TradeInfo tradeInfo = TradeInfo.of(tradeDate);
-    return toTrade(tradeInfo, startDate, endDate, buySell, notional, fixedRate);
+    return SingleCurrencySwapConvention.super.toTrade(tradeDate, startDate, endDate, buySell, notional, fixedRate);
   }
 
   /**
@@ -199,6 +186,7 @@ public interface FixedIborSwapConvention
    * @param fixedRate  the fixed rate, typically derived from the market
    * @return the trade
    */
+  @Override
   public abstract SwapTrade toTrade(
       TradeInfo tradeInfo,
       LocalDate startDate,
@@ -216,6 +204,7 @@ public interface FixedIborSwapConvention
    * @return the spot date
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
+  @Override
   public default LocalDate calculateSpotDateFromTradeDate(LocalDate tradeDate, ReferenceData refData) {
     return getSpotDateOffset().adjust(tradeDate, refData);
   }

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConvention.java
@@ -13,12 +13,10 @@ import org.joda.convert.ToString;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
-import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.named.ExtendedEnum;
 import com.opengamma.strata.collect.named.Named;
-import com.opengamma.strata.product.TradeConvention;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.swap.SwapTrade;
@@ -33,7 +31,7 @@ import com.opengamma.strata.product.swap.SwapTrade;
  * To register a specific convention, see {@code InflationSwapConvention.ini}.
  */
 public interface FixedInflationSwapConvention
-    extends TradeConvention, Named {
+    extends SingleCurrencySwapConvention, Named {
 
   /**
    * Obtains an instance from the specified unique name.
@@ -75,19 +73,12 @@ public interface FixedInflationSwapConvention
    */
   public abstract InflationRateSwapLegConvention getFloatingLeg();
 
-  /**
-   * Gets the offset of the spot value date from the trade date.
-   * <p>
-   * The offset is applied to the trade date to find the start date.
-   * A typical value is "plus 2 business days".
-   * 
-   * @return the spot date offset, not null
-   */
-  public abstract DaysAdjustment getSpotDateOffset();
-
   //-------------------------------------------------------------------------
   /**
    * Creates a forward-starting trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified tenor. For example, a tenor
+   * of 5 years creates a swap starting on the spot date and maturing 5 years later.
    * <p>
    * The notional is unsigned, with buy/sell determining the direction of the trade.
    * If buying the swap, the floating rate is received from the counterparty, with the fixed rate being paid.
@@ -102,6 +93,7 @@ public interface FixedInflationSwapConvention
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
+  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Tenor tenor,
@@ -110,10 +102,43 @@ public interface FixedInflationSwapConvention
       double fixedRate,
       ReferenceData refData) {
 
-    LocalDate spotValue = calculateSpotDateFromTradeDate(tradeDate, refData);
-    LocalDate startDate = spotValue.plus(Period.ZERO);
-    LocalDate endDate = startDate.plus(tenor.getPeriod());
-    return toTrade(tradeDate, startDate, endDate, buySell, notional, fixedRate);
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, tenor, buySell, notional, fixedRate, refData);
+  }
+
+  /**
+   * Creates a forward-starting trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified period and tenor. For example, a period of
+   * 3 months and a tenor of 5 years creates a swap starting three months after the spot date
+   * and maturing 5 years later.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the floating rate is received from the counterparty, with the fixed rate being paid.
+   * If selling the swap, the floating rate is paid to the counterparty, with the fixed rate being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param periodToStart  the period between the spot date and the start date
+   * @param tenor  the tenor of the trade
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param fixedRate  the fixed rate, typically derived from the market
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  @Override
+  public default SwapTrade createTrade(
+      LocalDate tradeDate,
+      Period periodToStart,
+      Tenor tenor,
+      BuySell buySell,
+      double notional,
+      double fixedRate,
+      ReferenceData refData) {
+
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, periodToStart, tenor, buySell, notional, fixedRate, refData);
   }
 
   /**
@@ -133,6 +158,7 @@ public interface FixedInflationSwapConvention
    * @param fixedRate  the fixed rate, typically derived from the market
    * @return the trade
    */
+  @Override
   public default SwapTrade toTrade(
       LocalDate tradeDate,
       LocalDate startDate,
@@ -141,8 +167,8 @@ public interface FixedInflationSwapConvention
       double notional,
       double fixedRate) {
 
-    TradeInfo tradeInfo = TradeInfo.of(tradeDate);
-    return toTrade(tradeInfo, startDate, endDate, buySell, notional, fixedRate);
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.toTrade(tradeDate, startDate, endDate, buySell, notional, fixedRate);
   }
 
   /**
@@ -162,6 +188,7 @@ public interface FixedInflationSwapConvention
    * @param fixedRate  the fixed rate, typically derived from the market
    * @return the trade
    */
+  @Override
   public abstract SwapTrade toTrade(
       TradeInfo tradeInfo,
       LocalDate startDate,
@@ -169,19 +196,6 @@ public interface FixedInflationSwapConvention
       BuySell buySell,
       double notional,
       double fixedRate);
-
-  //-------------------------------------------------------------------------
-  /**
-   * Calculates the spot date from the trade date.
-   * 
-   * @param tradeDate  the trade date
-   * @param refData  the reference data, used to resolve the date
-   * @return the spot date
-   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
-   */
-  public default LocalDate calculateSpotDateFromTradeDate(LocalDate tradeDate, ReferenceData refData) {
-    return getSpotDateOffset().adjust(tradeDate, refData);
-  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/SingleCurrencySwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/SingleCurrencySwapConvention.java
@@ -42,7 +42,7 @@ public interface SingleCurrencySwapConvention
   @FromString
   public static SingleCurrencySwapConvention of(String uniqueName) {
     ArgChecker.notNull(uniqueName, "uniqueName");
-    return Guavate.firstNotEmpty(
+    return Guavate.firstNonEmpty(
         () -> FixedIborSwapConvention.extendedEnum().find(uniqueName),
         () -> IborIborSwapConvention.extendedEnum().find(uniqueName),
         () -> FixedOvernightSwapConvention.extendedEnum().find(uniqueName),

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/SingleCurrencySwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/SingleCurrencySwapConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */
@@ -13,26 +13,24 @@ import org.joda.convert.ToString;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
+import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.ArgChecker;
-import com.opengamma.strata.collect.named.ExtendedEnum;
+import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.named.Named;
+import com.opengamma.strata.product.TradeConvention;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.swap.SwapTrade;
 
 /**
- * A market convention for Overnight-Ibor swap trades.
+ * A market convention for swap trades.
  * <p>
- * This defines the market convention for a Overnight-Ibor single currency swap.
- * In USD, this is often known as an <i>Fed Fund Swap</i>.
- * The convention is formed by combining two swap leg conventions in the same currency.
- * <p>
- * To manually create a convention, see {@link ImmutableOvernightIborSwapConvention}.
- * To register a specific convention, see {@code OvernightIborSwapConvention.ini}.
+ * This defines the market convention for a a swap.
+ * Each different type of swap has its own convention - this interface provides an abstraction.
  */
-public interface OvernightIborSwapConvention
-    extends SingleCurrencySwapConvention, Named {
+public interface SingleCurrencySwapConvention
+    extends TradeConvention, Named {
 
   /**
    * Obtains an instance from the specified unique name.
@@ -42,37 +40,28 @@ public interface OvernightIborSwapConvention
    * @throws IllegalArgumentException if the name is not known
    */
   @FromString
-  public static OvernightIborSwapConvention of(String uniqueName) {
+  public static SingleCurrencySwapConvention of(String uniqueName) {
     ArgChecker.notNull(uniqueName, "uniqueName");
-    return extendedEnum().lookup(uniqueName);
-  }
-
-  /**
-   * Gets the extended enum helper.
-   * <p>
-   * This helper allows instances of the convention to be looked up.
-   * It also provides the complete set of available instances.
-   * 
-   * @return the extended enum helper
-   */
-  public static ExtendedEnum<OvernightIborSwapConvention> extendedEnum() {
-    return OvernightIborSwapConventions.ENUM_LOOKUP;
+    return Guavate.firstNotEmpty(
+        () -> FixedIborSwapConvention.extendedEnum().find(uniqueName),
+        () -> IborIborSwapConvention.extendedEnum().find(uniqueName),
+        () -> FixedOvernightSwapConvention.extendedEnum().find(uniqueName),
+        () -> OvernightIborSwapConvention.extendedEnum().find(uniqueName),
+        () -> FixedInflationSwapConvention.extendedEnum().find(uniqueName),
+        () -> ThreeLegBasisSwapConvention.extendedEnum().find(uniqueName))
+        .orElseThrow(() -> new IllegalArgumentException("SingleCurrencySwapConvention not found: " + uniqueName));
   }
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the market convention of the overnight leg.
+   * Gets the offset of the spot value date from the trade date.
+   * <p>
+   * The offset is applied to the trade date to find the start date.
+   * A typical value is "plus 2 business days".
    * 
-   * @return the overnight leg convention
+   * @return the spot date offset, not null
    */
-  public abstract OvernightRateSwapLegConvention getOvernightLeg();
-
-  /**
-   * Gets the market convention of the Ibor leg.
-   * 
-   * @return the Ibor leg convention
-   */
-  public abstract IborRateSwapLegConvention getIborLeg();
+  public abstract DaysAdjustment getSpotDateOffset();
 
   //-------------------------------------------------------------------------
   /**
@@ -81,30 +70,26 @@ public interface OvernightIborSwapConvention
    * This returns a trade based on the specified tenor. For example, a tenor
    * of 5 years creates a swap starting on the spot date and maturing 5 years later.
    * <p>
-   * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * See the instrument-level documentation to understand how the fixed rate or spread is applied.
    * 
    * @param tradeDate  the date of the trade
    * @param tenor  the tenor of the swap
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param fixedRateOrSpread  the fixed rate or spread in decimal form, typically derived from the market
    * @param refData  the reference data, used to resolve the trade dates
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
-  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Tenor tenor,
       BuySell buySell,
       double notional,
-      double spread,
+      double fixedRateOrSpread,
       ReferenceData refData) {
 
-    // override for Javadoc
-    return SingleCurrencySwapConvention.super.createTrade(tradeDate, tenor, buySell, notional, spread, refData);
+    return createTrade(tradeDate, Period.ZERO, tenor, buySell, notional, fixedRateOrSpread, refData);
   }
 
   /**
@@ -114,32 +99,31 @@ public interface OvernightIborSwapConvention
    * 3 months and a tenor of 5 years creates a swap starting three months after the spot date
    * and maturing 5 years later.
    * <p>
-   * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * See the instrument-level documentation to understand how the fixed rate or spread is applied.
    * 
    * @param tradeDate  the date of the trade
    * @param periodToStart  the period between the spot date and the start date
    * @param tenor  the tenor of the swap
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param fixedRateOrSpread  the fixed rate or spread in decimal form, typically derived from the market
    * @param refData  the reference data, used to resolve the trade dates
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
-  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Period periodToStart,
       Tenor tenor,
       BuySell buySell,
       double notional,
-      double spread,
+      double fixedRateOrSpread,
       ReferenceData refData) {
 
-    // override for Javadoc
-    return SingleCurrencySwapConvention.super.createTrade(tradeDate, periodToStart, tenor, buySell, notional, spread, refData);
+    LocalDate spotValue = calculateSpotDateFromTradeDate(tradeDate, refData);
+    LocalDate startDate = spotValue.plus(periodToStart);
+    LocalDate endDate = startDate.plus(tenor.getPeriod());
+    return toTrade(tradeDate, startDate, endDate, buySell, notional, fixedRateOrSpread);
   }
 
   /**
@@ -147,29 +131,26 @@ public interface OvernightIborSwapConvention
    * <p>
    * This returns a trade based on the specified dates.
    * <p>
-   * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * See the instrument-level documentation to understand how the fixed rate or spread is applied.
    * 
    * @param tradeDate  the date of the trade
    * @param startDate  the start date
    * @param endDate  the end date
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param fixedRateOrSpread  the fixed rate or spread in decimal form, typically derived from the market
    * @return the trade
    */
-  @Override
   public default SwapTrade toTrade(
       LocalDate tradeDate,
       LocalDate startDate,
       LocalDate endDate,
       BuySell buySell,
       double notional,
-      double spread) {
+      double fixedRateOrSpread) {
 
-    // override for Javadoc
-    return SingleCurrencySwapConvention.super.toTrade(tradeDate, startDate, endDate, buySell, notional, spread);
+    TradeInfo tradeInfo = TradeInfo.of(tradeDate);
+    return toTrade(tradeInfo, startDate, endDate, buySell, notional, fixedRateOrSpread);
   }
 
   /**
@@ -177,26 +158,36 @@ public interface OvernightIborSwapConvention
    * <p>
    * This returns a trade based on the specified dates.
    * <p>
-   * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * See the instrument-level documentation to understand how the fixed rate or spread is applied.
    * 
    * @param tradeInfo  additional information about the trade
    * @param startDate  the start date
    * @param endDate  the end date
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param fixedRateOrSpread  the fixed rate or spread in decimal form, typically derived from the market
    * @return the trade
    */
-  @Override
   public abstract SwapTrade toTrade(
       TradeInfo tradeInfo,
       LocalDate startDate,
       LocalDate endDate,
       BuySell buySell,
       double notional,
-      double spread);
+      double fixedRateOrSpread);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the spot date from the trade date.
+   * 
+   * @param tradeDate  the trade date
+   * @param refData  the reference data, used to resolve the date
+   * @return the spot date
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  public default LocalDate calculateSpotDateFromTradeDate(LocalDate tradeDate, ReferenceData refData) {
+    return getSpotDateOffset().adjust(tradeDate, refData);
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ThreeLegBasisSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ThreeLegBasisSwapConvention.java
@@ -13,12 +13,10 @@ import org.joda.convert.ToString;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
-import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.named.ExtendedEnum;
 import com.opengamma.strata.collect.named.Named;
-import com.opengamma.strata.product.TradeConvention;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.swap.SwapTrade;
@@ -39,7 +37,7 @@ import com.opengamma.strata.product.swap.SwapTrade;
  * To register a specific convention, see {@code ThreeLegBasisSwapConvention.ini}.
  */
 public interface ThreeLegBasisSwapConvention
-    extends TradeConvention, Named {
+    extends SingleCurrencySwapConvention, Named {
 
   /**
    * Obtains an instance from the specified unique name.
@@ -88,16 +86,6 @@ public interface ThreeLegBasisSwapConvention
    */
   public abstract IborRateSwapLegConvention getFlatFloatingLeg();
 
-  /**
-   * Gets the offset of the spot value date from the trade date.
-   * <p>
-   * The offset is applied to the trade date to find the start date.
-   * A typical value is "plus 2 business days".
-   * 
-   * @return the spot date offset, not null
-   */
-  public abstract DaysAdjustment getSpotDateOffset();
-
   //-------------------------------------------------------------------------
   /**
    * Creates a spot-starting trade based on this convention.
@@ -119,6 +107,7 @@ public interface ThreeLegBasisSwapConvention
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
+  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Tenor tenor,
@@ -127,7 +116,8 @@ public interface ThreeLegBasisSwapConvention
       double spread,
       ReferenceData refData) {
 
-    return createTrade(tradeDate, Period.ZERO, tenor, buySell, notional, spread, refData);
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, tenor, buySell, notional, spread, refData);
   }
 
   /**
@@ -152,6 +142,7 @@ public interface ThreeLegBasisSwapConvention
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
    */
+  @Override
   public default SwapTrade createTrade(
       LocalDate tradeDate,
       Period periodToStart,
@@ -161,10 +152,8 @@ public interface ThreeLegBasisSwapConvention
       double spread,
       ReferenceData refData) {
 
-    LocalDate spotValue = calculateSpotDateFromTradeDate(tradeDate, refData);
-    LocalDate startDate = spotValue.plus(periodToStart);
-    LocalDate endDate = startDate.plus(tenor.getPeriod());
-    return toTrade(tradeDate, startDate, endDate, buySell, notional, spread);
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, periodToStart, tenor, buySell, notional, spread, refData);
   }
 
   /**
@@ -185,6 +174,7 @@ public interface ThreeLegBasisSwapConvention
    * @param spread  the spread, typically derived from the market
    * @return the trade
    */
+  @Override
   public default SwapTrade toTrade(
       LocalDate tradeDate,
       LocalDate startDate,
@@ -193,8 +183,8 @@ public interface ThreeLegBasisSwapConvention
       double notional,
       double spread) {
 
-    TradeInfo tradeInfo = TradeInfo.of(tradeDate);
-    return toTrade(tradeInfo, startDate, endDate, buySell, notional, spread);
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.toTrade(tradeDate, startDate, endDate, buySell, notional, spread);
   }
 
   /**
@@ -215,6 +205,7 @@ public interface ThreeLegBasisSwapConvention
    * @param spread  the spread, typically derived from the market
    * @return the trade
    */
+  @Override
   public abstract SwapTrade toTrade(
       TradeInfo tradeInfo,
       LocalDate startDate,
@@ -222,19 +213,6 @@ public interface ThreeLegBasisSwapConvention
       BuySell buySell,
       double notional,
       double spread);
-
-  //-------------------------------------------------------------------------
-  /**
-   * Calculates the spot date from the trade date.
-   * 
-   * @param tradeDate  the trade date
-   * @param refData  the reference data, used to resolve the date
-   * @return the spot date
-   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
-   */
-  public default LocalDate calculateSpotDateFromTradeDate(LocalDate tradeDate, ReferenceData refData) {
-    return getSpotDateOffset().adjust(tradeDate, refData);
-  }
 
   //-------------------------------------------------------------------------
   /**


### PR DESCRIPTION
All single currency swap conventions are similar, so this creates an abstraction.

Additional `Guavate` method to simulate `Optional.or`.