### PR TITLE
Extend quoting of CSV output

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvFile.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvFile.java
@@ -33,6 +33,7 @@ import com.opengamma.strata.collect.Unchecked;
  * Each line can contain one or more fields.
  * Each field is separated by a comma character ({@literal ,}) or tab.
  * Any field may be quoted using a double quote at the start and end.
+ * A quoted field may additionally be prefixed by an equals sign.
  * The content of a quoted field may include commas and additional double quotes.
  * Two adjacent double quotes in a quoted field will be replaced by a single double quote.
  * Quoted fields are not trimmed. Non-quoted fields are trimmed.
@@ -216,6 +217,12 @@ public final class CsvFile {
     int nextSeparator = terminated.indexOf(separator, start);
     while (nextSeparator >= 0) {
       String possible = terminated.substring(start, nextSeparator).trim();
+      // handle convention where ="xxx" means xxx
+      if (possible.startsWith("=\"")) {
+        start++;
+        possible = possible.substring(1);
+      }
+      // handle quoting where "xxx""yyy" means xxx"yyy
       if (possible.startsWith("\"")) {
         while (true) {
           if (possible.substring(1).replace("\"\"", "").endsWith("\"")) {

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.collect.Unchecked;
  * Each entry may be quoted using a double quote.
  * If an entry contains a double quote, comma or trimmable whitespace, it will be quoted.
  * Two double quotes will be used to escape a double quote.
+ * If it starts with an expression character, the quote section will be preceeded by equals.
  */
 public final class CsvOutput {
 
@@ -132,17 +133,28 @@ public final class CsvOutput {
     }
   }
 
-  // quoting is required if entry contains quote, comma or trimmable whitespace
-  private boolean isQuotingRequired(String line) {
-    return line.indexOf('"') >= 0 || line.indexOf(',') >= 0 || line.trim().length() != line.length();
+  // quoting is required if entry contains quote, comma, trimmable whitespace, or starts with an expression character
+  private boolean isQuotingRequired(String entry) {
+    return entry.indexOf('"') >= 0 ||
+        entry.indexOf(',') >= 0 ||
+        entry.trim().length() != entry.length() ||
+        isExpressionPrefix(entry);
+  }
+
+  private boolean isExpressionPrefix(String entry) {
+    char first = entry.length() == 0 ? ' ' : entry.charAt(0);
+    return first == '=' || first == '+' || first == '-' || first == '@';
   }
 
   // quotes the entry
   private String quotedEntry(String entry) {
     StringBuilder buf = new StringBuilder(entry.length() + 8);
-    buf.append('"')
-        .append(entry.replace("\"", "\"\""))
-        .append('"');
+    if (isExpressionPrefix(entry)) {
+      buf.append('=');
+    }
+    buf.append('"');
+    buf.append(entry.replace("\"", "\"\""));
+    buf.append('"');
     return buf.toString();
   }
 

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -142,7 +142,10 @@ public final class CsvOutput {
   }
 
   private boolean isExpressionPrefix(String entry) {
-    char first = entry.length() == 0 ? ' ' : entry.charAt(0);
+    if (entry.isEmpty()) {
+      return false;
+    }
+    char first = entry.charAt(0);
     return first == '=' || first == '+' || first == '-' || first == '@';
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvFileTest.java
@@ -60,6 +60,11 @@ public class CsvFileTest {
       "\"alpha\"\",\"be\"\"\", \"\"at\"\", one\"\n" +
       "r21,\" r22 \"\n";
 
+  private final String CSV4B = "" +
+      "=\"alpha\",=\"be, \"\"at\"\", one\"\n" +
+      "=\"alpha\"\",\"be\"\"\", =\"\"at\"\", one\"\n" +
+      "r21,=\" r22 \"\n";
+
   private final String CSV5 = "" +
       "a,b,c,b,c\n" +
       "aa,b1,c1,b2,c2\n";
@@ -314,6 +319,20 @@ public class CsvFileTest {
 
   public void test_of_quoting() {
     CsvFile csvFile = CsvFile.of(CharSource.wrap(CSV4), false);
+    assertEquals(csvFile.rowCount(), 3);
+    assertEquals(csvFile.row(0).fieldCount(), 2);
+    assertEquals(csvFile.row(0).field(0), "alpha");
+    assertEquals(csvFile.row(0).field(1), "be, \"at\", one");
+    assertEquals(csvFile.row(1).fieldCount(), 2);
+    assertEquals(csvFile.row(1).field(0), "alpha\",\"be\"");
+    assertEquals(csvFile.row(1).field(1), "\"at\", one");
+    assertEquals(csvFile.row(2).fieldCount(), 2);
+    assertEquals(csvFile.row(2).field(0), "r21");
+    assertEquals(csvFile.row(2).field(1), " r22 ");
+  }
+
+  public void test_of_quotingWithEquals() {
+    CsvFile csvFile = CsvFile.of(CharSource.wrap(CSV4B), false);
     assertEquals(csvFile.rowCount(), 3);
     assertEquals(csvFile.row(0).fieldCount(), 2);
     assertEquals(csvFile.row(0).field(0), "alpha");

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
@@ -64,4 +64,10 @@ public class CsvOutputTest {
     assertEquals(buf.toString(), "a\t\"1,000\"\n");
   }
 
+  public void test_expressionPrefix() {
+    StringBuilder buf = new StringBuilder();
+    new CsvOutput(buf, "\n").writeLine(Arrays.asList("=cmd", "+cmd", "-cmd", "@cmd"));
+    assertEquals(buf.toString(), "=\"=cmd\",=\"+cmd\",=\"-cmd\",=\"@cmd\"\n");
+  }
+
 }


### PR DESCRIPTION
If a CSV entry starts with an expression prefix character
then prefix the quoted section by equals
This is invalid pure CSV, but accepted by Excel/Google
to indicate a test formatted cell
Update CSV input to parse equals prefix format