### PR TITLE
SyntheticCurveCalibrator: market data without time series

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibrator.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.FxRateId;
 import com.opengamma.strata.data.ImmutableMarketData;
+import com.opengamma.strata.data.ImmutableMarketDataBuilder;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.MarketDataId;
 import com.opengamma.strata.market.curve.CurveDefinition;
@@ -143,6 +144,24 @@ public final class SyntheticCurveCalibrator {
       CurveGroupDefinition group,
       RatesProvider inputProvider,
       ReferenceData refData) {
+    
+    return marketData(group, inputProvider, true, refData);
+  }
+
+  /**
+   * Constructs the synthetic market data from an existing rates provider and the configuration of the new curves.
+   * 
+   * @param group  the curve group definition for the synthetic curves and instruments
+   * @param inputProvider  the input rates provider
+   * @param returnTimeSeries  flag indicating if the time series present in the input RatesProvider should be returned
+   * @param refData  the reference data, used to resolve the trades
+   * @return the market data
+   */
+  public ImmutableMarketData marketData(
+      CurveGroupDefinition group,
+      RatesProvider inputProvider,
+      boolean returnTimeSeries,
+      ReferenceData refData) {
 
     // Retrieve the set of required indices and the list of required currencies
     Set<Index> indicesRequired = new HashSet<Index>();
@@ -150,11 +169,6 @@ public final class SyntheticCurveCalibrator {
     for (CurveGroupEntry entry : group.getEntries()) {
       indicesRequired.addAll(entry.getIndices());
       ccyRequired.addAll(entry.getDiscountCurrencies());
-    }
-    // Retrieve the required time series if present in the original provider
-    Map<IndexQuoteId, LocalDateDoubleTimeSeries> ts = new HashMap<>();
-    for (Index idx : indicesRequired) {
-      ts.put(IndexQuoteId.of(idx), inputProvider.timeSeries(idx));
     }
 
     LocalDate valuationDate = inputProvider.getValuationDate();
@@ -188,9 +202,16 @@ public final class SyntheticCurveCalibrator {
       FxRateId fxId = FxRateId.of(ccyPair);
       mapIdSy.put(fxId, FxRate.of(ccyPair, inputProvider.fxRate(ccyPair)));
     }
-    return ImmutableMarketData.builder(valuationDate)
-        .addValueMap(mapIdSy)
-        .addTimeSeriesMap(ts).build();
+    ImmutableMarketDataBuilder builder = ImmutableMarketData.builder(valuationDate);
+    if (returnTimeSeries) {
+      // Retrieve the required time series if present in the original provider
+      Map<IndexQuoteId, LocalDateDoubleTimeSeries> ts = new HashMap<>();
+      for (Index idx : indicesRequired) {
+        ts.put(IndexQuoteId.of(idx), inputProvider.timeSeries(idx));
+      }
+      builder.addTimeSeriesMap(ts);
+    }
+    return builder.addValueMap(mapIdSy).build();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibratorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibratorTest.java
@@ -175,10 +175,18 @@ public class SyntheticCurveCalibratorTest {
     }
   }
 
+  // Check synthetic calibration in case no time-series is requested
+  public void calibrate_ts_notrequested() {
+    MarketData mad = CALIBRATOR_SYNTHETIC.marketData(GROUPS_SYN_EUR, MULTICURVE_INPUT_EUR_TSLARGE, false, REF_DATA);
+    assertTrue(mad.getTimeSeriesIds().isEmpty());
+  }
+
   // Check synthetic calibration in the case of existing time-series with fixing on the valuation date
   public void calibrate_ts_vd() {
     SyntheticCurveCalibrator calibratorDefault = SyntheticCurveCalibrator.standard();
     MarketData mad = calibratorDefault.marketData(GROUPS_SYN_EUR, MULTICURVE_INPUT_EUR_TSLARGE, REF_DATA);
+    MarketData mad2 = calibratorDefault.marketData(GROUPS_SYN_EUR, MULTICURVE_INPUT_EUR_TSLARGE, true, REF_DATA);
+    assertEquals(mad.getTimeSeriesIds().isEmpty(), mad2.getTimeSeriesIds().isEmpty());
     RatesProvider multicurveSyn = CALIBRATOR_SYNTHETIC.calibrate(GROUPS_SYN_EUR, MULTICURVE_INPUT_EUR_TSLARGE, REF_DATA);
     for (CurveDefinition entry : GROUPS_SYN_EUR.getCurveDefinitions()) {
       ImmutableList<CurveNode> nodes = entry.getNodes();


### PR DESCRIPTION
Added method to SyntheticCurveCalibrator which does not return the time-series from the input RatesProvider.