### PR TITLE
Fix interpolator extrapolator

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/AbstractBoundCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/AbstractBoundCurveInterpolator.java
@@ -93,11 +93,28 @@ public abstract class AbstractBoundCurveInterpolator
 
   /**
    * Method for subclasses to calculate the interpolated value.
+   * <p>
+   * Callers can assume that {@code xValue} is less than the x-value of the last node.
    * 
    * @param xValue  the x-value
    * @return the interpolated y-value
    */
   protected abstract double doInterpolate(double xValue);
+
+  /**
+   * Method for {@code InterpolatorCurveExtrapolator} to calculate the interpolated value.
+   * <p>
+   * This is separated from {@link #doInterpolate(double)} to allow the check for x-values
+   * beyond the last node to be treated separately.
+   * 
+   * @param xValue  the x-value
+   * @return the interpolated y-value
+   */
+  protected double doInterpolateFromExtrapolator(double xValue) {
+    // calling this method may fail on right extrapolation depending on the implementation
+    // if it fails, then this method should be overridden to fix the problem
+    return doInterpolate(xValue);
+  }
 
   @Override
   public final double firstDerivative(double xValue) {

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/InterpolatorCurveExtrapolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/InterpolatorCurveExtrapolator.java
@@ -77,7 +77,7 @@ final class InterpolatorCurveExtrapolator
     //-------------------------------------------------------------------------
     @Override
     public double leftExtrapolate(double xValue) {
-      return interpolator.doInterpolate(xValue);
+      return interpolator.doInterpolateFromExtrapolator(xValue);
     }
 
     @Override
@@ -93,7 +93,7 @@ final class InterpolatorCurveExtrapolator
     //-------------------------------------------------------------------------
     @Override
     public double rightExtrapolate(double xValue) {
-      return interpolator.doInterpolate(xValue);
+      return interpolator.doInterpolateFromExtrapolator(xValue);
     }
 
     @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/LinearCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/LinearCurveInterpolator.java
@@ -106,6 +106,19 @@ final class LinearCurveInterpolator
     }
 
     @Override
+    protected double doInterpolateFromExtrapolator(double xValue) {
+      int lowerIndex = lowerBoundIndex(xValue, xValues);
+      // check if x-value is at the last node
+      if (lowerIndex == intervalCount) {
+        // if value is at last node, calculate the gradient from the previous interval
+        lowerIndex--;
+      }
+      double x1 = xValues[lowerIndex];
+      double y1 = yValues[lowerIndex];
+      return y1 + (xValue - x1) * gradients[lowerIndex];
+    }
+
+    @Override
     protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       // check if x-value is at the last node

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/LogLinearCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/LogLinearCurveInterpolator.java
@@ -99,6 +99,21 @@ final class LogLinearCurveInterpolator
     }
 
     @Override
+    protected double doInterpolateFromExtrapolator(double xValue) {
+      int lowerIndex = lowerBoundIndex(xValue, xValues);
+      // check if x-value is at the last node
+      if (lowerIndex == intervalCount) {
+        // if value is at last node, calculate using the previous interval
+        lowerIndex--;
+      }
+      double x1 = xValues[lowerIndex];
+      double x2 = xValues[lowerIndex + 1];
+      double y1 = yValues[lowerIndex];
+      double y2 = yValues[lowerIndex + 1];
+      return Math.pow(y2 / y1, (xValue - x1) / (x2 - x1)) * y1;
+    }
+
+    @Override
     protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       // check if x-value is at the last node

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/SquareLinearCurveInterpolator.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/interpolator/SquareLinearCurveInterpolator.java
@@ -103,6 +103,28 @@ final class SquareLinearCurveInterpolator implements CurveInterpolator, Serializ
     }
 
     @Override
+    protected double doInterpolateFromExtrapolator(double xValue) {
+      int lowerIndex = lowerBoundIndex(xValue, xValues);
+      // check if x-value is at the last node
+      if (lowerIndex == dataSize - 1) {
+        // if value is at last node, calculate the gradient from the previous interval
+        lowerIndex--;
+      }
+      double x1 = xValues[lowerIndex];
+      double y1 = yValues[lowerIndex];
+
+      int higherIndex = lowerIndex + 1;
+      double x2 = xValues[higherIndex];
+      double y2 = yValues[higherIndex];
+
+      double w = (x2 - xValue) / (x2 - x1);
+      double y21 = y1 * y1;
+      double y22 = y2 * y2;
+      double ySq = w * y21 + (1.0 - w) * y22;
+      return Math.sqrt(ySq);
+    }
+
+    @Override
     protected double doFirstDerivative(double xValue) {
       int lowerIndex = lowerBoundIndex(xValue, xValues);
       int index;

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/LinearCurveInterpolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/LinearCurveInterpolatorTest.java
@@ -76,6 +76,20 @@ public class LinearCurveInterpolatorTest {
     assertEquals(bci.parameterSensitivity(5.0).get(X_DATA.size() - 1), 1d, TOL);
   }
 
+  public void test_interpolatorExtrapolator() {
+    DoubleArray xValues = DoubleArray.of(1, 2, 3);
+    DoubleArray yValues = DoubleArray.of(2, 3, 5);
+    CurveExtrapolator extrap = InterpolatorCurveExtrapolator.INSTANCE;
+    BoundCurveInterpolator boundInterp = LINEAR_INTERPOLATOR.bind(xValues, yValues, extrap, extrap);
+    assertEquals(boundInterp.interpolate(0.5), 1.5, TOL);
+    assertEquals(boundInterp.interpolate(1), 2, TOL);
+    assertEquals(boundInterp.interpolate(1.5), 2.5, TOL);
+    assertEquals(boundInterp.interpolate(2), 3, TOL);
+    assertEquals(boundInterp.interpolate(2.5), 4, TOL);
+    assertEquals(boundInterp.interpolate(3), 5, TOL);
+    assertEquals(boundInterp.interpolate(3.5), 6, TOL);
+  }
+
   //-------------------------------------------------------------------------
   public void test_serialization() {
     assertSerialization(LINEAR_INTERPOLATOR);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/LogLinearCurveInterpolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/LogLinearCurveInterpolatorTest.java
@@ -77,6 +77,23 @@ public class LogLinearCurveInterpolatorTest {
     assertEquals(bci.firstDerivative(5.0), bci.firstDerivative(4.99999999), 1e-6);
   }
 
+  public void test_interpolatorExtrapolator() {
+    DoubleArray xValues = DoubleArray.of(1, 2, 3);
+    DoubleArray yValues = DoubleArray.of(2, 3, 5);
+    DoubleArray yValuesLog = DoubleArray.of(Math.log(2), Math.log(3), Math.log(5));
+    CurveExtrapolator extrap = InterpolatorCurveExtrapolator.INSTANCE;
+    // log-linear same as linear where y-values have had log applied
+    BoundCurveInterpolator bciLinear = CurveInterpolators.LINEAR.bind(xValues, yValuesLog, extrap, extrap);
+    BoundCurveInterpolator bci = LL_INTERPOLATOR.bind(xValues, yValues, extrap, extrap);
+    assertEquals(Math.log(bci.interpolate(0.5)), bciLinear.interpolate(0.5), EPS);
+    assertEquals(Math.log(bci.interpolate(1)), bciLinear.interpolate(1), EPS);
+    assertEquals(Math.log(bci.interpolate(1.5)), bciLinear.interpolate(1.5), EPS);
+    assertEquals(Math.log(bci.interpolate(2)), bciLinear.interpolate(2), EPS);
+    assertEquals(Math.log(bci.interpolate(2.5)), bciLinear.interpolate(2.5), EPS);
+    assertEquals(Math.log(bci.interpolate(3)), bciLinear.interpolate(3), EPS);
+    assertEquals(Math.log(bci.interpolate(3.5)), bciLinear.interpolate(3.5), EPS);
+  }
+
   //-------------------------------------------------------------------------
   public void test_serialization() {
     assertSerialization(LL_INTERPOLATOR);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/SquareLinearCurveInterpolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/SquareLinearCurveInterpolatorTest.java
@@ -74,6 +74,28 @@ public class SquareLinearCurveInterpolatorTest {
     assertEquals(bci.parameterSensitivity(5.0).get(X_DATA.size() - 1), 1d, TOL);
   }
 
+  public void test_interpolatorExtrapolator() {
+    DoubleArray xValues = DoubleArray.of(1, 2, 3);
+    DoubleArray yValues = DoubleArray.of(2, 3, 5);
+    CurveExtrapolator extrap = InterpolatorCurveExtrapolator.INSTANCE;
+    BoundCurveInterpolator bci = SQUARE_LINEAR_INTERPOLATOR.bind(xValues, yValues, extrap, extrap);
+    assertEquals(bci.interpolate(0.5), calc(0.5, 1, 2, 2, 3), TOL);
+    assertEquals(bci.interpolate(1), 2, TOL);
+    assertEquals(bci.interpolate(1.5), calc(1.5, 1, 2, 2, 3), TOL);
+    assertEquals(bci.interpolate(2), 3, TOL);
+    assertEquals(bci.interpolate(2.5), calc(2.5, 2, 3, 3, 5), TOL);
+    assertEquals(bci.interpolate(3), 5, TOL);
+    assertEquals(bci.interpolate(3.5), calc(3.5, 2, 3, 3, 5), TOL);
+  }
+
+  private double calc(double xValue, double x1, double x2, double y1, double y2) {
+    double w = (x2 - xValue) / (x2 - x1);
+    double y21 = y1 * y1;
+    double y22 = y2 * y2;
+    double ySq = w * y21 + (1.0 - w) * y22;
+    return Math.sqrt(ySq);
+  }
+
   //-------------------------------------------------------------------------
   public void test_serialization() {
     assertSerialization(SQUARE_LINEAR_INTERPOLATOR);


### PR DESCRIPTION
Some interpolators cannot handle a value greater than the max x-value
Introduce dedicated additional method for InterpolatorCurveExtrapolator
This avoids any slow down of the main method
Fix three implementations
Fixes #1415