### PR TITLE
Repo curve without security ID

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLookupLegalEntityDiscountingProvider.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLookupLegalEntityDiscountingProvider.java
@@ -112,6 +112,15 @@ final class DefaultLookupLegalEntityDiscountingProvider
     return repoCurveDiscountFactors(repoGroup, currency);
   }
 
+  @Override
+  public RepoCurveDiscountFactors repoCurveDiscountFactors(StandardId issuerId, Currency currency) {
+    RepoGroup repoGroup = lookup.getRepoCurveGroups().get(issuerId);
+    if (repoGroup == null) {
+      throw new MarketDataNotFoundException("Unable to find repo curve mapping for ID: " + issuerId);
+    }
+    return repoCurveDiscountFactors(repoGroup, currency);
+  }
+
   // lookup the discount factors for the repo group
   private RepoCurveDiscountFactors repoCurveDiscountFactors(RepoGroup repoGroup, Currency currency) {
     CurveId curveId = lookup.getRepoCurves().get(Pair.of(repoGroup, currency));

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/ImmutableLegalEntityDiscountingProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/ImmutableLegalEntityDiscountingProvider.java
@@ -138,6 +138,15 @@ public final class ImmutableLegalEntityDiscountingProvider
     return repoCurveDiscountFactors(repoGroup, currency);
   }
 
+  @Override
+  public RepoCurveDiscountFactors repoCurveDiscountFactors(StandardId issuerId, Currency currency) {
+    RepoGroup repoGroup = repoCurveGroups.get(issuerId);
+    if (repoGroup == null) {
+      throw new IllegalArgumentException("Unable to find map for ID: " + issuerId);
+    }
+    return repoCurveDiscountFactors(repoGroup, currency);
+  }
+
   // lookup the discount factors for the repo group
   private RepoCurveDiscountFactors repoCurveDiscountFactors(RepoGroup repoGroup, Currency currency) {
     DiscountFactors discountFactors = repoCurves.get(Pair.of(repoGroup, currency));

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/LegalEntityDiscountingProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/LegalEntityDiscountingProvider.java
@@ -62,6 +62,22 @@ public interface LegalEntityDiscountingProvider {
       Currency currency);
 
   /**
+   * Gets the discount factors from a repo curve based on the issuer ID and currency.
+   * <p>
+   * This searches for a curve associated with the issuer ID and currency.
+   * <p>
+   * If the valuation date is on or after the specified date, the discount factor is 1.
+   * 
+   * @param issuerId  the standard ID of legal entity to get the discount factors for
+   * @param currency  the currency to get the discount factors for
+   * @return the discount factors
+   * @throws IllegalArgumentException if the discount factors are not available
+   */
+  public abstract RepoCurveDiscountFactors repoCurveDiscountFactors(
+      StandardId issuerId,
+      Currency currency);
+
+  /**
    * Gets the discount factors from an issuer based on the issuer ID and currency.
    * <p>
    * This searches for a curve associated with the issuer ID and currency.

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/ImmutableLegalEntityDiscountingProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/ImmutableLegalEntityDiscountingProviderTest.java
@@ -82,6 +82,7 @@ public class ImmutableLegalEntityDiscountingProviderTest {
         IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
     assertEquals(test.repoCurveDiscountFactors(ID_SECURITY, ID_ISSUER, GBP),
         RepoCurveDiscountFactors.of(DSC_FACTORS_REPO, GROUP_REPO_SECURITY));
+    assertThrowsIllegalArg(() -> test.repoCurveDiscountFactors(ID_ISSUER, GBP));
     assertEquals(test.getValuationDate(), DATE);
   }
 
@@ -98,6 +99,8 @@ public class ImmutableLegalEntityDiscountingProviderTest {
         test.issuerCurveDiscountFactors(ID_ISSUER, GBP),
         IssuerCurveDiscountFactors.of(DSC_FACTORS_ISSUER, GROUP_ISSUER));
     assertEquals(test.repoCurveDiscountFactors(ID_SECURITY, ID_ISSUER, GBP),
+        RepoCurveDiscountFactors.of(DSC_FACTORS_REPO, GROUP_REPO_ISSUER));
+    assertEquals(test.repoCurveDiscountFactors(ID_ISSUER, GBP),
         RepoCurveDiscountFactors.of(DSC_FACTORS_REPO, GROUP_REPO_ISSUER));
     assertEquals(test.getValuationDate(), DATE);
 


### PR DESCRIPTION
* Access a repo curve in `LegalEntityDiscountingProvider` without using `SecurityId`. 