### PR TITLE
Provide lenient mode in extended enums

### DIFF
--- a/modules/basics/src/main/resources/com/opengamma/strata/config/README.md
+++ b/modules/basics/src/main/resources/com/opengamma/strata/config/README.md
@@ -5,9 +5,10 @@ The resource configuration system is used to load and merge files from the class
 The standard location used by the configuration system is `com/opengamma/strata/config`.
 See the class `ResourceConfig` for more information.
 
-Two subdirectories are recognized by default:
+Three subdirectories are recognized by default:
 
 * `base` - the directory of configuration supplied by the Strata project
+* `library` - the directory of configuration supplied by libraries built on 
 * `application` - the directory of configuration supplied by applications
 
 For example, a typical setup might have these two files:
@@ -19,5 +20,5 @@ When the resource `Foo.ini` is requested from `ResourceConfig`, the two files ar
 Sections and properties from the `application` directory take precedence.
 
 The system property `com.opengamma.strata.config.directories` can be used to change the set of
-directories that are loaded. For example, it could be changed to `base,override,application,user`,
+directories that are loaded. For example, it could be changed to `base,library,application,user`,
 which would allow up to 4 files to be loaded and merged.

--- a/modules/basics/src/main/resources/com/opengamma/strata/config/base/BusinessDayConvention.ini
+++ b/modules/basics/src/main/resources/com/opengamma/strata/config/base/BusinessDayConvention.ini
@@ -22,22 +22,20 @@ PRECEDING = Preceding
 NEAREST = Nearest
 
 
-# The set of alternate names
-# The key is the alternate name
-# The value is the standard name (loaded by a provider)
-[alternates]
-# F = Following
+# The lenient patterns
+# The key is the regex pattern matched case insensitive
+# The value is the pattern result
+# The input is upper cased, all the patterns are run, then a lookup occurs
+[lenientPatterns]
+F = Following
 
-# M = ModifiedFollowing
-# MF = ModifiedFollowing
-# Modified = ModifiedFollowing
-# Modified Following = ModifiedFollowing
-# ModFollowing = ModifiedFollowing
+M = ModifiedFollowing
+MF = ModifiedFollowing
+Mod(ified)? ?(Following)? = ModifiedFollowing
 
-# P = Preceding
+P = Preceding
 
-# MP = ModifiedPreceding
-# Modified Preceding = ModifiedPreceding
-# ModPreceding = ModifiedPreceding
+MP = ModifiedPreceding
+Mod(ified)? ?Preceding = ModifiedPreceding
 
-# None = NoAdjust
+None = NoAdjust

--- a/modules/basics/src/main/resources/com/opengamma/strata/config/base/DayCount.ini
+++ b/modules/basics/src/main/resources/com/opengamma/strata/config/base/DayCount.ini
@@ -31,92 +31,63 @@ ACT/ACT.ISDA = Act/Act ISDA
 ACT/365.ISDA = Act/Act ISDA
 
 
-# The set of alternate names
-# The key is the alternate name
-# The value is the standard name (loaded by a provider)
-[alternates]
-# A/A ISDA = Act/Act ISDA
-# Actual/Actual ISDA = Act/Act ISDA
-# A/A (ISDA) = Act/Act ISDA
-# Act/Act (ISDA) = Act/Act ISDA
-# Actual/Actual (ISDA) = Act/Act ISDA
-# Act/Act = Act/Act ISDA
-# Actual/Actual = Act/Act ISDA
-# Actual/Actual (Historical) = Act/Act ISDA
+# The lenient patterns
+# The key is the regex pattern matched case insensitive
+# The value is the pattern result
+# The input is upper cased, all the patterns are run, then a lookup occurs
+[lenientPatterns]
+# convert actual
+ACTUAL/ACTUAL(.*) = Act/Act$1
+ACTUAL/(.*) = Act/$1
+ACT/ACT(.*) = Act/Act$1
+ACT/(.*) = Act/$1
+A/A(.*) = Act/Act$1
+A/(.*) = Act/$1
+# remove brackets
+(.*)[(](.*)[)] = $1$2
+# replace dot with space
+(.*)[.]([A-Z])(.*) = $1 $2$3
+# replace ISMA with ICMA
+(.*) ISMA = $1 ICMA
 
-# A/A ICMA = Act/Act ICMA
-# Actual/Actual ICMA = Act/Act ICMA
-# A/A (ICMA) = Act/Act ICMA
-# Act/Act (ICMA) = Act/Act ICMA
-# Actual/Actual (ICMA) = Act/Act ICMA
-# ISMA-99 = Act/Act ICMA
-# Actual/Actual (Bond) = Act/Act ICMA
+# Act/Act oddities
+Act/Act = Act/Act ISDA
+Act/365 ISDA = Act/Act ISDA
+Act/Act Historical = Act/Act ISDA
+Act/Act Bond = Act/Act ICMA
+ISMA-99 = Act/Act ICMA
+Act/Act Euro = Act/Act AFB
+Act/Act YEAR = Act/Act Year
 
-# A/A AFB = Act/Act AFB
-# Actual/Actual AFB = Act/Act AFB
-# A/A (AFB) = Act/Act AFB
-# Act/Act (AFB) = Act/Act AFB
-# Actual/Actual (AFB) = Act/Act AFB
-# Actual/Actual (Euro) = Act/Act AFB
+# Act/36x oddities
+Act/365 ACTUAL = Act/365 Actual
+Act/365A = Act/365 Actual
+Act/365 Leap year = Act/365L
+ISMA-Year = Act/365L
+French = Act/360
+Act/365 = Act/365F
+Act/365 Fixed = Act/365F
+Act/Fixed 365 = Act/365F
+English = Act/365F
+Act/NL = NL/365
+NL365 = NL/365
+Act/365 No leap year = NL/365
 
-# A/365 Actual = Act/365 Actual
-# Actual/365 Actual = Act/365 Actual
-# A/365 (Actual) = Act/365 Actual
-# Act/365 (Actual) = Act/365 Actual
-# Actual/365 (Actual) = Act/365 Actual
-# A/365A = Act/365 Actual
-# Act/365A = Act/365 Actual
-# Actual/365A = Act/365 Actual
+# 30/360 oddities
+30/360 = 30/360 ISDA
+Eurobond Basis = 30E/360
+30S/360 = 30E/360
+Special German = 30E/360
+30/360 ICMA = 30E/360
+30/360 German = 30E/360 ISDA
+German = 30E/360 ISDA
+30/360 US = 30U/360
+30US/360 = 30U/360
+360/360 = 30U/360
+Bond Basis = 30U/360
+US = 30U/360
+ISMA-30/360 = 30U/360
+30/360 SIA = 30U/360
 
-# A/365L = Act/365L
-# Actual/365L = Act/365L
-# A/365 Leap year = Act/365L
-# Act/365 Leap year = Act/365L
-# Actual/365 Leap year = Act/365L
-# ISMA-Year = Act/365L
-
-# Actual/360 = Act/360
-# A/360 = Act/360
-# French = Act/360
-
-# Actual/364 = Act/364
-# A/364 = Act/364
-
-# A/365F = Act/365F
-# Actual/365F = Act/365F
-# A/365 = Act/365F
-# Act/365 = Act/365F
-# Actual/365 = Act/365F
-# Act/365 (Fixed) = Act/365F
-# Actual/365 (Fixed) = Act/365F
-# A/365 (Fixed) = Act/365F
-# Actual/Fixed 365 = Act/365F
-# English = Act/365F
-
-# A/365.25 = Act/365.25
-# Actual/365.25 = Act/365.25
-
-# A/NL = NL/365
-# Actual/NL = NL/365
-# NL365 = NL/365
-# Act/365 No leap year = NL/365
-
-# Eurobond Basis = 30E/360
-# 30S/360 = 30E/360
-# Special German = 30E/360
-# 30/360 ICMA = 30E/360
-# 30/360 (ICMA) = 30E/360
-
-# 30/360 German = 30E/360 ISDA
-# German = 30E/360 ISDA
-
-# 30/360 US = 30U/360
-# 30/360 (US) = 30U/360
-# 30/360 = 30U/360
-# 30US/360 = 30U/360
-# 360/360 = 30U/360
-# Bond Basis = 30U/360
-# US = 30U/360
-# ISMA-30/360 = 30U/360
-# 30/360 SIA = 30U/360
-# 30/360 (SIA) = 30U/360
+# Bus/252, default to Brazil
+Bus/252 = Bus/252 BRBD

--- a/modules/basics/src/main/resources/com/opengamma/strata/config/base/RollConvention.ini
+++ b/modules/basics/src/main/resources/com/opengamma/strata/config/base/RollConvention.ini
@@ -62,7 +62,18 @@ SAT = DaySat
 SUN = DaySun
 
 
-# The set of alternate names
-# The key is the alternate name
-# The value is the standard name (loaded by a provider)
-[alternates]
+# The lenient patterns
+# The key is the regex pattern matched case insensitive
+# The value is the pattern result
+# The input is upper cased, all the patterns are run, then a lookup occurs
+[lenientPatterns]
+31 = EOM
+([1-3]?[0-9]) = Day$1
+NONE = None
+MON = DayMon
+TUE = DayTue
+WED = DayWed
+THU = DayThu
+FRI = DayFri
+SAT = DaySat
+SUN = DaySun

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/BusinessDayConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/BusinessDayConventionTest.java
@@ -22,6 +22,8 @@ import static java.time.DayOfWeek.SUNDAY;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
+import java.util.Locale;
+import java.util.Optional;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -196,6 +198,11 @@ public class BusinessDayConventionTest {
   }
 
   @Test(dataProvider = "name")
+  public void test_lenientLookup_standardNames(BusinessDayConvention convention, String name) {
+    assertEquals(BusinessDayConvention.extendedEnum().findLenient(name.toLowerCase(Locale.ENGLISH)).get(), convention);
+  }
+
+  @Test(dataProvider = "name")
   public void test_extendedEnum(BusinessDayConvention convention, String name) {
     ImmutableMap<String, BusinessDayConvention> map = BusinessDayConvention.extendedEnum().lookupAll();
     assertEquals(map.get(name), convention);
@@ -207,6 +214,34 @@ public class BusinessDayConventionTest {
 
   public void test_of_lookup_null() {
     assertThrowsIllegalArg(() -> BusinessDayConvention.of(null));
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "lenient")
+  static Object[][] data_lenient() {
+    return new Object[][] {
+        {"F", FOLLOWING},
+        {"M", MODIFIED_FOLLOWING},
+        {"MF", MODIFIED_FOLLOWING},
+        {"P", PRECEDING},
+        {"MP", MODIFIED_PRECEDING},
+        {"Modified", MODIFIED_FOLLOWING},
+        {"Mod", MODIFIED_FOLLOWING},
+        {"Modified Following", MODIFIED_FOLLOWING},
+        {"ModifiedFollowing", MODIFIED_FOLLOWING},
+        {"Mod Following", MODIFIED_FOLLOWING},
+        {"ModFollowing", MODIFIED_FOLLOWING},
+        {"Modified Preceding", MODIFIED_PRECEDING},
+        {"ModifiedPreceding", MODIFIED_PRECEDING},
+        {"Mod Preceding", MODIFIED_PRECEDING},
+        {"ModPreceding", MODIFIED_PRECEDING},
+        {"None", NO_ADJUST},
+    };
+  }
+
+  @Test(dataProvider = "lenient")
+  public void test_lenientLookup_specialNames(String name, BusinessDayConvention convention) {
+    assertEquals(BusinessDayConvention.extendedEnum().findLenient(name.toLowerCase(Locale.ENGLISH)), Optional.of(convention));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
@@ -38,6 +38,8 @@ import static com.opengamma.strata.collect.TestHelper.date;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
+import java.util.Locale;
+import java.util.Optional;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -1049,6 +1051,11 @@ public class DayCountTest {
   }
 
   @Test(dataProvider = "name")
+  public void test_lenientLookup_standardNames(DayCount convention, String name) {
+    assertEquals(DayCount.extendedEnum().findLenient(name.toLowerCase(Locale.ENGLISH)).get(), convention);
+  }
+
+  @Test(dataProvider = "name")
   public void test_extendedEnum(DayCount convention, String name) {
     ImmutableMap<String, DayCount> map = DayCount.extendedEnum().lookupAll();
     assertEquals(map.get(name), convention);
@@ -1060,6 +1067,109 @@ public class DayCountTest {
 
   public void test_of_lookup_null() {
     assertThrowsRuntime(() -> DayCount.of(null));
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "lenient")
+  static Object[][] data_lenient() {
+    return new Object[][] {
+        {"Actual/Actual", ACT_ACT_ISDA},
+        {"Act/Act", ACT_ACT_ISDA},
+        {"A/A", ACT_ACT_ISDA},
+        {"Actual/Actual ISDA", ACT_ACT_ISDA},
+        {"A/A ISDA", ACT_ACT_ISDA},
+        {"Actual/Actual ISDA", ACT_ACT_ISDA},
+        {"A/A (ISDA)", ACT_ACT_ISDA},
+        {"Act/Act (ISDA)", ACT_ACT_ISDA},
+        {"Actual/Actual (ISDA)", ACT_ACT_ISDA},
+        {"Act/Act", ACT_ACT_ISDA},
+        {"Actual/Actual (Historical)", ACT_ACT_ISDA},
+
+        {"A/A ICMA", ACT_ACT_ICMA},
+        {"Actual/Actual ICMA", ACT_ACT_ICMA},
+        {"A/A (ICMA)", ACT_ACT_ICMA},
+        {"Act/Act (ICMA)", ACT_ACT_ICMA},
+        {"Actual/Actual (ICMA)", ACT_ACT_ICMA},
+        {"ISMA-99", ACT_ACT_ICMA},
+        {"Actual/Actual (Bond)", ACT_ACT_ICMA},
+
+        {"A/A AFB", ACT_ACT_AFB},
+        {"Actual/Actual AFB", ACT_ACT_AFB},
+        {"A/A (AFB)", ACT_ACT_AFB},
+        {"Act/Act (AFB)", ACT_ACT_AFB},
+        {"Actual/Actual (AFB)", ACT_ACT_AFB},
+        {"Actual/Actual (Euro)", ACT_ACT_AFB},
+
+        {"A/365 Actual", ACT_365_ACTUAL},
+        {"Actual/365 Actual", ACT_365_ACTUAL},
+        {"A/365 (Actual)", ACT_365_ACTUAL},
+        {"Act/365 (Actual)", ACT_365_ACTUAL},
+        {"Actual/365 (Actual)", ACT_365_ACTUAL},
+        {"A/365A", ACT_365_ACTUAL},
+        {"Act/365A", ACT_365_ACTUAL},
+        {"Actual/365A", ACT_365_ACTUAL},
+
+        {"A/365L", ACT_365L},
+        {"Actual/365L", ACT_365L},
+        {"A/365 Leap year", ACT_365L},
+        {"Act/365 Leap year", ACT_365L},
+        {"Actual/365 Leap year", ACT_365L},
+        {"ISMA-Year", ACT_365L},
+
+        {"Actual/360", ACT_360},
+        {"A/360", ACT_360},
+        {"French", ACT_360},
+
+        {"Actual/364", ACT_364},
+        {"A/364", ACT_364},
+
+        {"A/365F", ACT_365F},
+        {"Actual/365F", ACT_365F},
+        {"A/365", ACT_365F},
+        {"Act/365", ACT_365F},
+        {"Actual/365", ACT_365F},
+        {"Act/365 (Fixed)", ACT_365F},
+        {"Actual/365 (Fixed)", ACT_365F},
+        {"A/365 (Fixed)", ACT_365F},
+        {"Actual/Fixed 365", ACT_365F},
+        {"English", ACT_365F},
+
+        {"A/365.25", ACT_365_25},
+        {"Actual/365.25", ACT_365_25},
+
+        {"A/NL", NL_365},
+        {"Actual/NL", NL_365},
+        {"NL365", NL_365},
+        {"Act/365 No leap year", NL_365},
+
+        {"30/360", THIRTY_360_ISDA},
+
+        {"Eurobond Basis", THIRTY_E_360},
+        {"30S/360", THIRTY_E_360},
+        {"Special German", THIRTY_E_360},
+        {"30/360 ICMA", THIRTY_E_360},
+        {"30/360 (ICMA)", THIRTY_E_360},
+
+        {"30/360 German", THIRTY_E_360_ISDA},
+        {"German", THIRTY_E_360_ISDA},
+
+        {"30/360 US", THIRTY_U_360},
+        {"30/360 (US)", THIRTY_U_360},
+        {"30US/360", THIRTY_U_360},
+        {"360/360", THIRTY_U_360},
+        {"Bond Basis", THIRTY_U_360},
+        {"US", THIRTY_U_360},
+        {"ISMA-30/360", THIRTY_U_360},
+        {"30/360 SIA", THIRTY_U_360},
+        {"30/360 (SIA)", THIRTY_U_360},
+
+        {"BUS/252", DayCount.ofBus252(HolidayCalendarIds.BRBD)},
+    };
+  }
+
+  @Test(dataProvider = "lenient")
+  public void test_lenientLookup_specialNames(String name, DayCount convention) {
+    assertEquals(DayCount.extendedEnum().findLenient(name.toLowerCase(Locale.ENGLISH)), Optional.of(convention));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/RollConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/RollConventionTest.java
@@ -10,6 +10,7 @@ import static com.opengamma.strata.basics.schedule.Frequency.P1M;
 import static com.opengamma.strata.basics.schedule.Frequency.P1W;
 import static com.opengamma.strata.basics.schedule.Frequency.P3M;
 import static com.opengamma.strata.basics.schedule.RollConventions.DAY_2;
+import static com.opengamma.strata.basics.schedule.RollConventions.DAY_30;
 import static com.opengamma.strata.basics.schedule.RollConventions.DAY_THU;
 import static com.opengamma.strata.basics.schedule.RollConventions.EOM;
 import static com.opengamma.strata.basics.schedule.RollConventions.IMM;
@@ -40,6 +41,8 @@ import static org.testng.Assert.assertSame;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
+import java.util.Locale;
+import java.util.Optional;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -559,6 +562,11 @@ public class RollConventionTest {
   }
 
   @Test(dataProvider = "name")
+  public void test_lenientLookup_standardNames(RollConvention convention, String name) {
+    assertEquals(RollConvention.extendedEnum().findLenient(name.toLowerCase(Locale.ENGLISH)).get(), convention);
+  }
+
+  @Test(dataProvider = "name")
   public void test_extendedEnum(RollConvention convention, String name) {
     ImmutableMap<String, RollConvention> map = RollConvention.extendedEnum().lookupAll();
     assertEquals(map.get(name), convention);
@@ -570,6 +578,22 @@ public class RollConventionTest {
 
   public void test_of_lookup_null() {
     assertThrowsIllegalArg(() -> RollConvention.of(null));
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "lenient")
+  static Object[][] data_lenient() {
+    return new Object[][] {
+        {"2", DAY_2},
+        {"30", DAY_30},
+        {"31", EOM},
+        {"THU", DAY_THU},
+    };
+  }
+
+  @Test(dataProvider = "lenient")
+  public void test_lenientLookup_specialNames(String name, RollConvention convention) {
+    assertEquals(RollConvention.extendedEnum().findLenient(name.toLowerCase(Locale.ENGLISH)), Optional.of(convention));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/named/ExtendedEnum.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/named/ExtendedEnum.java
@@ -8,12 +8,16 @@ package com.opengamma.strata.collect.named;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.joda.convert.RenameHandler;
 
@@ -26,6 +30,7 @@ import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.io.IniFile;
 import com.opengamma.strata.collect.io.PropertySet;
 import com.opengamma.strata.collect.io.ResourceConfig;
+import com.opengamma.strata.collect.tuple.Pair;
 
 /**
  * Manager for extended enums controlled by code or configuration.
@@ -90,6 +95,10 @@ public final class ExtendedEnum<T extends Named> {
    * Section name used for externals.
    */
   private static final String EXTERNALS_SECTION = "externals.";
+  /**
+   * Section name used for lenient patterns.
+   */
+  private static final String LENIENT_PATTERNS_SECTION = "lenientPatterns";
 
   /**
    * The enum type.
@@ -109,6 +118,10 @@ public final class ExtendedEnum<T extends Named> {
    * The inner map holds the mapping from external name to our name.
    */
   private final ImmutableMap<String, ImmutableMap<String, String>> externalNames;
+  /**
+   * The list of regex patterns for lenient lookup.
+   */
+  private final ImmutableList<Pair<Pattern, String>> lenientRegex;
 
   //-------------------------------------------------------------------------
   /**
@@ -132,14 +145,15 @@ public final class ExtendedEnum<T extends Named> {
       ImmutableList<NamedLookup<R>> lookups = parseProviders(config, type);
       ImmutableMap<String, String> alternateNames = parseAlternates(config);
       ImmutableMap<String, ImmutableMap<String, String>> externalNames = parseExternals(config);
+      ImmutableList<Pair<Pattern, String>> lenientRegex = parseLenientPatterns(config);
       log.fine(() -> "Loaded extended enum: " + name + ", providers: " + lookups);
-      return new ExtendedEnum<>(type, lookups, alternateNames, externalNames);
+      return new ExtendedEnum<>(type, lookups, alternateNames, externalNames, lenientRegex);
 
     } catch (RuntimeException ex) {
       // logging used because this is loaded in a static variable
       log.severe("Failed to load ExtendedEnum for " + type + ": " + Throwables.getStackTraceAsString(ex));
       // return an empty instance to avoid ExceptionInInitializerError
-      return new ExtendedEnum<>(type, ImmutableList.of(), ImmutableMap.of(), ImmutableMap.of());
+      return new ExtendedEnum<>(type, ImmutableList.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableList.of());
     }
   }
 
@@ -231,7 +245,7 @@ public final class ExtendedEnum<T extends Named> {
     };
   }
 
-  // parses the alternate names.
+  // parses the alternate names
   private static ImmutableMap<String, String> parseAlternates(IniFile config) {
     if (!config.contains(ALTERNATES_SECTION)) {
       return ImmutableMap.of();
@@ -244,7 +258,7 @@ public final class ExtendedEnum<T extends Named> {
     return ImmutableMap.copyOf(alternates);
   }
 
-  // parses the external names.
+  // parses the external names
   private static ImmutableMap<String, ImmutableMap<String, String>> parseExternals(IniFile config) {
     ImmutableMap.Builder<String, ImmutableMap<String, String>> builder = ImmutableMap.builder();
     for (String sectionName : config.sections()) {
@@ -254,6 +268,18 @@ public final class ExtendedEnum<T extends Named> {
       }
     }
     return builder.build();
+  }
+
+  // parses the lenient patterns
+  private static ImmutableList<Pair<Pattern, String>> parseLenientPatterns(IniFile config) {
+    if (!config.contains(LENIENT_PATTERNS_SECTION)) {
+      return ImmutableList.of();
+    }
+    List<Pair<Pattern, String>> alternates = new ArrayList<>();
+    for (Entry<String, String> entry : config.section(LENIENT_PATTERNS_SECTION).asMap().entrySet()) {
+      alternates.add(Pair.of(Pattern.compile(entry.getKey(), Pattern.CASE_INSENSITIVE), entry.getValue()));
+    }
+    return ImmutableList.copyOf(alternates);
   }
 
   //-------------------------------------------------------------------------
@@ -269,12 +295,14 @@ public final class ExtendedEnum<T extends Named> {
       Class<T> type,
       ImmutableList<NamedLookup<T>> lookups,
       ImmutableMap<String, String> alternateNames,
-      ImmutableMap<String, ImmutableMap<String, String>> externalNames) {
+      ImmutableMap<String, ImmutableMap<String, String>> externalNames,
+      ImmutableList<Pair<Pattern, String>> lenientRegex) {
 
     this.type = ArgChecker.notNull(type, "type");
     this.lookups = ArgChecker.notNull(lookups, "lookups");
     this.alternateNames = ArgChecker.notNull(alternateNames, "alternateNames");
     this.externalNames = ArgChecker.notNull(externalNames, "externalNames");
+    this.lenientRegex = ArgChecker.notNull(lenientRegex, "lenientRegex");
   }
 
   //-------------------------------------------------------------------------
@@ -437,6 +465,32 @@ public final class ExtendedEnum<T extends Named> {
       throw new IllegalArgumentException(type.getSimpleName() + " group not found: " + group);
     }
     return new ExternalEnumNames<>(this, group, externals);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Looks up an instance by name leniently.
+   * <p>
+   * This finds the instance matching the specified name using a lenient lookup strategy.
+   * An extended enum may include additional configuration defining how lenient search occurs.
+   * 
+   * @param name  the enum name to return
+   * @return the named enum
+   * @throws IllegalArgumentException if the name is not found
+   */
+  public Optional<T> findLenient(String name) {
+    Optional<T> alreadyValid = find(name);
+    if (alreadyValid.isPresent()) {
+      return alreadyValid;
+    }
+    String current = name.toUpperCase(Locale.ENGLISH);
+    for (Pair<Pattern, String> pair : lenientRegex) {
+      Matcher matcher = pair.getFirst().matcher(current);
+      if (matcher.matches()) {
+        current = matcher.replaceFirst(pair.getSecond());
+      }
+    }
+    return find(current);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/named/ExtendedEnumTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/named/ExtendedEnumTest.java
@@ -99,6 +99,13 @@ public class ExtendedEnumTest {
     assertEquals(test.toString(), "ExtendedEnum[SampleOther]");
   }
 
+  public void test_enum_lenient() {
+    ExtendedEnum<SampleNamed> test = ExtendedEnum.of(SampleNamed.class);
+    assertEquals(test.findLenient("Standard"), Optional.of(SampleNameds.STANDARD));
+    assertEquals(test.findLenient("A1"), Optional.of(SampleNameds.STANDARD));
+    assertEquals(test.findLenient("A2"), Optional.of(MoreSampleNameds.MORE));
+  }
+
   public void test_enum_invalid() {
     Logger logger = Logger.getLogger(ExtendedEnum.class.getName());
     Level level = logger.getLevel();

--- a/modules/collect/src/test/resources/com/opengamma/strata/config/base/SampleNamed.ini
+++ b/modules/collect/src/test/resources/com/opengamma/strata/config/base/SampleNamed.ini
@@ -17,3 +17,8 @@ Foo1 = Standard
 [externals.Bar]
 Foo1 = More
 Foo2 = Standard
+
+[lenientPatterns]
+A([1-2]) = B$1
+B1 = Standard
+B2 = More


### PR DESCRIPTION
There are many variants of valid input values for common enums.
This change allows extended enums to support this via regex patterns.