### PR TITLE
Wrong constants in FloatingRateNames

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/FloatingRateNames.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/FloatingRateNames.java
@@ -120,31 +120,31 @@ public final class FloatingRateNames {
   /**
    * Constant for AUD-AONIA Overnight index.
    */
-  public static final OvernightIndex AUD_AONIA = OvernightIndex.of("AUD-AONIA");
+  public static final FloatingRateName AUD_AONIA = FloatingRateName.of("AUD-AONIA");
   /**
    * Constant for BRL-CDI Overnight index.
    */
-  public static final OvernightIndex BRL_CDI = OvernightIndex.of("BRL-CDI");
+  public static final FloatingRateName BRL_CDI = FloatingRateName.of("BRL-CDI");
   /**
    * Constant for CAD-CORRA Overnight index.
    */
-  public static final OvernightIndex CAD_CORRA = OvernightIndex.of("CAD-CORRA");
+  public static final FloatingRateName CAD_CORRA = FloatingRateName.of("CAD-CORRA");
   /**
    * Constant for DKK-TNR Overnight index.
    */
-  public static final OvernightIndex DKK_TNR = OvernightIndex.of("DKK-TNR");
+  public static final FloatingRateName DKK_TNR = FloatingRateName.of("DKK-TNR");
   /**
    * Constant for NOK-NOWA Overnight index.
    */
-  public static final OvernightIndex NOK_NOWA = OvernightIndex.of("NOK-NOWA");
+  public static final FloatingRateName NOK_NOWA = FloatingRateName.of("NOK-NOWA");
   /**
    * Constant for PLN-POLONIA Overnight index.
    */
-  public static final OvernightIndex PLN_POLONIA = OvernightIndex.of("PLN-POLONIA");
+  public static final FloatingRateName PLN_POLONIA = FloatingRateName.of("PLN-POLONIA");
   /**
    * Constant for SEK-SIOR Overnight index.
    */
-  public static final OvernightIndex SEK_SIOR = OvernightIndex.of("SEK-SIOR");
+  public static final FloatingRateName SEK_SIOR = FloatingRateName.of("SEK-SIOR");
 
   /**
    * Constant for USD-FED-FUND Overnight index using averaging.

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNameTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNameTest.java
@@ -19,6 +19,9 @@ import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
 import org.joda.beans.ImmutableBean;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -216,6 +219,17 @@ public class FloatingRateNameTest {
   public void test_nzd() {
     assertEquals(FloatingRateName.of("NZD-BKBM").getCurrency(), Currency.NZD);
     assertEquals(FloatingRateName.of("NZD-NZIONA").getCurrency(), Currency.NZD);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_types() {
+    // ensure no stupid copy and paste errors
+    Field[] fields = FloatingRateNames.class.getFields();
+    for (Field field : fields) {
+      if (Modifier.isPublic(field.getModifiers()) && Modifier.isStatic(field.getModifiers())) {
+        assertEquals(field.getType(), FloatingRateName.class);
+      }
+    }
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Constants should not be declared as `OvernightIndex` in class `FloatingRateNames`.
This is a backwards incompatible bug fix.