### PR TITLE
Added counterparty field to CSV trade loader.

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharSource;
@@ -57,6 +58,10 @@ import com.opengamma.strata.product.swap.type.SingleCurrencySwapConvention;
  *   identifier is unique within, such as 'OG-Trade'
  * <li>The 'Id' column is optional, and is the identifier of the trade,
  *   such as 'FRA12345'
+ * <li>The 'Counterparty Scheme' column is optional, and is the name of the scheme that the trade
+ *   identifier is unique within, such as 'OG-Counterparty'
+ * <li>The 'Counterparty' column is optional, and is the identifier of the trade's counterparty,
+ *   such as 'Bank-A'
  * <li>The 'Trade Date' column is optional, and is the date that the trade occurred,
  *   such as '2017-08-01'
  * <li>The 'Trade Time' column is optional, and is the time of day that the trade occurred,
@@ -161,6 +166,8 @@ public final class TradeCsvLoader {
 
   // default schemes
   private static final String DEFAULT_TRADE_SCHEME = "OG-Trade";
+  private static final String DEFAULT_CTPY_SCHEME = "OG-Counterparty";
+  private static final String EMPTY = "";
 
   // shared CSV headers
   static final String TRADE_DATE_FIELD = "Trade Date";
@@ -183,6 +190,8 @@ public final class TradeCsvLoader {
   private static final String TYPE_FIELD = "Strata Trade Type";
   private static final String ID_SCHEME_FIELD = "Id Scheme";
   private static final String ID_FIELD = "Id";
+  private static final String CTPY_SCHEME_FIELD = "Counterparty Scheme";
+  private static final String CTPY_FIELD = "Counterparty";
   private static final String TRADE_TIME_FIELD = "Trade Time";
   private static final String TRADE_ZONE_FIELD = "Trade Zone";
 
@@ -424,6 +433,11 @@ public final class TradeCsvLoader {
     TradeInfoBuilder infoBuilder = TradeInfo.builder();
     String scheme = row.findField(ID_SCHEME_FIELD).orElse(DEFAULT_TRADE_SCHEME);
     row.findValue(ID_FIELD).ifPresent(id -> infoBuilder.id(StandardId.of(scheme, id)));
+    String schemeCpty = row.findField(CTPY_SCHEME_FIELD).orElse(DEFAULT_CTPY_SCHEME);
+    Optional<String> cptyOption = row.findValue(CTPY_FIELD);
+    if (cptyOption.isPresent() && !cptyOption.get().equals(EMPTY)) {
+      infoBuilder.counterparty(StandardId.of(schemeCpty, cptyOption.get()));
+    }
     row.findValue(TRADE_DATE_FIELD).ifPresent(dateStr -> infoBuilder.tradeDate(LoaderUtils.parseDate(dateStr)));
     row.findValue(TRADE_TIME_FIELD).ifPresent(timeStr -> infoBuilder.tradeTime(LoaderUtils.parseTime(timeStr)));
     row.findValue(TRADE_ZONE_FIELD).ifPresent(zoneStr -> infoBuilder.zone(ZoneId.of(zoneStr)));

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharSource;
@@ -166,8 +165,7 @@ public final class TradeCsvLoader {
 
   // default schemes
   private static final String DEFAULT_TRADE_SCHEME = "OG-Trade";
-  private static final String DEFAULT_CTPY_SCHEME = "OG-Counterparty";
-  private static final String EMPTY = "";
+  private static final String DEFAULT_CPTY_SCHEME = "OG-Counterparty";
 
   // shared CSV headers
   static final String TRADE_DATE_FIELD = "Trade Date";
@@ -190,8 +188,8 @@ public final class TradeCsvLoader {
   private static final String TYPE_FIELD = "Strata Trade Type";
   private static final String ID_SCHEME_FIELD = "Id Scheme";
   private static final String ID_FIELD = "Id";
-  private static final String CTPY_SCHEME_FIELD = "Counterparty Scheme";
-  private static final String CTPY_FIELD = "Counterparty";
+  private static final String CPTY_SCHEME_FIELD = "Counterparty Scheme";
+  private static final String CPTY_FIELD = "Counterparty";
   private static final String TRADE_TIME_FIELD = "Trade Time";
   private static final String TRADE_ZONE_FIELD = "Trade Zone";
 
@@ -433,11 +431,8 @@ public final class TradeCsvLoader {
     TradeInfoBuilder infoBuilder = TradeInfo.builder();
     String scheme = row.findField(ID_SCHEME_FIELD).orElse(DEFAULT_TRADE_SCHEME);
     row.findValue(ID_FIELD).ifPresent(id -> infoBuilder.id(StandardId.of(scheme, id)));
-    String schemeCpty = row.findField(CTPY_SCHEME_FIELD).orElse(DEFAULT_CTPY_SCHEME);
-    Optional<String> cptyOption = row.findValue(CTPY_FIELD);
-    if (cptyOption.isPresent() && !cptyOption.get().equals(EMPTY)) {
-      infoBuilder.counterparty(StandardId.of(schemeCpty, cptyOption.get()));
-    }
+    String schemeCpty = row.findValue(CPTY_SCHEME_FIELD).orElse(DEFAULT_CPTY_SCHEME);
+    row.findValue(CPTY_FIELD).ifPresent(cpty -> infoBuilder.counterparty(StandardId.of(schemeCpty, cpty)));
     row.findValue(TRADE_DATE_FIELD).ifPresent(dateStr -> infoBuilder.tradeDate(LoaderUtils.parseDate(dateStr)));
     row.findValue(TRADE_TIME_FIELD).ifPresent(timeStr -> infoBuilder.tradeTime(LoaderUtils.parseTime(timeStr)));
     row.findValue(TRADE_ZONE_FIELD).ifPresent(zoneStr -> infoBuilder.zone(ZoneId.of(zoneStr)));

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
@@ -104,6 +104,10 @@ public class TradeCsvLoaderTest {
 
   private static final ResourceLocator FILE =
       ResourceLocator.of("classpath:com/opengamma/strata/loader/csv/trades.csv");
+  private static final ResourceLocator FILE_CPTY =
+      ResourceLocator.of("classpath:com/opengamma/strata/loader/csv/trades-cpty.csv");
+  private static final ResourceLocator FILE_CPTY2 =
+      ResourceLocator.of("classpath:com/opengamma/strata/loader/csv/trades-cpty2.csv");
 
   //-------------------------------------------------------------------------
   public void test_isKnownFormat() {
@@ -150,6 +154,118 @@ public class TradeCsvLoaderTest {
             .tradeDate(date(2017, 6, 1))
             .tradeTime(LocalTime.of(12, 35))
             .zone(ZoneId.of("Europe/London"))
+            .build())
+        .build();
+    assertBeanEquals(expected2, filtered.get(1));
+
+    FraTrade expected3 = FraTrade.builder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123403"))
+            .tradeDate(date(2017, 6, 1))
+            .build())
+        .product(Fra.builder()
+            .buySell(SELL)
+            .startDate(date(2017, 8, 1))
+            .endDate(date(2018, 1, 15))
+            .notional(1_000_000)
+            .fixedRate(0.0055)
+            .index(IborIndices.GBP_LIBOR_3M)
+            .indexInterpolated(IborIndices.GBP_LIBOR_6M)
+            .dayCount(DayCounts.ACT_360)
+            .build())
+        .build();
+    assertBeanEquals(expected3, filtered.get(2));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_load_fra_cpty() {
+    TradeCsvLoader test = TradeCsvLoader.standard();
+    ValueWithFailures<List<Trade>> trades = test.load(FILE_CPTY);
+
+    List<FraTrade> filtered = trades.getValue().stream()
+        .filter(FraTrade.class::isInstance)
+        .map(FraTrade.class::cast)
+        .collect(toImmutableList());
+    assertEquals(filtered.size(), 3);
+
+    FraTrade expected1 = FraConventions.of(IborIndices.GBP_LIBOR_3M)
+        .createTrade(date(2017, 6, 1), Period.ofMonths(2), BUY, 1_000_000, 0.005, REF_DATA)
+        .toBuilder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123401"))
+            .tradeDate(date(2017, 6, 1))
+            .tradeTime(LocalTime.of(11, 5))
+            .zone(ZoneId.of("Europe/London"))
+            .counterparty(StandardId.of("CPTY", "Bank A"))
+            .build())
+        .build();
+    assertBeanEquals(expected1, filtered.get(0));
+
+    FraTrade expected2 = FraConventions.of(IborIndices.GBP_LIBOR_6M)
+        .toTrade(date(2017, 6, 1), date(2017, 8, 1), date(2018, 2, 1), date(2017, 8, 1), SELL, 1_000_000, 0.007)
+        .toBuilder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123402"))
+            .tradeDate(date(2017, 6, 1))
+            .tradeTime(LocalTime.of(12, 35))
+            .zone(ZoneId.of("Europe/London"))
+            .counterparty(StandardId.of("CPTY", "Bank B"))
+            .build())
+        .build();
+    assertBeanEquals(expected2, filtered.get(1));
+
+    FraTrade expected3 = FraTrade.builder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123403"))
+            .tradeDate(date(2017, 6, 1))
+            .build())
+        .product(Fra.builder()
+            .buySell(SELL)
+            .startDate(date(2017, 8, 1))
+            .endDate(date(2018, 1, 15))
+            .notional(1_000_000)
+            .fixedRate(0.0055)
+            .index(IborIndices.GBP_LIBOR_3M)
+            .indexInterpolated(IborIndices.GBP_LIBOR_6M)
+            .dayCount(DayCounts.ACT_360)
+            .build())
+        .build();
+    assertBeanEquals(expected3, filtered.get(2));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_load_fra_cpty2() {
+    TradeCsvLoader test = TradeCsvLoader.standard();
+    ValueWithFailures<List<Trade>> trades = test.load(FILE_CPTY2);
+
+    List<FraTrade> filtered = trades.getValue().stream()
+        .filter(FraTrade.class::isInstance)
+        .map(FraTrade.class::cast)
+        .collect(toImmutableList());
+    assertEquals(filtered.size(), 3);
+
+    FraTrade expected1 = FraConventions.of(IborIndices.GBP_LIBOR_3M)
+        .createTrade(date(2017, 6, 1), Period.ofMonths(2), BUY, 1_000_000, 0.005, REF_DATA)
+        .toBuilder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123401"))
+            .tradeDate(date(2017, 6, 1))
+            .tradeTime(LocalTime.of(11, 5))
+            .zone(ZoneId.of("Europe/London"))
+            .counterparty(StandardId.of("OG-Counterparty", "Bank A"))
+            .build())
+        .build();
+    assertBeanEquals(expected1, filtered.get(0));
+
+    FraTrade expected2 = FraConventions.of(IborIndices.GBP_LIBOR_6M)
+        .toTrade(date(2017, 6, 1), date(2017, 8, 1), date(2018, 2, 1), date(2017, 8, 1), SELL, 1_000_000, 0.007)
+        .toBuilder()
+        .info(TradeInfo.builder()
+            .id(StandardId.of("OG", "123402"))
+            .tradeDate(date(2017, 6, 1))
+            .tradeTime(LocalTime.of(12, 35))
+            .zone(ZoneId.of("Europe/London"))
+            .counterparty(StandardId.of("OG-Counterparty", "Bank B"))
             .build())
         .build();
     assertBeanEquals(expected2, filtered.get(1));

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
@@ -178,7 +178,7 @@ public class TradeCsvLoaderTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_load_fra_cpty() {
+  public void test_load_fra_bothCounterpartyColumnsPresent() {
     TradeCsvLoader test = TradeCsvLoader.standard();
     ValueWithFailures<List<Trade>> trades = test.load(FILE_CPTY);
 
@@ -209,7 +209,7 @@ public class TradeCsvLoaderTest {
             .tradeDate(date(2017, 6, 1))
             .tradeTime(LocalTime.of(12, 35))
             .zone(ZoneId.of("Europe/London"))
-            .counterparty(StandardId.of("CPTY", "Bank B"))
+            .counterparty(StandardId.of("OG-Counterparty", "Bank B"))
             .build())
         .build();
     assertBeanEquals(expected2, filtered.get(1));
@@ -234,7 +234,7 @@ public class TradeCsvLoaderTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_load_fra_cpty2() {
+  public void test_load_fra_counterpartyColumnPresentNoScheme() {
     TradeCsvLoader test = TradeCsvLoader.standard();
     ValueWithFailures<List<Trade>> trades = test.load(FILE_CPTY2);
 

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades-cpty.csv
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades-cpty.csv
@@ -1,6 +1,6 @@
 Strata Trade Type,Id Scheme,Id,Counterparty Scheme,Counterparty,Trade Date,Trade Time,Trade Zone,Convention,Buy Sell,Period To Start,Tenor,Index,Interpolated index,Fixed Rate,FX Rate,Day Count,Currency,Notional,Start Date,End Date,Date Convention,Date Calendar,Stub Convention,Leg 1 Direction,Leg 1 Start Date,Leg 1 End Date,Leg 1 Stub Convention,Leg 1 Roll Convention,Leg 1 Frequency,Leg 1 Currency,Leg 1 Notional,Leg 1 Fixed Rate,Leg 1 Day Count,Leg 1 Date Convention,Leg 1 Date Calendar,Leg 2 Direction,Leg 2 Start Date,Leg 2 End Date,Leg 2 Frequency,Leg 2 Currency,Leg 2 Notional,Leg 2 Index,Security Id Scheme,Security Id,Quantity,Long Quantity,Price
 Fra,OG,123401,CPTY,Bank A,01/06/2017,11:05,Europe/London,GBP-LIBOR-3M,Buy,P2M,,,,0.5,,,,1000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Fra,OG,123402,CPTY,Bank B,01/06/2017,12:35,Europe/London,GBP-LIBOR-6M,Sell,,,,,0.7,,,,1000000,01/08/2017,01/02/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123402,,Bank B,01/06/2017,12:35,Europe/London,GBP-LIBOR-6M,Sell,,,,,0.7,,,,1000000,01/08/2017,01/02/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Fra,OG,123403,,,01/06/2017,,,,Sell,,,GBP-LIBOR-3M,GBP-LIBOR-6M,0.55,,Act/360,,1000000,01/08/2017,15/01/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Swap,OG,123411,,,01/06/2017,,,GBP-FIXED-1Y-LIBOR-3M,Buy,P1M,P5Y,,,0.4,,,,2000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades-cpty.csv
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades-cpty.csv
@@ -1,0 +1,23 @@
+Strata Trade Type,Id Scheme,Id,Counterparty Scheme,Counterparty,Trade Date,Trade Time,Trade Zone,Convention,Buy Sell,Period To Start,Tenor,Index,Interpolated index,Fixed Rate,FX Rate,Day Count,Currency,Notional,Start Date,End Date,Date Convention,Date Calendar,Stub Convention,Leg 1 Direction,Leg 1 Start Date,Leg 1 End Date,Leg 1 Stub Convention,Leg 1 Roll Convention,Leg 1 Frequency,Leg 1 Currency,Leg 1 Notional,Leg 1 Fixed Rate,Leg 1 Day Count,Leg 1 Date Convention,Leg 1 Date Calendar,Leg 2 Direction,Leg 2 Start Date,Leg 2 End Date,Leg 2 Frequency,Leg 2 Currency,Leg 2 Notional,Leg 2 Index,Security Id Scheme,Security Id,Quantity,Long Quantity,Price
+Fra,OG,123401,CPTY,Bank A,01/06/2017,11:05,Europe/London,GBP-LIBOR-3M,Buy,P2M,,,,0.5,,,,1000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123402,CPTY,Bank B,01/06/2017,12:35,Europe/London,GBP-LIBOR-6M,Sell,,,,,0.7,,,,1000000,01/08/2017,01/02/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123403,,,01/06/2017,,,,Sell,,,GBP-LIBOR-3M,GBP-LIBOR-6M,0.55,,Act/360,,1000000,01/08/2017,15/01/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123411,,,01/06/2017,,,GBP-FIXED-1Y-LIBOR-3M,Buy,P1M,P5Y,,,0.4,,,,2000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123412,,,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,BUY,,,,,-0.01,,,,3100000,01/08/2017,01/08/2022,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123413,,,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,Buy,,,,,0.5,,,,5000000,01/08/2017,01/09/2022,,,LongFinal,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,,0.6,,,,4000000,01/08/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,,,,,,3000000,01/08/2019,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,,0.7,,,,2000000,01/08/2020,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,,,,,,1000000,01/08/2021,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123414,,,01/06/2017,,,GBP-LIBOR-3M-USD-LIBOR-3M,Buy,,P3Y,,,0.6,1.25,,,2000000,05/07/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123415,,,01/06/2017,,,,,,,,,,,,GBP,2500000,01/08/2017,01/08/2022,,,ShortFinal,Pay,,,,,3M,,,1.1,30/360 ISDA,,,Receive,,,3M,,,GBP-LIBOR-3M,,,,,
+Swap,OG,123416,,,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,01/08/2017,08/08/2022,LongInitial,Day8,3M,GBP,1200000,1.2,30/360 ISDA,Following,GBLO+EUTA,Receive,08/08/2017,08/08/2022,3M,GBP,1200000,GBP-LIBOR-BBA,,,,,
+Swap,OG,123417,,,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,08/08/2017,08/08/2022,,,3M,GBP,1500000,1.3,Act/365F,Preceding,GBLO+USNY,Receive,08/08/2017,08/08/2022,6M,GBP,1500000,GBP-SONIA,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123421,,,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,P2W,,,0.2,,,,400000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123422,,,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,,,,0.22,,,,500000,01/06/2017,15/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123423,,,01/06/2017,,,,Buy,,,,,0.23,,Act/365F,GBP,600000,01/06/2017,22/06/2017,ModifiedFollowing,GBLO,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Security,OG,123431,,,01/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,AAPL,12,,14.5
+Security,OG,123432,,,01/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,BBG,MSFT,,20,17.8

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades-cpty2.csv
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/csv/trades-cpty2.csv
@@ -1,0 +1,23 @@
+Strata Trade Type,Id Scheme,Id,Counterparty,Trade Date,Trade Time,Trade Zone,Convention,Buy Sell,Period To Start,Tenor,Index,Interpolated index,Fixed Rate,FX Rate,Day Count,Currency,Notional,Start Date,End Date,Date Convention,Date Calendar,Stub Convention,Leg 1 Direction,Leg 1 Start Date,Leg 1 End Date,Leg 1 Stub Convention,Leg 1 Roll Convention,Leg 1 Frequency,Leg 1 Currency,Leg 1 Notional,Leg 1 Fixed Rate,Leg 1 Day Count,Leg 1 Date Convention,Leg 1 Date Calendar,Leg 2 Direction,Leg 2 Start Date,Leg 2 End Date,Leg 2 Frequency,Leg 2 Currency,Leg 2 Notional,Leg 2 Index,Security Id Scheme,Security Id,Quantity,Long Quantity,Price
+Fra,OG,123401,Bank A,01/06/2017,11:05,Europe/London,GBP-LIBOR-3M,Buy,P2M,,,,0.5,,,,1000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123402,Bank B,01/06/2017,12:35,Europe/London,GBP-LIBOR-6M,Sell,,,,,0.7,,,,1000000,01/08/2017,01/02/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Fra,OG,123403,,01/06/2017,,,,Sell,,,GBP-LIBOR-3M,GBP-LIBOR-6M,0.55,,Act/360,,1000000,01/08/2017,15/01/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123411,,01/06/2017,,,GBP-FIXED-1Y-LIBOR-3M,Buy,P1M,P5Y,,,0.4,,,,2000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123412,,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,BUY,,,,,-0.01,,,,3100000,01/08/2017,01/08/2022,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123413,,01/06/2017,,,GBP-FIXED-6M-LIBOR-6M,Buy,,,,,0.5,,,,5000000,01/08/2017,01/09/2022,,,LongFinal,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,0.6,,,,4000000,01/08/2018,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,,,,,3000000,01/08/2019,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,0.7,,,,2000000,01/08/2020,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Variable,,,,,,,,,,,,,,,,,1000000,01/08/2021,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123414,,01/06/2017,,,GBP-LIBOR-3M-USD-LIBOR-3M,Buy,,P3Y,,,0.6,1.25,,,2000000,05/07/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Swap,OG,123415,,01/06/2017,,,,,,,,,,,,GBP,2500000,01/08/2017,01/08/2022,,,ShortFinal,Pay,,,,,3M,,,1.1,30/360 ISDA,,,Receive,,,3M,,,GBP-LIBOR-3M,,,,,
+Swap,OG,123416,,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,01/08/2017,08/08/2022,LongInitial,Day8,3M,GBP,1200000,1.2,30/360 ISDA,Following,GBLO+EUTA,Receive,08/08/2017,08/08/2022,3M,GBP,1200000,GBP-LIBOR-BBA,,,,,
+Swap,OG,123417,,01/06/2017,,,,,,,,,,,,,,,,,,,Pay,08/08/2017,08/08/2022,,,3M,GBP,1500000,1.3,Act/365F,Preceding,GBLO+USNY,Receive,08/08/2017,08/08/2022,6M,GBP,1500000,GBP-SONIA,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123421,,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,P2W,,,0.2,,,,400000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123422,,01/06/2017,,,GBP-ShortDeposit-T0,Sell,,,,,0.22,,,,500000,01/06/2017,15/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,
+TermDeposit,OG,123423,,01/06/2017,,,,Buy,,,,,0.23,,Act/365F,GBP,600000,01/06/2017,22/06/2017,ModifiedFollowing,GBLO,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Security,OG,123431,,01/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,AAPL,12,,14.5
+Security,OG,123432,,01/06/2017,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,BBG,MSFT,,20,17.8


### PR DESCRIPTION
Parse Counterparty field for loaded trades. The counterparty are loaded into the 'counterparty' field of the TradeInfo.
Close issue #1582 