### PR TITLE
Extend FpML support to handle multiple parties

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/fpml/FpmlPartySelector.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/fpml/FpmlPartySelector.java
@@ -5,7 +5,9 @@
  */
 package com.opengamma.strata.loader.fpml;
 
-import java.util.Optional;
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
+
+import java.util.List;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ListMultimap;
@@ -48,8 +50,9 @@ public interface FpmlPartySelector {
   public static FpmlPartySelector matching(String partyId) {
     return allParties -> allParties.entries().stream()
         .filter(e -> e.getValue().equals(partyId))
-        .findFirst()
-        .map(e -> e.getKey());
+        .map(e -> e.getKey())
+        .distinct()
+        .collect(toImmutableList());
   }
 
   /**
@@ -64,17 +67,19 @@ public interface FpmlPartySelector {
   public static FpmlPartySelector matchingRegex(Pattern partyIdRegex) {
     return allParties -> allParties.entries().stream()
         .filter(e -> partyIdRegex.matcher(e.getValue()).matches())
-        .findFirst()
-        .map(e -> e.getKey());
+        .map(e -> e.getKey())
+        .distinct()
+        .collect(toImmutableList());
   }
 
   //-------------------------------------------------------------------------
   /**
-   * Selects "our" party from the specified set.
+   * Given a map of all parties in the FpML document, extract those that
+   * represent "our" side of the trade.
    * 
    * @param allParties  the multimap of party href id to associated partyId
-   * @return the party href id to use, empty if unable to find "our" party
+   * @return the party href ids to use, empty if unable to find "our" party
    */
-  public abstract Optional<String> selectParty(ListMultimap<String, String> allParties);
+  public abstract List<String> selectParties(ListMultimap<String, String> allParties);
 
 }

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlPartySelectorTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlPartySelectorTest.java
@@ -7,11 +7,11 @@ package com.opengamma.strata.loader.fpml;
 
 import static org.testng.Assert.assertEquals;
 
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 
@@ -21,24 +21,26 @@ import com.google.common.collect.ListMultimap;
 @Test
 public class FpmlPartySelectorTest {
 
-  private static final ListMultimap<String, String> MAP = ImmutableListMultimap.of("A", "a1", "A", "a2", "B", "b");
+  private static final ListMultimap<String, String> MAP =
+      ImmutableListMultimap.of("A", "a1", "A", "a2", "B", "b", "C1", "c1", "C2", "c2");
 
   //-------------------------------------------------------------------------
-  public void test_auto() {
-    assertEquals(FpmlPartySelector.any().selectParty(MAP), Optional.empty());
+  public void test_any() {
+    assertEquals(FpmlPartySelector.any().selectParties(MAP), ImmutableList.of());
   }
 
   public void test_matching() {
-    assertEquals(FpmlPartySelector.matching("a1").selectParty(MAP), Optional.of("A"));
-    assertEquals(FpmlPartySelector.matching("a2").selectParty(MAP), Optional.of("A"));
-    assertEquals(FpmlPartySelector.matching("b").selectParty(MAP), Optional.of("B"));
-    assertEquals(FpmlPartySelector.matching("c").selectParty(MAP), Optional.empty());
+    assertEquals(FpmlPartySelector.matching("a1").selectParties(MAP), ImmutableList.of("A"));
+    assertEquals(FpmlPartySelector.matching("a2").selectParties(MAP), ImmutableList.of("A"));
+    assertEquals(FpmlPartySelector.matching("b").selectParties(MAP), ImmutableList.of("B"));
+    assertEquals(FpmlPartySelector.matching("c").selectParties(MAP), ImmutableList.of());
   }
 
   public void test_matchingRegex() {
-    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("a[12]")).selectParty(MAP), Optional.of("A"));
-    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("b")).selectParty(MAP), Optional.of("B"));
-    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("c")).selectParty(MAP), Optional.empty());
+    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("a[12]")).selectParties(MAP), ImmutableList.of("A"));
+    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("b")).selectParties(MAP), ImmutableList.of("B"));
+    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("c[0-9]")).selectParties(MAP), ImmutableList.of("C1", "C2"));
+    assertEquals(FpmlPartySelector.matchingRegex(Pattern.compile("d")).selectParties(MAP), ImmutableList.of());
   }
 
 }

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/bullet-payment-weird.xml
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/bullet-payment-weird.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataDocument xmlns="http://www.fpml.org/FpML-5/confirmation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" fpmlVersion="5-6" xsi:schemaLocation="http://www.fpml.org/FpML-5/confirmation ../../fpml-main-5-6.xsd http://www.w3.org/2000/09/xmldsig# ../../xmldsig-core-schema.xsd">
+  <trade>
+    <tradeHeader>
+      <partyTradeIdentifier>
+        <partyReference href="party1a" />
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">123</tradeId>
+      </partyTradeIdentifier>
+      <partyTradeIdentifier>
+        <partyReference href="party2a" />
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">223</tradeId>
+      </partyTradeIdentifier>
+      <tradeDate>2001-04-29</tradeDate>
+    </tradeHeader>
+    <bulletPayment>
+      <payment>
+        <payerPartyReference href="party1a" />
+        <receiverPartyReference href="party2a" />
+        <paymentAmount>
+          <currency>USD</currency>
+          <amount>15000.00</amount>
+        </paymentAmount>
+        <paymentDate>
+          <unadjustedDate>2001-07-27</unadjustedDate>
+          <dateAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCenters id="businessCenters0">
+              <businessCenter>GBLO</businessCenter>
+              <businessCenter>USNY</businessCenter>
+            </businessCenters>
+          </dateAdjustments>
+        </paymentDate>
+      </payment>
+    </bulletPayment>
+  </trade>
+  <trade>
+    <tradeHeader>
+      <partyTradeIdentifier>
+        <partyReference href="party1b" />
+        <tradeId tradeIdScheme="http://www.partyA.com/trade-id">124</tradeId>
+      </partyTradeIdentifier>
+      <partyTradeIdentifier>
+        <partyReference href="party2b" />
+        <tradeId tradeIdScheme="http://www.partyB.com/trade-id">224</tradeId>
+      </partyTradeIdentifier>
+      <tradeDate>2001-04-29</tradeDate>
+    </tradeHeader>
+    <bulletPayment>
+      <payment>
+        <payerPartyReference href="party2b" />
+        <receiverPartyReference href="party1b" />
+        <paymentAmount>
+          <currency>USD</currency>
+          <amount>15000.00</amount>
+        </paymentAmount>
+        <paymentDate>
+          <unadjustedDate>2001-08-27</unadjustedDate>
+          <dateAdjustments>
+            <businessDayConvention>MODFOLLOWING</businessDayConvention>
+            <businessCenters id="businessCenters0">
+              <businessCenter>GBLO</businessCenter>
+              <businessCenter>USNY</businessCenter>
+            </businessCenters>
+          </dateAdjustments>
+        </paymentDate>
+      </payment>
+    </bulletPayment>
+  </trade>
+  <party id="party1a">
+    <partyId>Party1a</partyId>
+  </party>
+  <party id="party2a">
+    <partyId>Party2a</partyId>
+  </party>
+  <party id="party1b">
+    <partyId>Party1b</partyId>
+  </party>
+  <party id="party2b">
+    <partyId>Party2b</partyId>
+  </party>
+</dataDocument>
+


### PR DESCRIPTION
The FpML parser did not handle an edge case where our party
has multiple party xml tags, potentially due to merging
separate FpML documents into one multi-trade document
To fix this required an incompatible change to `FpmlPartySelector`