### PR TITLE
RatesProvider time-series query

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
@@ -141,6 +141,15 @@ final class DefaultLookupRatesProvider
         .collect(toImmutableSet());
   }
 
+  @Override
+  public ImmutableSet<Index> getTimeSeriesIndices() {
+    return marketData.getTimeSeriesIds().stream()
+        .filter(IndexQuoteId.class::isInstance)
+        .map(IndexQuoteId.class::cast)
+        .map(id -> id.getIndex())
+        .collect(toImmutableSet());
+  }
+
   //-------------------------------------------------------------------------
   @Override
   public <T> T data(MarketDataId<T> key) {
@@ -182,8 +191,9 @@ final class DefaultLookupRatesProvider
   //-------------------------------------------------------------------------
   @Override
   public FxIndexRates fxIndexRates(FxIndex index) {
+    LocalDateDoubleTimeSeries fixings = timeSeries(index);
     FxForwardRates fxForwardRates = fxForwardRates(index.getCurrencyPair());
-    return ForwardFxIndexRates.of(index, fxForwardRates, timeSeries(index));
+    return ForwardFxIndexRates.of(index, fxForwardRates, fixings);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
@@ -166,6 +166,10 @@ public class RatesMarketDataLookupTest {
     assertEquals(ratesProvider.findData(CURVE_ID_DSC.getCurveName()), Optional.of(dscCurve));
     assertEquals(ratesProvider.findData(CURVE_ID_FWD.getCurveName()), Optional.of(fwdCurve));
     assertEquals(ratesProvider.findData(CurveName.of("Rubbish")), Optional.empty());
+    assertEquals(ratesProvider.getIborIndices(), ImmutableSet.of(USD_LIBOR_3M));
+    assertEquals(ratesProvider.getOvernightIndices(), ImmutableSet.of(USD_FED_FUND));
+    assertEquals(ratesProvider.getPriceIndices(), ImmutableSet.of(US_CPI_U));
+    assertEquals(ratesProvider.getTimeSeriesIndices(), ImmutableSet.of());
     // check discount factors
     SimpleDiscountFactors df = (SimpleDiscountFactors) ratesProvider.discountFactors(USD);
     assertEquals(df.getCurve().getName(), dscCurve.getName());

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibrator.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
@@ -153,7 +154,7 @@ public final class SyntheticCurveCalibrator {
     }
     // Retrieve the required time series if present in the original provider
     Map<IndexQuoteId, LocalDateDoubleTimeSeries> ts = new HashMap<>();
-    for (Index idx : indicesRequired) {
+    for (Index idx : Sets.intersection(inputProvider.getTimeSeriesIndices(), indicesRequired)) {
       ts.put(IndexQuoteId.of(idx), inputProvider.timeSeries(idx));
     }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
@@ -178,6 +178,11 @@ public final class ImmutableRatesProvider
         .collect(toImmutableSet());
   }
 
+  @Override
+  public ImmutableSet<Index> getTimeSeriesIndices() {
+    return timeSeries.keySet();
+  }
+
   //-------------------------------------------------------------------------
   @Override
   public <T> Optional<T> findData(MarketDataName<T> name) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.pricer.rate;
 import java.util.Optional;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.basics.index.FxIndex;
@@ -45,6 +46,9 @@ public interface RatesProvider
 
   /**
    * Gets the set of Ibor indices that are available.
+   * <p>
+   * If an index is present in the result of this method, then
+   * {@link #iborIndexRates(IborIndex)} should not throw an exception.
    *
    * @return the set of Ibor indices
    */
@@ -52,6 +56,9 @@ public interface RatesProvider
 
   /**
    * Gets the set of Overnight indices that are available.
+   * <p>
+   * If an index is present in the result of this method, then
+   * {@link #overnightIndexRates(OvernightIndex)} should not throw an exception.
    *
    * @return the set of Overnight indices
    */
@@ -59,10 +66,31 @@ public interface RatesProvider
 
   /**
    * Gets the set of Price indices that are available.
+   * <p>
+   * If an index is present in the result of this method, then
+   * {@link #priceIndexValues(PriceIndex)} should not throw an exception.
    *
    * @return the set of Price indices
    */
   public abstract Set<PriceIndex> getPriceIndices();
+
+  /**
+   * Gets the set of indices that have time-series available.
+   * <p>
+   * Note that the method {@link #timeSeries(Index)} returns an empty time-series
+   * when the index is not known, thus this method is useful to determine if there
+   * actually is a time-series in the underlying data.
+   *
+   * @return the set of indices with time-series
+   */
+  public default Set<Index> getTimeSeriesIndices() {
+    // imperfect implementation for compatibility
+    return ImmutableSet.<Index>builder()
+        .addAll(getIborIndices())
+        .addAll(getOvernightIndices())
+        .addAll(getPriceIndices())
+        .build();
+  }
 
   //-------------------------------------------------------------------------
   /**
@@ -235,7 +263,7 @@ public interface RatesProvider
    * This returns time series for the index.
    * 
    * @param index  the index
-   * @return the time series
+   * @return the time series, empty if time-series not found
    */
   public abstract LocalDateDoubleTimeSeries timeSeries(Index index);
 

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibratorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/SyntheticCurveCalibratorTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -158,6 +159,10 @@ public class SyntheticCurveCalibratorTest {
         }
       }
     }
+    assertEquals(madTsEmpty.getTimeSeriesIds(), ImmutableSet.of());
+    assertEquals(
+        madTsLarge.getTimeSeriesIds(),
+        ImmutableSet.of(IndexQuoteId.of(EUR_EURIBOR_3M), IndexQuoteId.of(EUR_EURIBOR_6M)));
   }
 
   // Check synthetic calibration in case no time-series is present
@@ -173,6 +178,7 @@ public class SyntheticCurveCalibratorTest {
         assertEquals(mqIn, mqSy, TOLERANCE_MQ);
       }
     }
+    assertEquals(mad.getTimeSeriesIds(), ImmutableSet.of());
   }
 
   // Check synthetic calibration in the case of existing time-series with fixing on the valuation date

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
@@ -82,6 +82,11 @@ public class MockRatesProvider
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public ImmutableSet<Index> getTimeSeriesIndices() {
+    throw new UnsupportedOperationException();
+  }
+
   //-------------------------------------------------------------------------
   @Override
   public <T> T data(MarketDataId<T> key) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
@@ -26,6 +26,7 @@ import org.joda.beans.ser.JodaBeanSer;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxMatrix;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -118,6 +119,7 @@ public class ImmutableRatesProviderTest {
         .build();
     assertEquals(test.fxIndexRates(GBP_USD_WM).getIndex(), GBP_USD_WM);
     assertEquals(test.fxIndexRates(GBP_USD_WM).getFixings(), ts);
+    assertEquals(test.getTimeSeriesIndices(), ImmutableSet.of(GBP_USD_WM));
   }
 
   //-------------------------------------------------------------------------
@@ -144,6 +146,8 @@ public class ImmutableRatesProviderTest {
         .build();
     assertEquals(test.iborIndexRates(USD_LIBOR_3M).getIndex(), USD_LIBOR_3M);
     assertEquals(test.iborIndexRates(USD_LIBOR_3M).getFixings(), ts);
+    assertEquals(test.getIborIndices(), ImmutableSet.of(USD_LIBOR_3M));
+    assertEquals(test.getTimeSeriesIndices(), ImmutableSet.of(USD_LIBOR_3M));
   }
 
   //-------------------------------------------------------------------------
@@ -155,6 +159,8 @@ public class ImmutableRatesProviderTest {
         .build();
     assertEquals(test.overnightIndexRates(USD_FED_FUND).getIndex(), USD_FED_FUND);
     assertEquals(test.overnightIndexRates(USD_FED_FUND).getFixings(), ts);
+    assertEquals(test.getOvernightIndices(), ImmutableSet.of(USD_FED_FUND));
+    assertEquals(test.getTimeSeriesIndices(), ImmutableSet.of(USD_FED_FUND));
   }
 
   //-------------------------------------------------------------------------
@@ -166,6 +172,8 @@ public class ImmutableRatesProviderTest {
         .build();
     assertEquals(test.priceIndexValues(GB_RPI).getIndex(), GB_RPI);
     assertEquals(test.priceIndexValues(GB_RPI).getFixings(), ts);
+    assertEquals(test.getPriceIndices(), ImmutableSet.of(GB_RPI));
+    assertEquals(test.getTimeSeriesIndices(), ImmutableSet.of(GB_RPI));
   }
 
   public void test_priceIndexValues_notKnown() {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimpleRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimpleRatesProvider.java
@@ -124,6 +124,11 @@ public final class SimpleRatesProvider
     return ImmutableSet.of();
   }
 
+  @Override
+  public ImmutableSet<Index> getTimeSeriesIndices() {
+    return ImmutableSet.of();
+  }
+
   //-------------------------------------------------------------------------
   @Override
   public <T> T data(MarketDataId<T> key) {


### PR DESCRIPTION
New method in `RatesProvider` - `getTimeSeriesIndices()`
Callers can now determine if a time-series exists in underlying data
Use in `SyntheticCurveCalibrator`