### PR TITLE
Market data public method on SyntheticCalibrator.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibrator.java
@@ -139,7 +139,7 @@ public final class SyntheticCurveCalibrator {
    * @param refData  the reference data, used to resolve the trades
    * @return the market data
    */
-  MarketData marketData(
+  public MarketData marketData(
       CurveGroupDefinition group,
       RatesProvider inputProvider,
       ReferenceData refData) {


### PR DESCRIPTION
Making the marketData method public in the SyntheticCurveCalibrator.
The method to create market data used is useful by itself.