### PR TITLE
Add structured logging to FailureItem

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -124,23 +124,6 @@ public final class FailureItem
     return new FailureItem(reason, message, ImmutableMap.of(), stackTrace, null);
   }
 
-  /**
-   * Obtains a failure from a reason and message.
-   * <p>
-   * The failure will still have a stack trace, but the cause type will not be present.
-   * 
-   * @param reason  the reason
-   * @param message  the failure message, not empty
-   * @param attributes the attributes associated with this failure
-   * @return the failure
-   */
-  public static FailureItem of(FailureReason reason, String message, Map<String, String> attributes) {
-    ArgChecker.notNull(reason, "reason");
-    ArgChecker.notEmpty(message, "message");
-    String stackTrace = localGetStackTraceAsString(message, 1);
-    return new FailureItem(reason, message, attributes, stackTrace, null);
-  }
-
   private static String localGetStackTraceAsString(String message, int skipFrames) {
     StringBuilder builder = new StringBuilder();
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -224,7 +224,7 @@ public final class FailureItem
     if (firstLine.endsWith(": " + message)) {
       return reason + ": " + message + ": " + firstLine.substring(0, firstLine.length() - message.length() - 2);
     }
-    if(!attributes.isEmpty()) {
+    if (!attributes.isEmpty()) {
       return reason + ": " + message + ": " + firstLine + " : " + attributes;
     }
     return reason + ": " + message + ": " + firstLine;

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -104,7 +104,7 @@ public final class FailureItem
    */
   public static FailureItem of(FailureReason reason, String message, Object... messageArgs) {
     Pair<String, Map<String, String>> msg = Messages.formatWithAttributes(message, messageArgs);
-    return of(reason, msg.getFirst(), msg.getSecond(), 1);
+    return of(reason, msg.getFirst(), msg.getSecond());
   }
 
   /**
@@ -132,13 +132,12 @@ public final class FailureItem
    * @param reason  the reason
    * @param message  the failure message, not empty
    * @param attributes the attributes associated with this failure
-   * @param skipFrames  the number of caller frames to skip, not including this one
    * @return the failure
    */
-  public static FailureItem of(FailureReason reason, String message, Map<String, String> attributes, int skipFrames) {
+  public static FailureItem of(FailureReason reason, String message, Map<String, String> attributes) {
     ArgChecker.notNull(reason, "reason");
     ArgChecker.notEmpty(message, "message");
-    String stackTrace = localGetStackTraceAsString(message, skipFrames);
+    String stackTrace = localGetStackTraceAsString(message, 1);
     return new FailureItem(reason, message, attributes, stackTrace, null);
   }
 

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -65,6 +65,7 @@ public final class FailureItem
   private final String message;
   /**
    * The attributes associated with this failure.
+   * Attributes can contain additional information about the failure. For example, a line number in a file or the ID of a trade.
    */
   @PropertyDefinition(validate = "notNull")
   private final ImmutableMap<String, String> attributes;
@@ -86,7 +87,8 @@ public final class FailureItem
    * Obtains a failure from a reason and message.
    * <p>
    * The message is produced using a template that contains zero to many "{}" or "{abc}" placeholders.
-   * Each placeholder is replaced by the next available argument. If the placeholder is name, it will be added to the attributes map.
+   * Each placeholder is replaced by the next available argument.
+   * If the placeholder has a name, its value is added to the attributes map with the name as a key.
    * If there are too few arguments, then the message will be left with placeholders.
    * If there are too many arguments, then the excess arguments are appended to the
    * end of the message. No attempt is made to format the arguments.
@@ -129,11 +131,11 @@ public final class FailureItem
    * 
    * @param reason  the reason
    * @param message  the failure message, not empty
-   * @param attributes the attributes associated to this failure
+   * @param attributes the attributes associated with this failure
    * @param skipFrames  the number of caller frames to skip, not including this one
    * @return the failure
    */
-  static FailureItem of(FailureReason reason, String message, Map<String, String> attributes, int skipFrames) {
+  public static FailureItem of(FailureReason reason, String message, Map<String, String> attributes, int skipFrames) {
     ArgChecker.notNull(reason, "reason");
     ArgChecker.notEmpty(message, "message");
     String stackTrace = localGetStackTraceAsString(message, skipFrames);

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -273,7 +273,7 @@ public final class FailureItem
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the list of attributes associated with this failure.
+   * Gets the attributes associated with this failure.
    * @return the value of the property, not null
    */
   public ImmutableMap<String, String> getAttributes() {

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -124,6 +124,23 @@ public final class FailureItem
     return new FailureItem(reason, message, ImmutableMap.of(), stackTrace, null);
   }
 
+  /**
+   * Obtains a failure from a reason and message.
+   * <p>
+   * The failure will still have a stack trace, but the cause type will not be present.
+   *
+   * @param reason  the reason
+   * @param message  the failure message, not empty
+   * @param attributes the attributes associated with this failure
+   * @return the failure
+   */
+  private static FailureItem of(FailureReason reason, String message, Map<String, String> attributes) {
+    ArgChecker.notNull(reason, "reason");
+    ArgChecker.notEmpty(message, "message");
+    String stackTrace = localGetStackTraceAsString(message, 1);
+    return new FailureItem(reason, message, attributes, stackTrace, null);
+  }
+
   private static String localGetStackTraceAsString(String message, int skipFrames) {
     StringBuilder builder = new StringBuilder();
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -276,6 +276,7 @@ public final class FailureItem
   //-----------------------------------------------------------------------
   /**
    * Gets the attributes associated with this failure.
+   * Attributes can contain additional information about the failure. For example, a line number in a file or the ID of a trade.
    * @return the value of the property, not null
    */
   public ImmutableMap<String, String> getAttributes() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
@@ -9,6 +9,8 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 /**
  * Test {@link FailureItem}.
  */
@@ -79,6 +81,7 @@ public class FailureItemTest {
     IllegalArgumentException innerEx = new IllegalArgumentException("inner");
     IllegalArgumentException ex = new IllegalArgumentException("message", innerEx);
     FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "my {foo} {bar} failure", "big", "bad");
+    assertEquals(test.getAttributes(), ImmutableMap.of("foo", "big", "bar", "bad"));
     assertEquals(test.getReason(), FailureReason.INVALID);
     assertEquals(test.getMessage(), "my big bad failure");
     assertEquals(test.getCauseType().isPresent(), true);

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
@@ -75,4 +75,15 @@ public class FailureItemTest {
     assertEquals(test.toString(), "INVALID: my big bad failure: java.lang.IllegalArgumentException: message");
   }
 
+  public void test_of_reasonMessageExceptionNestedExceptionWithAttributes() {
+    IllegalArgumentException innerEx = new IllegalArgumentException("inner");
+    IllegalArgumentException ex = new IllegalArgumentException("message", innerEx);
+    FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "my {foo} {bar} failure", "big", "bad");
+    assertEquals(test.getReason(), FailureReason.INVALID);
+    assertEquals(test.getMessage(), "my big bad failure");
+    assertEquals(test.getCauseType().isPresent(), true);
+    assertEquals(test.getCauseType().get(), IllegalArgumentException.class);
+    assertEquals(test.getStackTrace().contains(".test_of_reasonMessageExceptionNestedExceptionWithAttributes("), true);
+    assertEquals(test.toString(), "INVALID: my big bad failure: java.lang.IllegalArgumentException: message : {bar=bad, foo=big}");
+  }
 }


### PR DESCRIPTION
Making changes to FailureItem in order to use structured logging, provided by `Messages.formatWithAttributes()`.

Added a unit test for this use case.