### PR TITLE
Use actual start month and end month rather than proleptic months to determine EOM rolls.

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.basics.schedule;
 
+import static java.time.temporal.ChronoField.PROLEPTIC_MONTH;
+
 import java.time.LocalDate;
 
 import org.joda.convert.FromString;
@@ -257,9 +259,12 @@ public enum StubConvention implements NamedEnum {
     // dates are at the end of the month, and in different months
     if (this == NONE) {
       if (start.getDayOfMonth() != end.getDayOfMonth() &&
-          start.getMonth() != end.getMonth() &&
+          start.getLong(PROLEPTIC_MONTH) != end.getLong(PROLEPTIC_MONTH) &&
           (start.getDayOfMonth() == start.lengthOfMonth() || end.getDayOfMonth() == end.lengthOfMonth())) {
-        return RollConvention.ofDayOfMonth(Math.max(start.getDayOfMonth(), end.getDayOfMonth()));
+        
+        return preferEndOfMonth ?  
+            RollConventions.EOM : 
+            RollConvention.ofDayOfMonth(Math.max(start.getDayOfMonth(), end.getDayOfMonth()));
       }
     }
     if (isCalculateBackwards()) {

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.basics.schedule;
 
-import static java.time.temporal.ChronoField.PROLEPTIC_MONTH;
-
 import java.time.LocalDate;
 
 import org.joda.convert.FromString;
@@ -259,7 +257,7 @@ public enum StubConvention implements NamedEnum {
     // dates are at the end of the month, and in different months
     if (this == NONE) {
       if (start.getDayOfMonth() != end.getDayOfMonth() &&
-          start.getLong(PROLEPTIC_MONTH) != end.getLong(PROLEPTIC_MONTH) &&
+          start.getMonth() != end.getMonth() &&
           (start.getDayOfMonth() == start.lengthOfMonth() || end.getDayOfMonth() == end.lengthOfMonth())) {
         return RollConvention.ofDayOfMonth(Math.max(start.getDayOfMonth(), end.getDayOfMonth()));
       }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
@@ -81,6 +81,8 @@ public class StubConventionTest {
         {NONE, date(2014, APRIL, 30), date(2014, AUGUST, 31), P1M, true, RollConventions.EOM},
         {NONE, date(2014, APRIL, 30), date(2014, FEBRUARY, 28), P1M, true, RollConventions.EOM},
         {NONE, date(2016, FEBRUARY, 29), date(2019, FEBRUARY, 28), P6M, true, RollConventions.EOM},
+        {NONE, date(2015, FEBRUARY, 28), date(2016, FEBRUARY, 29), P6M, true, RollConventions.EOM},
+        {NONE, date(2015, APRIL, 30), date(2016, FEBRUARY, 29), P1M, true, RollConventions.EOM},
         {NONE, date(2016, MARCH, 31), date(2017, MARCH, 27), P6M, true, RollConventions.EOM},
         {NONE, date(2016, MARCH, 16), date(2016, MARCH, 31), P6M, true, RollConvention.ofDayOfMonth(16)},
         {NONE, date(2016, MARCH, 16), date(2017, MARCH, 31), P6M, true, RollConventions.EOM},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.basics.schedule;
 
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P2W;
+import static com.opengamma.strata.basics.schedule.Frequency.P6M;
 import static com.opengamma.strata.basics.schedule.Frequency.TERM;
 import static com.opengamma.strata.basics.schedule.RollConventions.DAY_14;
 import static com.opengamma.strata.basics.schedule.RollConventions.DAY_16;
@@ -27,9 +28,11 @@ import static com.opengamma.strata.collect.TestHelper.coverEnum;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static java.time.Month.APRIL;
 import static java.time.Month.AUGUST;
+import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
 import static java.time.Month.JULY;
 import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
 import static java.time.Month.OCTOBER;
 import static org.testng.Assert.assertEquals;
 
@@ -76,6 +79,11 @@ public class StubConventionTest {
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), TERM, true, RollConventions.NONE},
         {NONE, date(2014, JANUARY, 31), date(2014, APRIL, 30), P1M, true, RollConventions.EOM},
         {NONE, date(2014, APRIL, 30), date(2014, AUGUST, 31), P1M, true, RollConventions.EOM},
+        {NONE, date(2014, APRIL, 30), date(2014, FEBRUARY, 28), P1M, true, RollConvention.ofDayOfMonth(30)},
+        {NONE, date(2016, FEBRUARY, 29), date(2019, FEBRUARY, 28), P6M, true, RollConventions.EOM},
+        {NONE, date(2016, MARCH, 31), date(2017, MARCH, 27), P6M, true, RollConventions.EOM},
+        {NONE, date(2016, MARCH, 16), date(2016, MARCH, 31), P6M, true, RollConvention.ofDayOfMonth(16)},
+        {NONE, date(2016, MARCH, 16), date(2017, MARCH, 31), P6M, true, RollConvention.ofDayOfMonth(16)},
 
         {SHORT_INITIAL, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, false, DAY_16},
         {SHORT_INITIAL, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, true, DAY_16},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
@@ -79,11 +79,11 @@ public class StubConventionTest {
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), TERM, true, RollConventions.NONE},
         {NONE, date(2014, JANUARY, 31), date(2014, APRIL, 30), P1M, true, RollConventions.EOM},
         {NONE, date(2014, APRIL, 30), date(2014, AUGUST, 31), P1M, true, RollConventions.EOM},
-        {NONE, date(2014, APRIL, 30), date(2014, FEBRUARY, 28), P1M, true, RollConvention.ofDayOfMonth(30)},
+        {NONE, date(2014, APRIL, 30), date(2014, FEBRUARY, 28), P1M, true, RollConventions.EOM},
         {NONE, date(2016, FEBRUARY, 29), date(2019, FEBRUARY, 28), P6M, true, RollConventions.EOM},
         {NONE, date(2016, MARCH, 31), date(2017, MARCH, 27), P6M, true, RollConventions.EOM},
         {NONE, date(2016, MARCH, 16), date(2016, MARCH, 31), P6M, true, RollConvention.ofDayOfMonth(16)},
-        {NONE, date(2016, MARCH, 16), date(2017, MARCH, 31), P6M, true, RollConvention.ofDayOfMonth(16)},
+        {NONE, date(2016, MARCH, 16), date(2017, MARCH, 31), P6M, true, RollConventions.EOM},
 
         {SHORT_INITIAL, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, false, DAY_16},
         {SHORT_INITIAL, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, true, DAY_16},


### PR DESCRIPTION
This fixes an edge case for February. For EOM trades, If start and end date are in February and one (but not both) was in a a leap year then the roll convention was calculated as 29 rather than EOM.

In terms of existing behaviour, only other change is to the below use case:
* If start and end date are in same month but not the same year
* With different day of month
* End date day of month is the last day of the month

This case previously returned EOM roll day but now returns start day of month as the roll day. A trade with this combination of regular period start/end date should only be valid if it is a single period swap, in which case roll day would not be relevant.

Also added new tests for existing use cases.