### PR TITLE
Add currency accessors to Product

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/Product.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/Product.java
@@ -5,6 +5,9 @@
  */
 package com.opengamma.strata.product;
 
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.currency.Currency;
+
 /**
  * The product details of a financial instrument.
  * <p>
@@ -17,5 +20,38 @@ package com.opengamma.strata.product;
  * Implementations must be immutable and thread-safe beans.
  */
 public interface Product {
+
+  /**
+   * Checks if this product is cross-currency.
+   * <p>
+   * A cross currency product is defined as one that refers to two or more currencies.
+   * 
+   * @return true if cross currency
+   */
+  public default boolean isCrossCurrency() {
+    return allCurrencies().size() > 1;
+  }
+
+  /**
+   * Returns the set of currencies that the product pays in.
+   * <p>
+   * This returns the complete set of payment currencies.
+   * This will typically return one or two currencies.
+   * 
+   * @return the set of payment currencies
+   */
+  public default ImmutableSet<Currency> allPaymentCurrencies() {
+    return allCurrencies();
+  }
+
+  /**
+   * Returns the set of currencies the product refers to.
+   * <p>
+   * This returns the complete set of currencies, not just the payment currencies.
+   * The sets will differ when a currency is non-deliverable.
+   * 
+   * @return the set of currencies the product refers to
+   */
+  public abstract ImmutableSet<Currency> allCurrencies();
 
 }

--- a/modules/product/src/main/java/com/opengamma/strata/product/SecuritizedProduct.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/SecuritizedProduct.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 
 /**
@@ -40,5 +41,10 @@ public interface SecuritizedProduct
    * @return the trading currency
    */
   public abstract Currency getCurrency();
+
+  @Override
+  public default ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(getCurrency());
+  }
 
 }

--- a/modules/product/src/main/java/com/opengamma/strata/product/capfloor/IborCapFloor.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/capfloor/IborCapFloor.java
@@ -98,21 +98,25 @@ public final class IborCapFloor
   }
 
   //-------------------------------------------------------------------------
-  /**
-   * Returns the set of payment currencies referred to by the cap/floor.
-   * <p>
-   * This returns the complete set of payment currencies for the cap/floor.
-   * This will typically return one currency, but could return two.
-   * 
-   * @return the set of payment currencies referred to by this swap
-   */
+  @Override
   public ImmutableSet<Currency> allPaymentCurrencies() {
-    ImmutableSet.Builder<Currency> builder = ImmutableSet.builder();
-    builder.add(capFloorLeg.getCurrency());
-    if (payLeg != null) {
-      builder.add(payLeg.getCurrency());
+    if (payLeg == null) {
+      return ImmutableSet.of(capFloorLeg.getCurrency());
+    } else {
+      return ImmutableSet.of(capFloorLeg.getCurrency(), payLeg.getCurrency());
     }
-    return builder.build();
+  }
+
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    if (payLeg == null) {
+      return ImmutableSet.of(capFloorLeg.getCurrency());
+    } else {
+      ImmutableSet.Builder<Currency> builder = ImmutableSet.builder();
+      builder.add(capFloorLeg.getCurrency());
+      builder.addAll(payLeg.allCurrencies());
+      return builder.build();
+    }
   }
 
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/cms/Cms.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/cms/Cms.java
@@ -116,19 +116,25 @@ public final class Cms
   }
 
   //-------------------------------------------------------------------------
-  /**
-   * Returns the set of currencies referred to by the CMS.
-   * <p>
-   * This returns the complete set of payment currencies for the CMS.
-   * This will typically return one currency, but could return two.
-   * 
-   * @return the set of payment currencies referred to by this swap
-   */
+  @Override
   public ImmutableSet<Currency> allPaymentCurrencies() {
     if (payLeg == null) {
       return ImmutableSet.of(cmsLeg.getCurrency());
+    } else {
+      return ImmutableSet.of(cmsLeg.getCurrency(), payLeg.getCurrency());
     }
-    return ImmutableSet.of(cmsLeg.getCurrency(), payLeg.getCurrency());
+  }
+
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    if (payLeg == null) {
+      return ImmutableSet.of(cmsLeg.getCurrency());
+    } else {
+      ImmutableSet.Builder<Currency> builder = ImmutableSet.builder();
+      builder.add(cmsLeg.getCurrency());
+      builder.addAll(payLeg.allCurrencies());
+      return builder.build();
+    }
   }
 
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/credit/Cds.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/credit/Cds.java
@@ -25,6 +25,7 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.StandardId;
@@ -42,6 +43,7 @@ import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.product.Product;
 import com.opengamma.strata.product.common.BuySell;
 
 /**
@@ -54,7 +56,7 @@ import com.opengamma.strata.product.common.BuySell;
  */
 @BeanDefinition
 public final class Cds
-    implements Resolvable<ResolvedCds>, ImmutableBean, Serializable {
+    implements Product, Resolvable<ResolvedCds>, ImmutableBean, Serializable {
 
   /**
    * Whether the CDS is buy or sell.
@@ -213,6 +215,12 @@ public final class Cds
       builder.settlementDateOffset =
           DaysAdjustment.ofBusinessDays(3, builder.paymentSchedule.getBusinessDayAdjustment().getCalendar());
     }
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(currency);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/credit/CdsIndex.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/credit/CdsIndex.java
@@ -26,6 +26,7 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.StandardId;
@@ -43,6 +44,7 @@ import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.product.Product;
 import com.opengamma.strata.product.common.BuySell;
 
 /**
@@ -54,7 +56,7 @@ import com.opengamma.strata.product.common.BuySell;
  */
 @BeanDefinition
 public final class CdsIndex
-    implements Resolvable<ResolvedCdsIndex>, ImmutableBean, Serializable {
+    implements Product, Resolvable<ResolvedCdsIndex>, ImmutableBean, Serializable {
 
   /**
    * Whether the CDS index is buy or sell.
@@ -215,6 +217,12 @@ public final class CdsIndex
     builder.paymentOnDefault = PaymentOnDefault.ACCRUED_PREMIUM;
     builder.protectionStart = ProtectionStartOfDay.BEGINNING;
     builder.stepinDateOffset = DaysAdjustment.ofCalendarDays(1);
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(currency);
   }
 
   @ImmutablePreBuild

--- a/modules/product/src/main/java/com/opengamma/strata/product/credit/CdsIndexTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/credit/CdsIndexTrade.java
@@ -26,6 +26,7 @@ import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.AdjustablePayment;
 import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.product.PortfolioItemSummary;
+import com.opengamma.strata.product.ProductTrade;
 import com.opengamma.strata.product.ProductType;
 import com.opengamma.strata.product.ResolvableTrade;
 import com.opengamma.strata.product.TradeInfo;
@@ -42,7 +43,7 @@ import com.opengamma.strata.product.common.SummarizerUtils;
  */
 @BeanDefinition
 public final class CdsIndexTrade
-    implements ResolvableTrade<ResolvedCdsIndexTrade>, ImmutableBean, Serializable {
+    implements ProductTrade, ResolvableTrade<ResolvedCdsIndexTrade>, ImmutableBean, Serializable {
 
   /**
    * The additional trade information, defaulted to an empty instance.
@@ -56,7 +57,7 @@ public final class CdsIndexTrade
    * <p>
    * The product captures the contracted financial details of the trade.
    */
-  @PropertyDefinition(validate = "notNull")
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final CdsIndex product;
   /**
    * The upfront fee of the product.
@@ -165,6 +166,7 @@ public final class CdsIndexTrade
    * The product captures the contracted financial details of the trade.
    * @return the value of the property, not null
    */
+  @Override
   public CdsIndex getProduct() {
     return product;
   }

--- a/modules/product/src/main/java/com/opengamma/strata/product/credit/CdsTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/credit/CdsTrade.java
@@ -26,6 +26,7 @@ import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.AdjustablePayment;
 import com.opengamma.strata.basics.schedule.PeriodicSchedule;
 import com.opengamma.strata.product.PortfolioItemSummary;
+import com.opengamma.strata.product.ProductTrade;
 import com.opengamma.strata.product.ProductType;
 import com.opengamma.strata.product.ResolvableTrade;
 import com.opengamma.strata.product.TradeInfo;
@@ -43,7 +44,7 @@ import com.opengamma.strata.product.common.SummarizerUtils;
  */
 @BeanDefinition
 public final class CdsTrade
-    implements ResolvableTrade<ResolvedCdsTrade>, ImmutableBean, Serializable {
+    implements ProductTrade, ResolvableTrade<ResolvedCdsTrade>, ImmutableBean, Serializable {
 
   /**
    * The additional trade information, defaulted to an empty instance.
@@ -57,7 +58,7 @@ public final class CdsTrade
    * <p>
    * The product captures the contracted financial details of the trade.
    */
-  @PropertyDefinition(validate = "notNull")
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final Cds product;
   /**
    * The upfront fee of the product.
@@ -166,6 +167,7 @@ public final class CdsTrade
    * The product captures the contracted financial details of the trade.
    * @return the value of the property, not null
    */
+  @Override
   public Cds getProduct() {
     return product;
   }

--- a/modules/product/src/main/java/com/opengamma/strata/product/deposit/IborFixingDeposit.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/deposit/IborFixingDeposit.java
@@ -25,6 +25,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
@@ -165,6 +166,12 @@ public final class IborFixingDeposit
   @ImmutableValidator
   private void validate() {
     ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(currency);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/deposit/TermDeposit.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/deposit/TermDeposit.java
@@ -24,6 +24,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
@@ -120,6 +121,12 @@ public final class TermDeposit
   @ImmutableValidator
   private void validate() {
     ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(currency);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/fra/Fra.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fra/Fra.java
@@ -30,6 +30,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
@@ -232,6 +233,12 @@ public final class Fra
     if (index.equals(indexInterpolated)) {
       throw new IllegalArgumentException("Interpolation requires two different indices");
     }
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(currency);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/FxNdf.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/FxNdf.java
@@ -23,6 +23,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
@@ -97,14 +98,14 @@ public final class FxNdf
   }
 
   //-------------------------------------------------------------------------
-  /**
-   * Gets the currency pair in conventional order.
-   * 
-   * @return the currency pair
-   */
   @Override
   public CurrencyPair getCurrencyPair() {
     return index.getCurrencyPair().toConventional();
+  }
+
+  @Override
+  public ImmutableSet<Currency> allPaymentCurrencies() {
+    return ImmutableSet.of(getSettlementCurrency());
   }
 
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/FxProduct.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/FxProduct.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.product.fx;
 
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.product.Product;
 
@@ -15,6 +17,16 @@ import com.opengamma.strata.product.Product;
  * For example, it might represent the payment of USD 1,000 and the receipt of EUR 932.
  */
 public interface FxProduct extends Product {
+
+  @Override
+  default boolean isCrossCurrency() {
+    return true;
+  }
+
+  @Override
+  public default ImmutableSet<Currency> allCurrencies() {
+    return getCurrencyPair().toSet();
+  }
 
   /**
    * Gets the currency pair that the FX trade is based on, in conventional order.

--- a/modules/product/src/main/java/com/opengamma/strata/product/payment/BulletPayment.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/payment/BulletPayment.java
@@ -22,6 +22,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
@@ -80,6 +81,11 @@ public final class BulletPayment
    */
   public Currency getCurrency() {
     return value.getCurrency();
+  }
+
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(value.getCurrency());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/Swap.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/Swap.java
@@ -178,24 +178,6 @@ public final class Swap
 
   //-------------------------------------------------------------------------
   /**
-   * Checks if this trade is cross-currency.
-   * <p>
-   * A cross currency swap is defined as one with legs in two different currencies.
-   * 
-   * @return true if cross currency
-   */
-  public boolean isCrossCurrency() {
-    // optimized for performance
-    Currency firstCurrency = legs.get(0).getCurrency();
-    for (int i = 1; i < legs.size(); i++) {
-      if (!legs.get(i).getCurrency().equals(firstCurrency)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Returns the set of payment currencies referred to by the swap.
    * <p>
    * This returns the complete set of payment currencies for the swap.
@@ -207,6 +189,7 @@ public final class Swap
    * 
    * @return the set of payment currencies referred to by this swap
    */
+  @Override
   public ImmutableSet<Currency> allPaymentCurrencies() {
     return legs.stream().map(leg -> leg.getCurrency()).collect(toImmutableSet());
   }
@@ -218,6 +201,7 @@ public final class Swap
    * 
    * @return the set of currencies referred to by this swap
    */
+  @Override
   public ImmutableSet<Currency> allCurrencies() {
     ImmutableSet.Builder<Currency> builder = ImmutableSet.builder();
     legs.stream().forEach(leg -> leg.collectCurrencies(builder));

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/SwapLeg.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/SwapLeg.java
@@ -12,8 +12,6 @@ import com.opengamma.strata.basics.ReferenceDataNotFoundException;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.AdjustableDate;
-import com.opengamma.strata.basics.index.FloatingRateIndex;
-import com.opengamma.strata.basics.index.FxIndex;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.product.common.PayReceive;
 
@@ -112,19 +110,7 @@ public interface SwapLeg extends Resolvable<ResolvedSwapLeg> {
    * 
    * @param builder  the builder to populate
    */
-  public default void collectCurrencies(ImmutableSet.Builder<Currency> builder) {
-    // imperfect implementation for compatibility
-    builder.add(getCurrency());
-    for (Index index : allIndices()) {
-      if (index instanceof FloatingRateIndex) {
-        builder.add(((FloatingRateIndex) index).getCurrency());
-      } else if (index instanceof FxIndex) {
-        FxIndex fxIndex = (FxIndex) index;
-        builder.add(fxIndex.getCurrencyPair().getBase());
-        builder.add(fxIndex.getCurrencyPair().getCounter());
-      }
-    }
-  }
+  public abstract void collectCurrencies(ImmutableSet.Builder<Currency> builder);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/swaption/Swaption.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swaption/Swaption.java
@@ -27,6 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaBean;
 import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.Resolvable;
 import com.opengamma.strata.basics.currency.Currency;
@@ -137,6 +138,11 @@ public final class Swaption
         .distinct()
         .reduce(ensureOnlyOne())
         .get();
+  }
+
+  @Override
+  public ImmutableSet<Currency> allCurrencies() {
+    return ImmutableSet.of(getCurrency());
   }
 
   /**

--- a/modules/product/src/test/java/com/opengamma/strata/product/capfloor/IborCapFloorTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/capfloor/IborCapFloorTest.java
@@ -92,7 +92,9 @@ public class IborCapFloorTest {
     IborCapFloor test = IborCapFloor.of(CAPFLOOR_LEG);
     assertEquals(test.getCapFloorLeg(), CAPFLOOR_LEG);
     assertEquals(test.getPayLeg().isPresent(), false);
+    assertEquals(test.isCrossCurrency(), false);
     assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(EUR));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(EUR));
     assertEquals(test.allIndices(), ImmutableSet.of(EUR_EURIBOR_3M));
   }
 
@@ -100,7 +102,9 @@ public class IborCapFloorTest {
     IborCapFloor test = IborCapFloor.of(CAPFLOOR_LEG, PAY_LEG);
     assertEquals(test.getCapFloorLeg(), CAPFLOOR_LEG);
     assertEquals(test.getPayLeg().get(), PAY_LEG);
+    assertEquals(test.isCrossCurrency(), false);
     assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(EUR));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(EUR));
     assertEquals(test.allIndices(), ImmutableSet.of(EUR_EURIBOR_3M));
   }
 
@@ -108,7 +112,9 @@ public class IborCapFloorTest {
     IborCapFloor test = IborCapFloor.of(CAPFLOOR_LEG, PAY_LEG_XCCY);
     assertEquals(test.getCapFloorLeg(), CAPFLOOR_LEG);
     assertEquals(test.getPayLeg().get(), PAY_LEG_XCCY);
+    assertEquals(test.isCrossCurrency(), true);
     assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP, EUR));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP, EUR));
     assertEquals(test.allIndices(), ImmutableSet.of(GBP_LIBOR_3M, EUR_EURIBOR_3M));
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/cms/CmsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/cms/CmsTest.java
@@ -73,7 +73,9 @@ public class CmsTest {
     Cms test = sutCap();
     assertEquals(test.getCmsLeg(), CMS_LEG);
     assertEquals(test.getPayLeg().get(), PAY_LEG);
+    assertEquals(test.isCrossCurrency(), false);
     assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(CMS_LEG.getCurrency()));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(CMS_LEG.getCurrency()));
     assertEquals(test.allRateIndices(), ImmutableSet.of(CMS_LEG.getUnderlyingIndex()));
   }
 
@@ -81,7 +83,9 @@ public class CmsTest {
     Cms test = Cms.of(CMS_LEG);
     assertEquals(test.getCmsLeg(), CMS_LEG);
     assertFalse(test.getPayLeg().isPresent());
+    assertEquals(test.isCrossCurrency(), false);
     assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(CMS_LEG.getCurrency()));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(CMS_LEG.getCurrency()));
   }
 
   public void test_resolve_twoLegs() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/CdsIndexTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/CdsIndexTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
@@ -92,6 +93,9 @@ public class CdsIndexTest {
     assertEquals(test.getProtectionStart(), ProtectionStartOfDay.NONE);
     assertEquals(test.getSettlementDateOffset(), SETTLE_DAY_ADJ);
     assertEquals(test.getStepinDateOffset(), STEPIN_DAY_ADJ);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(JPY));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(JPY));
   }
 
   public void test_of() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/CdsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/CdsTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
@@ -87,6 +88,9 @@ public class CdsTest {
     assertEquals(test.getProtectionStart(), ProtectionStartOfDay.NONE);
     assertEquals(test.getSettlementDateOffset(), SETTLE_DAY_ADJ);
     assertEquals(test.getStepinDateOffset(), STEPIN_DAY_ADJ);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(JPY));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(JPY));
   }
 
   public void test_of() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/deposit/IborFixingDepositTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/deposit/IborFixingDepositTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
@@ -66,6 +67,9 @@ public class IborFixingDepositTest {
     assertEquals(test.getEndDate(), END_DATE);
     assertEquals(test.getIndex(), GBP_LIBOR_6M);
     assertEquals(test.getFixedRate(), RATE);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP));
   }
 
   public void test_builder_minimum() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/deposit/TermDepositTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/deposit/TermDepositTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.product.common.BuySell;
@@ -60,6 +61,9 @@ public class TermDepositTest {
     assertEquals(test.getNotional(), NOTIONAL);
     assertEquals(test.getRate(), RATE);
     assertEquals(test.getCurrency(), GBP);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP));
   }
 
   public void test_builder_wrongDates() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/dsf/DsfTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/dsf/DsfTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
@@ -72,6 +73,9 @@ public class DsfTest {
     assertEquals(test.getNotional(), NOTIONAL);
     assertEquals(test.getCurrency(), USD);
     assertEquals(test.getUnderlyingSwap(), SWAP);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(USD));
   }
 
   public void test_builder_deliveryAfterStart() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fra/FraTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fra/FraTest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
@@ -74,6 +75,9 @@ public class FraTest {
     assertEquals(test.getFixingDateOffset(), GBP_LIBOR_3M.getFixingDateOffset());  // defaulted
     assertEquals(test.getDayCount(), ACT_365F);  // defaulted
     assertEquals(test.getDiscounting(), ISDA);  // defaulted
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP));
   }
 
   public void test_builder_AUD() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/FxNdfTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/FxNdfTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -49,6 +50,9 @@ public class FxNdfTest {
     assertEquals(test.getSettlementCurrencyNotional(), CURRENCY_NOTIONAL);
     assertEquals(test.getPaymentDate(), PAYMENT_DATE);
     assertEquals(test.getSettlementCurrency(), GBP);
+    assertEquals(test.isCrossCurrency(), true);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP, USD));
   }
 
   public void test_builder_inverse() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/FxSingleTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/FxSingleTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.CurrencyPair;
@@ -54,6 +55,9 @@ public class FxSingleTest {
     assertEquals(test.getPaymentDateAdjustment(), Optional.empty());
     assertEquals(test.getCurrencyPair(), CurrencyPair.of(GBP, USD));
     assertEquals(test.getReceiveCurrencyAmount(), GBP_P1000);
+    assertEquals(test.isCrossCurrency(), true);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP, USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP, USD));
   }
 
   public void test_of_switchOrder() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/FxSwapTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/FxSwapTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -49,6 +50,9 @@ public class FxSwapTest {
     FxSwap test = sut();
     assertEquals(test.getNearLeg(), NEAR_LEG);
     assertEquals(test.getFarLeg(), FAR_LEG);
+    assertEquals(test.isCrossCurrency(), true);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP, USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP, USD));
   }
 
   public void test_of_wrongOrder() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fxopt/FxSingleBarrierOptionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fxopt/FxSingleBarrierOptionTest.java
@@ -23,6 +23,7 @@ import java.time.ZoneId;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.product.fx.FxSingle;
@@ -62,6 +63,9 @@ public class FxSingleBarrierOptionTest {
     assertEquals(test.getRebate().get(), REBATE);
     assertEquals(test.getUnderlyingOption(), VANILLA_OPTION);
     assertEquals(test.getCurrencyPair(), VANILLA_OPTION.getCurrencyPair());
+    assertEquals(test.isCrossCurrency(), true);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(EUR, USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(EUR, USD));
   }
 
   public void test_builder() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/fxopt/FxVanillaOptionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fxopt/FxVanillaOptionTest.java
@@ -21,6 +21,7 @@ import java.time.ZonedDateTime;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.product.common.LongShort;
@@ -53,6 +54,9 @@ public class FxVanillaOptionTest {
     assertEquals(test.getLongShort(), LONG);
     assertEquals(test.getUnderlying(), FX);
     assertEquals(test.getCurrencyPair(), FX.getCurrencyPair());
+    assertEquals(test.isCrossCurrency(), true);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(EUR, USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(EUR, USD));
   }
 
   public void test_builder_earlyPaymentDate() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/IborFutureOptionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/IborFutureOptionTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product.index;
 
+import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
@@ -21,6 +22,7 @@ import java.time.ZonedDateTime;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.value.Rounding;
 import com.opengamma.strata.product.SecurityId;
@@ -57,6 +59,9 @@ public class IborFutureOptionTest {
     assertEquals(test.getUnderlyingFuture(), FUTURE);
     assertEquals(test.getCurrency(), FUTURE.getCurrency());
     assertEquals(test.getIndex(), FUTURE.getIndex());
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(USD));
   }
 
   public void test_builder_expiryNotAfterTradeDate() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/payment/BulletPaymentTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/payment/BulletPaymentTest.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
@@ -48,6 +49,9 @@ public class BulletPaymentTest {
     assertEquals(test.getValue(), GBP_P1000);
     assertEquals(test.getDate(), AdjustableDate.of(DATE_2015_06_30));
     assertEquals(test.getCurrency(), GBP);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP));
   }
 
   public void test_builder_notNegative() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/MockSwapLeg.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/MockSwapLeg.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product.swap;
 
+import static com.opengamma.strata.basics.currency.Currency.EUR;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
@@ -100,6 +101,15 @@ public final class MockSwapLeg implements SwapLeg, ImmutableBean, Serializable {
       LocalDate endDate,
       Currency currency) {
     return new MockSwapLeg(type, payReceive, AdjustableDate.of(startDate), AdjustableDate.of(endDate), currency);
+  }
+
+  @Override
+  public void collectCurrencies(ImmutableSet.Builder<Currency> builder) {
+    if (this == MOCK_USD1) {
+      builder.add(GBP, EUR, USD);
+    } else {
+      builder.add(GBP);
+    }
   }
 
   @Override

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapTest.java
@@ -76,6 +76,9 @@ public class SwapTest {
         .legs(ImmutableList.of(MOCK_GBP1, MOCK_USD1))
         .build();
     assertEquals(test.getLegs(), ImmutableList.of(MOCK_GBP1, MOCK_USD1));
+    assertEquals(test.isCrossCurrency(), true);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(GBP, USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(GBP, EUR, USD));
   }
 
   public void test_builder_varargs() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/swaption/SwaptionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swaption/SwaptionTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product.swaption;
 
+import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.USNY;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
@@ -21,8 +22,8 @@ import java.time.ZoneId;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
-import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.BusinessDayConventions;
@@ -73,8 +74,11 @@ public class SwaptionTest {
     assertEquals(test.getLongShort(), LONG);
     assertEquals(test.getSwaptionSettlement(), PHYSICAL_SETTLE);
     assertEquals(test.getUnderlying(), SWAP);
-    assertEquals(test.getCurrency(), Currency.USD);
+    assertEquals(test.getCurrency(), USD);
     assertEquals(test.getIndex(), IborIndices.USD_LIBOR_3M);
+    assertEquals(test.isCrossCurrency(), false);
+    assertEquals(test.allPaymentCurrencies(), ImmutableSet.of(USD));
+    assertEquals(test.allCurrencies(), ImmutableSet.of(USD));
   }
 
   public void test_builder_expiryAfterStart() {


### PR DESCRIPTION
Currency is a key aspect of a product and should be easy to access
This change is backwards incompatible for Product implementations
Method on SwapLeg also changed from a poor default to be abstract