### PR TITLE
Conventional currency pair for EUR/GBP swap

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/type/FxSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/type/FxSwapConventions.java
@@ -27,12 +27,12 @@ public final class FxSwapConventions {
       FxSwapConvention.of(StandardFxSwapConventions.EUR_USD.getName());
 
   /**
-   * The "GBP/EUR" FX Swap convention.
+   * The "EUR/GBP" FX Swap convention.
    * <p>
-   * GBP/EUR convention with 2 days spot date.
+   * EUR/GBP convention with 2 days spot date.
    */
-  public static final FxSwapConvention GBP_EUR =
-      FxSwapConvention.of(StandardFxSwapConventions.GBP_EUR.getName());
+  public static final FxSwapConvention EUR_GBP =
+      FxSwapConvention.of(StandardFxSwapConventions.EUR_GBP.getName());
 
   /**
    * The "GBP/USD" FX Swap convention.

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/type/FxSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/type/FxSwapConventions.java
@@ -35,6 +35,15 @@ public final class FxSwapConventions {
       FxSwapConvention.of(StandardFxSwapConventions.EUR_GBP.getName());
 
   /**
+   * The "GBP/EUR" FX Swap convention.
+   * <p>
+   * @deprecated  Use {@code EUR_GBP} for the standard convention.
+   */
+  @Deprecated
+  public static final FxSwapConvention GBP_EUR =
+      FxSwapConvention.of(StandardFxSwapConventions.GBP_EUR.getName());
+
+  /**
    * The "GBP/USD" FX Swap convention.
    * <p>
    * GBP/USD convention with 2 days spot date.

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/type/StandardFxSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/type/StandardFxSwapConventions.java
@@ -38,11 +38,11 @@ public final class StandardFxSwapConventions {
           BusinessDayAdjustment.of(BusinessDayConventions.MODIFIED_FOLLOWING, EUTA_USNY));
 
   /**
-   * GBP/EUR convention with 2 days spot date.
+   * EUR/GBP convention with 2 days spot date.
    */
-  public static final FxSwapConvention GBP_EUR =
+  public static final FxSwapConvention EUR_GBP =
       ImmutableFxSwapConvention.of(
-          CurrencyPair.of(GBP, EUR),
+          CurrencyPair.of(EUR, GBP),
           DaysAdjustment.ofBusinessDays(2, GBLO_EUTA),
           BusinessDayAdjustment.of(BusinessDayConventions.MODIFIED_FOLLOWING, GBLO_EUTA));
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/type/StandardFxSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/type/StandardFxSwapConventions.java
@@ -47,6 +47,18 @@ public final class StandardFxSwapConventions {
           BusinessDayAdjustment.of(BusinessDayConventions.MODIFIED_FOLLOWING, GBLO_EUTA));
 
   /**
+   * GBP/EUR convention with 2 days spot date.
+   * <p>
+   * @deprecated {@code EUR_GBP} for the standard convention.
+   */
+  @Deprecated
+  public static final FxSwapConvention GBP_EUR =
+      ImmutableFxSwapConvention.of(
+          CurrencyPair.of(GBP, EUR),
+          DaysAdjustment.ofBusinessDays(2, GBLO_EUTA),
+          BusinessDayAdjustment.of(BusinessDayConventions.MODIFIED_FOLLOWING, GBLO_EUTA));
+
+  /**
    * GBP/USD convention with 2 days spot date.
    */
   public static final FxSwapConvention GBP_USD =

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/type/FxSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/type/FxSwapConventionsTest.java
@@ -29,7 +29,7 @@ public class FxSwapConventionsTest {
   static Object[][] data_spot_lag() {
     return new Object[][] {
         {FxSwapConventions.EUR_USD, 2},
-        {FxSwapConventions.GBP_EUR, 2},
+        {FxSwapConventions.EUR_GBP, 2},
         {FxSwapConventions.GBP_USD, 2}
     };
   }
@@ -43,7 +43,7 @@ public class FxSwapConventionsTest {
   static Object[][] data_currency_pair() {
     return new Object[][] {
         {FxSwapConventions.EUR_USD, CurrencyPair.of(EUR, USD)},
-        {FxSwapConventions.GBP_EUR, CurrencyPair.of(GBP, EUR)},
+        {FxSwapConventions.EUR_GBP, CurrencyPair.of(EUR, GBP)},
         {FxSwapConventions.GBP_USD, CurrencyPair.of(GBP, USD)}
     };
   }
@@ -57,7 +57,7 @@ public class FxSwapConventionsTest {
   static Object[][] data_calendar() {
     return new Object[][] {
         {FxSwapConventions.EUR_USD, EUTA_USNY},
-        {FxSwapConventions.GBP_EUR, GBLO_EUTA},
+        {FxSwapConventions.EUR_GBP, GBLO_EUTA},
         {FxSwapConventions.GBP_USD, GBLO_USNY}
     };
   }


### PR DESCRIPTION
The currency pair in EUR/GBP swap should be conventional. 