### PR TITLE
Control FX more effectively

### DIFF
--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
@@ -208,8 +208,12 @@ public final class CalculationTask implements ImmutableBean {
     // calculate the results
     Map<Measure, Result<?>> results = calculate(marketData, refData);
 
+    // get a suitable FX provider
+    ScenarioFxRateProvider fxProvider = parameters.findParameter(FxRateLookup.class)
+        .map(lookup -> LookupScenarioFxRateProvider.of(marketData, lookup))
+        .orElse(ScenarioFxRateProvider.of(marketData));
+
     // convert the results, using a normal loop for better stack traces
-    ScenarioFxRateProvider fxProvider = ScenarioFxRateProvider.of(marketData);
     ImmutableList.Builder<CalculationResult> resultBuilder = ImmutableList.builder();
     for (CalculationTaskCell cell : cells) {
       resultBuilder.add(cell.createResult(this, target, results, fxProvider, refData));

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultFxRateLookup.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/DefaultFxRateLookup.java
@@ -3,7 +3,7 @@
  *
  * Please see distribution for license.
  */
-package com.opengamma.strata.measure.rate;
+package com.opengamma.strata.calc.runner;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/FxRateLookup.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/FxRateLookup.java
@@ -3,7 +3,7 @@
  *
  * Please see distribution for license.
  */
-package com.opengamma.strata.measure.rate;
+package com.opengamma.strata.calc.runner;
 
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.FxMatrix;
@@ -16,11 +16,12 @@ import com.opengamma.strata.data.ObservableSource;
 /**
  * The lookup that provides access to FX rates in market data.
  * <p>
- * The FX rates lookup provides access to FX rates.
+ * An instance of {@link MarketData} can contain many different FX rates.
+ * This lookup allows a specific set of rates to be obtained.
  * <p>
  * Implementations of this interface must be immutable.
  */
-public interface FxRateLookup {
+public interface FxRateLookup extends CalculationParameter {
 
   /**
    * Obtains the standard instance.
@@ -104,6 +105,11 @@ public interface FxRateLookup {
   }
 
   //-------------------------------------------------------------------------
+  @Override
+  default Class<? extends CalculationParameter> queryType() {
+    return FxRateLookup.class;
+  }
+
   /**
    * Obtains an FX rate provider based on the specified market data.
    * <p>

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/LookupScenarioFxRateProvider.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/LookupScenarioFxRateProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.calc.runner;
+
+import java.io.Serializable;
+
+import com.opengamma.strata.basics.currency.FxRateProvider;
+import com.opengamma.strata.data.scenario.ScenarioFxRateProvider;
+import com.opengamma.strata.data.scenario.ScenarioMarketData;
+
+/**
+ * A provider of scenario FX rates that uses FX rate lookup.
+ * The use of {@link FxRateLookup} allows triangulation currency and observable source to be controlled.
+ */
+class LookupScenarioFxRateProvider
+    implements ScenarioFxRateProvider, Serializable {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * The market data for a set of scenarios.
+   */
+  private final ScenarioMarketData marketData;
+  /**
+   * The FX rate lookup.
+   */
+  private final FxRateLookup lookup;
+
+  // obtains an instance, returning the interface type to make type system happy at call site
+  static ScenarioFxRateProvider of(ScenarioMarketData marketData, FxRateLookup lookup) {
+    return new LookupScenarioFxRateProvider(marketData, lookup);
+  }
+
+  private LookupScenarioFxRateProvider(ScenarioMarketData marketData, FxRateLookup lookup) {
+    this.marketData = marketData;
+    this.lookup = lookup;
+  }
+
+  @Override
+  public int getScenarioCount() {
+    return marketData.getScenarioCount();
+  }
+
+  @Override
+  public FxRateProvider fxRateProvider(int scenarioIndex) {
+    return lookup.fxRateProvider(marketData.scenario(scenarioIndex));
+  }
+
+}

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/LookupScenarioFxRateProvider.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/LookupScenarioFxRateProvider.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.calc.runner;
 import java.io.Serializable;
 
 import com.opengamma.strata.basics.currency.FxRateProvider;
+import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.data.scenario.ScenarioFxRateProvider;
 import com.opengamma.strata.data.scenario.ScenarioMarketData;
 
@@ -36,8 +37,8 @@ class LookupScenarioFxRateProvider
   }
 
   private LookupScenarioFxRateProvider(ScenarioMarketData marketData, FxRateLookup lookup) {
-    this.marketData = marketData;
-    this.lookup = lookup;
+    this.marketData = ArgChecker.notNull(marketData, "marketData");
+    this.lookup = ArgChecker.notNull(lookup, "lookup");
   }
 
   @Override

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/MatrixFxRateLookup.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/MatrixFxRateLookup.java
@@ -3,7 +3,7 @@
  *
  * Please see distribution for license.
  */
-package com.opengamma.strata.measure.rate;
+package com.opengamma.strata.calc.runner;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationParametersTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationParametersTest.java
@@ -51,10 +51,24 @@ public class CalculationParametersTest {
     assertEquals(test.getParameters().size(), 0);
   }
 
-  public void getParameter() {
+  public void getParameter1() {
     CalculationParameters test = CalculationParameters.of(ImmutableList.of(PARAM));
     assertEquals(test.getParameter(TestParameter.class), PARAM);
     assertThrowsIllegalArg(() -> test.getParameter(TestParameter2.class));
+    assertThrowsIllegalArg(() -> test.getParameter(TestInterfaceParameter.class));
+    assertEquals(test.findParameter(TestParameter.class), Optional.of(PARAM));
+    assertEquals(test.findParameter(TestParameter2.class), Optional.empty());
+    assertEquals(test.findParameter(TestInterfaceParameter.class), Optional.empty());
+  }
+
+  public void getParameter2() {
+    CalculationParameters test = CalculationParameters.of(ImmutableList.of(PARAM2));
+    assertEquals(test.getParameter(TestParameter2.class), PARAM2);
+    assertEquals(test.getParameter(TestInterfaceParameter.class), PARAM2);
+    assertThrowsIllegalArg(() -> test.getParameter(TestParameter.class));
+    assertEquals(test.findParameter(TestParameter2.class), Optional.of(PARAM2));
+    assertEquals(test.findParameter(TestInterfaceParameter.class), Optional.of(PARAM2));
+    assertEquals(test.findParameter(TestParameter.class), Optional.empty());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/FxRateLookupTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/FxRateLookupTest.java
@@ -3,7 +3,7 @@
  *
  * Please see distribution for license.
  */
-package com.opengamma.strata.measure.rate;
+package com.opengamma.strata.calc.runner;
 
 import static com.opengamma.strata.basics.currency.Currency.EUR;
 import static com.opengamma.strata.basics.currency.Currency.GBP;

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/TestInterfaceParameter.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/TestInterfaceParameter.java
@@ -6,8 +6,8 @@
 package com.opengamma.strata.calc.runner;
 
 /**
- * Test implementation of {@link CalculationParameter}.
+ * Test interface of {@link CalculationParameter}.
  */
-public class TestParameter2 implements CalculationParameter, TestInterfaceParameter {
+public interface TestInterfaceParameter extends CalculationParameter {
 
 }

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultRatesMarketDataLookup.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultRatesMarketDataLookup.java
@@ -19,6 +19,7 @@ import org.joda.beans.TypedMetaBean;
 import org.joda.beans.gen.BeanDefinition;
 import org.joda.beans.gen.PropertyDefinition;
 import org.joda.beans.impl.light.LightMetaBean;
+import org.joda.convert.RenameHandler;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -29,6 +30,7 @@ import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.calc.CalculationRules;
 import com.opengamma.strata.calc.runner.CalculationParameter;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
+import com.opengamma.strata.calc.runner.FxRateLookup;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.MarketDataId;
@@ -51,6 +53,20 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
 @BeanDefinition(style = "light")
 final class DefaultRatesMarketDataLookup
     implements RatesMarketDataLookup, ImmutableBean, Serializable {
+
+  static {
+    // these classes have been moved
+    try {
+      RenameHandler.INSTANCE.renamedType(
+          "com.opengamma.strata.measure.rate.DefaultFxRateLookup",
+          Class.forName("com.opengamma.strata.calc.runner.DefaultFxRateLookup"));
+      RenameHandler.INSTANCE.renamedType(
+          "com.opengamma.strata.measure.rate.MatrixFxRateLookup",
+          Class.forName("com.opengamma.strata.calc.runner.MatrixFxRateLookup"));
+    } catch (ReflectiveOperationException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
 
   /**
    * The discount curves in the group, keyed by currency.

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/RatesMarketDataLookup.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/RatesMarketDataLookup.java
@@ -17,6 +17,7 @@ import com.opengamma.strata.calc.CalculationRules;
 import com.opengamma.strata.calc.runner.CalculationParameter;
 import com.opengamma.strata.calc.runner.CalculationParameters;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
+import com.opengamma.strata.calc.runner.FxRateLookup;
 import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.MarketDataId;
@@ -43,7 +44,7 @@ import com.opengamma.strata.pricer.rate.RatesProvider;
  * <p>
  * Implementations of this interface must be immutable.
  */
-public interface RatesMarketDataLookup extends CalculationParameter {
+public interface RatesMarketDataLookup extends FxRateLookup, CalculationParameter {
 
   /**
    * Obtains an instance based on a map of discount and forward curve identifiers.
@@ -333,6 +334,7 @@ public interface RatesMarketDataLookup extends CalculationParameter {
    * @param marketData  the complete set of market data for one scenario
    * @return the FX rate provider
    */
+  @Override
   public abstract FxRateProvider fxRateProvider(MarketData marketData);
 
   //-------------------------------------------------------------------------
@@ -351,7 +353,7 @@ public interface RatesMarketDataLookup extends CalculationParameter {
    * @return the underlying FX lookup
    */
   public default FxRateLookup getFxRateLookup() {
-    return this::fxRateProvider;
+    return this;
   }
 
 }

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxOptionVolatilitiesDefinitionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxOptionVolatilitiesDefinitionTest.java
@@ -59,6 +59,7 @@ public class FxOptionVolatilitiesDefinitionTest {
   private static final ImmutableList<ValueType> QUOTE_TYPE = ImmutableList.of(
       STRANGLE, RISK_REVERSAL, BLACK_VOLATILITY, BLACK_VOLATILITY, STRANGLE, RISK_REVERSAL);
   private static final ImmutableList<FxOptionVolatilitiesNode> NODES;
+  @SuppressWarnings("unused")
   private static final ImmutableList<QuoteId> QUOTE_IDS;
   static {
     ImmutableList.Builder<FxOptionVolatilitiesNode> builder = ImmutableList.builder();

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
@@ -37,6 +37,7 @@ import com.opengamma.strata.basics.currency.FxRate;
 import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.calc.runner.FunctionRequirements;
+import com.opengamma.strata.calc.runner.FxRateLookup;
 import com.opengamma.strata.data.FxRateId;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;


### PR DESCRIPTION
Move `FxRateLookup` to strata-calc and extend `CakculationParameter`
Change `CalculationTask` to use parameter
Extend `CalculationParameters` to search parent interfaces

This is a backwards incompatible change, however serialized instances of `RatesMarketDataLookup` will deserialize fine. Fixing the incompatibility simply requires an organize imports. 