### PR TITLE
Remove argument checker to allow pricing ON period starting in past.

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoader.java
@@ -591,7 +591,7 @@ public final class RatesCalibrationCsvLoader {
       CurveNodeDate date,
       CurveNodeDateOrder order) {
 
-    Matcher matcher = SIMPLE_YM_TIME_REGEX.matcher(timeStr.toUpperCase(Locale.ENGLISH));
+    Matcher matcher = SIMPLE_YMD_TIME_REGEX.matcher(timeStr.toUpperCase(Locale.ENGLISH));
     if (!matcher.matches()) {
       throw new IllegalArgumentException(Messages.format("Invalid time format for Fixed-Ibor swap: {}", timeStr));
     }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/DiscountOvernightIndexRates.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/DiscountOvernightIndexRates.java
@@ -218,7 +218,6 @@ public final class DiscountOvernightIndexRates
 
     LocalDate startDate = startDateObservation.getEffectiveDate();
     ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
-    ArgChecker.inOrderOrEqual(getValuationDate(), startDate, "valuationDate", "startDate");
     return OvernightRateSensitivity.ofPeriod(startDateObservation, endDate, 1d);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/DiscountOvernightIndexRatesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/DiscountOvernightIndexRatesTest.java
@@ -229,7 +229,7 @@ public class DiscountOvernightIndexRatesTest {
         .build();
     DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(USD_FED_FUND, df, series);
     OvernightIndexObservation obs = OvernightIndexObservation.of(USD_FED_FUND, gbdBeforeValDate, REF_DATA);
-    OvernightRateSensitivity expected = OvernightRateSensitivity.ofPeriod(obs, gbdAfterValDate, GBP, 1d);
+    OvernightRateSensitivity expected = OvernightRateSensitivity.ofPeriod(obs, gbdAfterValDate, USD, 1d);
     assertEquals(test.periodRatePointSensitivity(obs, gbdAfterValDate), expected);
   }
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/DiscountOvernightIndexRatesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/DiscountOvernightIndexRatesTest.java
@@ -215,10 +215,26 @@ public class DiscountOvernightIndexRatesTest {
     OvernightRateSensitivity expected = OvernightRateSensitivity.ofPeriod(GBP_SONIA_AFTER, DATE_AFTER_END, GBP, 1d);
     assertEquals(test.periodRatePointSensitivity(GBP_SONIA_AFTER, DATE_AFTER_END), expected);
   }
+  
+  public void test_periodRatePointSensitivity_onholidaybeforepublication() {
+    LocalDate lastFixingDate = LocalDate.of(2017, 6, 30);
+    LocalDate gbdBeforeValDate = LocalDate.of(2017, 7, 3);
+    LocalDate gbdAfterValDate = LocalDate.of(2017, 7, 5);
+    double fixingValue = 0.0010;
+    InterpolatedNodalCurve curve =
+        InterpolatedNodalCurve.of(METADATA, DoubleArray.of(-1.0d, 10.0d), DoubleArray.of(0.01, 0.02), INTERPOLATOR);
+    ZeroRateDiscountFactors df = ZeroRateDiscountFactors.of(USD, LocalDate.of(2017, 7, 4), curve);
+    LocalDateDoubleTimeSeries series = LocalDateDoubleTimeSeries.builder()
+        .put(lastFixingDate, fixingValue)
+        .build();
+    DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(USD_FED_FUND, df, series);
+    OvernightIndexObservation obs = OvernightIndexObservation.of(USD_FED_FUND, gbdBeforeValDate, REF_DATA);
+    OvernightRateSensitivity expected = OvernightRateSensitivity.ofPeriod(obs, gbdAfterValDate, GBP, 1d);
+    assertEquals(test.periodRatePointSensitivity(obs, gbdAfterValDate), expected);
+  }
 
   public void test_periodRatePointSensitivity_badDates() {
     DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, DFCURVE, SERIES);
-    assertThrowsIllegalArg(() -> test.periodRatePointSensitivity(GBP_SONIA_BEFORE, DATE_VAL));
     assertThrowsIllegalArg(() -> test.periodRatePointSensitivity(GBP_SONIA_AFTER_END, DATE_AFTER));
   }
 
@@ -229,7 +245,7 @@ public class DiscountOvernightIndexRatesTest {
     OvernightRateSensitivity point = OvernightRateSensitivity.ofPeriod(GBP_SONIA_AFTER, DATE_AFTER_END, GBP, 1d);
     assertEquals(test.parameterSensitivity(point).size(), 1);
   }
-
+  
   //-------------------------------------------------------------------------
   public void test_createParameterSensitivity() {
     DiscountOvernightIndexRates test = DiscountOvernightIndexRates.of(GBP_SONIA, DFCURVE, SERIES);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swap/SwapDummyData.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swap/SwapDummyData.java
@@ -18,6 +18,7 @@ import static com.opengamma.strata.product.swap.PriceIndexCalculationMethod.MONT
 import static com.opengamma.strata.product.swap.SwapLegType.FIXED;
 import static com.opengamma.strata.product.swap.SwapLegType.IBOR;
 
+import java.time.LocalDate;
 import java.time.Period;
 
 import com.opengamma.strata.basics.ReferenceData;
@@ -26,12 +27,14 @@ import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DayCounts;
 import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.index.FxIndexObservation;
 import com.opengamma.strata.basics.index.FxIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
 import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.common.PayReceive;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 import com.opengamma.strata.product.rate.IborRateComputation;
@@ -50,6 +53,7 @@ import com.opengamma.strata.product.swap.RatePaymentPeriod;
 import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.ResolvedSwapTrade;
+import com.opengamma.strata.product.swap.type.FixedOvernightSwapConventions;
 
 /**
  * Basic dummy objects used when the data within is not important.
@@ -411,6 +415,11 @@ public final class SwapDummyData {
    */
   public static final ResolvedSwap SWAP =
       ResolvedSwap.of(IBOR_SWAP_LEG_REC_GBP, FIXED_SWAP_LEG_PAY);
+  /**
+   * OvernightIndexedSwap.
+   */
+  public static final ResolvedSwap OIS = FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS
+      .createTrade(LocalDate.of(2017, 6, 28), Tenor.TENOR_1Y, BuySell.BUY, 1_000_000, 0.01, REF_DATA).getProduct().resolve(REF_DATA);
   /**
    * Cross currency swap.
    */


### PR DESCRIPTION
When valuation of ON coupons is done on a non-good business day and the ON date is published only at the end of the ON period, it is nessary to have a period which start before the valuation date, in general the good business day before the valuation date. 
This PR remove the ArgChecker for that retriction and add a test that check the sensitivity for ON coupons on that case.