### PR TITLE
Single stub period

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/Schedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/Schedule.java
@@ -114,6 +114,18 @@ public final class Schedule
 
   //-------------------------------------------------------------------------
   /**
+   * Checks if this schedule represents a single period, but its frequency is not {@code Frequency.TERM}.
+   * <p>
+   * This occurs when the single period is stub.
+   * 
+   * @return true if this is a single period
+   */
+  public boolean isSinglePeriod() {
+    return !frequency.equals(Frequency.TERM) && size() == 1;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Gets a schedule period by index.
    * <p>
    * This returns a period using a zero-based index.
@@ -208,7 +220,9 @@ public final class Schedule
 
   // checks if there is an initial stub
   private boolean isInitialStub() {
-    return !isTerm() && !getFirstPeriod().isRegular(frequency, rollConvention);
+    return isSinglePeriod() ?
+        !getFirstPeriod().isRegular(frequency, rollConvention) :
+        (!isTerm() && !getFirstPeriod().isRegular(frequency, rollConvention));
   }
 
   /**
@@ -225,7 +239,9 @@ public final class Schedule
 
   // checks if there is a final stub
   private boolean isFinalStub() {
-    return !isTerm() && !getLastPeriod().isRegular(frequency, rollConvention);
+    return isSinglePeriod() ?
+        !getLastPeriod().isRegular(frequency, rollConvention) :
+        (!isTerm() && !getLastPeriod().isRegular(frequency, rollConvention));
   }
 
   /**
@@ -239,6 +255,9 @@ public final class Schedule
    * @return the non-stub schedule periods
    */
   public ImmutableList<SchedulePeriod> getRegularPeriods() {
+    if (isSinglePeriod()) {
+      return getFirstPeriod().isRegular(frequency, rollConvention) ? periods : ImmutableList.of();
+    }
     if (isTerm()) {
       return periods;
     }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/Schedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/Schedule.java
@@ -104,24 +104,21 @@ public final class Schedule
   /**
    * Checks if this schedule represents a single 'Term' period.
    * <p>
-   * A 'Term' schedule has one period.
+   * A 'Term' schedule has one period and a frequency of 'Term'.
    * 
    * @return true if this is a 'Term' schedule
    */
   public boolean isTerm() {
-    return size() == 1;
+    return size() == 1 && frequency.equals(Frequency.TERM);
   }
 
-  //-------------------------------------------------------------------------
   /**
-   * Checks if this schedule represents a single period, but its frequency is not {@code Frequency.TERM}.
-   * <p>
-   * This occurs when the single period is stub.
+   * Checks if this schedule has a single period.
    * 
    * @return true if this is a single period
    */
   public boolean isSinglePeriod() {
-    return !frequency.equals(Frequency.TERM) && size() == 1;
+    return size() == 1;
   }
 
   //-------------------------------------------------------------------------
@@ -209,8 +206,10 @@ public final class Schedule
   /**
    * Gets the initial stub if it exists.
    * <p>
-   * There is an initial stub if there is more than one period and the first
-   * period is a stub.
+   * There is an initial stub if the first period is a stub and the frequency is not 'Term'.
+   * <p>
+   * A period will be allocated to one and only one of {@link #getInitialStub()},
+   * {@link #getRegularPeriods()} and {@link #getFinalStub()}.
    * 
    * @return the initial stub, empty if no initial stub
    */
@@ -220,9 +219,7 @@ public final class Schedule
 
   // checks if there is an initial stub
   private boolean isInitialStub() {
-    return isSinglePeriod() ?
-        !getFirstPeriod().isRegular(frequency, rollConvention) :
-        (!isTerm() && !getFirstPeriod().isRegular(frequency, rollConvention));
+    return !isTerm() && !getFirstPeriod().isRegular(frequency, rollConvention);
   }
 
   /**
@@ -230,6 +227,9 @@ public final class Schedule
    * <p>
    * There is a final stub if there is more than one period and the last
    * period is a stub.
+   * <p>
+   * A period will be allocated to one and only one of {@link #getInitialStub()},
+   * {@link #getRegularPeriods()} and {@link #getFinalStub()}.
    * 
    * @return the final stub, empty if no final stub
    */
@@ -239,9 +239,7 @@ public final class Schedule
 
   // checks if there is a final stub
   private boolean isFinalStub() {
-    return isSinglePeriod() ?
-        !getLastPeriod().isRegular(frequency, rollConvention) :
-        (!isTerm() && !getLastPeriod().isRegular(frequency, rollConvention));
+    return !isSinglePeriod() && !getLastPeriod().isRegular(frequency, rollConvention);
   }
 
   /**
@@ -250,14 +248,15 @@ public final class Schedule
    * The regular periods exclude any initial or final stub.
    * In most cases, the periods returned will be regular, corresponding to the periodic
    * frequency and roll convention, however there are cases when this is not true.
+   * This includes the case where {@link #isTerm()} returns true.
    * See {@link SchedulePeriod#isRegular(Frequency, RollConvention)}.
+   * <p>
+   * A period will be allocated to one and only one of {@link #getInitialStub()},
+   * {@link #getRegularPeriods()} and {@link #getFinalStub()}.
    * 
    * @return the non-stub schedule periods
    */
   public ImmutableList<SchedulePeriod> getRegularPeriods() {
-    if (isSinglePeriod()) {
-      return getFirstPeriod().isRegular(frequency, rollConvention) ? periods : ImmutableList.of();
-    }
     if (isTerm()) {
       return periods;
     }
@@ -371,7 +370,7 @@ public final class Schedule
   public Schedule merge(int groupSize, LocalDate firstRegularStartDate, LocalDate lastRegularEndDate) {
     ArgChecker.notNegativeOrZero(groupSize, "groupSize");
     ArgChecker.inOrderOrEqual(firstRegularStartDate, lastRegularEndDate, "firstRegularStartDate", "lastRegularEndDate");
-    if (isTerm() || groupSize == 1) {
+    if (isSinglePeriod() || groupSize == 1) {
       return this;
     }
     // determine stubs and regular
@@ -452,7 +451,7 @@ public final class Schedule
    */
   public Schedule mergeRegular(int groupSize, boolean rollForwards) {
     ArgChecker.notNegativeOrZero(groupSize, "groupSize");
-    if (isTerm() || groupSize == 1) {
+    if (isSinglePeriod() || groupSize == 1) {
       return this;
     }
     List<SchedulePeriod> newSchedule = new ArrayList<>();

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
@@ -80,6 +80,7 @@ public class ScheduleTest {
     Schedule test = Schedule.ofTerm(P1_STUB);
     assertEquals(test.size(), 1);
     assertEquals(test.isTerm(), true);
+    assertEquals(test.isSinglePeriod(), false);
     assertEquals(test.getFrequency(), TERM);
     assertEquals(test.getRollConvention(), RollConventions.NONE);
     assertEquals(test.isEndOfMonthConvention(), false);
@@ -98,6 +99,33 @@ public class ScheduleTest {
     assertEquals(test.getUnadjustedDates(), ImmutableList.of(JUL_04, JUL_17));
   }
 
+  public void test_size1_stub() {
+    Schedule test = Schedule.builder()
+        .periods(ImmutableList.of(P1_STUB))
+        .frequency(P1M)
+        .rollConvention(DAY_17)
+        .build();
+    assertEquals(test.size(), 1);
+    assertEquals(test.isTerm(), true);
+    assertEquals(test.isSinglePeriod(), true);
+    assertEquals(test.getFrequency(), P1M);
+    assertEquals(test.getRollConvention(), DAY_17);
+    assertEquals(test.isEndOfMonthConvention(), false);
+    assertEquals(test.getPeriods(), ImmutableList.of(P1_STUB));
+    assertEquals(test.getPeriod(0), P1_STUB);
+    assertEquals(test.getStartDate(), P1_STUB.getStartDate());
+    assertEquals(test.getEndDate(), P1_STUB.getEndDate());
+    assertEquals(test.getUnadjustedStartDate(), P1_STUB.getUnadjustedStartDate());
+    assertEquals(test.getUnadjustedEndDate(), P1_STUB.getUnadjustedEndDate());
+    assertEquals(test.getFirstPeriod(), P1_STUB);
+    assertEquals(test.getLastPeriod(), P1_STUB);
+    assertEquals(test.getInitialStub(), Optional.of(P1_STUB));
+    assertEquals(test.getFinalStub(), Optional.of(P1_STUB));
+    assertEquals(test.getRegularPeriods(), ImmutableList.of());
+    assertThrows(() -> test.getPeriod(1), IndexOutOfBoundsException.class);
+    assertEquals(test.getUnadjustedDates(), ImmutableList.of(JUL_04, JUL_17));
+  }
+
   public void test_of_size2_initialStub() {
     Schedule test = Schedule.builder()
         .periods(ImmutableList.of(P1_STUB, P2_NORMAL))
@@ -106,6 +134,7 @@ public class ScheduleTest {
         .build();
     assertEquals(test.size(), 2);
     assertEquals(test.isTerm(), false);
+    assertEquals(test.isSinglePeriod(), false);
     assertEquals(test.getFrequency(), P1M);
     assertEquals(test.getRollConvention(), DAY_17);
     assertEquals(test.isEndOfMonthConvention(), false);

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
@@ -80,7 +80,7 @@ public class ScheduleTest {
     Schedule test = Schedule.ofTerm(P1_STUB);
     assertEquals(test.size(), 1);
     assertEquals(test.isTerm(), true);
-    assertEquals(test.isSinglePeriod(), false);
+    assertEquals(test.isSinglePeriod(), true);
     assertEquals(test.getFrequency(), TERM);
     assertEquals(test.getRollConvention(), RollConventions.NONE);
     assertEquals(test.isEndOfMonthConvention(), false);
@@ -106,7 +106,7 @@ public class ScheduleTest {
         .rollConvention(DAY_17)
         .build();
     assertEquals(test.size(), 1);
-    assertEquals(test.isTerm(), true);
+    assertEquals(test.isTerm(), false);
     assertEquals(test.isSinglePeriod(), true);
     assertEquals(test.getFrequency(), P1M);
     assertEquals(test.getRollConvention(), DAY_17);
@@ -120,10 +120,37 @@ public class ScheduleTest {
     assertEquals(test.getFirstPeriod(), P1_STUB);
     assertEquals(test.getLastPeriod(), P1_STUB);
     assertEquals(test.getInitialStub(), Optional.of(P1_STUB));
-    assertEquals(test.getFinalStub(), Optional.of(P1_STUB));
+    assertEquals(test.getFinalStub(), Optional.empty());
     assertEquals(test.getRegularPeriods(), ImmutableList.of());
     assertThrows(() -> test.getPeriod(1), IndexOutOfBoundsException.class);
     assertEquals(test.getUnadjustedDates(), ImmutableList.of(JUL_04, JUL_17));
+  }
+
+  public void test_size1_noStub() {
+    Schedule test = Schedule.builder()
+        .periods(ImmutableList.of(P2_NORMAL))
+        .frequency(P1M)
+        .rollConvention(DAY_17)
+        .build();
+    assertEquals(test.size(), 1);
+    assertEquals(test.isTerm(), false);
+    assertEquals(test.isSinglePeriod(), true);
+    assertEquals(test.getFrequency(), P1M);
+    assertEquals(test.getRollConvention(), DAY_17);
+    assertEquals(test.isEndOfMonthConvention(), false);
+    assertEquals(test.getPeriods(), ImmutableList.of(P2_NORMAL));
+    assertEquals(test.getPeriod(0), P2_NORMAL);
+    assertEquals(test.getStartDate(), P2_NORMAL.getStartDate());
+    assertEquals(test.getEndDate(), P2_NORMAL.getEndDate());
+    assertEquals(test.getUnadjustedStartDate(), P2_NORMAL.getUnadjustedStartDate());
+    assertEquals(test.getUnadjustedEndDate(), P2_NORMAL.getUnadjustedEndDate());
+    assertEquals(test.getFirstPeriod(), P2_NORMAL);
+    assertEquals(test.getLastPeriod(), P2_NORMAL);
+    assertEquals(test.getInitialStub(), Optional.empty());
+    assertEquals(test.getFinalStub(), Optional.empty());
+    assertEquals(test.getRegularPeriods(), ImmutableList.of(P2_NORMAL));
+    assertThrows(() -> test.getPeriod(1), IndexOutOfBoundsException.class);
+    assertEquals(test.getUnadjustedDates(), ImmutableList.of(JUL_17, AUG_17));
   }
 
   public void test_of_size2_initialStub() {
@@ -162,6 +189,7 @@ public class ScheduleTest {
         .build();
     assertEquals(test.size(), 2);
     assertEquals(test.isTerm(), false);
+    assertEquals(test.isSinglePeriod(), false);
     assertEquals(test.getFrequency(), P1M);
     assertEquals(test.getRollConvention(), DAY_17);
     assertEquals(test.isEndOfMonthConvention(), false);
@@ -189,6 +217,7 @@ public class ScheduleTest {
         .build();
     assertEquals(test.size(), 2);
     assertEquals(test.isTerm(), false);
+    assertEquals(test.isSinglePeriod(), false);
     assertEquals(test.getFrequency(), P1M);
     assertEquals(test.getRollConvention(), DAY_17);
     assertEquals(test.isEndOfMonthConvention(), false);
@@ -216,6 +245,7 @@ public class ScheduleTest {
         .build();
     assertEquals(test.size(), 3);
     assertEquals(test.isTerm(), false);
+    assertEquals(test.isSinglePeriod(), false);
     assertEquals(test.getFrequency(), P1M);
     assertEquals(test.getRollConvention(), DAY_17);
     assertEquals(test.isEndOfMonthConvention(), false);
@@ -244,6 +274,7 @@ public class ScheduleTest {
         .build();
     assertEquals(test.size(), 4);
     assertEquals(test.isTerm(), false);
+    assertEquals(test.isSinglePeriod(), false);
     assertEquals(test.getFrequency(), P1M);
     assertEquals(test.getRollConvention(), DAY_17);
     assertEquals(test.isEndOfMonthConvention(), false);
@@ -300,6 +331,15 @@ public class ScheduleTest {
         .build();
     assertEquals(testNormal.mergeToTerm(), Schedule.ofTerm(P1_3));
     assertEquals(testNormal.mergeToTerm().mergeToTerm(), Schedule.ofTerm(P1_3));
+  }
+
+  public void test_mergeToTerm_size1_stub() {
+    Schedule test = Schedule.builder()
+        .periods(ImmutableList.of(P1_STUB))
+        .frequency(P1M)
+        .rollConvention(DAY_17)
+        .build();
+    assertEquals(test.mergeToTerm(), Schedule.ofTerm(P1_STUB));
   }
 
   //-------------------------------------------------------------------------
@@ -482,6 +522,18 @@ public class ScheduleTest {
 
   public void test_merge_termNoChange() {
     Schedule test = Schedule.ofTerm(P1_STUB);
+    assertEquals(test.mergeRegular(2, true), test);
+    assertEquals(test.mergeRegular(2, false), test);
+    assertEquals(test.merge(2, P1_STUB.getUnadjustedStartDate(), P1_STUB.getUnadjustedEndDate()), test);
+    assertEquals(test.merge(2, P1_STUB.getStartDate(), P1_STUB.getEndDate()), test);
+  }
+
+  public void test_merge_size1_stub() {
+    Schedule test = Schedule.builder()
+        .periods(ImmutableList.of(P1_STUB))
+        .frequency(P1M)
+        .rollConvention(DAY_17)
+        .build();
     assertEquals(test.mergeRegular(2, true), test);
     assertEquals(test.mergeRegular(2, false), test);
     assertEquals(test.merge(2, P1_STUB.getUnadjustedStartDate(), P1_STUB.getUnadjustedEndDate()), test);

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateCalculationTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateCalculationTest.java
@@ -11,6 +11,7 @@ import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_1M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_1W;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_2M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_6M;
 import static com.opengamma.strata.basics.schedule.Frequency.P1M;
@@ -110,6 +111,11 @@ public class IborRateCalculationTest {
   private static final Schedule ACCRUAL_SCHEDULE_FINAL_STUB = Schedule.builder()
       .periods(ACCRUAL1, ACCRUAL2, ACCRUAL3STUB)
       .frequency(P1M)
+      .rollConvention(DAY_5)
+      .build();
+  private static final Schedule SINGLE_ACCRUAL_SCHEDULE_STUB = Schedule.builder()
+      .periods(ACCRUAL1STUB)
+      .frequency(P3M)
       .rollConvention(DAY_5)
       .build();
 
@@ -350,6 +356,22 @@ public class IborRateCalculationTest {
     ImmutableList<RateAccrualPeriod> periods =
         test.createAccrualPeriods(ACCRUAL_SCHEDULE_STUBS, ACCRUAL_SCHEDULE_STUBS, REF_DATA);
     assertEquals(periods, ImmutableList.of(rap1, rap2, rap3));
+  }
+
+  public void test_expand_singlePeriod_stubCalcsInitialStub_interpolated() {
+    IborRateCalculation test = IborRateCalculation.builder()
+        .dayCount(ACT_365F)
+        .index(GBP_LIBOR_2M)
+        .fixingDateOffset(MINUS_TWO_DAYS)
+        .initialStub(IborRateStubCalculation.ofIborInterpolatedRate(GBP_LIBOR_1W, GBP_LIBOR_1M))
+        .build();
+    RateAccrualPeriod rap1 = RateAccrualPeriod.builder(ACCRUAL1STUB)
+        .yearFraction(ACCRUAL1STUB.yearFraction(ACT_365F, ACCRUAL_SCHEDULE_STUBS))
+        .rateComputation(IborInterpolatedRateComputation.of(GBP_LIBOR_1W, GBP_LIBOR_1M, DATE_01_06, REF_DATA))
+        .build();
+    ImmutableList<RateAccrualPeriod> periods =
+        test.createAccrualPeriods(SINGLE_ACCRUAL_SCHEDULE_STUB, SINGLE_ACCRUAL_SCHEDULE_STUB, REF_DATA);
+    assertEquals(periods, ImmutableList.of(rap1));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Handling for a single period swap with initial stub, where `Schedule` has a single stub period. 

* `isTerm()` only returns true when frequency is `Term`
* 'isSinglePeriod()` returns true if there is one period
* `getInitialStub()` returns a single period if it is a stub
* `getInitialStub()`, `getRegularPeriods()` and `getFinalStub()` form a set, with each period being in one of the three methods

