### PR TITLE
Data lookup for repo rate curves

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLegalEntityDiscountingMarketDataLookup.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/bond/DefaultLegalEntityDiscountingMarketDataLookup.java
@@ -114,6 +114,29 @@ final class DefaultLegalEntityDiscountingMarketDataLookup
         repoCurveGroups, repoCurveIds, issuerCurveGroups, issuerCurveIds, obsSource);
   }
 
+  /**
+   * Obtains an instance based on maps for repo curves.
+   * <p>
+   * The repo curves are defined in two parts.
+   * The first part maps the issuer ID to a group, and the second part maps the
+   * group and currency to the identifier of the curve.
+   * <p>
+   * Issuer curves are not defined in the instance.
+   * 
+   * @param repoCurveGroups  the repo curve groups, mapping issuer ID to group
+   * @param repoCurveIds  the repo curve identifiers, keyed by repo group and currency
+   * @param obsSource  the source of market data for quotes and other observable market data
+   * @return the rates lookup containing the specified curves
+   */
+  public static DefaultLegalEntityDiscountingMarketDataLookup of(
+      Map<StandardId, RepoGroup> repoCurveGroups,
+      Map<Pair<RepoGroup, Currency>, CurveId> repoCurveIds,
+      ObservableSource obsSource) {
+
+    return new DefaultLegalEntityDiscountingMarketDataLookup(
+        repoCurveGroups, repoCurveIds, ImmutableMap.of(), ImmutableMap.of(), obsSource);
+  }
+
   @ImmutableValidator
   private void validate() {
     Set<RepoGroup> uniqueRepoGroups = new HashSet<>(repoCurveGroups.values());
@@ -163,6 +186,27 @@ final class DefaultLegalEntityDiscountingMarketDataLookup
     // result
     return FunctionRequirements.builder()
         .valueRequirements(ImmutableSet.of(repoCurveId, issuerCurveId))
+        .outputCurrencies(currency)
+        .observableSource(observableSource)
+        .build();
+  }
+
+  @Override
+  public FunctionRequirements requirements(StandardId issuerId, Currency currency) {
+    // repo
+    RepoGroup repoKey = repoCurveGroups.get(issuerId);
+    if (repoKey == null) {
+      throw new IllegalArgumentException(Messages.format(
+          "Legal entity discounting lookup has no repo curve defined for '{}'", issuerId));
+    }
+    CurveId repoCurveId = repoCurves.get(Pair.of(repoKey, currency));
+    if (repoCurveId == null) {
+      throw new IllegalArgumentException(Messages.format(
+          "Legal entity discounting lookup has no repo curve defined for '{}'", issuerId));
+    }
+    // result
+    return FunctionRequirements.builder()
+        .valueRequirements(ImmutableSet.of(repoCurveId))
         .outputCurrencies(currency)
         .observableSource(observableSource)
         .build();

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/bond/LegalEntityDiscountingMarketDataLookup.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/bond/LegalEntityDiscountingMarketDataLookup.java
@@ -115,6 +115,71 @@ public interface LegalEntityDiscountingMarketDataLookup extends CalculationParam
 
   //-------------------------------------------------------------------------
   /**
+   * Obtains an instance based on maps for repo curves.
+   * <p>
+   * The repo curves are defined in two parts.
+   * The first part maps the issuer ID to a group, and the second part maps the
+   * group and currency to the identifier of the curve.
+   * <p>
+   * Issuer curves are not defined in the instance.
+   * 
+   * @param repoCurveGroups  the repo curve groups, mapping issuer ID to group
+   * @param repoCurveIds  the repo curve identifiers, keyed by repo group and currency
+   * @return the rates lookup containing the specified curves
+   */
+  public static LegalEntityDiscountingMarketDataLookup of(
+      Map<StandardId, RepoGroup> repoCurveGroups,
+      Map<Pair<RepoGroup, Currency>, CurveId> repoCurveIds) {
+
+    return LegalEntityDiscountingMarketDataLookup.of(repoCurveGroups, repoCurveIds, ObservableSource.NONE);
+  }
+
+  /**
+   * Obtains an instance based on maps for repo curves.
+   * <p>
+   * The repo curves are defined in two parts.
+   * The first part maps the issuer ID to a group, and the second part maps the
+   * group and currency to the identifier of the curve.
+   * <p>
+   * Issuer curves are not defined in the instance.
+   * 
+   * @param repoCurveGroups  the repo curve groups, mapping issuer ID to group
+   * @param repoCurveIds  the repo curve identifiers, keyed by repo group and currency
+   * @param obsSource  the source of market data for quotes and other observable market data
+   * @return the rates lookup containing the specified curves
+   */
+  public static LegalEntityDiscountingMarketDataLookup of(
+      Map<StandardId, RepoGroup> repoCurveGroups,
+      Map<Pair<RepoGroup, Currency>, CurveId> repoCurveIds,
+      ObservableSource obsSource) {
+
+    return DefaultLegalEntityDiscountingMarketDataLookup.of(repoCurveGroups, repoCurveIds, obsSource);
+  }
+
+  /**
+   * Obtains an instance based on a curve group and group map.
+   * <p>
+   * The two maps define mapping from the issuer ID to a group.
+   * <p>
+   * Issuer curves are not defined in the instance.
+   * 
+   * @param curveGroup  the curve group to base the lookup on
+   * @param repoCurveGroups  the repo curve groups, mapping issuer ID to group
+   * @return the rates lookup containing the specified curves 
+   */
+  public static LegalEntityDiscountingMarketDataLookup of(
+      LegalEntityCurveGroup curveGroup,
+      Map<StandardId, RepoGroup> repoCurveGroups) {
+
+    CurveGroupName groupName = curveGroup.getName();
+    Map<Pair<RepoGroup, Currency>, CurveId> repoCurveIds = MapStream.of(curveGroup.getRepoCurves())
+        .mapValues(c -> CurveId.of(groupName, c.getName()))
+        .toMap();
+    return LegalEntityDiscountingMarketDataLookup.of(repoCurveGroups, repoCurveIds, ObservableSource.NONE);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Gets the type that the lookup will be queried by.
    * <p>
    * This returns {@code LegalEntityDiscountingMarketDataLookup.class}.
@@ -139,6 +204,16 @@ public interface LegalEntityDiscountingMarketDataLookup extends CalculationParam
    * @throws IllegalArgumentException if unable to create requirements
    */
   public abstract FunctionRequirements requirements(SecurityId securityId, StandardId issuerId, Currency currency);
+
+  /**
+   * Creates market data requirements for the specified issuer.
+   * 
+   * @param issuerId  the legal entity issuer ID
+   * @param currency  the currency of the security
+   * @return the requirements
+   * @throws IllegalArgumentException if unable to create requirements
+   */
+  public abstract FunctionRequirements requirements(StandardId issuerId, Currency currency);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/bond/LegalEntityDiscountingMarketDataLookupTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/bond/LegalEntityDiscountingMarketDataLookupTest.java
@@ -124,6 +124,37 @@ public class LegalEntityDiscountingMarketDataLookupTest {
         DefaultLookupLegalEntityDiscountingProvider.of((DefaultLegalEntityDiscountingMarketDataLookup) test, MOCK_MARKET_DATA));
   }
 
+  public void test_of_repoMap() {
+    ImmutableMap<StandardId, RepoGroup> repoGroups = ImmutableMap.of(
+        ISSUER_A, GROUP_REPO_X,
+        ISSUER_B, GROUP_REPO_Y,
+        ISSUER_C, GROUP_REPO_Y,
+        ISSUER_D, GROUP_REPO_Y);
+    ImmutableMap<Pair<RepoGroup, Currency>, CurveId> repoCurves = ImmutableMap.of(
+        Pair.of(GROUP_REPO_X, USD), CURVE_ID_USD1,
+        Pair.of(GROUP_REPO_Y, USD), CURVE_ID_USD2,
+        Pair.of(GROUP_REPO_Y, GBP), CURVE_ID_GBP1);
+    LegalEntityDiscountingMarketDataLookup test =
+        LegalEntityDiscountingMarketDataLookup.of(repoGroups, repoCurves);
+    assertEquals(test.queryType(), LegalEntityDiscountingMarketDataLookup.class);
+
+    assertEquals(
+        test.requirements(ISSUER_A, USD),
+        FunctionRequirements.builder().valueRequirements(CURVE_ID_USD1).outputCurrencies(USD).build());
+    assertEquals(
+        test.requirements(ISSUER_B, USD),
+        FunctionRequirements.builder().valueRequirements(CURVE_ID_USD2).outputCurrencies(USD).build());
+    assertEquals(
+        test.requirements(ISSUER_B, GBP),
+        FunctionRequirements.builder().valueRequirements(CURVE_ID_GBP1).outputCurrencies(GBP).build());
+    assertThrowsIllegalArg(() -> test.requirements(SEC_A2, ISSUER_A, USD));
+    assertThrowsIllegalArg(() -> test.requirements(StandardId.of("XXX", "XXX"), GBP));
+    assertThrowsIllegalArg(() -> test.requirements(ISSUER_A, GBP));
+    assertEquals(
+        test.discountingProvider(MOCK_MARKET_DATA),
+        DefaultLookupLegalEntityDiscountingProvider.of((DefaultLegalEntityDiscountingMarketDataLookup) test, MOCK_MARKET_DATA));
+  }
+
   //-------------------------------------------------------------------------
   public void test_of_map_invalid() {
     ImmutableMap<StandardId, RepoGroup> repoGroups = ImmutableMap.of(


### PR DESCRIPTION
* Allows `LegalEntityDiscountingMarketDataLookup` to have only repo rate curves. 
* This is used for repo pricing. 