### PR TITLE
Date logic for FX option volatility node

### DIFF
--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/BlackFxOptionInterpolatedNodalSurfaceVolatilitiesSpecificationTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/BlackFxOptionInterpolatedNodalSurfaceVolatilitiesSpecificationTest.java
@@ -119,16 +119,17 @@ public class BlackFxOptionInterpolatedNodalSurfaceVolatilitiesSpecificationTest 
             .timeInterpolator(PCHIP)
             .strikeInterpolator(DOUBLE_QUADRATIC)
             .build();
-    ZonedDateTime dateTime = LocalDate.of(2017, 9, 25).atStartOfDay().atZone(ZoneId.of("Europe/London"));
+    LocalDate date = LocalDate.of(2017, 9, 25);
+    ZonedDateTime dateTime = date.atStartOfDay().atZone(ZoneId.of("Europe/London"));
     DoubleArray parameters = DoubleArray.of(0.19, 0.15, 0.13, 0.14, 0.14, 0.11, 0.09, 0.09, 0.11, 0.09, 0.07, 0.07);
     BlackFxOptionSurfaceVolatilities computed = base.volatilities(dateTime, parameters, REF_DATA);
+    DaysAdjustment expOffset = DaysAdjustment.ofBusinessDays(-2, NY_LO);
     double[] expiries = new double[STRIKES.size() * TENORS.size()];
     double[] strikes = new double[STRIKES.size() * TENORS.size()];
     ImmutableList.Builder<ParameterMetadata> paramMetadata = ImmutableList.builder();
     for (int i = 0; i < TENORS.size(); ++i) {
       double expiry = ACT_365F.relativeYearFraction(
-          dateTime.toLocalDate(),
-          BDA.adjust(SPOT_OFFSET.adjust(dateTime.toLocalDate(), REF_DATA).plus(TENORS.get(i)), REF_DATA));
+          date, expOffset.adjust(BDA.adjust(SPOT_OFFSET.adjust(date, REF_DATA).plus(TENORS.get(i)), REF_DATA), REF_DATA));
       for (int j = 0; j < STRIKES.size(); ++j) {
         paramMetadata.add(FxVolatilitySurfaceYearFractionParameterMetadata.of(expiry, SimpleStrike.of(STRIKES.get(j)), GBP_USD));
         expiries[STRIKES.size() * i + j] = expiry;

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/BlackFxOptionSmileVolatilitiesSpecificationTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/BlackFxOptionSmileVolatilitiesSpecificationTest.java
@@ -118,13 +118,15 @@ public class BlackFxOptionSmileVolatilitiesSpecificationTest {
         .timeInterpolator(PCHIP)
         .strikeInterpolator(PCHIP)
         .build();
-    ZonedDateTime dateTime = LocalDate.of(2017, 9, 25).atStartOfDay().atZone(ZoneId.of("Europe/London"));
+    LocalDate date = LocalDate.of(2017, 9, 25);
+    ZonedDateTime dateTime = date.atStartOfDay().atZone(ZoneId.of("Europe/London"));
     DoubleArray parameters = DoubleArray.of(0.05, -0.05, 0.15, 0.25, 0.1, -0.1);
     BlackFxOptionSmileVolatilities computed = base.volatilities(dateTime, parameters, REF_DATA);
     LocalDate spotDate = SPOT_OFFSET.adjust(dateTime.toLocalDate(), REF_DATA);
+    DaysAdjustment expOffset = DaysAdjustment.ofBusinessDays(-2, TA_LO);
     DoubleArray expiries = DoubleArray.of(
-        ACT_360.relativeYearFraction(dateTime.toLocalDate(), BUS_ADJ.adjust(spotDate.plus(Tenor.TENOR_3M), REF_DATA)),
-        ACT_360.relativeYearFraction(dateTime.toLocalDate(), BUS_ADJ.adjust(spotDate.plus(Tenor.TENOR_1Y), REF_DATA)));
+        ACT_360.relativeYearFraction(date, expOffset.adjust(BUS_ADJ.adjust(spotDate.plus(Tenor.TENOR_3M), REF_DATA), REF_DATA)),
+        ACT_360.relativeYearFraction(date, expOffset.adjust(BUS_ADJ.adjust(spotDate.plus(Tenor.TENOR_1Y), REF_DATA), REF_DATA)));
     SmileDeltaTermStructure smiles = InterpolatedStrikeSmileDeltaTermStructure.of(
         expiries, DoubleArray.of(0.1), DoubleArray.of(0.25, 0.15), DoubleMatrix.ofUnsafe(new double[][] {{-0.1}, {-0.05}}),
         DoubleMatrix.ofUnsafe(new double[][] {{0.1}, {0.05}}), ACT_360, PCHIP, FLAT, FLAT, PCHIP, FLAT, FLAT);

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxOptionVolatilitiesNodeTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxOptionVolatilitiesNodeTest.java
@@ -11,6 +11,7 @@ import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.EUTA;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.USNY;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -44,21 +45,68 @@ public class FxOptionVolatilitiesNodeTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
   private static final CurrencyPair EUR_GBP = CurrencyPair.of(EUR, GBP);
+  private static final CurrencyPair GBP_USD = CurrencyPair.of(GBP, USD);
   private static final String LABEL = new String("LABEL");
-  private static final HolidayCalendarId CALENDAR = GBLO.combinedWith(EUTA);
-  private static final DaysAdjustment SPOT_DATE_OFFSET = DaysAdjustment.ofBusinessDays(2, CALENDAR);
-  private static final BusinessDayAdjustment BDA = BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, CALENDAR);
+  private static final HolidayCalendarId LO_TA = GBLO.combinedWith(EUTA);
+  private static final HolidayCalendarId LO_NY = GBLO.combinedWith(USNY);
+  private static final DaysAdjustment SPOT_DATE_OFFSET = DaysAdjustment.ofBusinessDays(2, LO_TA);
+  private static final BusinessDayAdjustment BDA = BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, LO_TA);
+  private static final DaysAdjustment EXPIRY_DATE_OFFSET = DaysAdjustment.ofBusinessDays(-3, LO_TA);
   private static final QuoteId QUOTE_ID = QuoteId.of(StandardId.of("OG", "TEST"));
   private static final Strike STRIKE = SimpleStrike.of(0.95);
 
-  public void test_of() {
-    FxOptionVolatilitiesNode test = FxOptionVolatilitiesNode.of(
-        EUR_GBP, LABEL, SPOT_DATE_OFFSET, BDA, ValueType.BLACK_VOLATILITY, QUOTE_ID, Tenor.TENOR_3M, STRIKE);
+  public void test_builder() {
+    FxOptionVolatilitiesNode test = FxOptionVolatilitiesNode.builder()
+        .currencyPair(EUR_GBP)
+        .label(LABEL)
+        .spotDateOffset(SPOT_DATE_OFFSET)
+        .businessDayAdjustment(BDA)
+        .expiryDateOffset(EXPIRY_DATE_OFFSET)
+        .quoteValueType(ValueType.BLACK_VOLATILITY)
+        .quoteId(QUOTE_ID)
+        .tenor(Tenor.TENOR_3M)
+        .strike(STRIKE)
+        .build();
     assertEquals(test.getBusinessDayAdjustment(), BDA);
     assertEquals(test.getCurrencyPair(), EUR_GBP);
     assertEquals(test.getLabel(), LABEL);
     assertEquals(test.getQuoteValueType(), ValueType.BLACK_VOLATILITY);
     assertEquals(test.getSpotDateOffset(), SPOT_DATE_OFFSET);
+    assertEquals(test.getExpiryDateOffset(), EXPIRY_DATE_OFFSET);
+    assertEquals(test.getStrike(), STRIKE);
+    assertEquals(test.getTenor(), Tenor.TENOR_3M);
+  }
+
+  public void test_builder_noExp() {
+    FxOptionVolatilitiesNode test = FxOptionVolatilitiesNode.builder()
+        .currencyPair(EUR_GBP)
+        .label(LABEL)
+        .spotDateOffset(SPOT_DATE_OFFSET)
+        .businessDayAdjustment(BDA)
+        .quoteValueType(ValueType.BLACK_VOLATILITY)
+        .quoteId(QUOTE_ID)
+        .tenor(Tenor.TENOR_3M)
+        .strike(STRIKE)
+        .build();
+    assertEquals(test.getBusinessDayAdjustment(), BDA);
+    assertEquals(test.getCurrencyPair(), EUR_GBP);
+    assertEquals(test.getLabel(), LABEL);
+    assertEquals(test.getQuoteValueType(), ValueType.BLACK_VOLATILITY);
+    assertEquals(test.getSpotDateOffset(), SPOT_DATE_OFFSET);
+    assertEquals(test.getExpiryDateOffset(), DaysAdjustment.ofBusinessDays(-2, LO_TA));
+    assertEquals(test.getStrike(), STRIKE);
+    assertEquals(test.getTenor(), Tenor.TENOR_3M);
+  }
+
+  public void test_of() {
+    FxOptionVolatilitiesNode test = FxOptionVolatilitiesNode.of(
+        EUR_GBP, SPOT_DATE_OFFSET, BDA, ValueType.BLACK_VOLATILITY, QUOTE_ID, Tenor.TENOR_3M, STRIKE);
+    assertEquals(test.getBusinessDayAdjustment(), BDA);
+    assertEquals(test.getCurrencyPair(), EUR_GBP);
+    assertEquals(test.getLabel(), QUOTE_ID.toString());
+    assertEquals(test.getQuoteValueType(), ValueType.BLACK_VOLATILITY);
+    assertEquals(test.getSpotDateOffset(), SPOT_DATE_OFFSET);
+    assertEquals(test.getExpiryDateOffset(), DaysAdjustment.ofBusinessDays(-2, LO_TA));
     assertEquals(test.getStrike(), STRIKE);
     assertEquals(test.getTenor(), Tenor.TENOR_3M);
   }
@@ -67,11 +115,32 @@ public class FxOptionVolatilitiesNodeTest {
     FxOptionVolatilitiesNode test = FxOptionVolatilitiesNode.of(
         EUR_GBP, SPOT_DATE_OFFSET, BDA, ValueType.BLACK_VOLATILITY, QUOTE_ID, Tenor.TENOR_3M, STRIKE);
     ZonedDateTime dateTime = LocalDate.of(2016, 1, 23).atStartOfDay(ZoneId.of("Europe/London"));
+    DaysAdjustment expAdj = DaysAdjustment.ofBusinessDays(-2, LO_TA);
     double computed = test.timeToExpiry(dateTime, ACT_365F, REF_DATA);
     double expected = ACT_365F.relativeYearFraction(
         dateTime.toLocalDate(),
-        BDA.adjust(SPOT_DATE_OFFSET.adjust(dateTime.toLocalDate(), REF_DATA).plus(Tenor.TENOR_3M), REF_DATA));
+        expAdj.adjust(BDA.adjust(SPOT_DATE_OFFSET.adjust(dateTime.toLocalDate(), REF_DATA).plus(Tenor.TENOR_3M), REF_DATA),
+            REF_DATA));
     assertEquals(computed, expected);
+  }
+
+  public void test_expiry_standard() {
+    DaysAdjustment spotLag = DaysAdjustment.ofBusinessDays(2, LO_NY);
+    BusinessDayAdjustment bda = BusinessDayAdjustment.of(BusinessDayConventions.FOLLOWING, LO_NY);
+    FxOptionVolatilitiesNode[] nodes = new FxOptionVolatilitiesNode[] {
+        FxOptionVolatilitiesNode.of(GBP_USD, spotLag, bda, ValueType.BLACK_VOLATILITY, QUOTE_ID, Tenor.TENOR_2M, STRIKE),
+        FxOptionVolatilitiesNode.of(GBP_USD, spotLag, bda, ValueType.BLACK_VOLATILITY, QUOTE_ID, Tenor.TENOR_10M, STRIKE),
+        FxOptionVolatilitiesNode.of(GBP_USD, spotLag, bda, ValueType.BLACK_VOLATILITY, QUOTE_ID, Tenor.TENOR_4M, STRIKE)};
+    ZonedDateTime[] valDates = new ZonedDateTime[] {
+        LocalDate.of(2017, 10, 25).atStartOfDay(ZoneId.of("Europe/London")),
+        LocalDate.of(2017, 10, 25).atStartOfDay(ZoneId.of("Europe/London")),
+        LocalDate.of(2017, 10, 27).atStartOfDay(ZoneId.of("Europe/London"))};
+    LocalDate[] expDates = new LocalDate[] {LocalDate.of(2017, 12, 21), LocalDate.of(2018, 8, 23), LocalDate.of(2018, 2, 26)};
+    for (int i = 0; i < expDates.length; ++i) {
+      double computed = nodes[i].timeToExpiry(valDates[i], ACT_365F, REF_DATA);
+      double expected = ACT_365F.relativeYearFraction(valDates[i].toLocalDate(), expDates[i]);
+      assertEquals(computed, expected);
+    }
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
* Allows flexibility to calculate expiry date for FX option volatility node as valuationDate + spotLag + tenor + businessDayAdjustment - spotLag. 