### PR TITLE
Resolve targets in calculation runner

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/report/ReportRunnerTool.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/report/ReportRunnerTool.java
@@ -198,7 +198,7 @@ public final class ReportRunnerTool implements AutoCloseable {
     ReferenceData refData = ReferenceData.standard();
 
     // calculate the results
-    CalculationTasks tasks = CalculationTasks.of(rules, trades, columns);
+    CalculationTasks tasks = CalculationTasks.of(rules, trades, columns, refData);
     MarketDataRequirements reqs = tasks.requirements(refData);
     MarketData calibratedMarketData = marketDataFactory().create(reqs, MarketDataConfig.empty(), marketData, refData);
     Results results = runner.getTaskRunner().calculate(tasks, calibratedMarketData, refData);

--- a/examples/src/test/java/com/opengamma/strata/examples/regression/SwapReportRegressionTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/regression/SwapReportRegressionTest.java
@@ -85,7 +85,7 @@ public class SwapReportRegressionTest {
     MarketData marketData = marketDataBuilder.buildSnapshot(valuationDate);
 
     // using the direct executor means there is no need to close/shutdown the runner
-    CalculationTasks tasks = CalculationTasks.of(rules, trades, columns);
+    CalculationTasks tasks = CalculationTasks.of(rules, trades, columns, REF_DATA);
     MarketDataRequirements reqs = tasks.requirements(REF_DATA);
     MarketData calibratedMarketData = marketDataFactory().create(reqs, MarketDataConfig.empty(), marketData, REF_DATA);
     CalculationTaskRunner runner = CalculationTaskRunner.of(MoreExecutors.newDirectExecutorService());

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/DefaultCalculationRunner.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/DefaultCalculationRunner.java
@@ -78,7 +78,7 @@ class DefaultCalculationRunner implements CalculationRunner {
       MarketData marketData,
       ReferenceData refData) {
 
-    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns);
+    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns, refData);
     return taskRunner.calculate(tasks, marketData, refData);
   }
 
@@ -91,7 +91,7 @@ class DefaultCalculationRunner implements CalculationRunner {
       ReferenceData refData,
       CalculationListener listener) {
 
-    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns);
+    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns, refData);
     taskRunner.calculateAsync(tasks, marketData, refData, listener);
   }
 
@@ -104,7 +104,7 @@ class DefaultCalculationRunner implements CalculationRunner {
       ScenarioMarketData marketData,
       ReferenceData refData) {
 
-    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns);
+    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns, refData);
     return taskRunner.calculateMultiScenario(tasks, marketData, refData);
   }
 
@@ -117,7 +117,7 @@ class DefaultCalculationRunner implements CalculationRunner {
       ReferenceData refData,
       CalculationListener listener) {
 
-    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns);
+    CalculationTasks tasks = CalculationTasks.of(calculationRules, targets, columns, refData);
     taskRunner.calculateMultiScenarioAsync(tasks, marketData, refData, listener);
   }
 

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketDataRequirements.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/marketdata/MarketDataRequirements.java
@@ -84,7 +84,7 @@ public final class MarketDataRequirements implements ImmutableBean {
       List<Column> columns,
       ReferenceData refData) {
 
-    return CalculationTasks.of(calculationRules, targets, columns).requirements(refData);
+    return CalculationTasks.of(calculationRules, targets, columns, refData).requirements(refData);
   }
 
   /**

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationFunction.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationFunction.java
@@ -100,6 +100,17 @@ public interface CalculationFunction<T extends CalculationTarget> {
   public abstract Currency naturalCurrency(T target, ReferenceData refData);
 
   /**
+   * Resolves the target, potentially returning a different target.
+   * 
+   * @param target  the target to be resolved
+   * @param refData  the reference data to use for resolving
+   * @return the resolved target
+   */
+  public default CalculationTarget resolveTarget(T target, ReferenceData refData) {
+    return target;
+  }
+
+  /**
    * Determines the market data required by this function to perform its calculations.
    * <p>
    * Any market data needed by the {@code calculate} method should be specified.

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTaskRunner.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTaskRunner.java
@@ -27,7 +27,7 @@ import com.opengamma.strata.data.scenario.ScenarioMarketData;
  * are passed in using an instance of {@code CalculationTasks}.
  * <p>
  * The {@code CalculationTasks} instance is obtained using a
- * {@linkplain CalculationTasks#of(CalculationRules, List, List) static factory method}.
+ * {@linkplain CalculationTasks#of(CalculationRules, List, List, ReferenceData) static factory method}.
  * It consists of a list of {@code CalculationTask} instances, where each task instance
  * corresponds to a single cell in the grid of results. When the {@code CalculationTasks}
  * instance is created for a set of trades and measures some one-off initialization is performed.

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTasks.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTasks.java
@@ -71,6 +71,8 @@ public final class CalculationTasks implements ImmutableBean {
    * <p>
    * The targets will typically be trades.
    * The columns represent the measures to calculate.
+   * <p>
+   * This uses the minimal set of reference data.
    * 
    * @param rules  the rules defining how the calculation is performed
    * @param targets  the targets for which values of the measures will be calculated
@@ -82,6 +84,29 @@ public final class CalculationTasks implements ImmutableBean {
       List<? extends CalculationTarget> targets,
       List<Column> columns) {
 
+    return CalculationTasks.of(rules, targets, columns, ReferenceData.minimal());
+  }
+
+  /**
+   * Obtains an instance from a set of targets, columns and rules.
+   * <p>
+   * The targets will typically be trades.
+   * The columns represent the measures to calculate.
+   * <p>
+   * The reference data is used when the function needs to resolve the targets.
+   * 
+   * @param rules  the rules defining how the calculation is performed
+   * @param targets  the targets for which values of the measures will be calculated
+   * @param columns  the columns that will be calculated
+   * @param refData  the reference data to use for resolving
+   * @return the calculation tasks
+   */
+  public static CalculationTasks of(
+      CalculationRules rules,
+      List<? extends CalculationTarget> targets,
+      List<Column> columns,
+      ReferenceData refData) {
+
     // create columns that are a combination of the column overrides and the defaults
     // this is done once as it is the same for all targets
     List<Column> effectiveColumns =
@@ -92,7 +117,8 @@ public final class CalculationTasks implements ImmutableBean {
     // loop around the targets, then the columns, to build the tasks
     ImmutableList.Builder<CalculationTask> taskBuilder = ImmutableList.builder();
     for (int rowIndex = 0; rowIndex < targets.size(); rowIndex++) {
-      CalculationTarget target = targets.get(rowIndex);
+      // resolves the target, potentially changing its type
+      CalculationTarget target = resolveTarget(targets.get(rowIndex), rules, refData);
 
       // find the applicable function
       CalculationFunction<?> fn = rules.getFunctions().getFunction(target);
@@ -104,6 +130,21 @@ public final class CalculationTasks implements ImmutableBean {
 
     // calculation tasks holds the original user-specified columns, not the derived ones
     return new CalculationTasks(taskBuilder.build(), columns);
+  }
+
+  // resolves the target via the function
+  private static <T extends CalculationTarget> CalculationTarget resolveTarget(
+      T target,
+      CalculationRules rules,
+      ReferenceData refData) {
+
+    try {
+      CalculationFunction<? super T> fn = rules.getFunctions().getFunction(target);
+      return fn.resolveTarget(target, refData);
+    } catch (RuntimeException ex) {
+      // retain the original target
+      return target;
+    }
   }
 
   // creates the tasks for a single target

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationTaskTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationTaskTest.java
@@ -479,6 +479,8 @@ public class CalculationTaskTest {
    */
   public static final class TestFunction implements CalculationFunction<TestTarget> {
 
+    public boolean resolved;
+
     @Override
     public Class<TestTarget> targetType() {
       return TestTarget.class;
@@ -492,6 +494,12 @@ public class CalculationTaskTest {
     @Override
     public Currency naturalCurrency(TestTarget trade, ReferenceData refData) {
       return USD;
+    }
+
+    @Override
+    public CalculationTarget resolveTarget(TestTarget target, ReferenceData refData) {
+      resolved = true;
+      return target;
     }
 
     @Override

--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationTasksTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/CalculationTasksTest.java
@@ -43,12 +43,14 @@ public class CalculationTasksTest {
 
   //-------------------------------------------------------------------------
   public void test_of() {
-    CalculationFunctions functions = CalculationFunctions.of(ImmutableMap.of(TestTarget.class, new TestFunction()));
+    TestFunction fn = new TestFunction();
+    CalculationFunctions functions = CalculationFunctions.of(ImmutableMap.of(TestTarget.class, fn));
     List<TestTarget> targets = ImmutableList.of(TARGET1, TARGET2);
     List<Column> columns = ImmutableList.of(Column.of(TestingMeasures.PRESENT_VALUE), Column.of(TestingMeasures.PAR_RATE));
     CalculationRules calculationRules = CalculationRules.of(functions, USD);
 
-    CalculationTasks test = CalculationTasks.of(calculationRules, targets, columns);
+    CalculationTasks test = CalculationTasks.of(calculationRules, targets, columns, REF_DATA);
+    assertThat(fn.resolved).isTrue();
     assertThat(test.getTargets()).hasSize(2);
     assertThat(test.getTargets()).containsExactly(TARGET1, TARGET2);
     assertThat(test.getColumns()).hasSize(2);
@@ -83,7 +85,7 @@ public class CalculationTasksTest {
     List<TestTarget> targets = ImmutableList.of(TARGET1);
     List<Column> columns = ImmutableList.of(Column.of(TestingMeasures.PRESENT_VALUE));
 
-    CalculationTasks test = CalculationTasks.of(calculationRules, targets, columns);
+    CalculationTasks test = CalculationTasks.of(calculationRules, targets, columns, REF_DATA);
 
     MarketDataRequirements requirements = test.requirements(REF_DATA);
     Set<? extends MarketDataId<?>> nonObservables = requirements.getNonObservables();
@@ -110,7 +112,7 @@ public class CalculationTasksTest {
         Column.of(TestingMeasures.PRESENT_VALUE),
         Column.of(TestingMeasures.PRESENT_VALUE));
     CalculationRules rules = CalculationRules.of(CALC_FUNCTIONS, USD);
-    CalculationTasks task = CalculationTasks.of(rules, targets, columns);
+    CalculationTasks task = CalculationTasks.of(rules, targets, columns, REF_DATA);
     assertThat(task.toString()).isEqualTo("CalculationTasks[grid=2x3]");
   }
 

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunction.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.calc.Measure;
@@ -74,6 +75,11 @@ public class SecurityTradeCalculationFunction
   public Currency naturalCurrency(SecurityTrade trade, ReferenceData refData) {
     Security security = refData.getValue(trade.getSecurityId());
     return security.getCurrency();
+  }
+
+  @Override
+  public CalculationTarget resolveTarget(SecurityTrade trade, ReferenceData refData) {
+    return trade.resolveSecurity(refData);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/curve/CurveEndToEndTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/curve/CurveEndToEndTest.java
@@ -150,7 +150,7 @@ public class CurveEndToEndTest {
     MarketData knownMarketData = MarketData.of(date(2011, 3, 8), parRateData);
 
     // using the direct executor means there is no need to close/shutdown the runner
-    CalculationTasks tasks = CalculationTasks.of(calculationRules, trades, columns);
+    CalculationTasks tasks = CalculationTasks.of(calculationRules, trades, columns, REF_DATA);
     MarketDataRequirements reqs = tasks.requirements(REF_DATA);
     MarketData enhancedMarketData = marketDataFactory().create(reqs, marketDataConfig, knownMarketData, REF_DATA);
     CalculationTaskRunner runner = CalculationTaskRunner.of(MoreExecutors.newDirectExecutorService());

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/security/SecurityTradeCalculationFunctionTest.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.basics.ImmutableReferenceData;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.Currency;
@@ -31,6 +32,7 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.measure.Measures;
 import com.opengamma.strata.measure.curve.TestMarketDataMap;
 import com.opengamma.strata.product.GenericSecurity;
+import com.opengamma.strata.product.GenericSecurityTrade;
 import com.opengamma.strata.product.SecurityId;
 import com.opengamma.strata.product.SecurityInfo;
 import com.opengamma.strata.product.SecurityTrade;
@@ -47,6 +49,7 @@ public class SecurityTradeCalculationFunctionTest {
   private static final double TICK_SIZE = 0.01;
   private static final int TICK_VALUE = 10;
   private static final int QUANTITY = 20;
+  private static final double PRICE = 99.550;
   private static final SecurityId SEC_ID = SecurityId.of("OG-Future", "Foo-Womble-Mar14");
   public static final SecurityTrade TRADE = SecurityTrade.builder()
       .info(TradeInfo.builder()
@@ -54,7 +57,7 @@ public class SecurityTradeCalculationFunctionTest {
           .build())
       .securityId(SEC_ID)
       .quantity(QUANTITY)
-      .price(99.550)
+      .price(PRICE)
       .build();
   private static final GenericSecurity FUTURE = GenericSecurity.of(
       SecurityInfo.of(SEC_ID, TICK_SIZE, CurrencyAmount.of(EUR, TICK_VALUE)));
@@ -63,6 +66,16 @@ public class SecurityTradeCalculationFunctionTest {
   private static final LocalDate VAL_DATE = LocalDate.of(2013, 12, 8);
 
   //-------------------------------------------------------------------------
+  public void test_resolveTarget() {
+    SecurityTradeCalculationFunction function = new SecurityTradeCalculationFunction();
+    CalculationTarget target = function.resolveTarget(TRADE, REF_DATA);
+    assertThat(target).isInstanceOf(GenericSecurityTrade.class);
+    GenericSecurityTrade trade = (GenericSecurityTrade) target;
+    assertThat(trade.getSecurity()).isEqualTo(FUTURE);
+    assertThat(trade.getQuantity()).isEqualTo(QUANTITY);
+    assertThat(trade.getPrice()).isEqualTo(PRICE);
+  }
+
   public void test_requirementsAndCurrency() {
     SecurityTradeCalculationFunction function = new SecurityTradeCalculationFunction();
     Set<Measure> measures = function.supportedMeasures();

--- a/modules/product/src/main/java/com/opengamma/strata/product/SecurityTrade.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/SecurityTrade.java
@@ -23,6 +23,7 @@ import org.joda.beans.impl.direct.DirectMetaProperty;
 import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.ReferenceDataNotFoundException;
 import com.opengamma.strata.product.common.SummarizerUtils;
 
 /**
@@ -124,6 +125,7 @@ public final class SecurityTrade
    * 
    * @param refData  the reference data used to 
    * @return an equivalent trade with the security resolved
+   * @throws ReferenceDataNotFoundException if the security cannot be found in reference data
    */
   public Trade resolveSecurity(ReferenceData refData) {
     Security security = refData.getValue(securityId);


### PR DESCRIPTION
When processing `SecurityTrade` it is desirable to resolve the trade
before determining the function to use for calculation
This change ensures that the target is resolved at the correct stage
This may change behaviour where reference data contains real securities