### PR TITLE
Swap Calculation Function to support custom logic when resolving a swap trade

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunction.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -86,11 +87,24 @@ public class SwapTradeCalculationFunction
 
   private static final ImmutableSet<Measure> MEASURES = CALCULATORS.keySet();
 
+  private final BiFunction<SwapTrade, ReferenceData, ResolvedSwapTrade> swapTradeResolver;
+
   /**
    * Creates an instance.
    */
   public SwapTradeCalculationFunction() {
+    this((swapTrade, referenceData) -> swapTrade.resolve(referenceData));
   }
+
+  /**
+   * Creates an instance using custom logic for resolving the SwapTrade
+   *
+   * @param swapTradeResolver function which calculates the resolved swap
+   */
+  public SwapTradeCalculationFunction(BiFunction<SwapTrade, ReferenceData, ResolvedSwapTrade> swapTradeResolver) {
+    this.swapTradeResolver = swapTradeResolver;
+  }
+
 
   //-------------------------------------------------------------------------
   @Override
@@ -140,7 +154,7 @@ public class SwapTradeCalculationFunction
       ReferenceData refData) {
 
     // resolve the trade once for all measures and all scenarios
-    ResolvedSwapTrade resolved = trade.resolve(refData);
+    ResolvedSwapTrade resolved = swapTradeResolver.apply(trade, refData);
 
     // use lookup to query market data
     RatesMarketDataLookup ratesLookup = parameters.getParameter(RatesMarketDataLookup.class);

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunction.java
@@ -97,7 +97,7 @@ public class SwapTradeCalculationFunction
   }
 
   /**
-   * Creates an instance using custom logic for resolving the SwapTrade
+   * Creates an instance using custom logic for resolving the SwapTrade.
    *
    * @param swapTradeResolver function which calculates the resolved swap
    */

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/swap/SwapTradeCalculationFunctionTest.java
@@ -168,7 +168,7 @@ public class SwapTradeCalculationFunctionTest {
   }
 
   //Resolve a swap and remove all cashflows except for first
-  public ResolvedSwapTrade resolveToSingleCashflow(SwapTrade swapTrade, ReferenceData referenceData) {
+  private ResolvedSwapTrade resolveToSingleCashflow(SwapTrade swapTrade, ReferenceData referenceData) {
 
     ResolvedSwap resolvedSwap = swapTrade.resolve(referenceData).getProduct();
     List<ResolvedSwapLeg> modifiedLegs = new ArrayList<>(2);

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/PaymentSchedule.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/PaymentSchedule.java
@@ -228,7 +228,8 @@ public final class PaymentSchedule
         }
         List<RateAccrualPeriod> paymentAccrualPeriods = accrualPeriods.subList(accrualStartIndex, accrualIndex + 1);
         paymentPeriods.add(createPaymentPeriod(
-            paymentIndex, payPeriod,
+            paymentIndex,
+            payPeriod,
             paymentAccrualPeriods,
             paymentDateAdjuster,
             fxResetFn,


### PR DESCRIPTION
Allows client to inject more complicated logic for converting SwapTrade to ResolvedSwapTrade.

Default behaviour is unchanged.