### PR TITLE
Provide ability to lookup any index

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/Index.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/Index.java
@@ -5,6 +5,10 @@
  */
 package com.opengamma.strata.basics.index;
 
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.named.Named;
 
 /**
@@ -20,5 +24,30 @@ import com.opengamma.strata.collect.named.Named;
  */
 public interface Index
     extends Named {
+
+  /**
+   * Obtains an instance from the specified unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the index
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static Index of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return Indices.ENUM_LOOKUP.lookup(uniqueName);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this index.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public abstract String getName();
 
 }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/Indices.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/Indices.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.index;
+
+import com.opengamma.strata.collect.named.CombinedExtendedEnum;
+
+/**
+ * Helper for {@code Index}
+ */
+final class Indices {
+
+  /**
+   * The extended enum lookup from name to instance.
+   */
+  static final CombinedExtendedEnum<Index> ENUM_LOOKUP = CombinedExtendedEnum.of(Index.class);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private Indices() {
+  }
+
+}

--- a/modules/basics/src/main/resources/com/opengamma/strata/config/base/Index.ini
+++ b/modules/basics/src/main/resources/com/opengamma/strata/config/base/Index.ini
@@ -1,0 +1,8 @@
+# CombinedExtendedEnum configuration
+
+# The enum types to combine
+[types]
+com.opengamma.strata.basics.index.IborIndex
+com.opengamma.strata.basics.index.OvernightIndex
+com.opengamma.strata.basics.index.PriceIndex
+com.opengamma.strata.basics.index.FxIndex

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/IndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/IndexTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.index;
+
+import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
+import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link Index}.
+ */
+@Test
+public class IndexTest {
+
+  @DataProvider(name = "name")
+  static Object[][] data_name() {
+    return new Object[][] {
+        {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
+        {IborIndices.CHF_LIBOR_6M, "CHF-LIBOR-6M"},
+        {IborIndices.EUR_LIBOR_6M, "EUR-LIBOR-6M"},
+        {IborIndices.JPY_LIBOR_6M, "JPY-LIBOR-6M"},
+        {IborIndices.USD_LIBOR_6M, "USD-LIBOR-6M"},
+
+        {OvernightIndices.GBP_SONIA, "GBP-SONIA"},
+        {OvernightIndices.CHF_TOIS, "CHF-TOIS"},
+        {OvernightIndices.EUR_EONIA, "EUR-EONIA"},
+        {OvernightIndices.JPY_TONAR, "JPY-TONAR"},
+        {OvernightIndices.USD_FED_FUND, "USD-FED-FUND"},
+
+        {PriceIndices.GB_HICP, "GB-HICP"},
+        {PriceIndices.CH_CPI, "CH-CPI"},
+        {PriceIndices.EU_AI_CPI, "EU-AI-CPI"},
+
+        {FxIndices.EUR_CHF_ECB, "EUR/CHF-ECB"},
+        {FxIndices.EUR_GBP_ECB, "EUR/GBP-ECB"},
+        {FxIndices.GBP_USD_WM, "GBP/USD-WM"},
+        {FxIndices.USD_JPY_WM, "USD/JPY-WM"},
+    };
+  }
+
+  @Test(dataProvider = "name")
+  public void test_name(Index convention, String name) {
+    assertEquals(convention.getName(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_toString(Index convention, String name) {
+    assertEquals(convention.toString(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_of_lookup(Index convention, String name) {
+    assertEquals(Index.of(name), convention);
+  }
+
+  public void test_of_lookup_notFound() {
+    assertThrowsIllegalArg(() -> Index.of("Rubbish"));
+  }
+
+  public void test_of_lookup_null() {
+    assertThrowsIllegalArg(() -> Index.of((String) null));
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverPrivateConstructor(Indices.class);
+  }
+
+}

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/named/CombinedExtendedEnum.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/named/CombinedExtendedEnum.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.collect.named;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import org.joda.convert.RenameHandler;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.io.IniFile;
+import com.opengamma.strata.collect.io.PropertySet;
+import com.opengamma.strata.collect.io.ResourceConfig;
+
+/**
+ * Combines multiple extended enums into one lookup.
+ * <p>
+ * Each {@link ExtendedEnum} is kept separate to ensure fast lookup of the common case.
+ * This class uses a configuration file to determine the extended enums to combine.
+ * <p>
+ * It is intended that this class is used as a helper class to load the configuration
+ * and manage the map of names to instances. It should be created and used by the author
+ * of the main abstract extended enum class, and not be application developers.
+ * 
+ * @param <T>  the type of the enum
+ */
+public final class CombinedExtendedEnum<T extends Named> {
+
+  /**
+   * The logger.
+   */
+  private static final Logger log = Logger.getLogger(CombinedExtendedEnum.class.getName());
+  /**
+   * Section name used for types.
+   */
+  private static final String TYPES_SECTION = "types";
+
+  /**
+   * The combined enum type.
+   */
+  private final Class<T> type;
+  /**
+   * The underlying extended enums.
+   */
+  private final ImmutableList<ExtendedEnum<? extends T>> children;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains a combined extended enum instance.
+   * <p>
+   * Calling this method loads configuration files to determine which extended enums to combine.
+   * The configuration file has the same simple name as the specified type and is a
+   * {@linkplain IniFile INI file} with the suffix '.ini'.
+   * 
+   * @param <R>  the type of the enum
+   * @param type  the type to load
+   * @return the extended enum
+   */
+  public static <R extends Named> CombinedExtendedEnum<R> of(Class<R> type) {
+    try {
+      // load all matching files
+      String name = type.getSimpleName() + ".ini";
+      IniFile config = ResourceConfig.combinedIniFile(name);
+      // parse files
+      ImmutableList<ExtendedEnum<? extends R>> children = parseChildren(config, type);
+      log.fine(() -> "Loaded combined extended enum: " + name + ", providers: " + children);
+      return new CombinedExtendedEnum<>(type, children);
+
+    } catch (RuntimeException ex) {
+      // logging used because this is loaded in a static variable
+      log.severe("Failed to load CombinedExtendedEnum for " + type + ": " + Throwables.getStackTraceAsString(ex));
+      // return an empty instance to avoid ExceptionInInitializerError
+      return new CombinedExtendedEnum<>(type, ImmutableList.of());
+    }
+  }
+
+  // parses the alternate names
+  @SuppressWarnings("unchecked")
+  private static <R extends Named> ImmutableList<ExtendedEnum<? extends R>> parseChildren(
+      IniFile config,
+      Class<R> enumType) {
+
+    if (!config.contains(TYPES_SECTION)) {
+      return ImmutableList.of();
+    }
+    PropertySet section = config.section(TYPES_SECTION);
+    ImmutableList.Builder<ExtendedEnum<? extends R>> builder = ImmutableList.builder();
+    for (String key : section.keys()) {
+      Class<?> cls;
+      try {
+        cls = RenameHandler.INSTANCE.lookupType(key);
+      } catch (Exception ex) {
+        throw new IllegalArgumentException("Unable to find extended enum class: " + key, ex);
+      }
+      Method method;
+      try {
+        method = cls.getMethod("extendedEnum");
+      } catch (Exception ex) {
+        throw new IllegalArgumentException("Unable to find extendedEnum() method on class: " + cls.getName(), ex);
+      }
+      if (!method.getReturnType().equals(ExtendedEnum.class)) {
+        throw new IllegalArgumentException("Method extendedEnum() does not return ExtendedEnum on class: " + cls.getName());
+      }
+      ExtendedEnum<?> result;
+      try {
+        result = ExtendedEnum.class.cast(method.invoke(null));
+      } catch (Exception ex) {
+        throw new IllegalArgumentException("Unable to call extendedEnum() method on class: " + cls.getName(), ex);
+      }
+      if (!enumType.isAssignableFrom(result.getType())) {
+        throw new IllegalArgumentException(
+            "Method extendedEnum() returned an ExtendedEnum with an incompatible type on class: " + cls.getName());
+      }
+      builder.add((ExtendedEnum<? extends R>) result);
+    }
+    return builder.build();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates an instance.
+   * 
+   * @param type  the enum type
+   * @param lookups  the lookup functions to find instances
+   * @param alternateNames  the map of alternate name to standard name
+   * @param externalNames  the map of external name groups
+   */
+  private CombinedExtendedEnum(
+      Class<T> type,
+      ImmutableList<ExtendedEnum<? extends T>> children) {
+
+    this.type = ArgChecker.notNull(type, "type");
+    this.children = ArgChecker.notNull(children, "children");
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Finds an instance by name.
+   * <p>
+   * This finds the instance matching the specified name.
+   * Instances may have alternate names (aliases), thus the returned instance
+   * may have a name other than that requested.
+   * 
+   * @param name  the enum name to return
+   * @return the named enum
+   */
+  public Optional<T> find(String name) {
+    for (ExtendedEnum<? extends T> child : children) {
+      @SuppressWarnings("unchecked")
+      Optional<T> found = (Optional<T>) child.find(name);
+      if (found.isPresent()) {
+        return found;
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Looks up an instance by name.
+   * <p>
+   * This finds the instance matching the specified name.
+   * Instances may have alternate names (aliases), thus the returned instance
+   * may have a name other than that requested.
+   * 
+   * @param name  the enum name to return
+   * @return the named enum
+   * @throws IllegalArgumentException if the name is not found
+   */
+  public T lookup(String name) {
+    return find(name).orElseThrow(() -> new IllegalArgumentException(type.getSimpleName() + " name not found: " + name));
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public String toString() {
+    return "CombinedExtendedEnum[" + type.getSimpleName() + "]";
+  }
+
+}

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/named/CombinedExtendedEnum.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/named/CombinedExtendedEnum.java
@@ -127,9 +127,7 @@ public final class CombinedExtendedEnum<T extends Named> {
    * Creates an instance.
    * 
    * @param type  the enum type
-   * @param lookups  the lookup functions to find instances
-   * @param alternateNames  the map of alternate name to standard name
-   * @param externalNames  the map of external name groups
+   * @param children  the child extended enums to delegate to
    */
   private CombinedExtendedEnum(
       Class<T> type,

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/named/ExtendedEnum.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/named/ExtendedEnum.java
@@ -307,6 +307,15 @@ public final class ExtendedEnum<T extends Named> {
 
   //-------------------------------------------------------------------------
   /**
+   * Gets the enum type.
+   * 
+   * @return the enum type
+   */
+  public Class<T> getType() {
+    return type;
+  }
+
+  /**
    * Finds an instance by name.
    * <p>
    * This finds the instance matching the specified name.

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/named/CombinedExtendedEnumTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/named/CombinedExtendedEnumTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.collect.named;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import java.util.Optional;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link CombinedExtendedEnum}.
+ */
+@Test
+public class CombinedExtendedEnumTest {
+
+  public void test_lookup() {
+    assertEquals(UberNamed.of("Standard"), SampleNameds.STANDARD);
+    assertEquals(UberNamed.of("More"), MoreSampleNameds.MORE);
+    CombinedExtendedEnum<UberNamed> combined = CombinedExtendedEnum.of(UberNamed.class);
+    assertEquals(combined.find("Rubbish"), Optional.empty());
+    assertThrows(IllegalArgumentException.class, () -> combined.lookup("Rubbish"));
+    assertEquals(combined.toString(), "CombinedExtendedEnum[UberNamed]");
+  }
+
+}

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/named/ExtendedEnumTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/named/ExtendedEnumTest.java
@@ -47,6 +47,7 @@ public class ExtendedEnumTest {
             .put("Another2", SampleNamedInstanceLookup2.ANOTHER2)
             .build());
     assertEquals(test.alternateNames(), ImmutableMap.of("Alternate", "Standard", "ALTERNATE", "Standard"));
+    assertEquals(test.getType(), SampleNamed.class);
     assertEquals(test.find("Standard"), Optional.of(SampleNameds.STANDARD));
     assertEquals(test.find("STANDARD"), Optional.of(SampleNameds.STANDARD));
     assertEquals(test.find("Rubbish"), Optional.empty());

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/named/SampleNamed.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/named/SampleNamed.java
@@ -8,7 +8,7 @@ package com.opengamma.strata.collect.named;
 /**
  * Mock named object.
  */
-public interface SampleNamed extends Named {
+public interface SampleNamed extends UberNamed {
 
   // for NamedTest
   public static SampleNamed of(String name) {
@@ -16,6 +16,10 @@ public interface SampleNamed extends Named {
       return SampleNameds.STANDARD;
     }
     throw new IllegalArgumentException("Name not found");
+  }
+
+  public static ExtendedEnum<SampleNamed> extendedEnum() {
+    return ExtendedEnum.of(SampleNamed.class);
   }
 
 }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/named/UberNamed.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/named/UberNamed.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.collect.named;
+
+/**
+ * Mock named object.
+ */
+public interface UberNamed extends Named {
+
+  // for NamedTest
+  public static UberNamed of(String name) {
+    return CombinedExtendedEnum.of(UberNamed.class).lookup(name);
+  }
+
+}

--- a/modules/collect/src/test/resources/com/opengamma/strata/config/base/UberNamed.ini
+++ b/modules/collect/src/test/resources/com/opengamma/strata/config/base/UberNamed.ini
@@ -1,0 +1,2 @@
+[types]
+com.opengamma.strata.collect.named.SampleNamed

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.joda.beans.ImmutableBean;
+import org.joda.beans.ser.JodaBeanSer;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -249,6 +250,18 @@ public class RatesMarketDataLookupTest {
     MarketData md = MarketData.of(date(2016, 6, 30), valuesMap);
     assertSerialization(test.marketDataView(md));
     assertSerialization(test.ratesProvider(md));
+  }
+
+  public void test_jodaSerialization() {
+    ImmutableMap<Currency, CurveId> discounts = ImmutableMap.of(USD, CURVE_ID_DSC);
+    ImmutableMap<Index, CurveId> forwards = ImmutableMap.of(USD_LIBOR_3M, CURVE_ID_FWD);
+    DefaultRatesMarketDataLookup test =
+        DefaultRatesMarketDataLookup.of(discounts, forwards, ObservableSource.NONE, FxRateLookup.ofRates());
+    String xml = JodaBeanSer.PRETTY.xmlWriter().write(test);
+    System.out.println(xml);
+    assertEquals(xml.contains("<entry key=\"USD-LIBOR-3M\">"), true);
+    assertEquals(xml.contains("<fixingDateOffset>"), false);
+    assertEquals(xml.contains("<effectiveDateOffset>"), false);
   }
 
 }

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesMarketDataLookupTest.java
@@ -258,7 +258,6 @@ public class RatesMarketDataLookupTest {
     DefaultRatesMarketDataLookup test =
         DefaultRatesMarketDataLookup.of(discounts, forwards, ObservableSource.NONE, FxRateLookup.ofRates());
     String xml = JodaBeanSer.PRETTY.xmlWriter().write(test);
-    System.out.println(xml);
     assertEquals(xml.contains("<entry key=\"USD-LIBOR-3M\">"), true);
     assertEquals(xml.contains("<fixingDateOffset>"), false);
     assertEquals(xml.contains("<effectiveDateOffset>"), false);

--- a/modules/product/src/main/resources/com/opengamma/strata/config/base1/Index.ini
+++ b/modules/product/src/main/resources/com/opengamma/strata/config/base1/Index.ini
@@ -1,0 +1,5 @@
+# CombinedExtendedEnum configuration
+
+# The enum types to combine
+[types]
+com.opengamma.strata.product.swap.SwapIndex

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapIndexTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapIndexTest.java
@@ -17,11 +17,17 @@ import static org.testng.Assert.assertTrue;
 import java.time.LocalTime;
 import java.time.ZoneId;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.basics.index.FxIndices;
+import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.basics.index.Index;
+import com.opengamma.strata.basics.index.OvernightIndices;
+import com.opengamma.strata.basics.index.PriceIndices;
 import com.opengamma.strata.product.swap.type.FixedIborSwapConvention;
 import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 import com.opengamma.strata.product.swap.type.FixedIborSwapTemplate;
@@ -97,6 +103,35 @@ public class SwapIndexTest {
       }
       assertEquals(index.calculateFixingDateTime(date(2015, 6, 30)), date(2015, 6, 30).atTime(time).atZone(zone));
     }
+  }
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "indexName")
+  static Object[][] data_name() {
+    return new Object[][] {
+        {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
+        {OvernightIndices.GBP_SONIA, "GBP-SONIA"},
+        {PriceIndices.GB_HICP, "GB-HICP"},
+        {FxIndices.EUR_CHF_ECB, "EUR/CHF-ECB"},
+
+        {SwapIndices.EUR_EURIBOR_1100_12Y, "EUR-EURIBOR-1100-12Y"},
+        {SwapIndices.GBP_LIBOR_1100_2Y, "GBP-LIBOR-1100-2Y"},
+    };
+  }
+
+  @Test(dataProvider = "indexName")
+  public void test_name(Index convention, String name) {
+    assertEquals(convention.getName(), name);
+  }
+
+  @Test(dataProvider = "indexName")
+  public void test_toString(Index convention, String name) {
+    assertEquals(convention.toString(), name);
+  }
+
+  @Test(dataProvider = "indexName")
+  public void test_of_lookup(Index convention, String name) {
+    assertEquals(Index.of(name), convention);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Enhance ExtendedEnum to support ability to combine separate enums.
Add lookup method to Index.
Ensure that Joda serialization with maps keyed by Index work correctly.

This will reduce the size of certain pieces of stored data.