### PR TITLE
minor: bump checkstyle to 8.6 version

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -688,7 +688,7 @@
     <mockito.version>2.15.0</mockito.version>
     <slf4j.version>1.7.25</slf4j.version>
     <testng.version>6.14.2</testng.version>
-    <checkstyle.version>8.0</checkstyle.version>
+    <checkstyle.version>8.6</checkstyle.version>
     <!-- Properties for maven-checkstyle-plugin -->
     <checkstyle.config.location>checkstyle/checkstyle-oss.xml</checkstyle.config.location>
     <!-- Properties for maven-javadoc-plugin -->


### PR DESCRIPTION
as config is updated to 8.6 state at https://github.com/OpenGamma/OG-Tools/pull/8

binaries have to be updated too, to let build pass.