### PR TITLE
Improve par spread for swaps with only one period.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swap/DiscountingSwapProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swap/DiscountingSwapProductPricer.java
@@ -230,33 +230,23 @@ public class DiscountingSwapProductPricer {
   public double parSpread(ResolvedSwap swap, RatesProvider provider) {
     ResolvedSwapLeg referenceLeg = swap.getLegs().get(0);
     Currency ccyReferenceLeg = referenceLeg.getCurrency();
-    if (referenceLeg.getPaymentPeriods().size() > 1) { // try multiperiod par-spread
-      double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
-      double pvbp = legPricer.pvbp(referenceLeg, provider);
-      return -convertedPv / pvbp;
-    }
-    SwapPaymentPeriod firstPeriod = referenceLeg.getPaymentPeriods().get(0);
-    ArgChecker.isTrue(firstPeriod instanceof RatePaymentPeriod, "PaymentPeriod must be instance of RatePaymentPeriod");
-    RatePaymentPeriod payment = (RatePaymentPeriod) firstPeriod;
-    if (payment.getAccrualPeriods().size() == 1) { // no compounding
-      double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
-      // PVBP
-      double pvbpFixedLeg = legPricer.pvbp(referenceLeg, provider);
-      // Par rate
-      return -convertedPv / pvbpFixedLeg;
-    }
-    // try Compounding
+    // try one payment compounding, typically for inflation swaps
     Triple<Boolean, Integer, Double> fixedCompounded = checkFixedCompounded(referenceLeg);
-    ArgChecker.isTrue(fixedCompounded.getFirst(),
-        "Swap should have a fixed leg and for one payment it should be based on compunding witout spread.");
-    double df = provider.discountFactor(ccyReferenceLeg, referenceLeg.getPaymentPeriods().get(0).getPaymentDate());
+    if (fixedCompounded.getFirst()) {
+      double df = provider.discountFactor(ccyReferenceLeg, referenceLeg.getPaymentPeriods().get(0).getPaymentDate());
+      double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
+      double referenceConvertedPv = legPricer.presentValue(referenceLeg, provider).getAmount();
+      double notional = ((RatePaymentPeriod) referenceLeg.getPaymentPeriods().get(0)).getNotional();
+      double parSpread =
+          Math.pow(-(convertedPv - referenceConvertedPv) / (df * notional) + 1.0d, 1.0d / fixedCompounded.getSecond()) -
+              (1.0d + fixedCompounded.getThird());
+      return parSpread;
+
+    }
+    // In other cases, try the standard multiperiod par spread
     double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
-    double referenceConvertedPv = legPricer.presentValue(referenceLeg, provider).getAmount();
-    double notional = ((RatePaymentPeriod) referenceLeg.getPaymentPeriods().get(0)).getNotional();
-    double parSpread =
-        Math.pow(-(convertedPv - referenceConvertedPv) / (df * notional) + 1.0d, 1.0d / fixedCompounded.getSecond()) -
-            (1.0d + fixedCompounded.getThird());
-    return parSpread;
+    double pvbp = legPricer.pvbp(referenceLeg, provider);
+    return -convertedPv / pvbp;
   }
 
   //-------------------------------------------------------------------------
@@ -385,43 +375,29 @@ public class DiscountingSwapProductPricer {
     Currency ccyReferenceLeg = referenceLeg.getCurrency();
     double convertedPv = presentValue(swap, ccyReferenceLeg, provider).getAmount();
     PointSensitivityBuilder convertedPvDr = presentValueSensitivity(swap, ccyReferenceLeg, provider);
-    if (referenceLeg.getPaymentPeriods().size() > 1) { // try multiperiod par-spread
-      double pvbp = legPricer.pvbp(referenceLeg, provider);
-      // Backward sweep
-      double convertedPvBar = -1d / pvbp;
-      double pvbpBar = convertedPv / (pvbp * pvbp);
-      PointSensitivityBuilder pvbpDr = legPricer.pvbpSensitivity(referenceLeg, provider);
-      return convertedPvDr.multipliedBy(convertedPvBar).combinedWith(pvbpDr.multipliedBy(pvbpBar));
-    }
-    SwapPaymentPeriod firstPeriod = referenceLeg.getPaymentPeriods().get(0);
-    ArgChecker.isTrue(firstPeriod instanceof RatePaymentPeriod, "PaymentPeriod must be instance of RatePaymentPeriod");
-    RatePaymentPeriod payment = (RatePaymentPeriod) firstPeriod;
-    if (payment.getAccrualPeriods().size() == 1) { // no compounding
-      // PVBP
-      double pvbp = legPricer.pvbp(referenceLeg, provider);
-      // Backward sweep
-      double convertedPvBar = -1d / pvbp;
-      double pvbpBar = convertedPv / (pvbp * pvbp);
-      PointSensitivityBuilder pvbpDr = legPricer.pvbpSensitivity(referenceLeg, provider);
-      return convertedPvDr.multipliedBy(convertedPvBar).combinedWith(pvbpDr.multipliedBy(pvbpBar));
-    }
-    // try Compounding
+    // try one payment compounding, typically for inflation swaps
     Triple<Boolean, Integer, Double> fixedCompounded = checkFixedCompounded(referenceLeg);
-    ArgChecker.isTrue(fixedCompounded.getFirst(),
-        "Swap should have a fixed leg and for one payment it should be based on compunding witout spread.");
-    double df = provider.discountFactor(ccyReferenceLeg, referenceLeg.getPaymentPeriods().get(0).getPaymentDate());
-    PointSensitivityBuilder dfDr = provider.discountFactors(ccyReferenceLeg)
-        .zeroRatePointSensitivity(referenceLeg.getPaymentPeriods().get(0).getPaymentDate());
-    double referenceConvertedPv = legPricer.presentValue(referenceLeg, provider).getAmount();
-    PointSensitivityBuilder referenceConvertedPvDr = legPricer.presentValueSensitivity(referenceLeg, provider);
-    double notional = ((RatePaymentPeriod) referenceLeg.getPaymentPeriods().get(0)).getNotional();
-    PointSensitivityBuilder dParSpreadDr =
-        convertedPvDr.combinedWith(referenceConvertedPvDr.multipliedBy(-1)).multipliedBy(-1.0d / (df * notional))
-            .combinedWith(dfDr.multipliedBy((convertedPv - referenceConvertedPv) / (df * df * notional)))
-            .multipliedBy(1.0d / fixedCompounded.getSecond() *
-                Math.pow(-(convertedPv - referenceConvertedPv) / (df * notional) + 1.0d,
-                    1.0d / fixedCompounded.getSecond() - 1.0d));
-    return dParSpreadDr;
+    if (fixedCompounded.getFirst()) {
+      double df = provider.discountFactor(ccyReferenceLeg, referenceLeg.getPaymentPeriods().get(0).getPaymentDate());
+      PointSensitivityBuilder dfDr = provider.discountFactors(ccyReferenceLeg)
+          .zeroRatePointSensitivity(referenceLeg.getPaymentPeriods().get(0).getPaymentDate());
+      double referenceConvertedPv = legPricer.presentValue(referenceLeg, provider).getAmount();
+      PointSensitivityBuilder referenceConvertedPvDr = legPricer.presentValueSensitivity(referenceLeg, provider);
+      double notional = ((RatePaymentPeriod) referenceLeg.getPaymentPeriods().get(0)).getNotional();
+      PointSensitivityBuilder dParSpreadDr =
+          convertedPvDr.combinedWith(referenceConvertedPvDr.multipliedBy(-1)).multipliedBy(-1.0d / (df * notional))
+              .combinedWith(dfDr.multipliedBy((convertedPv - referenceConvertedPv) / (df * df * notional)))
+              .multipliedBy(1.0d / fixedCompounded.getSecond() *
+                  Math.pow(-(convertedPv - referenceConvertedPv) / (df * notional) + 1.0d,
+                      1.0d / fixedCompounded.getSecond() - 1.0d));
+      return dParSpreadDr;
+    }
+    double pvbp = legPricer.pvbp(referenceLeg, provider);
+    // Backward sweep
+    double convertedPvBar = -1d / pvbp;
+    double pvbpBar = convertedPv / (pvbp * pvbp);
+    PointSensitivityBuilder pvbpDr = legPricer.pvbpSensitivity(referenceLeg, provider);
+    return convertedPvDr.multipliedBy(convertedPvBar).combinedWith(pvbpDr.multipliedBy(pvbpBar));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Previously, swap with only one payment period and composition on the IBOR leg did not return a par spread.
The logic of the code has been reversed, first checking if the fixed leg is compounded and then using the standard par spread. This allow to remove the restriction on the number of periods.
All swap for which the par spread was computed in the previous code should still be computed and provide the same result.
Solves #1605 