### PR TITLE
Support adjusted start date for StandardRollConventions (e.g. IMM).

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -880,7 +880,7 @@ public final class PeriodicSchedule
       //Find the valid (unadjusted) roll date for the given month or week
       LocalDate unadjustedValidRollDate = rollConvention.adjust(baseDate);
       
-      if(!unadjustedValidRollDate.equals(baseDate)) {
+      if (!unadjustedValidRollDate.equals(baseDate)) {
   
         //If roll date is relative to the month the assumption is that the adjusted date is not in a different month to
         //the original unadjusted date. This is safe as the roll day produced by monthly roll conventions are typically 

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -830,11 +830,16 @@ public final class PeriodicSchedule
   // applies de facto rule where EOM means last business day for startDate
   // and similar rule for numeric roll conventions
   // http://www.fpml.org/forums/topic/can-a-roll-convention-imply-a-stub/#post-7659
+  // For 'StandardRollConventions', such as IMM, adjusted date is identified by finding the closest valid roll date
+  // and applying the the trade level business day adjustment
   private LocalDate calculatedUnadjustedStartDate(ReferenceData refData) {
-    // change date if numeric roll convention
-    // and day-of-month actually differs
-    // and reference data is available
+    // change date if 
+    // reference data is available
     // and explicit start adjustment must be NONE (not ideal, but meets backwards compatibility)
+    // and either
+    // numeric roll convention and day-of-month actually differs 
+    // or  
+    // StandardDayConvention is used and the day is not a valid roll date
 
     if (refData != null && BusinessDayAdjustment.NONE.equals(startDateBusinessDayAdjustment)) {
         return calculatedUnadjustedDateFromAdjusted(startDate, rollConvention, businessDayAdjustment, refData);
@@ -843,7 +848,6 @@ public final class PeriodicSchedule
   }
 
   // calculates the applicable end date
-  // adjust when numeric roll convention present
   private LocalDate calculatedUnadjustedEndDate(ReferenceData refData) {
     if (refData != null) {
       return calculatedUnadjustedDateFromAdjusted(endDate, rollConvention, calculatedEndDateBusinessDayAdjustment(), refData);
@@ -854,7 +858,7 @@ public final class PeriodicSchedule
   // calculates an unadjusted date
   // for EOM and day of month roll conventions the unadjusted date is based on the roll day-of-month
   // for other conventions, the nearest unadjusted roll date is calculated, adjusted and compared to the base date
-  // this is known not to work for day of week conventions if the passed adjusted date has been rolled forwards
+  // this is known not to work for day of week conventions if the passed date has been adjusted forwards
   private static LocalDate calculatedUnadjustedDateFromAdjusted(
       LocalDate baseDate,
       RollConvention rollConvention,

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -9,12 +9,14 @@ import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_PRECEDING;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.PRECEDING;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.JPTO;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.NO_HOLIDAYS;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.SAT_SUN;
 import static com.opengamma.strata.basics.schedule.Frequency.P12M;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P2M;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
+import static com.opengamma.strata.basics.schedule.Frequency.P6M;
 import static com.opengamma.strata.basics.schedule.Frequency.TERM;
 import static com.opengamma.strata.basics.schedule.RollConventions.DAY_11;
 import static com.opengamma.strata.basics.schedule.RollConventions.DAY_17;
@@ -71,6 +73,8 @@ public class PeriodicScheduleTest {
   private static final StubConvention STUB_NONE = StubConvention.NONE;
   private static final StubConvention STUB_BOTH = StubConvention.BOTH;
   private static final BusinessDayAdjustment BDA = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, SAT_SUN);
+  private static final BusinessDayAdjustment BDA_JPY_MF = BusinessDayAdjustment.of(MODIFIED_FOLLOWING, JPTO);
+  private static final BusinessDayAdjustment BDA_JPY_P = BusinessDayAdjustment.of(PRECEDING, JPTO);
   private static final BusinessDayAdjustment BDA_NONE = BusinessDayAdjustment.NONE;
   private static final LocalDate NOV_29_2013 = date(2013, NOVEMBER, 29);  // Fri
   private static final LocalDate NOV_30_2013 = date(2013, NOVEMBER, 30);  // Sat
@@ -217,238 +221,246 @@ public class PeriodicScheduleTest {
   Object[][] data_generation() {
     return new Object[][] {
         // stub null
-        {JUN_17, SEP_17, P1M, null, null, null, null, null,
+        {JUN_17, SEP_17, P1M, null, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
 
         // stub NONE
-        {JUN_17, SEP_17, P1M, STUB_NONE, null, null, null, null,
+        {JUN_17, SEP_17, P1M, STUB_NONE, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, JUL_17, P1M, STUB_NONE, null, null, null, null,
+        {JUN_17, JUL_17, P1M, STUB_NONE, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17),
             ImmutableList.of(JUN_17, JUL_17), DAY_17},
 
         // stub SHORT_INITIAL
-        {JUN_04, SEP_17, P1M, SHORT_INITIAL, null, null, null, null,
+        {JUN_04, SEP_17, P1M, SHORT_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_04, JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_04, JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, SEP_17, P1M, SHORT_INITIAL, null, null, null, null,
+        {JUN_17, SEP_17, P1M, SHORT_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, JUL_04, P1M, SHORT_INITIAL, null, null, null, null,
+        {JUN_17, JUL_04, P1M, SHORT_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_04),
             ImmutableList.of(JUN_17, JUL_04), DAY_4},
-        {date(2011, 6, 28), date(2011, 6, 30), P1M, SHORT_INITIAL, EOM, null, null, null,
+        {date(2011, 6, 28), date(2011, 6, 30), P1M, SHORT_INITIAL, EOM, BDA, null, null, null,
             ImmutableList.of(date(2011, 6, 28), date(2011, 6, 30)),
             ImmutableList.of(date(2011, 6, 28), date(2011, 6, 30)), EOM},
-        {date(2014, 12, 12), date(2015, 8, 24), P3M, SHORT_INITIAL, null, null, null, null,
+        {date(2014, 12, 12), date(2015, 8, 24), P3M, SHORT_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(date(2014, 12, 12), date(2015, 2, 24), date(2015, 5, 24), date(2015, 8, 24)),
             ImmutableList.of(date(2014, 12, 12), date(2015, 2, 24), date(2015, 5, 25), date(2015, 8, 24)), DAY_24},
-        {date(2014, 12, 12), date(2015, 8, 24), P3M, SHORT_INITIAL, RollConventions.NONE, null, null, null,
+        {date(2014, 12, 12), date(2015, 8, 24), P3M, SHORT_INITIAL, RollConventions.NONE, BDA, null, null, null,
             ImmutableList.of(date(2014, 12, 12), date(2015, 2, 24), date(2015, 5, 24), date(2015, 8, 24)),
             ImmutableList.of(date(2014, 12, 12), date(2015, 2, 24), date(2015, 5, 25), date(2015, 8, 24)), DAY_24},
-        {date(2014, 11, 24), date(2015, 8, 24), P3M, null, RollConventions.NONE, null, null, null,
+        {date(2014, 11, 24), date(2015, 8, 24), P3M, null, RollConventions.NONE, BDA, null, null, null,
             ImmutableList.of(date(2014, 11, 24), date(2015, 2, 24), date(2015, 5, 24), date(2015, 8, 24)),
             ImmutableList.of(date(2014, 11, 24), date(2015, 2, 24), date(2015, 5, 25), date(2015, 8, 24)), DAY_24},
 
         // stub LONG_INITIAL
-        {JUN_04, SEP_17, P1M, LONG_INITIAL, null, null, null, null,
+        {JUN_04, SEP_17, P1M, LONG_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_04, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_04, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, SEP_17, P1M, LONG_INITIAL, null, null, null, null,
+        {JUN_17, SEP_17, P1M, LONG_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, JUL_04, P1M, LONG_INITIAL, null, null, null, null,
+        {JUN_17, JUL_04, P1M, LONG_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_04),
             ImmutableList.of(JUN_17, JUL_04), DAY_4},
-        {JUN_17, AUG_04, P1M, LONG_INITIAL, null, null, null, null,
+        {JUN_17, AUG_04, P1M, LONG_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, AUG_04),
             ImmutableList.of(JUN_17, AUG_04), DAY_4},
 
         // stub SHORT_FINAL
-        {JUN_04, SEP_17, P1M, SHORT_FINAL, null, null, null, null,
+        {JUN_04, SEP_17, P1M, SHORT_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_04, SEP_17),
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_04, SEP_17), DAY_4},
-        {JUN_17, SEP_17, P1M, SHORT_FINAL, null, null, null, null,
+        {JUN_17, SEP_17, P1M, SHORT_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, JUL_04, P1M, SHORT_FINAL, null, null, null, null,
+        {JUN_17, JUL_04, P1M, SHORT_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_04),
             ImmutableList.of(JUN_17, JUL_04), DAY_17},
-        {date(2011, 6, 28), date(2011, 6, 30), P1M, SHORT_FINAL, EOM, null, null, null,
+        {date(2011, 6, 28), date(2011, 6, 30), P1M, SHORT_FINAL, EOM, BDA, null, null, null,
             ImmutableList.of(date(2011, 6, 28), date(2011, 6, 30)),
             ImmutableList.of(date(2011, 6, 28), date(2011, 6, 30)), DAY_28},
-        {date(2014, 11, 29), date(2015, 9, 2), P3M, SHORT_FINAL, null, null, null, null,
+        {date(2014, 11, 29), date(2015, 9, 2), P3M, SHORT_FINAL, null, BDA, null, null, null,
             ImmutableList.of(date(2014, 11, 29), date(2015, 2, 28), date(2015, 5, 29), date(2015, 8, 29), date(2015, 9, 2)),
             ImmutableList.of(date(2014, 11, 28), date(2015, 2, 27), date(2015, 5, 29), date(2015, 8, 31), date(2015, 9, 2)),
             DAY_29},
-        {date(2014, 11, 29), date(2015, 9, 2), P3M, SHORT_FINAL, RollConventions.NONE, null, null, null,
+        {date(2014, 11, 29), date(2015, 9, 2), P3M, SHORT_FINAL, RollConventions.NONE, BDA, null, null, null,
             ImmutableList.of(date(2014, 11, 29), date(2015, 2, 28), date(2015, 5, 29), date(2015, 8, 29), date(2015, 9, 2)),
             ImmutableList.of(date(2014, 11, 28), date(2015, 2, 27), date(2015, 5, 29), date(2015, 8, 31), date(2015, 9, 2)),
             DAY_29},
 
         // stub LONG_FINAL
-        {JUN_04, SEP_17, P1M, LONG_FINAL, null, null, null, null,
+        {JUN_04, SEP_17, P1M, LONG_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_17),
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_17), DAY_4},
-        {JUN_17, SEP_17, P1M, LONG_FINAL, null, null, null, null,
+        {JUN_17, SEP_17, P1M, LONG_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, JUL_04, P1M, LONG_FINAL, null, null, null, null,
+        {JUN_17, JUL_04, P1M, LONG_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, JUL_04),
             ImmutableList.of(JUN_17, JUL_04), DAY_17},
-        {JUN_17, AUG_04, P1M, LONG_FINAL, null, null, null, null,
+        {JUN_17, AUG_04, P1M, LONG_FINAL, null, BDA, null, null, null,
             ImmutableList.of(JUN_17, AUG_04),
             ImmutableList.of(JUN_17, AUG_04), DAY_17},
 
         // explicit initial stub
-        {JUN_04, SEP_17, P1M, null, null, JUN_17, null, null,
+        {JUN_04, SEP_17, P1M, null, null, BDA, JUN_17, null, null,
             ImmutableList.of(JUN_04, JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_04, JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_04, SEP_17, P1M, SHORT_INITIAL, null, JUN_17, null, null,
+        {JUN_04, SEP_17, P1M, SHORT_INITIAL, null, BDA, JUN_17, null, null,
             ImmutableList.of(JUN_04, JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_04, JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
-        {JUN_17, SEP_17, P1M, null, null, JUN_17, null, null,
+        {JUN_17, SEP_17, P1M, null, null, BDA, JUN_17, null, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
 
         // explicit final stub
-        {JUN_04, SEP_17, P1M, null, null, null, AUG_04, null,
+        {JUN_04, SEP_17, P1M, null, null, BDA, null, AUG_04, null,
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_17),
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_17), DAY_4},
-        {JUN_04, SEP_17, P1M, SHORT_FINAL, null, null, AUG_04, null,
+        {JUN_04, SEP_17, P1M, SHORT_FINAL, null, BDA, null, AUG_04, null,
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_17),
             ImmutableList.of(JUN_04, JUL_04, AUG_04, SEP_17), DAY_4},
-        {JUN_17, SEP_17, P1M, null, null, null, AUG_17, null,
+        {JUN_17, SEP_17, P1M, null, null, BDA, null, AUG_17, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
 
         // explicit double stub
-        {JUN_04, SEP_17, P1M, null, null, JUL_11, AUG_11, null,
+        {JUN_04, SEP_17, P1M, null, null, BDA, JUL_11, AUG_11, null,
             ImmutableList.of(JUN_04, JUL_11, AUG_11, SEP_17),
             ImmutableList.of(JUN_04, JUL_11, AUG_11, SEP_17), DAY_11},
-        {JUN_04, OCT_17, P1M, STUB_BOTH, null, JUL_11, SEP_11, null,
+        {JUN_04, OCT_17, P1M, STUB_BOTH, null, BDA, JUL_11, SEP_11, null,
             ImmutableList.of(JUN_04, JUL_11, AUG_11, SEP_11, OCT_17),
             ImmutableList.of(JUN_04, JUL_11, AUG_11, SEP_11, OCT_17), DAY_11},
-        {JUN_17, SEP_17, P1M, null, null, JUN_17, SEP_17, null,
+        {JUN_17, SEP_17, P1M, null, null, BDA, JUN_17, SEP_17, null,
             ImmutableList.of(JUN_17, JUL_17, AUG_17, SEP_17),
             ImmutableList.of(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
 
         // near end of month
         // EOM flag false, thus roll on 30th
-        {NOV_30_2013, NOV_30, P3M, STUB_NONE, null, null, null, null,
+        {NOV_30_2013, NOV_30, P3M, STUB_NONE, null, BDA, null, null, null,
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_30, AUG_30, NOV_30),
             ImmutableList.of(NOV_29_2013, FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), DAY_30},
         // EOM flag true and is EOM, thus roll at EOM
-        {NOV_30_2013, NOV_30, P3M, STUB_NONE, EOM, null, null, null,
+        {NOV_30_2013, NOV_30, P3M, STUB_NONE, EOM, BDA, null, null, null,
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_31, AUG_31, NOV_30),
             ImmutableList.of(NOV_29_2013, FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), EOM},
         // EOM flag true, but not EOM, thus roll on 30th (stub convention defined)
-        {MAY_30, NOV_30, P3M, STUB_NONE, EOM, null, null, null,
+        {MAY_30, NOV_30, P3M, STUB_NONE, EOM, BDA, null, null, null,
             ImmutableList.of(MAY_30, AUG_30, NOV_30),
             ImmutableList.of(MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), DAY_30},
         // EOM flag true, but not EOM, thus roll on 30th (no stub convention defined)
-        {MAY_30, NOV_30, P3M, null, EOM, null, null, null,
+        {MAY_30, NOV_30, P3M, null, EOM, BDA, null, null, null,
             ImmutableList.of(MAY_30, AUG_30, NOV_30),
             ImmutableList.of(MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), DAY_30},
         // EOM flag true and is EOM, double stub, thus roll at EOM
-        {date(2014, 1, 3), SEP_17, P3M, STUB_BOTH, EOM, FEB_28, AUG_31, null,
+        {date(2014, 1, 3), SEP_17, P3M, STUB_BOTH, EOM, BDA, FEB_28, AUG_31, null,
             ImmutableList.of(date(2014, 1, 3), FEB_28, MAY_31, AUG_31, SEP_17),
             ImmutableList.of(date(2014, 1, 3), FEB_28, MAY_30, date(2014, AUGUST, 29), SEP_17), EOM},
         // EOM flag true plus start date as last business day of month with start date adjust of NONE
-        {NOV_29_2013, NOV_30, P3M, STUB_NONE, EOM, null, null, BDA_NONE,
+        {NOV_29_2013, NOV_30, P3M, STUB_NONE, EOM, BDA, null, null, BDA_NONE,
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_31, AUG_31, NOV_30),
             ImmutableList.of(NOV_29_2013, FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), EOM},
         // EOM flag true plus start date as last business day of month with start date adjust of NONE
-        {NOV_29_2013, NOV_30, P3M, null, EOM, null, null, BDA_NONE,
+        {NOV_29_2013, NOV_30, P3M, null, EOM, BDA, null, null, BDA_NONE,
             ImmutableList.of(NOV_30_2013, FEB_28, MAY_31, AUG_31, NOV_30),
             ImmutableList.of(NOV_29_2013, FEB_28, MAY_30, date(2014, AUGUST, 29), date(2014, NOVEMBER, 28)), EOM},
         // EOM flag false, short initial, implies EOM true
-        {date(2011, 6, 2), date(2011, 8, 31), P1M, SHORT_INITIAL, null, null, null, null,
+        {date(2011, 6, 2), date(2011, 8, 31), P1M, SHORT_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 31), date(2011, 8, 31)),
             ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 29), date(2011, 8, 31)), EOM},
         // EOM flag false, explicit stub, implies EOM true
-        {date(2011, 6, 2), date(2011, 8, 31), P1M, null, null, date(2011, 6, 30), null, null,
+        {date(2011, 6, 2), date(2011, 8, 31), P1M, null, null, BDA, date(2011, 6, 30), null, null,
             ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 31), date(2011, 8, 31)),
             ImmutableList.of(date(2011, 6, 2), date(2011, 6, 30), date(2011, 7, 29), date(2011, 8, 31)), EOM},
         // EOM flag false, explicit stub, implies EOM true
-        {date(2011, 7, 31), date(2011, 10, 10), P1M, null, null, null, date(2011, 9, 30), null,
+        {date(2011, 7, 31), date(2011, 10, 10), P1M, null, null, BDA, null, date(2011, 9, 30), null,
             ImmutableList.of(date(2011, 7, 31), date(2011, 8, 31), date(2011, 9, 30), date(2011, 10, 10)),
             ImmutableList.of(date(2011, 7, 29), date(2011, 8, 31), date(2011, 9, 30), date(2011, 10, 10)), EOM},
         // EOM flag false, explicit stub, implies EOM true
-        {date(2011, 2, 2), date(2011, 5, 30), P1M, null, null, date(2011, 2, 28), null, null,
+        {date(2011, 2, 2), date(2011, 5, 30), P1M, null, null, BDA, date(2011, 2, 28), null, null,
             ImmutableList.of(date(2011, 2, 2), date(2011, 2, 28), date(2011, 3, 30), date(2011, 4, 30), date(2011, 5, 30)),
             ImmutableList.of(date(2011, 2, 2), date(2011, 2, 28), date(2011, 3, 30), date(2011, 4, 29), date(2011, 5, 30)),
             DAY_30},
 
         // pre-adjusted start date, no change needed
-        {JUL_17, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,
+        {JUL_17, OCT_17, P1M, null, DAY_17, BDA, null, null, BDA_NONE,
             ImmutableList.of(JUL_17, AUG_17, SEP_17, OCT_17),
             ImmutableList.of(JUL_17, AUG_18, SEP_17, OCT_17), DAY_17},
         // pre-adjusted start date, change needed
-        {AUG_18, OCT_17, P1M, null, DAY_17, null, null, BDA_NONE,
+        {AUG_18, OCT_17, P1M, null, DAY_17, BDA, null, null, BDA_NONE,
             ImmutableList.of(AUG_17, SEP_17, OCT_17),
             ImmutableList.of(AUG_18, SEP_17, OCT_17), DAY_17},
         // pre-adjusted first regular, change needed
-        {JUL_11, OCT_17, P1M, null, DAY_17, AUG_18, null, BDA_NONE,
+        {JUL_11, OCT_17, P1M, null, DAY_17, BDA, AUG_18, null, BDA_NONE,
             ImmutableList.of(JUL_11, AUG_17, SEP_17, OCT_17),
             ImmutableList.of(JUL_11, AUG_18, SEP_17, OCT_17), DAY_17},
         // pre-adjusted last regular, change needed
-        {JUL_17, OCT_17, P1M, null, DAY_17, null, AUG_18, BDA_NONE,
+        {JUL_17, OCT_17, P1M, null, DAY_17, BDA, null, AUG_18, BDA_NONE,
             ImmutableList.of(JUL_17, AUG_17, OCT_17),
             ImmutableList.of(JUL_17, AUG_18, OCT_17), DAY_17},
         // pre-adjusted first+last regular, change needed
-        {APR_01, OCT_17, P1M, null, DAY_17, MAY_19, AUG_18, BDA_NONE,
+        {APR_01, OCT_17, P1M, null, DAY_17, BDA, MAY_19, AUG_18, BDA_NONE,
             ImmutableList.of(APR_01, MAY_17, JUN_17, JUL_17, AUG_17, OCT_17),
             ImmutableList.of(APR_01, MAY_19, JUN_17, JUL_17, AUG_18, OCT_17), DAY_17},
         // pre-adjusted end date, change needed
-        {JUL_17, AUG_18, P1M, null, DAY_17, null, null, BDA_NONE,
+        {JUL_17, AUG_18, P1M, null, DAY_17, BDA, null, null, BDA_NONE,
             ImmutableList.of(JUL_17, AUG_17),
             ImmutableList.of(JUL_17, AUG_18), DAY_17},
         // pre-adjusted end date, change needed, with adjustment
-        {JUL_17, AUG_18, P1M, null, DAY_17, null, null, BDA,
+        {JUL_17, AUG_18, P1M, null, DAY_17, BDA, null, null, BDA,
             ImmutableList.of(JUL_17, AUG_17),
             ImmutableList.of(JUL_17, AUG_18), DAY_17},
 
         // TERM period
-        {JUN_04, SEP_17, TERM, STUB_NONE, null, null, null, null,
+        {JUN_04, SEP_17, TERM, STUB_NONE, null, BDA, null, null, null,
             ImmutableList.of(JUN_04, SEP_17),
             ImmutableList.of(JUN_04, SEP_17), ROLL_NONE},
         // TERM period defined as a stub and no regular periods
-        {JUN_04, SEP_17, P12M, SHORT_INITIAL, null, SEP_17, null, null,
+        {JUN_04, SEP_17, P12M, SHORT_INITIAL, null, BDA, SEP_17, null, null,
             ImmutableList.of(JUN_04, SEP_17),
             ImmutableList.of(JUN_04, SEP_17), DAY_17},
-        {JUN_04, SEP_17, P12M, SHORT_INITIAL, null, null, JUN_04, null,
+        {JUN_04, SEP_17, P12M, SHORT_INITIAL, null, BDA, null, JUN_04, null,
             ImmutableList.of(JUN_04, SEP_17),
             ImmutableList.of(JUN_04, SEP_17), DAY_4},
-        {date(2014, 9, 24), date(2016, 11, 24), Frequency.ofYears(2), SHORT_INITIAL, null, null, null, null,
+        {date(2014, 9, 24), date(2016, 11, 24), Frequency.ofYears(2), SHORT_INITIAL, null, BDA, null, null, null,
             ImmutableList.of(date(2014, 9, 24), date(2014, 11, 24), date(2016, 11, 24)),
             ImmutableList.of(date(2014, 9, 24), date(2014, 11, 24), date(2016, 11, 24)), DAY_24},
 
         // IMM
-        {date(2014, 9, 17), date(2014, 10, 15), P1M, STUB_NONE, IMM, null, null, null,
+        {date(2014, 9, 17), date(2014, 10, 15), P1M, STUB_NONE, IMM, BDA, null, null, null,
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 15)),
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 15)), IMM},
-        {date(2014, 9, 17), date(2014, 10, 15), TERM, STUB_NONE, IMM, null, null, null,
+        {date(2014, 9, 17), date(2014, 10, 15), TERM, STUB_NONE, IMM, BDA, null, null, null,
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 15)),
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 15)), IMM},
         // IMM with stupid short period still works
-        {date(2014, 9, 17), date(2014, 10, 15), Frequency.ofDays(2), STUB_NONE, IMM, null, null, null,
+        {date(2014, 9, 17), date(2014, 10, 15), Frequency.ofDays(2), STUB_NONE, IMM, BDA, null, null, null,
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 15)),
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 15)), IMM},
-        {date(2014, 9, 17), date(2014, 10, 1), Frequency.ofDays(2), STUB_NONE, IMM, null, null, null,
+        {date(2014, 9, 17), date(2014, 10, 1), Frequency.ofDays(2), STUB_NONE, IMM, BDA, null, null, null,
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 1)),
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 1)), IMM},
 
+        //IMM with adjusted start dates and various conventions
+        {date(2018, 3, 22), date(2020, 03, 18), P6M, STUB_NONE, IMM, BDA_JPY_MF, null, null, BDA_NONE,
+            ImmutableList.of(date(2018, 3, 21), date(2018, 9, 19), date(2019, 3, 20), date(2019, 9, 18), date(2020, 3, 18)),
+            ImmutableList.of(date(2018, 3, 22), date(2018, 9, 19), date(2019, 3, 20), date(2019, 9, 18), date(2020, 3, 18)), IMM},
+        {date(2018, 3, 20), date(2019, 03, 20), P6M, STUB_NONE, IMM, BDA_JPY_P, null, null, BDA_NONE,
+            ImmutableList.of(date(2018, 3, 21), date(2018, 9, 19), date(2019, 3, 20)),
+            ImmutableList.of(date(2018, 3, 20), date(2018, 9, 19), date(2019, 3, 20)), IMM},
+        
         // Day30 rolling with February
-        {date(2015, 1, 30), date(2015, 4, 30), P1M, STUB_NONE, DAY_30, null, null, null,
+        {date(2015, 1, 30), date(2015, 4, 30), P1M, STUB_NONE, DAY_30, BDA, null, null, null,
             ImmutableList.of(date(2015, 1, 30), date(2015, 2, 28), date(2015, 3, 30), date(2015, 4, 30)),
             ImmutableList.of(date(2015, 1, 30), date(2015, 2, 27), date(2015, 3, 30), date(2015, 4, 30)), DAY_30},
-        {date(2015, 2, 28), date(2015, 4, 30), P1M, STUB_NONE, DAY_30, null, null, null,
+        {date(2015, 2, 28), date(2015, 4, 30), P1M, STUB_NONE, DAY_30, BDA, null, null, null,
             ImmutableList.of(date(2015, 2, 28), date(2015, 3, 30), date(2015, 4, 30)),
             ImmutableList.of(date(2015, 2, 27), date(2015, 3, 30), date(2015, 4, 30)), DAY_30},
-        {date(2015, 2, 28), date(2015, 4, 30), P1M, SHORT_INITIAL, DAY_30, null, null, null,
+        {date(2015, 2, 28), date(2015, 4, 30), P1M, SHORT_INITIAL, DAY_30, BDA, null, null, null,
             ImmutableList.of(date(2015, 2, 28), date(2015, 3, 30), date(2015, 4, 30)),
             ImmutableList.of(date(2015, 2, 27), date(2015, 3, 30), date(2015, 4, 30)), DAY_30},
     };
@@ -456,15 +468,25 @@ public class PeriodicScheduleTest {
 
   @Test(dataProvider = "generation")
   public void test_monthly_schedule(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment businessDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+    
     PeriodicSchedule defn = PeriodicSchedule.builder()
         .startDate(start)
         .endDate(end)
         .frequency(freq)
         .startDateBusinessDayAdjustment(startBusDayAdjustment)
-        .businessDayAdjustment(BDA)
+        .businessDayAdjustment(businessDayAdjustment)
         .stubConvention(stubConv)
         .rollConvention(rollConv)
         .firstRegularStartDate(firstReg)
@@ -485,15 +507,25 @@ public class PeriodicScheduleTest {
 
   @Test(dataProvider = "generation")
   public void test_monthly_schedule_withOverride(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment businessDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+    
     PeriodicSchedule defn = PeriodicSchedule.builder()
         .startDate(start)
         .endDate(end)
         .frequency(freq)
         .startDateBusinessDayAdjustment(startBusDayAdjustment)
-        .businessDayAdjustment(BDA)
+        .businessDayAdjustment(businessDayAdjustment)
         .stubConvention(stubConv)
         .rollConvention(rollConv)
         .firstRegularStartDate(firstReg)
@@ -520,15 +552,25 @@ public class PeriodicScheduleTest {
 
   @Test(dataProvider = "generation")
   public void test_monthly_unadjusted(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment businessDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+    
     PeriodicSchedule defn = PeriodicSchedule.builder()
         .startDate(start)
         .endDate(end)
         .frequency(freq)
         .startDateBusinessDayAdjustment(startBusDayAdjustment)
-        .businessDayAdjustment(BDA)
+        .businessDayAdjustment(businessDayAdjustment)
         .stubConvention(stubConv)
         .rollConvention(rollConv)
         .firstRegularStartDate(firstReg)
@@ -545,15 +587,25 @@ public class PeriodicScheduleTest {
 
   @Test(dataProvider = "generation")
   public void test_monthly_unadjusted_withOverride(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment businessDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+    
     PeriodicSchedule defn = PeriodicSchedule.builder()
         .startDate(start)
         .endDate(end)
         .frequency(freq)
         .startDateBusinessDayAdjustment(startBusDayAdjustment)
-        .businessDayAdjustment(BDA)
+        .businessDayAdjustment(businessDayAdjustment)
         .stubConvention(stubConv)
         .rollConvention(rollConv)
         .firstRegularStartDate(firstReg)
@@ -573,15 +625,25 @@ public class PeriodicScheduleTest {
 
   @Test(dataProvider = "generation")
   public void test_monthly_adjusted(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment businessDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+    
     PeriodicSchedule defn = PeriodicSchedule.builder()
         .startDate(start)
         .endDate(end)
         .frequency(freq)
         .startDateBusinessDayAdjustment(startBusDayAdjustment)
-        .businessDayAdjustment(BDA)
+        .businessDayAdjustment(businessDayAdjustment)
         .stubConvention(stubConv)
         .rollConvention(rollConv)
         .firstRegularStartDate(firstReg)
@@ -593,15 +655,25 @@ public class PeriodicScheduleTest {
 
   @Test(dataProvider = "generation")
   public void test_monthly_adjusted_withOverride(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment businessDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+
     PeriodicSchedule defn = PeriodicSchedule.builder()
         .startDate(start)
         .endDate(end)
         .frequency(freq)
         .startDateBusinessDayAdjustment(startBusDayAdjustment)
-        .businessDayAdjustment(BDA)
+        .businessDayAdjustment(businessDayAdjustment)
         .stubConvention(stubConv)
         .rollConvention(rollConv)
         .firstRegularStartDate(firstReg)
@@ -961,26 +1033,36 @@ public class PeriodicScheduleTest {
   //-------------------------------------------------------------------------
   @Test(dataProvider = "generation")
   public void coverage_equals(
-      LocalDate start, LocalDate end, Frequency freq, StubConvention stubConv, RollConvention rollConv,
-      LocalDate firstReg, LocalDate lastReg, BusinessDayAdjustment startBusDayAdjustment,
-      List<LocalDate> unadjusted, List<LocalDate> adjusted, RollConvention expRoll) {
-    PeriodicSchedule a1 = of(start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, null, null);
-    PeriodicSchedule a2 = of(start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, null, null);
-    PeriodicSchedule b = of(LocalDate.MIN, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, null, null);
-    PeriodicSchedule c = of(start, LocalDate.MAX, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, null, null);
+      LocalDate start,
+      LocalDate end,
+      Frequency freq,
+      StubConvention stubConv,
+      RollConvention rollConv,
+      BusinessDayAdjustment busDayAdjustment,
+      LocalDate firstReg,
+      LocalDate lastReg,
+      BusinessDayAdjustment startBusDayAdjustment,
+      List<LocalDate> unadjusted,
+      List<LocalDate> adjusted,
+      RollConvention expRoll) {
+    
+    PeriodicSchedule a1 = of(start, end, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, null, null);
+    PeriodicSchedule a2 = of(start, end, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, null, null);
+    PeriodicSchedule b = of(LocalDate.MIN, end, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, null, null);
+    PeriodicSchedule c = of(start, LocalDate.MAX, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, null, null);
     PeriodicSchedule d = of(
-        start, end, freq == P1M ? P3M : P1M, BDA, stubConv, rollConv, firstReg, lastReg, null, null, null);
+        start, end, freq == P1M ? P3M : P1M, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, null, null);
     PeriodicSchedule e = of(
         start, end, freq, BDA_NONE, stubConv, rollConv, firstReg, lastReg, null, null, null);
     PeriodicSchedule f = of(
-        start, end, freq, BDA, stubConv == STUB_NONE ? SHORT_FINAL : STUB_NONE, rollConv, firstReg, lastReg, null, null, null);
-    PeriodicSchedule g = of(start, end, freq, BDA, stubConv, SFE, firstReg, lastReg, null, null, null);
-    PeriodicSchedule h = of(start, end, freq, BDA, stubConv, rollConv, start.plusDays(1), null, null, null, null);
-    PeriodicSchedule i = of(start, end, freq, BDA, stubConv, rollConv, null, end.minusDays(1), null, null, null);
-    PeriodicSchedule j = of(start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, BDA, null, null);
-    PeriodicSchedule k = of(start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, BDA, null);
+        start, end, freq, busDayAdjustment, stubConv == STUB_NONE ? SHORT_FINAL : STUB_NONE, rollConv, firstReg, lastReg, null, null, null);
+    PeriodicSchedule g = of(start, end, freq, busDayAdjustment, stubConv, SFE, firstReg, lastReg, null, null, null);
+    PeriodicSchedule h = of(start, end, freq, busDayAdjustment, stubConv, rollConv, start.plusDays(1), null, null, null, null);
+    PeriodicSchedule i = of(start, end, freq, busDayAdjustment, stubConv, rollConv, null, end.minusDays(1), null, null, null);
+    PeriodicSchedule j = of(start, end, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, BDA, null, null);
+    PeriodicSchedule k = of(start, end, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, BDA, null);
     PeriodicSchedule m = of(
-        start, end, freq, BDA, stubConv, rollConv, firstReg, lastReg, null, null, AdjustableDate.of(start.minusDays(1)));
+        start, end, freq, busDayAdjustment, stubConv, rollConv, firstReg, lastReg, null, null, AdjustableDate.of(start.minusDays(1)));
     assertEquals(a1.equals(a1), true);
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -446,12 +446,30 @@ public class PeriodicScheduleTest {
             ImmutableList.of(date(2014, 9, 17), date(2014, 10, 1)), IMM},
 
         //IMM with adjusted start dates and various conventions
+        //MF, no stub 
         {date(2018, 3, 22), date(2020, 03, 18), P6M, STUB_NONE, IMM, BDA_JPY_MF, null, null, BDA_NONE,
             ImmutableList.of(date(2018, 3, 21), date(2018, 9, 19), date(2019, 3, 20), date(2019, 9, 18), date(2020, 3, 18)),
             ImmutableList.of(date(2018, 3, 22), date(2018, 9, 19), date(2019, 3, 20), date(2019, 9, 18), date(2020, 3, 18)), IMM},
+        //Preceding, no stub
         {date(2018, 3, 20), date(2019, 03, 20), P6M, STUB_NONE, IMM, BDA_JPY_P, null, null, BDA_NONE,
             ImmutableList.of(date(2018, 3, 21), date(2018, 9, 19), date(2019, 3, 20)),
             ImmutableList.of(date(2018, 3, 20), date(2018, 9, 19), date(2019, 3, 20)), IMM},
+        //MF, null stub
+        {date(2018, 3, 22), date(2019, 03, 20), P6M, null, IMM, BDA_JPY_MF, null, null, BDA_NONE,
+            ImmutableList.of(date(2018, 3, 21), date(2018, 9, 19), date(2019, 3, 20)),
+            ImmutableList.of(date(2018, 3, 22), date(2018, 9, 19), date(2019, 3, 20)), IMM},
+        //Explicit long front stub with (adjusted) first regular start date
+        {date(2017, 9, 2), date(2018, 9, 19), P6M, LONG_INITIAL, IMM, BDA_JPY_MF, date(2018, 3, 22), null, BDA_NONE,
+            ImmutableList.of(date(2017, 9, 2), date(2018, 3, 21), date(2018, 9, 19)),
+            ImmutableList.of(date(2017, 9, 2), date(2018, 3, 22), date(2018, 9, 19)), IMM},
+        //Implicit short front stub with (adjusted) first regular start date
+        {date(2018, 1, 2), date(2018, 9, 19), P6M, null, IMM, BDA_JPY_MF, date(2018, 3, 22), null, BDA_NONE,
+            ImmutableList.of(date(2018, 1, 2), date(2018, 3, 21), date(2018, 9, 19)),
+            ImmutableList.of(date(2018, 1, 2), date(2018, 3, 22), date(2018, 9, 19)), IMM},
+        //Implicit back stub with (adjusted) last regular start date
+        {date(2017, 3, 15), date(2018, 5, 19), P6M, null, IMM, BDA_JPY_MF, null, date(2018, 3, 22), BDA_NONE,
+            ImmutableList.of(date(2017, 3, 15), date(2017, 9, 20), date(2018, 3, 21), date(2018, 5, 19)),
+            ImmutableList.of(date(2017, 3, 15), date(2017, 9, 20), date(2018, 3, 22), date(2018, 5, 21)), IMM},
         
         // Day30 rolling with February
         {date(2015, 1, 30), date(2015, 4, 30), P1M, STUB_NONE, DAY_30, BDA, null, null, null,


### PR DESCRIPTION
Previous code only supported conversion of adjusted to unadjusted dates for numeric or EOD convention.

This code attempts to calculate an unadjusted date from an adjusted date as follows
-  Calculate the valid unadjusted date for the month of the passed date
-  Adjust the calculated date according to the trade adjustment convention 
-  Compare the calculated adjusted date to the passed date. 
- If the passed date matches the calculated adjusted date it is assumed the passed date has been pre-adjusted and the unadjusted date is returned instead.

This relies on the assumption that the adjusted roll date will never be in a different month to the original unadjusted date. This is relatively safe for the existing StandardRollConventions as the rules for choosing a day in the month will never result in a date close to EOM.  The latest possible calculated roll day for the existing roll convention is the 21st of the month (for IMM, if the first of the month is a Thursday). This is sufficiently far from EOM that no reasonable adjustment will result in the adjusted date being in the next month. Similarly the earliest possible date is 7th of the month (for IMMNZD).

The existing implementation for numeric roll convention suffers from a similar problem e.g. if unadjusted roll day of 28th is adjusted using FOLLOWING then the resulting adjusted date could be in the following month. This would result in the date not being identified as adjusted.

This logic will not work for weekly roll conventions in most cases. adjust() method for weekly roll conventions calculates the next weekday which matches the convention. If the passed date has been adjusted forward then it will not be identified as a valid adjusted date; the calculated unadjusted date will be the next occurrence of that weekday, rather than the previous e.g.
- For weekly roll convention  = Wednesday
- If unadjusted start date is a Wednesday which is a bad business day and adjusted start date is the following Thursday.
- Dow.adjust(startDate) will return the next Wednesday, which, when adjusted, will never equal the passed adjustedDate. Hence unadjusted date will not be calculated


See comments in code for (even) more detail.

An alternative approach could be to associate the logic for converting to unadjusted with each roll convention by adding a new method to the RollConvention interface; this would however be an intrusive and breaking change.

This is still a bit of a hack, so open to suggestions for alternatives!