### PR TITLE
Add ETD CSV parser

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvInfoResolver.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvInfoResolver.java
@@ -53,21 +53,28 @@ public interface CsvInfoResolver {
 
   /**
    * Parses attributes into {@code TradeInfo}.
+   * <p>
+   * If they are available, the trade ID, date, time and zone will have been set
+   * before this method is called. They may be altered if necessary, although
+   * this is not recommended.
    * 
    * @param row  the CSV row to parse
    * @param builder  the builder to update
    */
-  public default void parseTradeAttributes(CsvRow row, TradeInfoBuilder builder) {
+  public default void parseTradeInfo(CsvRow row, TradeInfoBuilder builder) {
     // do nothing
   }
 
   /**
    * Parses attributes into {@code PositionInfo}.
+   * <p>
+   * If it is available, the position ID will have been set before this method is called.
+   * It may be altered if necessary, although this is not recommended.
    * 
    * @param row  the CSV row to parse
    * @param builder  the builder to update
    */
-  public default void parsePositionAttributes(CsvRow row, PositionInfoBuilder builder) {
+  public default void parsePositionInfo(CsvRow row, PositionInfoBuilder builder) {
     // do nothing
   }
 

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvInfoResolver.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvInfoResolver.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.collect.io.CsvRow;
+import com.opengamma.strata.product.PositionInfoBuilder;
+import com.opengamma.strata.product.TradeInfoBuilder;
+import com.opengamma.strata.product.common.ExchangeId;
+import com.opengamma.strata.product.etd.EtdContractCode;
+import com.opengamma.strata.product.etd.EtdContractSpec;
+import com.opengamma.strata.product.etd.EtdContractSpecId;
+import com.opengamma.strata.product.etd.EtdIdUtils;
+import com.opengamma.strata.product.etd.EtdType;
+
+/**
+ * Resolves security information from CSV files, enriching the parser.
+ * <p>
+ * Data loaded from a CSV may contain additional information that needs to be captured.
+ * This plugin point allows the additional CSV columns to be parsed and captured.
+ */
+public interface CsvInfoResolver {
+
+  /**
+   * Obtains an instance that uses the standard set of reference data.
+   * 
+   * @return the loader
+   */
+  public static CsvInfoResolver standard() {
+    return StandardCsvInfoResolver.of(ReferenceData.standard());
+  }
+
+  /**
+   * Obtains an instance that uses the specified set of reference data.
+   * 
+   * @param refData  the reference data
+   * @return the loader
+   */
+  public static CsvInfoResolver of(ReferenceData refData) {
+    return StandardCsvInfoResolver.of(refData);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the reference data being used.
+   * 
+   * @return the reference data
+   */
+  public abstract ReferenceData getReferenceData();
+
+  /**
+   * Parses attributes into {@code TradeInfo}.
+   * 
+   * @param row  the CSV row to parse
+   * @param builder  the builder to update
+   */
+  public default void parseTradeAttributes(CsvRow row, TradeInfoBuilder builder) {
+    // do nothing
+  }
+
+  /**
+   * Parses attributes into {@code PositionInfo}.
+   * 
+   * @param row  the CSV row to parse
+   * @param builder  the builder to update
+   */
+  public default void parsePositionAttributes(CsvRow row, PositionInfoBuilder builder) {
+    // do nothing
+  }
+
+  /**
+   * Parses the contract specification from the row.
+   * 
+   * @param row  the CSV row to parse
+   * @param type  the ETD type
+   * @return the loaded positions, position-level errors are captured in the result
+   */
+  public default EtdContractSpec parseEtdContractSpec(CsvRow row, EtdType type) {
+    ExchangeId exchangeId = ExchangeId.of(row.getValue(StandardCsvInfoResolver.EXCHANGE_FIELD));
+    EtdContractCode contractCode = EtdContractCode.of(row.getValue(StandardCsvInfoResolver.CONTRACT_CODE_FIELD));
+    EtdContractSpecId specId = EtdIdUtils.contractSpecId(type, exchangeId, contractCode);
+    return getReferenceData().findValue(specId).orElseThrow(
+        () -> new IllegalArgumentException("ETD contract specification not found in reference data: " + specId));
+  }
+
+}

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FraTradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FraTradeCsvLoader.java
@@ -24,7 +24,6 @@ import java.time.Period;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
-import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
 import com.opengamma.strata.basics.date.BusinessDayConventions;
@@ -50,10 +49,10 @@ final class FraTradeCsvLoader {
    * 
    * @param row  the CSV row
    * @param info  the trade info
-   * @param refData  the reference data
+   * @param resolver  the resolver used to parse additional information
    * @return the parsed trade
    */
-  static FraTrade parse(CsvRow row, TradeInfo info, ReferenceData refData) {
+  static FraTrade parse(CsvRow row, TradeInfo info, CsvInfoResolver resolver) {
     BuySell buySell = LoaderUtils.parseBuySell(row.getValue(BUY_SELL_FIELD));
     double notional = LoaderUtils.parseDouble(row.getValue(NOTIONAL_FIELD));
     double fixedRate = LoaderUtils.parseDoublePercent(row.getValue(FIXED_RATE_FIELD));
@@ -104,7 +103,8 @@ final class FraTradeCsvLoader {
         }
         LocalDate tradeDate = info.getTradeDate().get();
         Period periodToStart = periodToStartOpt.get();
-        FraTrade trade = convention.createTrade(tradeDate, periodToStart, buySell, notional, fixedRate, refData);
+        FraTrade trade =
+            convention.createTrade(tradeDate, periodToStart, buySell, notional, fixedRate, resolver.getReferenceData());
         trade = trade.toBuilder().info(info).build();
         return adjustTrade(trade, dateCnv, dateCalOpt);
       }

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharSource;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.Guavate;
+import com.opengamma.strata.collect.io.CsvIterator;
+import com.opengamma.strata.collect.io.CsvRow;
+import com.opengamma.strata.collect.io.ResourceLocator;
+import com.opengamma.strata.collect.io.UnicodeBom;
+import com.opengamma.strata.collect.result.FailureItem;
+import com.opengamma.strata.collect.result.FailureReason;
+import com.opengamma.strata.collect.result.ValueWithFailures;
+import com.opengamma.strata.product.Position;
+import com.opengamma.strata.product.PositionInfo;
+import com.opengamma.strata.product.PositionInfoBuilder;
+import com.opengamma.strata.product.SecurityPosition;
+import com.opengamma.strata.product.etd.EtdContractSpecId;
+import com.opengamma.strata.product.etd.EtdFuturePosition;
+import com.opengamma.strata.product.etd.EtdOptionPosition;
+import com.opengamma.strata.product.etd.EtdOptionType;
+import com.opengamma.strata.product.etd.EtdPosition;
+import com.opengamma.strata.product.etd.EtdSettlementType;
+
+/**
+ * Loads positions from CSV files.
+ * <p>
+ * The positions are expected to be in a CSV format known to Strata.
+ * The parser is flexible, understanding a number of different ways to define each position.
+ * Columns may occur in any order.
+ * 
+ * <h4>Common</h4>
+ * <p>
+ * The following standard columns are supported:<br />
+ * <ul>
+ * <li>The 'Type' column is option, and defines the instrument type,
+ *   'SEC' or'Security' for standard securities,
+ *   'FUT' or 'Future' for ETD futures, and
+ *   'OPT' or 'Option' for ETD options.
+ *   If absent, the type is derived based on the presence or absence of the 'Expiry' column.
+ * <li>The 'Id Scheme' column is optional, and is the name of the scheme that the position
+ *   identifier is unique within, such as 'OG-Position'.
+ * <li>The 'Id' column is optional, and is the identifier of the position,
+ *   such as 'POS12345'.
+ * </ul>
+ * 
+ * <h4>SEC/Security</h4>
+ * <p>
+ * The following columns are supported:
+ * <ul>
+ * <li>'Security Id Scheme' - optional, defaults to 'OG-Security'
+ * <li>'Security Id' - mandatory
+ * <li>'Quantity' - see below
+ * <li>'Long Quantity' - see below
+ * <li>'Short Quantity' - see below
+ * </ul>
+ * <p>
+ * The quantity will normally be set from the 'Quantity' column.
+ * If that column is not found, the 'Long Quantity' and 'Short Quantity' columns will be used instead.
+ * 
+ * <h4>FUT/Future</h4>
+ * <p>
+ * The following columns are supported:
+ * <ul>
+ * <li>'Exchange' - mandatory, the MIC code of the exchange where the ETD is traded
+ * <li>'Contract Code' - mandatory, the contract code of the ETD at the exchange
+ * <li>'Quantity' - see below
+ * <li>'Long Quantity' - see below
+ * <li>'Short Quantity' - see below
+ * <li>'Expiry' - mandatory, the year-month of the expiry, in the format 'yyyy-MM'
+ * <li>'Expiry Week' - optional, only used to obtain a weekly-expiring ETD
+ * <li>'Expiry Day' - optional, only used to obtain a daily-expiring ETD, or Flex
+ * <li>'Settlement Type' - optional, only used for Flex, see {@link EtdSettlementType}
+ * </ul>
+ * <p>
+ * The exchange and contract code are combined to form an {@link EtdContractSpecId} which is
+ * resolved in {@link ReferenceData} to find additional details about the ETD.
+ * This process can be changed by providing an alternative {@link CsvInfoResolver}.
+ * <p>
+ * The quantity will normally be set from the 'Quantity' column.
+ * If that column is not found, the 'Long Quantity' and 'Short Quantity' columns will be used instead.
+ * <p>
+ * The single 'Expiry' column will normally just be set. Flex futures will also set the 'Expiry Day' and 'Settlement Type'.
+ * 
+ * <h4>OPT/Option</h4>
+ * <p>
+ * The following columns are supported:
+ * <ul>
+ * <li>'Exchange' - mandatory, the MIC code of the exchange where the ETD is traded
+ * <li>'Contract Code' - mandatory, the contract code of the ETD at the exchange
+ * <li>'Quantity' - see below
+ * <li>'Long Quantity' - see below
+ * <li>'Short Quantity' - see below
+ * <li>'Expiry' - mandatory, the year-month of the expiry, in the format 'yyyy-MM'
+ * <li>'Expiry Week' - optional, only used to obtain a weekly-expiring ETD
+ * <li>'Expiry Day' - optional, only used to obtain a daily-expiring ETD, or Flex
+ * <li>'Settlement Type' - optional, only used for Flex, see {@link EtdSettlementType}
+ * <li>'Exercise Style' - optional,  only used for Flex, see {@link EtdOptionType}
+ * <li>'Put Call' - mandatory,  'Put', 'P', 'Call' or 'C'
+ * <li>'Exercise Price' - mandatory,  the strike price, such as 1.23
+ * <li>'Version' - optional, the version of the contract, not widely used, defaults to zero
+ * </ul>
+ * <p>
+ * The exchange and contract code are combined to form an {@link EtdContractSpecId} which is
+ * resolved in {@link ReferenceData} to find additional details about the ETD.
+ * This process can be changed by providing an alternative {@link CsvInfoResolver}.
+ * <p>
+ * The quantity will normally be set from the 'Quantity' column.
+ * If that column is not found, the 'Long Quantity' and 'Short Quantity' columns will be used instead.
+ * <p>
+ * The single 'Expiry' column will normally just be set.
+ * Flex futures will also set the 'Expiry Day', 'Settlement Type' and 'Exercise Style'.
+ */
+public final class PositionCsvLoader {
+
+  // default schemes
+  static final String DEFAULT_POSITION_SCHEME = "OG-Position";
+  static final String DEFAULT_SECURITY_SCHEME = "OG-Security";
+
+  // CSV column headers
+  private static final String TYPE_FIELD = "Type";
+  private static final String ID_SCHEME_FIELD = "Id Scheme";
+  private static final String ID_FIELD = "Id";
+
+  /**
+   * The resolver, providing additional information.
+   */
+  private final CsvInfoResolver resolver;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains an instance that uses the standard set of reference data.
+   * 
+   * @return the loader
+   */
+  public static PositionCsvLoader standard() {
+    return new PositionCsvLoader(CsvInfoResolver.standard());
+  }
+
+  /**
+   * Obtains an instance that uses the specified set of reference data.
+   * 
+   * @param refData  the reference data
+   * @return the loader
+   */
+  public static PositionCsvLoader of(ReferenceData refData) {
+    return new PositionCsvLoader(CsvInfoResolver.of(refData));
+  }
+
+  /**
+   * Obtains an instance that uses the specified resolver for additional information.
+   * 
+   * @param resolver  the resolver used to parse additional information
+   * @return the loader
+   */
+  public static PositionCsvLoader of(CsvInfoResolver resolver) {
+    return new PositionCsvLoader(resolver);
+  }
+
+  // restricted constructor
+  private PositionCsvLoader(CsvInfoResolver resolver) {
+    this.resolver = ArgChecker.notNull(resolver, "resolver");
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Loads one or more CSV format position files.
+   * <p>
+   * CSV files sometimes contain a Unicode Byte Order Mark.
+   * This method uses {@link UnicodeBom} to interpret it.
+   * 
+   * @param resources  the CSV resources
+   * @return the loaded positions, position-level errors are captured in the result
+   */
+  public ValueWithFailures<List<Position>> load(ResourceLocator... resources) {
+    return load(Arrays.asList(resources));
+  }
+
+  /**
+   * Loads one or more CSV format position files.
+   * <p>
+   * CSV files sometimes contain a Unicode Byte Order Mark.
+   * This method uses {@link UnicodeBom} to interpret it.
+   * 
+   * @param resources  the CSV resources
+   * @return the loaded positions, all errors are captured in the result
+   */
+  public ValueWithFailures<List<Position>> load(Collection<ResourceLocator> resources) {
+    Collection<CharSource> charSources = resources.stream()
+        .map(r -> UnicodeBom.toCharSource(r.getByteSource()))
+        .collect(toList());
+    return parse(charSources);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Parses one or more CSV format position files.
+   * <p>
+   * CSV files sometimes contain a Unicode Byte Order Mark.
+   * Callers are responsible for handling this, such as by using {@link UnicodeBom}.
+   * 
+   * @param charSources  the CSV character sources
+   * @return the loaded positions, all errors are captured in the result
+   */
+  public ValueWithFailures<List<Position>> parse(Collection<CharSource> charSources) {
+    return parse(charSources, Position.class);
+  }
+
+  /**
+   * Parses one or more CSV format position files.
+   * <p>
+   * A type is specified to filter the positions.
+   * <p>
+   * CSV files sometimes contain a Unicode Byte Order Mark.
+   * Callers are responsible for handling this, such as by using {@link UnicodeBom}.
+   * 
+   * @param <T>  the position type
+   * @param charSources  the CSV character sources
+   * @param positionType  the position type to return
+   * @return the loaded positions, all errors are captured in the result
+   */
+  public <T extends Position> ValueWithFailures<List<T>> parse(Collection<CharSource> charSources, Class<T> positionType) {
+    try {
+      ValueWithFailures<List<T>> result = ValueWithFailures.of(ImmutableList.of());
+      for (CharSource charSource : charSources) {
+        ValueWithFailures<List<T>> singleResult = parseFile(charSource, positionType);
+        result = result.combinedWith(singleResult, Guavate::concatToList);
+      }
+      return result;
+
+    } catch (RuntimeException ex) {
+      return ValueWithFailures.of(ImmutableList.of(), FailureItem.of(FailureReason.ERROR, ex));
+    }
+  }
+
+  // loads a single CSV file, filtering by position type
+  private <T extends Position> ValueWithFailures<List<T>> parseFile(CharSource charSource, Class<T> positionType) {
+    try (CsvIterator csv = CsvIterator.of(charSource, true)) {
+      if (!csv.headers().contains(TYPE_FIELD)) {
+        return ValueWithFailures.of(ImmutableList.of(),
+            FailureItem.of(FailureReason.PARSING, "CSV file does not contain 'Type' header: {}", charSource));
+      }
+      return parseFile(csv, positionType);
+
+    } catch (RuntimeException ex) {
+      return ValueWithFailures.of(ImmutableList.of(),
+          FailureItem.of(FailureReason.PARSING, ex, "CSV file could not be parsed: {}", charSource));
+    }
+  }
+
+  // loads a single CSV file
+  private <T extends Position> ValueWithFailures<List<T>> parseFile(CsvIterator csv, Class<T> posType) {
+    List<T> positions = new ArrayList<>();
+    List<FailureItem> failures = new ArrayList<>();
+    int line = 2;
+    for (CsvRow row : (Iterable<CsvRow>) () -> csv) {
+      try {
+        PositionInfo info = parsePositionInfo(row);
+        Optional<String> typeRawOpt = row.findValue(TYPE_FIELD);
+        if (typeRawOpt.isPresent()) {
+          // type specified
+          String type = typeRawOpt.get().toUpperCase(Locale.ENGLISH);
+          switch (type.toUpperCase(Locale.ENGLISH)) {
+            case "SEC":
+            case "SECURITY":
+              if (posType == SecurityPosition.class || posType == Position.class) {
+                positions.add(posType.cast(SecurityCsvLoader.parseSimple(row, info, resolver)));
+              }
+              break;
+            case "FUT":
+            case "FUTURE":
+              if (posType == EtdPosition.class || posType == EtdFuturePosition.class || posType == Position.class) {
+                positions.add(posType.cast(SecurityCsvLoader.parseFuture(row, info, resolver)));
+              }
+              break;
+            case "OPT":
+            case "OPTION":
+              if (posType == EtdPosition.class || posType == EtdOptionPosition.class || posType == Position.class) {
+                positions.add(posType.cast(SecurityCsvLoader.parseOption(row, info, resolver)));
+              }
+              break;
+            default:
+              failures.add(FailureItem.of(
+                  FailureReason.PARSING, "CSV file position type '{}' is not known at line {}", typeRawOpt.get(), line));
+              break;
+          }
+        } else {
+          // infer type
+          Position position = SecurityCsvLoader.parsePosition(row, info, resolver);
+          if (posType.isInstance(position)) {
+            positions.add(posType.cast(position));
+          }
+        }
+      } catch (RuntimeException ex) {
+        failures.add(FailureItem.of(
+            FailureReason.PARSING, ex, "CSV file position could not be parsed at line {}: {}", line, ex.getMessage()));
+      }
+      line++;
+    }
+    return ValueWithFailures.of(positions, failures);
+  }
+
+  // parse the position info
+  private PositionInfo parsePositionInfo(CsvRow row) {
+    PositionInfoBuilder infoBuilder = PositionInfo.builder();
+    String scheme = row.findField(ID_SCHEME_FIELD).orElse(DEFAULT_POSITION_SCHEME);
+    row.findValue(ID_FIELD).ifPresent(id -> infoBuilder.id(StandardId.of(scheme, id)));
+    resolver.parsePositionAttributes(row, infoBuilder);
+    return infoBuilder.build();
+  }
+
+}

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
@@ -49,7 +49,8 @@ import com.opengamma.strata.product.etd.EtdSettlementType;
  * <p>
  * The following standard columns are supported:<br />
  * <ul>
- * <li>The 'Strata Position Type' column is option, and defines the instrument type,
+ * <li>The 'Strata Position Type' column is optional, but mandatory when checking headers
+ * to see if the file is a known format. It defines the instrument type,
  *   'SEC' or'Security' for standard securities,
  *   'FUT' or 'Future' for ETD futures, and
  *   'OPT' or 'Option' for ETD options.
@@ -96,7 +97,8 @@ import com.opengamma.strata.product.etd.EtdSettlementType;
  * The quantity will normally be set from the 'Quantity' column.
  * If that column is not found, the 'Long Quantity' and 'Short Quantity' columns will be used instead.
  * <p>
- * The single 'Expiry' column will normally just be set. Flex futures will also set the 'Expiry Day' and 'Settlement Type'.
+ * The expiry is normally controlled using just the 'Expiry' column.
+ * Flex options will also set the 'Expiry Day' and 'Settlement Type'.
  * 
  * <h4>OPT/Option</h4>
  * <p>
@@ -124,8 +126,8 @@ import com.opengamma.strata.product.etd.EtdSettlementType;
  * The quantity will normally be set from the 'Quantity' column.
  * If that column is not found, the 'Long Quantity' and 'Short Quantity' columns will be used instead.
  * <p>
- * The single 'Expiry' column will normally just be set.
- * Flex futures will also set the 'Expiry Day', 'Settlement Type' and 'Exercise Style'.
+ * The expiry is normally controlled using just the 'Expiry' column.
+ * Flex options will also set the 'Expiry Day', 'Settlement Type' and 'Exercise Style'.
  */
 public final class PositionCsvLoader {
 
@@ -339,7 +341,7 @@ public final class PositionCsvLoader {
     PositionInfoBuilder infoBuilder = PositionInfo.builder();
     String scheme = row.findField(ID_SCHEME_FIELD).orElse(DEFAULT_POSITION_SCHEME);
     row.findValue(ID_FIELD).ifPresent(id -> infoBuilder.id(StandardId.of(scheme, id)));
-    resolver.parsePositionAttributes(row, infoBuilder);
+    resolver.parsePositionInfo(row, infoBuilder);
     return infoBuilder.build();
   }
 

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
@@ -49,7 +49,7 @@ import com.opengamma.strata.product.etd.EtdSettlementType;
  * <p>
  * The following standard columns are supported:<br />
  * <ul>
- * <li>The 'Type' column is option, and defines the instrument type,
+ * <li>The 'Strata Position Type' column is option, and defines the instrument type,
  *   'SEC' or'Security' for standard securities,
  *   'FUT' or 'Future' for ETD futures, and
  *   'OPT' or 'Option' for ETD options.
@@ -134,7 +134,7 @@ public final class PositionCsvLoader {
   static final String DEFAULT_SECURITY_SCHEME = "OG-Security";
 
   // CSV column headers
-  private static final String TYPE_FIELD = "Type";
+  private static final String TYPE_FIELD = "Strata Position Type";
   private static final String ID_SCHEME_FIELD = "Id Scheme";
   private static final String ID_FIELD = "Id";
 
@@ -210,6 +210,24 @@ public final class PositionCsvLoader {
 
   //-------------------------------------------------------------------------
   /**
+   * Checks whether the source is a CSV format position file.
+   * <p>
+   * This parses the headers as CSV and checks that mandatory headers are present.
+   * This is determined entirely from the 'Strata Position Type' column.
+   * 
+   * @param charSource  the CSV character source to check
+   * @return true if the source is a CSV file with known headers, false otherwise
+   */
+  public boolean isKnownFormat(CharSource charSource) {
+    try (CsvIterator csv = CsvIterator.of(charSource, true)) {
+      return csv.containsHeader(TYPE_FIELD);
+    } catch (RuntimeException ex) {
+      return false;
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Parses one or more CSV format position files.
    * <p>
    * CSV files sometimes contain a Unicode Byte Order Mark.
@@ -254,7 +272,7 @@ public final class PositionCsvLoader {
     try (CsvIterator csv = CsvIterator.of(charSource, true)) {
       if (!csv.headers().contains(TYPE_FIELD)) {
         return ValueWithFailures.of(ImmutableList.of(),
-            FailureItem.of(FailureReason.PARSING, "CSV file does not contain 'Type' header: {}", charSource));
+            FailureItem.of(FailureReason.PARSING, "CSV file does not contain '{}' header: {}", TYPE_FIELD, charSource));
       }
       return parseFile(csv, positionType);
 

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/SecurityCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/SecurityCsvLoader.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import static com.opengamma.strata.collect.Guavate.toImmutableMap;
+import static com.opengamma.strata.loader.csv.PositionCsvLoader.DEFAULT_SECURITY_SCHEME;
+
+import java.time.YearMonth;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.io.CsvRow;
+import com.opengamma.strata.collect.tuple.Pair;
+import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Position;
+import com.opengamma.strata.product.PositionInfo;
+import com.opengamma.strata.product.SecurityId;
+import com.opengamma.strata.product.SecurityPosition;
+import com.opengamma.strata.product.SecurityTrade;
+import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.common.PutCall;
+import com.opengamma.strata.product.etd.EtdContractSpec;
+import com.opengamma.strata.product.etd.EtdFuturePosition;
+import com.opengamma.strata.product.etd.EtdFutureSecurity;
+import com.opengamma.strata.product.etd.EtdOptionPosition;
+import com.opengamma.strata.product.etd.EtdOptionSecurity;
+import com.opengamma.strata.product.etd.EtdOptionType;
+import com.opengamma.strata.product.etd.EtdSettlementType;
+import com.opengamma.strata.product.etd.EtdType;
+import com.opengamma.strata.product.etd.EtdVariant;
+
+/**
+ * Loads security trades from CSV files.
+ */
+final class SecurityCsvLoader {
+
+  // CSV column headers
+  private static final String SECURITY_ID_SCHEME_FIELD = "Security Id Scheme";
+  private static final String SECURITY_ID_FIELD = "Security Id";
+  private static final String LONG_QUANTITY_FIELD = "Long Quantity";
+  private static final String SHORT_QUANTITY_FIELD = "Short Quantity";
+  private static final String QUANTITY_FIELD = "Quantity";
+  private static final String PRICE_FIELD = "Price";
+
+  // ETD columns
+  private static final String EXPIRY_FIELD = "Expiry";
+  private static final String EXPIRY_WEEK_FIELD = "Expiry Week";
+  private static final String EXPIRY_DAY_FIELD = "Expiry Day";
+  private static final String SETTLEMENT_TYPE_FIELD = "Settlement Type";
+  private static final String EXERCISE_STYLE_FIELD = "Exercise Style";
+  private static final String VERSION_FIELD = "Version";
+  private static final String PUT_CALL_FIELD = "Put Call";
+  private static final String EXERCISE_PRICE_FIELD = "Exercise Price";
+
+  // Option might not specify a version number, which is when we use this default
+  private static final int DEFAULT_OPTION_VERSION_NUMBER = 0;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Parses from the CSV row.
+   * 
+   * @param row  the CSV row
+   * @param info  the trade info
+   * @param resolver  the resolver used to parse additional information
+   * @return the parsed trade
+   */
+  static SecurityTrade parseTrade(CsvRow row, TradeInfo info, CsvInfoResolver resolver) {
+    String securityIdScheme = row.findValue(SECURITY_ID_SCHEME_FIELD).orElse(DEFAULT_SECURITY_SCHEME);
+    String securityIdValue = row.getValue(SECURITY_ID_FIELD);
+    SecurityId securityId = SecurityId.of(securityIdScheme, securityIdValue);
+    Optional<Double> quantityOpt = row.findValue(QUANTITY_FIELD).map(s -> LoaderUtils.parseDouble(s));
+    double price = LoaderUtils.parseDouble(row.getValue(PRICE_FIELD));
+    if (quantityOpt.isPresent()) {
+      return SecurityTrade.of(info, securityId, quantityOpt.get(), price);
+    }
+    // handle longQuantity and shortQuantity
+    double longQuantity = parseQuantity(row, LONG_QUANTITY_FIELD);
+    double shortQuantity = parseQuantity(row, SHORT_QUANTITY_FIELD);
+    double quantity = longQuantity - shortQuantity;
+    return SecurityTrade.of(info, securityId, quantity, price);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Parses from the CSV row, inferring the position type.
+   * 
+   * @param row  the CSV row
+   * @param info  the trade info
+   * @param resolver  the resolver used to parse additional information
+   * @return the parsed position
+   */
+  static Position parsePosition(CsvRow row, PositionInfo info, CsvInfoResolver resolver) {
+    if (row.findValue(EXPIRY_FIELD).isPresent()) {
+      // etd
+      if (row.findValue(PUT_CALL_FIELD).isPresent() || row.findValue(EXERCISE_PRICE_FIELD).isPresent()) {
+        return parseOption(row, info, resolver);
+      } else {
+        return parseFuture(row, info, resolver);
+      }
+    } else {
+      // simple
+      return parseSimple(row, info, resolver);
+    }
+  }
+
+  /**
+   * Parses from the CSV row.
+   * 
+   * @param row  the CSV row
+   * @param info  the trade info
+   * @param resolver  the resolver used to parse additional information
+   * @return the parsed position
+   */
+  static SecurityPosition parseSimple(CsvRow row, PositionInfo info, CsvInfoResolver resolver) {
+    String securityIdScheme = row.findValue(SECURITY_ID_SCHEME_FIELD).orElse(DEFAULT_SECURITY_SCHEME);
+    String securityIdValue = row.getValue(SECURITY_ID_FIELD);
+    SecurityId securityId = SecurityId.of(securityIdScheme, securityIdValue);
+    Optional<Double> quantityOpt = row.findValue(QUANTITY_FIELD).map(s -> LoaderUtils.parseDouble(s));
+    if (quantityOpt.isPresent()) {
+      return SecurityPosition.ofNet(info, securityId, quantityOpt.get());
+    }
+    // handle longQuantity and shortQuantity
+    double longQuantity = parseQuantity(row, LONG_QUANTITY_FIELD);
+    double shortQuantity = parseQuantity(row, SHORT_QUANTITY_FIELD);
+    return SecurityPosition.ofLongShort(info, securityId, longQuantity, shortQuantity);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Parses from the CSV row.
+   * 
+   * @param row  the CSV row
+   * @param info  the position info
+   * @param resolver  the resolver of additional security information
+   * @return the parsed position
+   */
+  static EtdFuturePosition parseFuture(CsvRow row, PositionInfo info, CsvInfoResolver resolver) {
+    EtdContractSpec contract = resolver.parseEtdContractSpec(row, EtdType.FUTURE);
+    Pair<YearMonth, EtdVariant> variant = parseVariant(row, EtdType.FUTURE);
+    EtdFutureSecurity security = contract.createFuture(variant.getFirst(), variant.getSecond());
+    Optional<Double> quantityOpt = row.findValue(QUANTITY_FIELD).map(s -> LoaderUtils.parseDouble(s));
+    if (quantityOpt.isPresent()) {
+      return EtdFuturePosition.ofNet(info, security, quantityOpt.get());
+    }
+    // handle longQuantity and shortQuantity
+    double longQuantity = parseQuantity(row, LONG_QUANTITY_FIELD);
+    double shortQuantity = parseQuantity(row, SHORT_QUANTITY_FIELD);
+    return EtdFuturePosition.ofLongShort(info, security, longQuantity, shortQuantity);
+  }
+
+  /**
+   * Parses from the CSV row.
+   * 
+   * @param row  the CSV row
+   * @param info  the position info
+   * @param resolver  the resolver of additional security information
+   * @return the parsed position
+   */
+  static EtdOptionPosition parseOption(CsvRow row, PositionInfo info, CsvInfoResolver resolver) {
+    EtdContractSpec contract = resolver.parseEtdContractSpec(row, EtdType.OPTION);
+    Pair<YearMonth, EtdVariant> variant = parseVariant(row, EtdType.OPTION);
+    int version = row.findValue(VERSION_FIELD).map(Integer::parseInt).orElse(DEFAULT_OPTION_VERSION_NUMBER);
+    PutCall putCall = LoaderUtils.parsePutCall(row.getValue(PUT_CALL_FIELD));
+    double strikePrice = Double.parseDouble(row.getValue(EXERCISE_PRICE_FIELD));
+    EtdOptionSecurity security = contract.createOption(variant.getFirst(), variant.getSecond(), version, putCall, strikePrice);
+    Optional<Double> quantityOpt = row.findValue(QUANTITY_FIELD).map(s -> LoaderUtils.parseDouble(s));
+    if (quantityOpt.isPresent()) {
+      return EtdOptionPosition.ofNet(info, security, quantityOpt.get());
+    }
+    // handle longQuantity and shortQuantity
+    double longQuantity = parseQuantity(row, LONG_QUANTITY_FIELD);
+    double shortQuantity = parseQuantity(row, SHORT_QUANTITY_FIELD);
+    return EtdOptionPosition.ofLongShort(info, security, longQuantity, shortQuantity);
+  }
+
+  //-------------------------------------------------------------------------
+  // parses a quantity field
+  private static double parseQuantity(CsvRow row, String field) {
+    Optional<Double> quantityOpt = row.findValue(field).map(s -> LoaderUtils.parseDouble(s));
+    quantityOpt.ifPresent(q -> ArgChecker.notNegative(q, field));
+    return quantityOpt.orElse(0d);
+  }
+
+  // parses the year-month and variant
+  private static Pair<YearMonth, EtdVariant> parseVariant(CsvRow row, EtdType type) {
+    YearMonth yearMonth = LoaderUtils.parseYearMonth(row.getValue(EXPIRY_FIELD));
+    int week = row.findValue(EXPIRY_WEEK_FIELD).map(s -> LoaderUtils.parseInteger(s)).orElse(0);
+    int day = row.findValue(EXPIRY_DAY_FIELD).map(s -> LoaderUtils.parseInteger(s)).orElse(0);
+    Optional<EtdSettlementType> settleType = row.findValue(SETTLEMENT_TYPE_FIELD).map(s -> parseEtdSettlementType(s));
+    Optional<EtdOptionType> optionType = row.findValue(EXERCISE_STYLE_FIELD).map(s -> parseEtdOptionType(s));
+    // check valid combinations
+    if (!settleType.isPresent()) {
+      if (day == 0) {
+        if (week == 0) {
+          return Pair.of(yearMonth, EtdVariant.ofMonthly());
+        } else {
+          return Pair.of(yearMonth, EtdVariant.ofWeekly(week));
+        }
+      } else {
+        if (week == 0) {
+          return Pair.of(yearMonth, EtdVariant.ofDaily(day));
+        } else {
+          throw new IllegalArgumentException("ETD date columns conflict, cannot set both expiry day and expiry week");
+        }
+      }
+    } else {
+      if (day == 0) {
+        throw new IllegalArgumentException("ETD date columns conflict, must set expiry day for Flex " + type);
+      }
+      if (week != 0) {
+        throw new IllegalArgumentException("ETD date columns conflict, cannot set expiry week for Flex " + type);
+      }
+      if (type == EtdType.FUTURE) {
+        return Pair.of(yearMonth, EtdVariant.ofFlexFuture(day, settleType.get()));
+      } else {
+        if (!optionType.isPresent()) {
+          throw new IllegalArgumentException("ETD option type not found for Flex Option");
+        }
+        return Pair.of(yearMonth, EtdVariant.ofFlexOption(day, settleType.get(), optionType.get()));
+      }
+    }
+  }
+
+  // parses the ETD settlement type form short code or full name
+  private static EtdSettlementType parseEtdSettlementType(String str) {
+    String upper = str.toUpperCase(Locale.ENGLISH);
+    Map<String, EtdSettlementType> valuesByCode =
+        Stream.of(EtdSettlementType.values()).collect(toImmutableMap(EtdSettlementType::getCode));
+    EtdSettlementType fromCode = valuesByCode.get(upper);
+    return fromCode != null ? fromCode : EtdSettlementType.of(str);
+  }
+
+  // parses the ETD option type form short code or full name
+  private static EtdOptionType parseEtdOptionType(String str) {
+    switch (str.toUpperCase(Locale.ENGLISH)) {
+      case "AMERICAN":
+      case "A":
+        return EtdOptionType.AMERICAN;
+      case "EUROPEAN":
+      case "E":
+        return EtdOptionType.EUROPEAN;
+      default:
+        throw new IllegalArgumentException(
+            "Unknown EtdOptionType value, must be 'American' or 'European' but was '" + str + "'; " +
+                "parser is case insensitive and also accepts 'A' and 'E'");
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  // Restricted constructor.
+  private SecurityCsvLoader() {
+  }
+
+}

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/StandardCsvInfoResolver.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/StandardCsvInfoResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.collect.ArgChecker;
+
+/**
+ * Standard CSV information resolver.
+ */
+final class StandardCsvInfoResolver implements CsvInfoResolver {
+
+  static final String EXCHANGE_FIELD = "Exchange";
+  static final String CONTRACT_CODE_FIELD = "Contract Code";
+
+  /**
+   * The reference data.
+   */
+  private final ReferenceData refData;
+
+  /**
+   * Obtains an instance that uses the specified set of reference data.
+   * 
+   * @param refData  the reference data
+   * @return the loader
+   */
+  public static StandardCsvInfoResolver of(ReferenceData refData) {
+    return new StandardCsvInfoResolver(refData);
+  }
+
+  // restricted constructor
+  private StandardCsvInfoResolver(ReferenceData refData) {
+    this.refData = ArgChecker.notNull(refData, "refData");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ReferenceData getReferenceData() {
+    return refData;
+  }
+
+}

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TermDepositTradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TermDepositTradeCsvLoader.java
@@ -23,7 +23,6 @@ import java.time.Period;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
-import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
@@ -49,10 +48,10 @@ final class TermDepositTradeCsvLoader {
    * 
    * @param row  the CSV row
    * @param info  the trade info
-   * @param refData  the reference data
+   * @param resolver  the resolver used to parse additional information
    * @return the parsed trade
    */
-  static TermDepositTrade parse(CsvRow row, TradeInfo info, ReferenceData refData) {
+  static TermDepositTrade parse(CsvRow row, TradeInfo info, CsvInfoResolver resolver) {
     BuySell buySell = LoaderUtils.parseBuySell(row.getValue(BUY_SELL_FIELD));
     double notional = LoaderUtils.parseDouble(row.getValue(NOTIONAL_FIELD));
     double fixedRate = LoaderUtils.parseDoublePercent(row.getValue(FIXED_RATE_FIELD));
@@ -100,7 +99,8 @@ final class TermDepositTradeCsvLoader {
         }
         LocalDate tradeDate = info.getTradeDate().get();
         Period periodToStart = tenorOpt.get();
-        TermDepositTrade trade = convention.createTrade(tradeDate, periodToStart, buySell, notional, fixedRate, refData);
+        TermDepositTrade trade = convention.createTrade(
+            tradeDate, periodToStart, buySell, notional, fixedRate, resolver.getReferenceData());
         trade = trade.toBuilder().info(info).build();
         return adjustTrade(trade, dateCnv, dateCalOpt);
       }

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
@@ -381,7 +381,7 @@ public final class TradeCsvLoader {
     row.findValue(TRADE_DATE_FIELD).ifPresent(dateStr -> infoBuilder.tradeDate(LoaderUtils.parseDate(dateStr)));
     row.findValue(TRADE_TIME_FIELD).ifPresent(timeStr -> infoBuilder.tradeTime(LoaderUtils.parseTime(timeStr)));
     row.findValue(TRADE_ZONE_FIELD).ifPresent(zoneStr -> infoBuilder.zone(ZoneId.of(zoneStr)));
-    resolver.parseTradeAttributes(row, infoBuilder);
+    resolver.parseTradeInfo(row, infoBuilder);
     return infoBuilder.build();
   }
 

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/LoaderUtilsTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/LoaderUtilsTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
 
 import org.testng.annotations.Test;
 
@@ -20,6 +21,7 @@ import com.opengamma.strata.basics.index.OvernightIndices;
 import com.opengamma.strata.basics.index.PriceIndices;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.common.PayReceive;
+import com.opengamma.strata.product.common.PutCall;
 
 /**
  * Test {@link LoaderUtils}.
@@ -49,6 +51,11 @@ public class LoaderUtilsTest {
     assertEquals(LoaderUtils.parseBoolean("no"), false);
     assertEquals(LoaderUtils.parseBoolean("n"), false);
     assertThrowsIllegalArg(() -> LoaderUtils.parseBoolean("Rubbish"));
+  }
+
+  public void test_parseInteger() {
+    assertEquals(LoaderUtils.parseInteger("2"), 2);
+    assertThrowsIllegalArg(() -> LoaderUtils.parseInteger("Rubbish"));
   }
 
   public void test_parseDouble() {
@@ -85,6 +92,24 @@ public class LoaderUtilsTest {
     assertThrowsIllegalArg(() -> LoaderUtils.parseDate("Rubbish"));
   }
 
+  public void test_parseYearMonth() {
+    assertEquals(LoaderUtils.parseYearMonth("2012-06"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("201206"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("Jun-2012"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("Jun-12"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("Jun2012"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("Jun12"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("1/6/2012"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("01/6/2012"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("1/06/2012"), YearMonth.of(2012, 6));
+    assertEquals(LoaderUtils.parseYearMonth("01/06/2012"), YearMonth.of(2012, 6));
+    assertThrowsIllegalArg(() -> LoaderUtils.parseYearMonth("2/6/2012"));
+    assertThrowsIllegalArg(() -> LoaderUtils.parseYearMonth("1/6/12"));
+    assertThrowsIllegalArg(() -> LoaderUtils.parseYearMonth("Jun1"));
+    assertThrowsIllegalArg(() -> LoaderUtils.parseYearMonth("12345678"));
+    assertThrowsIllegalArg(() -> LoaderUtils.parseYearMonth("Rubbish"));
+  }
+
   public void test_parseTime() {
     assertEquals(LoaderUtils.parseTime("11"), LocalTime.of(11, 0));
     assertEquals(LoaderUtils.parseTime("11:30"), LocalTime.of(11, 30));
@@ -118,6 +143,19 @@ public class LoaderUtilsTest {
     assertThrowsIllegalArg(() -> LoaderUtils.parseBoolean("Rubbish"));
   }
 
+  public void test_parsePutCall() {
+    assertEquals(LoaderUtils.parsePutCall("PUT"), PutCall.PUT);
+    assertEquals(LoaderUtils.parsePutCall("Put"), PutCall.PUT);
+    assertEquals(LoaderUtils.parsePutCall("put"), PutCall.PUT);
+    assertEquals(LoaderUtils.parsePutCall("p"), PutCall.PUT);
+    assertEquals(LoaderUtils.parsePutCall("CALL"), PutCall.CALL);
+    assertEquals(LoaderUtils.parsePutCall("Call"), PutCall.CALL);
+    assertEquals(LoaderUtils.parsePutCall("call"), PutCall.CALL);
+    assertEquals(LoaderUtils.parsePutCall("c"), PutCall.CALL);
+    assertThrowsIllegalArg(() -> LoaderUtils.parseBoolean("Rubbish"));
+  }
+
+  //-------------------------------------------------------------------------
   public void coverage() {
     coverPrivateConstructor(LoaderUtils.class);
   }

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
@@ -53,6 +53,12 @@ public class PositionCsvLoaderTest {
       ResourceLocator.of("classpath:com/opengamma/strata/loader/csv/positions.csv");
 
   //-------------------------------------------------------------------------
+  public void test_isKnownFormat() {
+    PositionCsvLoader test = PositionCsvLoader.standard();
+    assertEquals(test.isKnownFormat(FILE.getCharSource()), true);
+  }
+
+  //-------------------------------------------------------------------------
   public void test_load_security() {
     PositionCsvLoader test = PositionCsvLoader.standard();
     ValueWithFailures<List<Position>> trades = test.load(FILE);
@@ -217,12 +223,12 @@ public class PositionCsvLoaderTest {
     assertEquals(trades.getFailures().size(), 1);
     FailureItem failure = trades.getFailures().get(0);
     assertEquals(failure.getReason(), FailureReason.PARSING);
-    assertEquals(failure.getMessage().contains("CSV file does not contain 'Type' header"), true);
+    assertEquals(failure.getMessage().contains("CSV file does not contain 'Strata Position Type' header"), true);
   }
 
   public void test_load_invalidUnknownType() {
     PositionCsvLoader test = PositionCsvLoader.standard();
-    ValueWithFailures<List<Position>> trades = test.parse(ImmutableList.of(CharSource.wrap("Type\nFoo")));
+    ValueWithFailures<List<Position>> trades = test.parse(ImmutableList.of(CharSource.wrap("Strata Position Type\nFoo")));
 
     assertEquals(trades.getFailures().size(), 1);
     FailureItem failure = trades.getFailures().get(0);

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2017 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+import static org.joda.beans.test.BeanAssert.assertBeanEquals;
+import static org.testng.Assert.assertEquals;
+
+import java.time.YearMonth;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharSource;
+import com.opengamma.strata.basics.ImmutableReferenceData;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.collect.io.ResourceLocator;
+import com.opengamma.strata.collect.result.FailureItem;
+import com.opengamma.strata.collect.result.FailureReason;
+import com.opengamma.strata.collect.result.ValueWithFailures;
+import com.opengamma.strata.product.Position;
+import com.opengamma.strata.product.PositionInfo;
+import com.opengamma.strata.product.SecurityId;
+import com.opengamma.strata.product.SecurityPosition;
+import com.opengamma.strata.product.SecurityPriceInfo;
+import com.opengamma.strata.product.common.ExchangeIds;
+import com.opengamma.strata.product.common.PutCall;
+import com.opengamma.strata.product.etd.EtdContractCode;
+import com.opengamma.strata.product.etd.EtdContractSpec;
+import com.opengamma.strata.product.etd.EtdContractSpecId;
+import com.opengamma.strata.product.etd.EtdFuturePosition;
+import com.opengamma.strata.product.etd.EtdFutureSecurity;
+import com.opengamma.strata.product.etd.EtdOptionPosition;
+import com.opengamma.strata.product.etd.EtdOptionSecurity;
+import com.opengamma.strata.product.etd.EtdOptionType;
+import com.opengamma.strata.product.etd.EtdSettlementType;
+import com.opengamma.strata.product.etd.EtdType;
+import com.opengamma.strata.product.etd.EtdVariant;
+
+/**
+ * Test {@link PositionCsvLoader}.
+ */
+@Test
+public class PositionCsvLoaderTest {
+
+  private static final ResourceLocator FILE =
+      ResourceLocator.of("classpath:com/opengamma/strata/loader/csv/positions.csv");
+
+  //-------------------------------------------------------------------------
+  public void test_load_security() {
+    PositionCsvLoader test = PositionCsvLoader.standard();
+    ValueWithFailures<List<Position>> trades = test.load(FILE);
+
+    List<SecurityPosition> filtered = trades.getValue().stream()
+        .filter(SecurityPosition.class::isInstance)
+        .map(SecurityPosition.class::cast)
+        .collect(toImmutableList());
+    assertEquals(filtered.size(), 2);
+
+    SecurityPosition expected1 = SecurityPosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123431"))
+            .build())
+        .securityId(SecurityId.of("OG-Security", "AAPL"))
+        .longQuantity(12d)
+        .shortQuantity(14.5d)
+        .build();
+    assertBeanEquals(expected1, filtered.get(0));
+
+    SecurityPosition expected2 = SecurityPosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123432"))
+            .build())
+        .securityId(SecurityId.of("BBG", "MSFT"))
+        .longQuantity(20d)
+        .shortQuantity(0d)
+        .build();
+    assertBeanEquals(expected2, filtered.get(1));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_parse_future() {
+    EtdContractSpecId specId = EtdContractSpecId.of("OG-ETD", "F-ECAG-FGBL");
+    EtdContractSpec contract = EtdContractSpec.builder()
+        .id(specId)
+        .type(EtdType.FUTURE)
+        .exchangeId(ExchangeIds.ECAG)
+        .contractCode(EtdContractCode.of("FGBL"))
+        .description("Dummy")
+        .priceInfo(SecurityPriceInfo.of(Currency.GBP, 100))
+        .build();
+    ReferenceData refData = ImmutableReferenceData.of(specId, contract);
+    PositionCsvLoader test = PositionCsvLoader.of(refData);
+    ValueWithFailures<List<EtdFuturePosition>> trades =
+        test.parse(ImmutableList.of(FILE.getCharSource()), EtdFuturePosition.class);
+    List<EtdFuturePosition> filtered = trades.getValue();
+    assertEquals(filtered.size(), 4);
+
+    EtdFuturePosition expected1 = EtdFuturePosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123421"))
+            .build())
+        .security(EtdFutureSecurity.of(contract, YearMonth.of(2017, 6), EtdVariant.ofMonthly()))
+        .longQuantity(15d)
+        .shortQuantity(2d)
+        .build();
+    assertBeanEquals(expected1, filtered.get(0));
+
+    EtdFuturePosition expected2 = EtdFuturePosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123422"))
+            .build())
+        .security(EtdFutureSecurity.of(contract, YearMonth.of(2017, 6), EtdVariant.ofFlexFuture(13, EtdSettlementType.CASH)))
+        .longQuantity(0d)
+        .shortQuantity(13d)
+        .build();
+    assertBeanEquals(expected2, filtered.get(1));
+
+    EtdFuturePosition expected3 = EtdFuturePosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123423"))
+            .build())
+        .security(EtdFutureSecurity.of(contract, YearMonth.of(2017, 6), EtdVariant.ofWeekly(2)))
+        .longQuantity(0d)
+        .shortQuantity(20d)
+        .build();
+    assertBeanEquals(expected3, filtered.get(2));
+
+    EtdFuturePosition expected4 = EtdFuturePosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123424"))
+            .build())
+        .security(EtdFutureSecurity.of(contract, YearMonth.of(2017, 6), EtdVariant.ofDaily(3)))
+        .longQuantity(30d)
+        .shortQuantity(0d)
+        .build();
+    assertBeanEquals(expected4, filtered.get(3));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_parse_option() {
+    EtdContractSpecId specId = EtdContractSpecId.of("OG-ETD", "O-ECAG-OGBL");
+    EtdContractSpec contract = EtdContractSpec.builder()
+        .id(specId)
+        .type(EtdType.OPTION)
+        .exchangeId(ExchangeIds.ECAG)
+        .contractCode(EtdContractCode.of("OGBL"))
+        .description("Dummy")
+        .priceInfo(SecurityPriceInfo.of(Currency.GBP, 100))
+        .build();
+    ReferenceData refData = ImmutableReferenceData.of(specId, contract);
+    PositionCsvLoader test = PositionCsvLoader.of(refData);
+    ValueWithFailures<List<EtdOptionPosition>> trades =
+        test.parse(ImmutableList.of(FILE.getCharSource()), EtdOptionPosition.class);
+
+    List<EtdOptionPosition> filtered = trades.getValue();
+    assertEquals(filtered.size(), 3);
+
+    EtdOptionPosition expected1 = EtdOptionPosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123431"))
+            .build())
+        .security(EtdOptionSecurity.of(contract, YearMonth.of(2017, 6), EtdVariant.ofMonthly(), 0, PutCall.PUT, 3d))
+        .longQuantity(15d)
+        .shortQuantity(2d)
+        .build();
+    assertBeanEquals(expected1, filtered.get(0));
+
+    EtdOptionPosition expected2 = EtdOptionPosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123432"))
+            .build())
+        .security(EtdOptionSecurity.of(
+            contract,
+            YearMonth.of(2017, 6),
+            EtdVariant.ofFlexOption(13, EtdSettlementType.CASH, EtdOptionType.AMERICAN),
+            0,
+            PutCall.CALL,
+            4d))
+        .longQuantity(0d)
+        .shortQuantity(13d)
+        .build();
+    assertBeanEquals(expected2, filtered.get(1));
+
+    EtdOptionPosition expected3 = EtdOptionPosition.builder()
+        .info(PositionInfo.builder()
+            .id(StandardId.of("OG", "123433"))
+            .build())
+        .security(EtdOptionSecurity.of(contract, YearMonth.of(2017, 6), EtdVariant.ofWeekly(2), 0, PutCall.PUT, 5.1d))
+        .longQuantity(0d)
+        .shortQuantity(20d)
+        .build();
+    assertBeanEquals(expected3, filtered.get(2));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_load_invalidNoHeader() {
+    PositionCsvLoader test = PositionCsvLoader.standard();
+    ValueWithFailures<List<Position>> trades = test.parse(ImmutableList.of(CharSource.wrap("")));
+
+    assertEquals(trades.getFailures().size(), 1);
+    FailureItem failure = trades.getFailures().get(0);
+    assertEquals(failure.getReason(), FailureReason.PARSING);
+    assertEquals(failure.getMessage().contains("CSV file could not be parsed"), true);
+  }
+
+  public void test_load_invalidNoType() {
+    PositionCsvLoader test = PositionCsvLoader.standard();
+    ValueWithFailures<List<Position>> trades = test.parse(ImmutableList.of(CharSource.wrap("Id")));
+
+    assertEquals(trades.getFailures().size(), 1);
+    FailureItem failure = trades.getFailures().get(0);
+    assertEquals(failure.getReason(), FailureReason.PARSING);
+    assertEquals(failure.getMessage().contains("CSV file does not contain 'Type' header"), true);
+  }
+
+  public void test_load_invalidUnknownType() {
+    PositionCsvLoader test = PositionCsvLoader.standard();
+    ValueWithFailures<List<Position>> trades = test.parse(ImmutableList.of(CharSource.wrap("Type\nFoo")));
+
+    assertEquals(trades.getFailures().size(), 1);
+    FailureItem failure = trades.getFailures().get(0);
+    assertEquals(failure.getReason(), FailureReason.PARSING);
+    assertEquals(failure.getMessage(), "CSV file position type 'Foo' is not known at line 2");
+  }
+
+}

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
@@ -236,4 +236,28 @@ public class PositionCsvLoaderTest {
     assertEquals(failure.getMessage(), "CSV file position type 'Foo' is not known at line 2");
   }
 
+  public void test_load_invalidNoQuantity() {
+    EtdContractSpecId specId = EtdContractSpecId.of("OG-ETD", "F-ECAG-FGBL");
+    EtdContractSpec contract = EtdContractSpec.builder()
+        .id(specId)
+        .type(EtdType.FUTURE)
+        .exchangeId(ExchangeIds.ECAG)
+        .contractCode(EtdContractCode.of("FGBL"))
+        .description("Dummy")
+        .priceInfo(SecurityPriceInfo.of(Currency.GBP, 100))
+        .build();
+    ReferenceData refData = ImmutableReferenceData.of(specId, contract);
+    PositionCsvLoader test = PositionCsvLoader.of(refData);
+    ValueWithFailures<List<Position>> trades =
+        test.parse(
+            ImmutableList.of(CharSource.wrap("Strata Position Type,Exchange,Contract Code,Expiry\nFUT,ECAG,FGBL,2017-06")));
+
+    assertEquals(trades.getFailures().size(), 1);
+    FailureItem failure = trades.getFailures().get(0);
+    assertEquals(failure.getReason(), FailureReason.PARSING);
+    assertEquals(failure.getMessage(),
+        "CSV file position could not be parsed at line 2: " +
+            "Security must contain a quantity column, either 'Quantity' or 'Long Quantity' and 'Short Quantity'");
+  }
+
 }

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
@@ -55,6 +55,8 @@ import com.opengamma.strata.collect.io.ResourceLocator;
 import com.opengamma.strata.collect.result.FailureItem;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.ValueWithFailures;
+import com.opengamma.strata.product.SecurityId;
+import com.opengamma.strata.product.SecurityTrade;
 import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.deposit.TermDeposit;
@@ -798,6 +800,40 @@ public class TradeCsvLoaderTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_load_security() {
+    TradeCsvLoader test = TradeCsvLoader.standard();
+    ValueWithFailures<List<Trade>> trades = test.load(FILE);
+
+    List<SecurityTrade> filtered = trades.getValue().stream()
+        .filter(SecurityTrade.class::isInstance)
+        .map(SecurityTrade.class::cast)
+        .collect(toImmutableList());
+    assertEquals(filtered.size(), 2);
+
+    SecurityTrade expected1 = SecurityTrade.builder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123431"))
+            .tradeDate(date(2017, 6, 1))
+            .build())
+        .securityId(SecurityId.of("OG-Security", "AAPL"))
+        .quantity(12)
+        .price(14.5)
+        .build();
+    assertBeanEquals(expected1, filtered.get(0));
+
+    SecurityTrade expected2 = SecurityTrade.builder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123432"))
+            .tradeDate(date(2017, 6, 1))
+            .build())
+        .securityId(SecurityId.of("BBG", "MSFT"))
+        .quantity(20)
+        .price(17.8)
+        .build();
+    assertBeanEquals(expected2, filtered.get(1));
+  }
+
+  //-------------------------------------------------------------------------
   public void test_load_invalidNoHeader() {
     TradeCsvLoader test = TradeCsvLoader.standard();
     ValueWithFailures<List<Trade>> trades = test.parse(ImmutableList.of(CharSource.wrap("")));
@@ -864,6 +900,7 @@ public class TradeCsvLoaderTest {
   //-------------------------------------------------------------------------
   public void coverage() {
     coverPrivateConstructor(FraTradeCsvLoader.class);
+    coverPrivateConstructor(SecurityCsvLoader.class);
     coverPrivateConstructor(SwapTradeCsvLoader.class);
     coverPrivateConstructor(TermDepositTradeCsvLoader.class);
     coverPrivateConstructor(FullSwapTradeCsvLoader.class);

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/positions.csv
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/positions.csv
@@ -1,0 +1,12 @@
+Type,Id Scheme,Id,Security Id Scheme,Security Id,Quantity,Long Quantity,Short Quantity,Exchange,Contract Code,Expiry,Expiry Week,Expiry Day,Settlement Type,Exercise Style,Put Call,Exercise Price
+SEC,OG,123431,,AAPL,,12,14.5,,,,,,,,,
+,OG,123432,BBG,MSFT,20,,,,,,,,,,,
+,,,,,,,,,,,,,,,,
+FUT,OG,123421,,,,15,2,ECAG,FGBL,2017-06,,,,,,
+FUT,OG,123422,,,,,13,ECAG,FGBL,01/06/2017,,13,C,,,
+FUT,OG,123423,,,-20,,,ECAG,FGBL,2017-06,2,,,,,
+,OG,123424,,,30,,,ECAG,FGBL,2017-06,,3,,,,
+,,,,,,,,,,,,,,,,
+OPT,OG,123431,,,,15,2,ECAG,OGBL,2017-06,,,,,P,3
+OPT,OG,123432,,,,,13,ECAG,OGBL,01/06/2017,,13,C,A,C,4
+,OG,123433,,,-20,,,ECAG,OGBL,01/06/2017,2,,,,P,5.1

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/positions.csv
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/positions.csv
@@ -1,4 +1,4 @@
-Type,Id Scheme,Id,Security Id Scheme,Security Id,Quantity,Long Quantity,Short Quantity,Exchange,Contract Code,Expiry,Expiry Week,Expiry Day,Settlement Type,Exercise Style,Put Call,Exercise Price
+Strata Position Type,Id Scheme,Id,Security Id Scheme,Security Id,Quantity,Long Quantity,Short Quantity,Exchange,Contract Code,Expiry,Expiry Week,Expiry Day,Settlement Type,Exercise Style,Put Call,Exercise Price
 SEC,OG,123431,,AAPL,,12,14.5,,,,,,,,,
 ,OG,123432,BBG,MSFT,20,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades.csv
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades.csv
@@ -1,16 +1,19 @@
-Strata Trade Type,Id Scheme,Id,Trade Date,Trade Time,Trade Zone,Convention,Buy Sell,Period To Start,Tenor,Index,Interpolated index,Fixed Rate,FX Rate,Day Count,Currency,Notional,Start Date,End Date,Date Convention,Date Calendar,Stub Convention,Leg 1 Direction,Leg 1 Start Date,Leg 1 End Date,Leg 1 Stub Convention,Leg 1 Roll Convention,Leg 1 Frequency,Leg 1 Currency,Leg 1 Notional,Leg 1 Fixed Rate,Leg 1 Day Count,Leg 1 Date Convention,Leg 1 Date Calendar,Leg 2 Direction,Leg 2 Start Date,Leg 2 End Date,Leg 2 Frequency,Leg 2 Currency,Leg 2 Notional,Leg 2 Index
-Fra,OG,123401,01/06/2017,11:05,Europe/London,GBP-LIBOR-3M,Buy,P2M,,,,0.5,,,,1000000,,,,,,,,,,,,,,,,,,,,,,,,
-Fra,OG,123402,01/06/2017,12:35,Europe/London,GBP-LIBOR-6M,Sell,,,,,0.7,,,,1000000,01/08/2017,01/02/2018,,,,,,,,,,,,,,,,,,,,,,
-Fra,OG,123403,01/06/2017,,,,Sell,,,GBP-LIBOR-3M,GBP-LIBOR-6M,0.55,,Act/360,,1000000,01/08/2017,15/01/2018,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Swap,OG,123411,01/06/2017,,,GBP-FIXED-1Y-LIBOR-3M,Buy,P1M,P5Y,,,0.4,,,,2000000,,,,,,,,,,,,,,,,,,,,,,,,
-Swap,OG,123412,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,BUY,,,,,-0.01,,,,3100000,01/08/2017,01/08/2022,,,,,,,,,,,,,,,,,,,,,,
-Swap,OG,123413,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,Buy,,,,,0.5,,,,4000000,01/08/2017,01/09/2022,,,LongFinal,,,,,,,,,,,,,,,,,,,
-Swap,OG,123414,01/06/2017,,,GBP-LIBOR-3M-USD-LIBOR-3M,Buy,,P3Y,,,0.6,1.25,,,2000000,05/07/2017,,,,,,,,,,,,,,,,,,,,,,,
-Swap,OG,123415,01/06/2017,,,,,,,,,,,,GBP,2500000,01/08/2017,01/08/2022,,,ShortFinal,Pay,,,,,3M,,,1.1,30/360 ISDA,,,Receive,,,3M,,,GBP-LIBOR-3M
-Swap,OG,123416,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,01/08/2017,08/08/2022,LongInitial,Day8,3M,GBP,1200000,1.2,30/360 ISDA,Following,GBLO+EUTA,Receive,08/08/2017,08/08/2022,3M,GBP,1200000,GBP-LIBOR-BBA
-Swap,OG,123417,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,08/08/2017,08/08/2022,,,3M,GBP,1500000,1.3,Act/365F,Preceding,GBLO+USNY,Receive,08/08/2017,08/08/2022,6M,GBP,1500000,GBP-SONIA
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-TermDeposit,OG,123421,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,P2W,,,0.2,,,,400000,,,,,,,,,,,,,,,,,,,,,,,,
-TermDeposit,OG,123422,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,,,,0.22,,,,500000,01/06/2017,15/06/2017,,,,,,,,,,,,,,,,,,,,,,
-TermDeposit,OG,123423,01/06/2017,,,,Buy,,,,,0.23,,Act/365F,GBP,600000,01/06/2017,22/06/2017,ModifiedFollowing,GBLO,,,,,,,,,,,,,,,,,,,,
+Strata Trade Type,Id Scheme,Id,Trade Date,Trade Time,Trade Zone,Convention,Buy Sell,Period To Start,Tenor,Index,Interpolated index,Fixed Rate,FX Rate,Day Count,Currency,Notional,Start Date,End Date,Date Convention,Date Calendar,Stub Convention,Leg 1 Direction,Leg 1 Start Date,Leg 1 End Date,Leg 1 Stub Convention,Leg 1 Roll Convention,Leg 1 Frequency,Leg 1 Currency,Leg 1 Notional,Leg 1 Fixed Rate,Leg 1 Day Count,Leg 1 Date Convention,Leg 1 Date Calendar,Leg 2 Direction,Leg 2 Start Date,Leg 2 End Date,Leg 2 Frequency,Leg 2 Currency,Leg 2 Notional,Leg 2 Index,Security Id Scheme,Security Id,Quantity,Long Quantity,Price
+Fra,OG,123401,01/06/2017,11:05,Europe/London,GBP-LIBOR-3M,Buy,P2M,,,,0.5,,,,1000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123402,01/06/2017,12:35,Europe/London,GBP-LIBOR-6M,Sell,,,,,0.7,,,,1000000,01/08/2017,01/02/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123403,01/06/2017,,,,Sell,,,GBP-LIBOR-3M,GBP-LIBOR-6M,0.55,,Act/360,,1000000,01/08/2017,15/01/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123411,01/06/2017,,,GBP-FIXED-1Y-LIBOR-3M,Buy,P1M,P5Y,,,0.4,,,,2000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123412,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,BUY,,,,,-0.01,,,,3100000,01/08/2017,01/08/2022,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123413,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,Buy,,,,,0.5,,,,4000000,01/08/2017,01/09/2022,,,LongFinal,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123414,01/06/2017,,,GBP-LIBOR-3M-USD-LIBOR-3M,Buy,,P3Y,,,0.6,1.25,,,2000000,05/07/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123415,01/06/2017,,,,,,,,,,,,GBP,2500000,01/08/2017,01/08/2022,,,ShortFinal,Pay,,,,,3M,,,1.1,30/360 ISDA,,,Receive,,,3M,,,GBP-LIBOR-3M,,,,,
+Swap,OG,123416,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,01/08/2017,08/08/2022,LongInitial,Day8,3M,GBP,1200000,1.2,30/360 ISDA,Following,GBLO+EUTA,Receive,08/08/2017,08/08/2022,3M,GBP,1200000,GBP-LIBOR-BBA,,,,,
+Swap,OG,123417,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,08/08/2017,08/08/2022,,,3M,GBP,1500000,1.3,Act/365F,Preceding,GBLO+USNY,Receive,08/08/2017,08/08/2022,6M,GBP,1500000,GBP-SONIA,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123421,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,P2W,,,0.2,,,,400000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123422,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,,,,0.22,,,,500000,01/06/2017,15/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123423,01/06/2017,,,,Buy,,,,,0.23,,Act/365F,GBP,600000,01/06/2017,22/06/2017,ModifiedFollowing,GBLO,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Security,OG,123431,01/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,AAPL,12,,14.5
+Security,OG,123432,01/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,BBG,MSFT,,20,17.8


### PR DESCRIPTION
Add `PositionCsvLoader` to complement `TradeCsvLoader`.
Update trade loader to parse security trades.
Add extensibility to parser using a plugin, to pickup attributes.
