### PR TITLE
SimplePriceIndexValues: Time series item in future

### DIFF
--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondPaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondPaymentPeriodPricerTest.java
@@ -80,8 +80,8 @@ public class DiscountingCapitalIndexedBondPaymentPeriodPricerTest {
       .build();
   // rates providers
   private static final LocalDate VALUATION_BEFORE_START = LocalDate.of(2007, 10, 9);
-  private static final LocalDate VALUATION_ON_FIX = LocalDate.of(2008, 4, 29);
-  private static final LocalDate VALUATION_AFTER_FIX = LocalDate.of(2008, 5, 20);
+  private static final LocalDate VALUATION_ON_FIX = LocalDate.of(2008, 5, 29);
+  private static final LocalDate VALUATION_AFTER_FIX = LocalDate.of(2008, 6, 20);
   private static final LocalDate VALUATION_AFTER_PAY = LocalDate.of(2008, 8, 9);
   private static final double Z_SPREAD = 0.005;
   private static final int PERIOD_PER_YEAR = 4;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimplePriceIndexValuesTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/SimplePriceIndexValuesTest.java
@@ -45,6 +45,7 @@ import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 public class SimplePriceIndexValuesTest {
 
   private static final LocalDate VAL_DATE = LocalDate.of(2015, 5, 3);
+  private static final LocalDate VAL_DATE_2 = LocalDate.of(2015, 2, 6);
   private static final YearMonth VAL_MONTH = YearMonth.of(2015, 5);
 
   // USD HICP, CPURNSA Index
@@ -78,17 +79,26 @@ public class SimplePriceIndexValuesTest {
       1.002754153722096, 1.001058905136103, 1.006398754528882, 1.000862459308375,
       0.998885402944655, 0.995571243121412, 1.001419845026233, 1.001663068058397,
       0.999147014890734, 0.998377467899150, 0.999570726482709, 0.994346721844999);
+  private static final SeasonalityDefinition SEASONALITY_DEF = 
+      SeasonalityDefinition.of(SEASONALITY_MULTIPLICATIVE, ShiftType.SCALED);
+  private static final InflationNodalCurve CURVE_INFL = InflationNodalCurve
+      .of(CURVE_NOFIX, VAL_DATE, YearMonth.from(USCPI_TS.getLatestDate()), USCPI_TS.getLatestValue(), SEASONALITY_DEF);
+  private static final InflationNodalCurve CURVE_INFL2 = InflationNodalCurve
+      .of(CURVE_NOFIX, VAL_DATE_2, YearMonth.of(2014, 12), USCPI_TS.get(LocalDate.of(2014, 12, 31)).getAsDouble(), SEASONALITY_DEF);
   private static final SimplePriceIndexValues INSTANCE =
-      SimplePriceIndexValues.of(US_CPI_U, VAL_DATE, CURVE_NOFIX, USCPI_TS);
+      SimplePriceIndexValues.of(US_CPI_U, VAL_DATE, CURVE_INFL, USCPI_TS);
+  private static final SimplePriceIndexValues INSTANCE_WITH_FUTFIXING =
+      SimplePriceIndexValues.of(US_CPI_U, VAL_DATE_2, CURVE_INFL2, USCPI_TS);
 
   private static final YearMonth[] TEST_MONTHS = new YearMonth[] {
-      YearMonth.of(2015, 1), YearMonth.of(2015, 5), YearMonth.of(2016, 5), YearMonth.of(2016, 6), YearMonth.of(2024, 12)};
-  private static final PriceIndexObservation[] TEST_OBS = new PriceIndexObservation[] {
-      PriceIndexObservation.of(US_CPI_U, YearMonth.of(2015, 1)),
-      PriceIndexObservation.of(US_CPI_U, YearMonth.of(2015, 5)),
-      PriceIndexObservation.of(US_CPI_U, YearMonth.of(2016, 5)),
-      PriceIndexObservation.of(US_CPI_U, YearMonth.of(2016, 6)),
-      PriceIndexObservation.of(US_CPI_U, YearMonth.of(2024, 12))};
+      YearMonth.of(2015, 1), YearMonth.of(2015, 2), YearMonth.of(2015, 5), YearMonth.of(2016, 5), YearMonth.of(2016, 6),
+      YearMonth.of(2024, 12)};
+  private static final PriceIndexObservation[] TEST_OBS = new PriceIndexObservation[TEST_MONTHS.length];
+  static {
+    for (int i = 0; i < TEST_MONTHS.length; i++) {
+      TEST_OBS[i] = PriceIndexObservation.of(US_CPI_U, TEST_MONTHS[i]);
+    }
+  }
   private static final double TOLERANCE_VALUE = 1.0E-10;
   private static final double TOLERANCE_DELTA = 1.0E-6;
 
@@ -206,7 +216,23 @@ public class SimplePriceIndexValuesTest {
         valueExpected = USCPI_TS.get(fixingMonth.atEndOfMonth()).getAsDouble();
       } else {
         double x = YearMonth.from(VAL_DATE).until(fixingMonth, MONTHS);
-        valueExpected = CURVE_NOFIX.yValue(x);
+        valueExpected = CURVE_INFL.yValue(x);
+      }
+      assertEquals(valueComputed, valueExpected, TOLERANCE_VALUE, "test " + i);
+    }
+  }
+  
+  /* Test values when a fixing in the futures in present in the TS. */
+  public void test_value_futfixing() {
+    for (int i = 0; i < TEST_MONTHS.length; i++) {
+      double valueComputed = INSTANCE_WITH_FUTFIXING.value(TEST_OBS[i]);
+      YearMonth fixingMonth = TEST_OBS[i].getFixingMonth();
+      double valueExpected;
+      if (fixingMonth.isBefore(YearMonth.from(VAL_DATE_2)) && USCPI_TS.containsDate(fixingMonth.atEndOfMonth())) {
+        valueExpected = USCPI_TS.get(fixingMonth.atEndOfMonth()).getAsDouble();
+      } else {
+        double x = YearMonth.from(VAL_DATE_2).until(fixingMonth, MONTHS);
+        valueExpected = CURVE_INFL2.yValue(x);
       }
       assertEquals(valueComputed, valueExpected, TOLERANCE_VALUE, "test " + i);
     }
@@ -226,6 +252,20 @@ public class SimplePriceIndexValuesTest {
     }
   }
 
+  public void test_value_pts_sensitivity_futfixing() {
+    for (int i = 0; i < TEST_MONTHS.length; i++) {
+      PointSensitivityBuilder ptsComputed = INSTANCE_WITH_FUTFIXING.valuePointSensitivity(TEST_OBS[i]);
+      YearMonth fixingMonth = TEST_OBS[i].getFixingMonth();
+      PointSensitivityBuilder ptsExpected;
+      if (fixingMonth.isBefore(YearMonth.from(VAL_DATE_2)) && USCPI_TS.containsDate(fixingMonth.atEndOfMonth())) {
+        ptsExpected = PointSensitivityBuilder.none();
+      } else {
+        ptsExpected = InflationRateSensitivity.of(TEST_OBS[i], 1d);
+      }
+      assertTrue(ptsComputed.build().equalWithTolerance(ptsExpected.build(), TOLERANCE_VALUE), "test " + i);
+    }
+  }
+
   public void test_value_parameter_sensitivity() {
     for (int i = 0; i < TEST_MONTHS.length; i++) {
       YearMonth fixingMonth = TEST_OBS[i].getFixingMonth();
@@ -233,7 +273,22 @@ public class SimplePriceIndexValuesTest {
         InflationRateSensitivity ptsExpected = (InflationRateSensitivity) InflationRateSensitivity.of(TEST_OBS[i], 1d);
         CurrencyParameterSensitivities psComputed = INSTANCE.parameterSensitivity(ptsExpected);
         double x = YearMonth.from(VAL_DATE).until(fixingMonth, MONTHS);
-        UnitParameterSensitivities sens1 = UnitParameterSensitivities.of(CURVE_NOFIX.yValueParameterSensitivity(x));
+        UnitParameterSensitivities sens1 = UnitParameterSensitivities.of(CURVE_INFL.yValueParameterSensitivity(x));
+        CurrencyParameterSensitivities psExpected =
+            sens1.multipliedBy(ptsExpected.getCurrency(), ptsExpected.getSensitivity());
+        assertTrue(psComputed.equalWithTolerance(psExpected, TOLERANCE_DELTA), "test " + i);
+      }
+    }
+  }
+
+  public void test_value_parameter_sensitivity_futfixing() {
+    for (int i = 0; i < TEST_MONTHS.length; i++) {
+      YearMonth fixingMonth = TEST_OBS[i].getFixingMonth();
+      if (!fixingMonth.isBefore(YearMonth.from(VAL_DATE_2)) && !USCPI_TS.containsDate(fixingMonth.atEndOfMonth())) {
+        InflationRateSensitivity ptsExpected = (InflationRateSensitivity) InflationRateSensitivity.of(TEST_OBS[i], 1d);
+        CurrencyParameterSensitivities psComputed = INSTANCE_WITH_FUTFIXING.parameterSensitivity(ptsExpected);
+        double x = YearMonth.from(VAL_DATE_2).until(fixingMonth, MONTHS);
+        UnitParameterSensitivities sens1 = UnitParameterSensitivities.of(CURVE_INFL2.yValueParameterSensitivity(x));
         CurrencyParameterSensitivities psExpected =
             sens1.multipliedBy(ptsExpected.getCurrency(), ptsExpected.getSensitivity());
         assertTrue(psComputed.equalWithTolerance(psExpected, TOLERANCE_DELTA), "test " + i);


### PR DESCRIPTION
Change SimplePriceIndexValues to not use TS results in the future of the valuation date. When the TS contains items with dates in the futures of the valuation date, those items are ignored. 
This is consistent with the way the SimpleIborIndexRates uses the time series.