### PR TITLE
Ensure test methods are public

### DIFF
--- a/modules/basics/src/test/java/com/opengamma/strata/basics/StandardIdTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/StandardIdTest.java
@@ -46,7 +46,7 @@ public class StandardIdTest {
   }
 
   @DataProvider(name = "factoryValid")
-  Object[][] data_factoryValid() {
+  public static Object[][] data_factoryValid() {
     return new Object[][] {
         {"ABCDEFGHIJKLMNOPQRSTUVWXYZ", "123"},
         {"abcdefghijklmnopqrstuvwxyz", "123"},
@@ -61,7 +61,7 @@ public class StandardIdTest {
   }
 
   @DataProvider(name = "factoryInvalid")
-  Object[][] data_factoryInvalid() {
+  public static Object[][] data_factoryInvalid() {
     return new Object[][] {
         {"", ""},
         {" ", "123"},
@@ -85,7 +85,7 @@ public class StandardIdTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "formats")
-  Object[][] data_formats() {
+  public static Object[][] data_formats() {
     return new Object[][] {
         {"Value", "A~Value"},
         {"a+b", "A~a+b"},
@@ -114,7 +114,7 @@ public class StandardIdTest {
   }
 
   @DataProvider(name = "parseInvalidFormat")
-  Object[][] data_parseInvalidFormat() {
+  public static Object[][] data_parseInvalidFormat() {
     return new Object[][] {
         {"Scheme"},
         {"Scheme~"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyAmountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyAmountTest.java
@@ -73,7 +73,7 @@ public class CurrencyAmountTest {
   }
 
   @DataProvider(name = "parseGood")
-  Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"AUD 100.001", Currency.AUD, 100.001d},
         {"AUD 321.123", Currency.AUD, 321.123d},
@@ -90,7 +90,7 @@ public class CurrencyAmountTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {"AUD"},
         {"AUD aa"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyPairTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyPairTest.java
@@ -77,7 +77,7 @@ public class CurrencyPairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "parseGood")
-  Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"USD/EUR", USD, EUR},
         {"EUR/USD", EUR, USD},
@@ -92,7 +92,7 @@ public class CurrencyPairTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {"AUD"},
         {"AUD/GB"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyTest.java
@@ -75,7 +75,7 @@ public class CurrencyTest {
   }
 
   @DataProvider(name = "ofBad")
-  Object[][] data_ofBad() {
+  public static Object[][] data_ofBad() {
     return new Object[][] {
         {""},
         {"AB"},
@@ -113,7 +113,7 @@ public class CurrencyTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {""},
         {"AB"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRateTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRateTest.java
@@ -97,7 +97,7 @@ public class FxRateTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "parseGood")
-  Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"USD/EUR 205.123", USD, EUR, 205.123d},
         {"USD/EUR 3.00000000", USD, EUR, 3d},
@@ -115,7 +115,7 @@ public class FxRateTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {"AUD 1.25"},
         {"AUD/GB 1.25"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/AdjustableDateTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/AdjustableDateTest.java
@@ -69,7 +69,7 @@ public class AdjustableDateTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "adjusted")
-  static Object[][] data_adjusted() {
+  public static Object[][] data_adjusted() {
     return new Object[][] {
         {THU_2014_07_10, THU_2014_07_10},
         {FRI_2014_07_11, FRI_2014_07_11},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/BusinessDayConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/BusinessDayConventionTest.java
@@ -60,7 +60,7 @@ public class BusinessDayConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "convention")
-  static Object[][] data_convention() {
+  public static Object[][] data_convention() {
     return new Object[][] {
         {NO_ADJUST, FRI_2014_07_11, FRI_2014_07_11},
         {NO_ADJUST, SAT_2014_07_12, SAT_2014_07_12},
@@ -170,7 +170,7 @@ public class BusinessDayConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {NO_ADJUST, "NoAdjust"},
         {FOLLOWING, "Following"},
@@ -218,7 +218,7 @@ public class BusinessDayConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "lenient")
-  static Object[][] data_lenient() {
+  public static Object[][] data_lenient() {
     return new Object[][] {
         {"F", FOLLOWING},
         {"M", MODIFIED_FOLLOWING},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/DateAdjustersTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/DateAdjustersTest.java
@@ -21,7 +21,7 @@ public class DateAdjustersTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "nextLeapDay")
-  static Object[][] data_nextLeapDay() {
+  public static Object[][] data_nextLeapDay() {
     return new Object[][] {
         {2000, 1, 1, 2000},
         {2000, 2, 1, 2000},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/DateSequenceTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/DateSequenceTest.java
@@ -38,7 +38,7 @@ public class DateSequenceTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "quarterlyImm")
-  static Object[][] data_quarterlyImm() {
+  public static Object[][] data_quarterlyImm() {
     return new Object[][] {
         {date(2013, 1, 1), date(2013, 3, 20), date(2013, 6, 19), date(2013, 9, 18)},
         {date(2013, 3, 20), date(2013, 6, 19), date(2013, 9, 18), date(2013, 12, 18)},
@@ -80,7 +80,7 @@ public class DateSequenceTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "monthlyImm")
-  static Object[][] data_monthlyImm() {
+  public static Object[][] data_monthlyImm() {
     return new Object[][] {
         {date(2014, 12, 17), date(2015, 1, 21), date(2015, 2, 18), date(2015, 3, 18)},
         {date(2015, 1, 21), date(2015, 2, 18), date(2015, 3, 18), date(2015, 4, 15)},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/DayCountTest.java
@@ -63,7 +63,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "types")
-  static Object[][] data_types() {
+  public static Object[][] data_types() {
     StandardDayCounts[] conv = StandardDayCounts.values();
     Object[][] result = new Object[conv.length][];
     for (int i = 0; i < conv.length; i++) {
@@ -123,7 +123,7 @@ public class DayCountTest {
   private static int SIMPLE_30_360Days = 0;
 
   @DataProvider(name = "yearFraction")
-  static Object[][] data_yearFraction() {
+  public static Object[][] data_yearFraction() {
     return new Object[][] {
         {ONE_ONE, 2011, 12, 28, 2012, 2, 28, 1d},
         {ONE_ONE, 2011, 12, 28, 2012, 2, 29, 1d},
@@ -372,7 +372,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "days")
-  static Object[][] data_days() {
+  public static Object[][] data_days() {
     return new Object[][] {
         {ONE_ONE, 2011, 12, 28, 2012, 2, 28, 1},
         {ONE_ONE, 2011, 12, 28, 2012, 2, 29, 1},
@@ -577,7 +577,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "30U360")
-  static Object[][] data_30U360() {
+  public static Object[][] data_30U360() {
     return new Object[][] {
         {2011, 12, 28, 2012, 2, 28, SIMPLE_30_360, SIMPLE_30_360},
         {2011, 12, 28, 2012, 2, 29, SIMPLE_30_360, SIMPLE_30_360},
@@ -648,7 +648,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "30E360ISDA")
-  static Object[][] data_30E360ISDA() {
+  public static Object[][] data_30E360ISDA() {
     return new Object[][] {
         {2011, 12, 28, 2012, 2, 28, SIMPLE_30_360, SIMPLE_30_360},
         {2011, 12, 28, 2012, 2, 29, calc360(2011, 12, 28, 2012, 2, 30), SIMPLE_30_360},
@@ -709,7 +709,7 @@ public class DayCountTest {
   // 4) In all cases, the rule has strange effects when interest through a period encounters
   // February 29th and the denominator suddenly changes from 365 to 366 for the rest of the year
   @DataProvider(name = "ACTACTAFB")
-  static Object[][] data_ACTACTAFB() {
+  public static Object[][] data_ACTACTAFB() {
     return new Object[][] {
         // example from the original French specification
         {1994, 2, 10, 1997, 6, 30, 140d / 365d + 3},
@@ -799,7 +799,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "ACT365L")
-  static Object[][] data_ACT365L() {
+  public static Object[][] data_ACT365L() {
     return new Object[][] {
         {2011, 12, 28, 2012, 2, 28, P12M, 2012, 2, 28, 62d / 365d},
         {2011, 12, 28, 2012, 2, 28, P12M, 2012, 2, 29, 62d / 366d},
@@ -1011,7 +1011,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {ONE_ONE, "1/1"},
         {ACT_ACT_ISDA, "Act/Act ISDA"},
@@ -1071,7 +1071,7 @@ public class DayCountTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "lenient")
-  static Object[][] data_lenient() {
+  public static Object[][] data_lenient() {
     return new Object[][] {
         {"Actual/Actual", ACT_ACT_ISDA},
         {"Act/Act", ACT_ACT_ISDA},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList;
 public class GlobalHolidayCalendarsTest {
 
   @DataProvider(name = "easter")
-  Object[][] data_easter() {
+  public static Object[][] data_easter() {
     return new Object[][] {
         {15, 4, 1900},
         {15, 4, 1900},
@@ -243,7 +243,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar GBLO = GlobalHolidayCalendars.generateLondon();
 
   @DataProvider(name = "gblo")
-  Object[][] data_gblo() {
+  public static Object[][] data_gblo() {
     return new Object[][] {
         // Whitsun, Last Mon Aug - http://hansard.millbanksystems.com/commons/1964/mar/04/staggered-holidays
         {1965, mds(1965, md(4, 16), md(4, 19), md(6, 7), md(8, 30), md(12, 27), md(12, 28))},
@@ -286,7 +286,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar FRPA = GlobalHolidayCalendars.generateParis();
 
   @DataProvider(name = "frpa")
-  Object[][] data_frpa() {
+  public static Object[][] data_frpa() {
     return new Object[][] {
         // dates not shifted if fall on a weekend
         {2003, mds(2003, md(1, 1), md(4, 18), md(4, 21), md(5, 1), md(5, 2), md(5, 8), md(5, 9), md(5, 29), md(5, 30),
@@ -330,7 +330,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar DEFR = GlobalHolidayCalendars.generateFrankfurt();
 
   @DataProvider(name = "defr")
-  Object[][] data_defr() {
+  public static Object[][] data_defr() {
     return new Object[][] {
         // dates not shifted if fall on a weekend
         {2014, mds(2014, md(1, 1), md(4, 18), md(4, 21), md(5, 1), md(5, 29), md(6, 9), md(6, 19),
@@ -359,7 +359,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar CHZU = GlobalHolidayCalendars.generateZurich();
 
   @DataProvider(name = "chzu")
-  Object[][] data_chzu() {
+  public static Object[][] data_chzu() {
     return new Object[][] {
         // dates not shifted if fall on a weekend
         {2012, mds(2012, md(1, 1), md(1, 2), md(4, 6), md(4, 9), md(5, 1), md(5, 17), md(5, 28),
@@ -390,7 +390,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar EUTA = GlobalHolidayCalendars.generateEuropeanTarget();
 
   @DataProvider(name = "euta")
-  Object[][] data_euta() {
+  public static Object[][] data_euta() {
     return new Object[][] {
         // 1997 - 1998 (testing phase), Jan 1, christmas day
         {1997, mds(1997, md(1, 1), md(12, 25))},
@@ -425,7 +425,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar USGS = GlobalHolidayCalendars.generateUsGovtSecurities();
 
   @DataProvider(name = "usgs")
-  Object[][] data_usgs() {
+  public static Object[][] data_usgs() {
     return new Object[][] {
         // http://www.sifma.org/uploadedfiles/research/statistics/statisticsfiles/misc-us-historical-holiday-market-recommendations-sifma.pdf?n=53384
         {1996, mds(1996, md(1, 1), md(1, 15), md(2, 19), md(4, 5), md(5, 27), md(7, 4),
@@ -486,7 +486,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar USNY = GlobalHolidayCalendars.generateUsNewYork();
 
   @DataProvider(name = "usny")
-  Object[][] data_usny() {
+  public static Object[][] data_usny() {
     return new Object[][] {
         // http://www.cs.ny.gov/attendance_leave/2012_legal_holidays.cfm
         // change year for other pages
@@ -524,7 +524,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar NYFD = GlobalHolidayCalendars.generateNewYorkFed();
 
   @DataProvider(name = "nyfd")
-  Object[][] data_nyfd() {
+  public static Object[][] data_nyfd() {
     return new Object[][] {
         // http://www.ny.frb.org/aboutthefed/holiday_schedule.html
         // http://web.archive.org/web/20080403230805/http://www.ny.frb.org/aboutthefed/holiday_schedule.html
@@ -581,7 +581,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar NYSE = GlobalHolidayCalendars.generateNewYorkStockExchange();
 
   @DataProvider(name = "nyse")
-  Object[][] data_nyse() {
+  public static Object[][] data_nyse() {
     return new Object[][] {
         // https://www.nyse.com/markets/hours-calendars
         // http://web.archive.org/web/20110320011340/http://www.nyse.com/about/newsevents/1176373643795.html?sa_campaign=/internal_ads/homepage/08262008holidays
@@ -620,7 +620,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar JPTO = GlobalHolidayCalendars.generateTokyo();
 
   @DataProvider(name = "jpto")
-  Object[][] data_jpto() {
+  public static Object[][] data_jpto() {
     return new Object[][] {
         // https://www.boj.or.jp/en/about/outline/holi.htm/
         // http://web.archive.org/web/20110513190217/http://www.boj.or.jp/en/about/outline/holi.htm/
@@ -671,7 +671,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar AUSY = GlobalHolidayCalendars.generateSydney();
 
   @DataProvider(name = "ausy")
-  Object[][] data_ausy() {
+  public static Object[][] data_ausy() {
     return new Object[][] {
         {2012, mds(2012, md(1, 1), md(1, 2), md(1, 26), md(4, 6), md(4, 7), md(4, 8), md(4, 9),
             md(4, 25), md(6, 11), md(8, 6), md(10, 1), md(12, 25), md(12, 26))},
@@ -703,7 +703,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar BRBD = GlobalHolidayCalendars.generateBrazil();
 
   @DataProvider(name = "brbd")
-  Object[][] data_brbd() {
+  public static Object[][] data_brbd() {
     // http://www.planalto.gov.br/ccivil_03/leis/2002/L10607.htm
     // fixing data
     return new Object[][] {
@@ -733,7 +733,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar CAMO = GlobalHolidayCalendars.generateMontreal();
 
   @DataProvider(name = "camo")
-  Object[][] data_camo() {
+  public static Object[][] data_camo() {
     // https://www.bankofcanada.ca/about/contact-information/bank-of-canada-holiday-schedule/
     // also indicate day after new year and boxing day, but no other sources for this
     return new Object[][] {
@@ -759,7 +759,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar CATO = GlobalHolidayCalendars.generateToronto();
 
   @DataProvider(name = "cato")
-  Object[][] data_cato() {
+  public static Object[][] data_cato() {
     return new Object[][] {
         {2009, mds(2009, md(1, 1), md(2, 16), md(4, 10),
             md(5, 18), md(7, 1), md(8, 3), md(9, 7), md(10, 12), md(11, 11), md(12, 25), md(12, 28))},
@@ -795,7 +795,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar CZPR = GlobalHolidayCalendars.generatePrague();
 
   @DataProvider(name = "czpr")
-  Object[][] data_czpr() {
+  public static Object[][] data_czpr() {
     // official data from Czech National Bank
     // https://www.cnb.cz/en/public/media_service/schedules/media_svatky.html
     return new Object[][] {
@@ -837,7 +837,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar DKCO = GlobalHolidayCalendars.generateCopenhagen();
 
   @DataProvider(name = "dkco")
-  Object[][] data_dkco() {
+  public static Object[][] data_dkco() {
     // official data from Danish Bankers association via web archive
     return new Object[][] {
         {2013, mds(2013, md(1, 1), md(3, 28), md(3, 29), md(4, 1),
@@ -866,7 +866,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar HUBU = GlobalHolidayCalendars.generateBudapest();
 
   @DataProvider(name = "hubu")
-  Object[][] data_hubu() {
+  public static Object[][] data_hubu() {
     // http://www.mnb.hu/letoltes/bubor2.xls
     // http://holidays.kayaposoft.com/public_holidays.php?year=2013&country=hun&region=#
     return new Object[][] {
@@ -905,7 +905,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar MXMC = GlobalHolidayCalendars.generateMexicoCity();
 
   @DataProvider(name = "mxmc")
-  Object[][] data_mxmc() {
+  public static Object[][] data_mxmc() {
     // http://www.banxico.org.mx/SieInternet/consultarDirectorioInternetAction.do?accion=consultarCuadro&idCuadro=CF111&locale=en
     return new Object[][] {
         {2012, mds(2012, md(1, 1), md(2, 6), md(3, 19), md(4, 5), md(4, 6),
@@ -936,7 +936,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar NOOS = GlobalHolidayCalendars.generateOslo();
 
   @DataProvider(name = "noos")
-  Object[][] data_noos() {
+  public static Object[][] data_noos() {
     // official data from Oslo Bors via web archive
     return new Object[][] {
         {2009, mds(2009, md(1, 1), md(4, 9), md(4, 10), md(4, 13),
@@ -973,7 +973,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar NZAU = GlobalHolidayCalendars.generateAuckland();
 
   @DataProvider(name = "nzau")
-  Object[][] data_nzau() {
+  public static Object[][] data_nzau() {
     // https://www.govt.nz/browse/work/public-holidays-and-work/public-holidays-and-anniversary-dates/
     // https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/dates-for-previous-years/
     return new Object[][] {
@@ -1003,7 +1003,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar NZWE = GlobalHolidayCalendars.generateWellington();
 
   @DataProvider(name = "nzwe")
-  Object[][] data_nzwe() {
+  public static Object[][] data_nzwe() {
     // https://www.govt.nz/browse/work/public-holidays-and-work/public-holidays-and-anniversary-dates/
     // https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/dates-for-previous-years/
     return new Object[][] {
@@ -1033,7 +1033,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar NZBD = GlobalHolidayCalendars.generateNewZealand();
 
   @DataProvider(name = "nzbd")
-  Object[][] data_nzbd() {
+  public static Object[][] data_nzbd() {
     // https://www.govt.nz/browse/work/public-holidays-and-work/public-holidays-and-anniversary-dates/
     // https://www.employment.govt.nz/leave-and-holidays/public-holidays/public-holidays-and-anniversary-dates/dates-for-previous-years/
     return new Object[][] {
@@ -1063,7 +1063,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar PLWA = GlobalHolidayCalendars.generateWarsaw();
 
   @DataProvider(name = "plwa")
-  Object[][] data_plwa() {
+  public static Object[][] data_plwa() {
     // based on government law data and stock exchange holidays
     return new Object[][] {
         {2013, mds(2013, md(1, 1), md(3, 29), md(4, 1),
@@ -1094,7 +1094,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar SEST = GlobalHolidayCalendars.generateStockholm();
 
   @DataProvider(name = "sest")
-  Object[][] data_sest() {
+  public static Object[][] data_sest() {
     // official data from published fixing dates
     return new Object[][] {
         {2014, mds(2014, md(1, 1), md(1, 6), md(4, 18), md(4, 21),
@@ -1121,7 +1121,7 @@ public class GlobalHolidayCalendarsTest {
   private static final HolidayCalendar ZAJO = GlobalHolidayCalendars.generateJohannesburg();
 
   @DataProvider(name = "zajo")
-  Object[][] data_zajo() {
+  public static Object[][] data_zajo() {
     // http://www.gov.za/about-sa/public-holidays
     // https://web.archive.org/web/20151230214958/http://www.gov.za/about-sa/public-holidays
     return new Object[][] {

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/HolidayCalendarTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/HolidayCalendarTest.java
@@ -294,7 +294,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "shift")
-  static Object[][] data_shift() {
+  public static Object[][] data_shift() {
     return new Object[][] {
         {THU_2014_07_10, 1, FRI_2014_07_11},
         {FRI_2014_07_11, 1, MON_2014_07_14},
@@ -378,7 +378,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "next")
-  static Object[][] data_next() {
+  public static Object[][] data_next() {
     return new Object[][] {
         {THU_2014_07_10, FRI_2014_07_11},
         {FRI_2014_07_11, MON_2014_07_14},
@@ -403,7 +403,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "nextOrSame")
-  static Object[][] data_nextOrSame() {
+  public static Object[][] data_nextOrSame() {
     return new Object[][] {
         {THU_2014_07_10, THU_2014_07_10},
         {FRI_2014_07_11, FRI_2014_07_11},
@@ -428,7 +428,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "previous")
-  static Object[][] data_previous() {
+  public static Object[][] data_previous() {
     return new Object[][] {
         {FRI_2014_07_11, THU_2014_07_10},
         {SAT_2014_07_12, FRI_2014_07_11},
@@ -453,7 +453,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "previousOrSame")
-  static Object[][] data_previousOrSame() {
+  public static Object[][] data_previousOrSame() {
     return new Object[][] {
         {FRI_2014_07_11, FRI_2014_07_11},
         {SAT_2014_07_12, FRI_2014_07_11},
@@ -478,7 +478,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "nextSameOrLastInMonth")
-  static Object[][] data_nextSameOrLastInMonth() {
+  public static Object[][] data_nextSameOrLastInMonth() {
     return new Object[][] {
         {THU_2014_07_10, THU_2014_07_10},
         {FRI_2014_07_11, FRI_2014_07_11},
@@ -506,7 +506,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "lastBusinessDayOfMonth")
-  static Object[][] data_lastBusinessDayOfMonth() {
+  public static Object[][] data_lastBusinessDayOfMonth() {
     return new Object[][] {
         // June 30th is Monday holiday, June 28/29 is weekend
         {date(2014, 6, 26), date(2014, 6, 27)},
@@ -544,7 +544,7 @@ public class HolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "daysBetween")
-  static Object[][] data_daysBetween() {
+  public static Object[][] data_daysBetween() {
     return new Object[][] {
         {FRI_2014_07_11, FRI_2014_07_11, 0},
         {FRI_2014_07_11, SAT_2014_07_12, 1},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendarTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendarTest.java
@@ -104,7 +104,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "createSatSunWeekend")
-  static Object[][] data_createSatSunWeekend() {
+  public static Object[][] data_createSatSunWeekend() {
     return new Object[][] {
         {FRI_2014_07_11, true},
         {SAT_2014_07_12, false},
@@ -144,7 +144,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "createThuFriWeekend")
-  static Object[][] data_createThuFriWeekend() {
+  public static Object[][] data_createThuFriWeekend() {
     return new Object[][] {
         {FRI_2014_07_11, false},
         {SAT_2014_07_12, true},
@@ -184,7 +184,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "createSunWeekend")
-  static Object[][] data_createSunWeekend() {
+  public static Object[][] data_createSunWeekend() {
     return new Object[][] {
         {FRI_2014_07_11, true},
         {SAT_2014_07_12, true},
@@ -224,7 +224,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "createThuFriSatWeekend")
-  static Object[][] data_createThuFriSatWeekend() {
+  public static Object[][] data_createThuFriSatWeekend() {
     return new Object[][] {
         {FRI_2014_07_11, false},
         {SAT_2014_07_12, false},
@@ -254,7 +254,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "createNoWeekends")
-  static Object[][] data_createNoWeekends() {
+  public static Object[][] data_createNoWeekends() {
     return new Object[][] {
         {FRI_2014_07_11, true},
         {SAT_2014_07_12, true},
@@ -284,7 +284,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "createNoHolidays")
-  static Object[][] data_createNoHolidays() {
+  public static Object[][] data_createNoHolidays() {
     return new Object[][] {
         {FRI_2014_07_11, false},
         {SAT_2014_07_12, false},
@@ -371,7 +371,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "shift")
-  static Object[][] data_shift() {
+  public static Object[][] data_shift() {
     return new Object[][] {
         {THU_2014_07_10, 1, FRI_2014_07_11},
         {FRI_2014_07_11, 1, TUE_2014_07_15},
@@ -463,7 +463,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "next")
-  static Object[][] data_next() {
+  public static Object[][] data_next() {
     return new Object[][] {
         {THU_2014_07_10, FRI_2014_07_11, HOLCAL_MON_WED},
         {FRI_2014_07_11, TUE_2014_07_15, HOLCAL_MON_WED},
@@ -504,7 +504,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "nextOrSame")
-  static Object[][] data_nextOrSame() {
+  public static Object[][] data_nextOrSame() {
     return new Object[][] {
         {THU_2014_07_10, THU_2014_07_10, HOLCAL_MON_WED},
         {FRI_2014_07_11, FRI_2014_07_11, HOLCAL_MON_WED},
@@ -546,7 +546,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "previous")
-  static Object[][] data_previous() {
+  public static Object[][] data_previous() {
     return new Object[][] {
         {FRI_2014_07_11, THU_2014_07_10, HOLCAL_MON_WED},
         {SAT_2014_07_12, FRI_2014_07_11, HOLCAL_MON_WED},
@@ -587,7 +587,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "previousOrSame")
-  static Object[][] data_previousOrSame() {
+  public static Object[][] data_previousOrSame() {
     return new Object[][] {
         {FRI_2014_07_11, FRI_2014_07_11, HOLCAL_MON_WED},
         {SAT_2014_07_12, FRI_2014_07_11, HOLCAL_MON_WED},
@@ -630,7 +630,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "nextSameOrLastInMonth")
-  static Object[][] data_nextSameOrLastInMonth() {
+  public static Object[][] data_nextSameOrLastInMonth() {
     return new Object[][] {
         {THU_2014_07_10, THU_2014_07_10, HOLCAL_MON_WED},
         {FRI_2014_07_11, FRI_2014_07_11, HOLCAL_MON_WED},
@@ -676,7 +676,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "lastBusinessDayOfMonth")
-  static Object[][] data_lastBusinessDayOfMonth() {
+  public static Object[][] data_lastBusinessDayOfMonth() {
     return new Object[][] {
         // June 30th is Monday holiday, June 28/29 is weekend
         {date(2014, 6, 26), date(2014, 6, 27)},
@@ -729,7 +729,7 @@ public class ImmutableHolidayCalendarTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "daysBetween")
-  static Object[][] data_daysBetween() {
+  public static Object[][] data_daysBetween() {
     return new Object[][] {
         {FRI_2014_07_11, FRI_2014_07_11, 0},
         {FRI_2014_07_11, SAT_2014_07_12, 1},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/PeriodAdditionConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/PeriodAdditionConventionTest.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableMap;
 public class PeriodAdditionConventionTest {
 
   @DataProvider(name = "types")
-  static Object[][] data_types() {
+  public static Object[][] data_types() {
     StandardPeriodAdditionConventions[] conv = StandardPeriodAdditionConventions.values();
     Object[][] result = new Object[conv.length][];
     for (int i = 0; i < conv.length; i++) {
@@ -50,7 +50,7 @@ public class PeriodAdditionConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "convention")
-  static Object[][] data_convention() {
+  public static Object[][] data_convention() {
     return new Object[][] {
         // None
         {NONE, date(2014, 7, 11), 1, date(2014, 8, 11)},  // Fri, Mon
@@ -74,7 +74,7 @@ public class PeriodAdditionConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {NONE, "None"},
         {LAST_DAY, "LastDay"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/PeriodAdjustmentTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/PeriodAdjustmentTest.java
@@ -84,7 +84,7 @@ public class PeriodAdjustmentTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "adjust")
-  static Object[][] data_adjust() {
+  public static Object[][] data_adjust() {
     return new Object[][] {
         // not last day
         {0, date(2014, 8, 15), date(2014, 8, 15)},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/TenorAdjustmentTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/TenorAdjustmentTest.java
@@ -78,7 +78,7 @@ public class TenorAdjustmentTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "adjust")
-  static Object[][] data_adjust() {
+  public static Object[][] data_adjust() {
     return new Object[][] {
         // not last day
         {1, date(2014, 8, 15), date(2014, 9, 15)},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/TenorTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/TenorTest.java
@@ -60,7 +60,7 @@ import com.google.common.collect.ImmutableList;
 public class TenorTest {
 
   @DataProvider(name = "ofPeriod")
-  static Object[][] data_ofPeriod() {
+  public static Object[][] data_ofPeriod() {
     return new Object[][] {
         {Period.ofDays(1), Period.ofDays(1), "1D"},
         {Period.ofDays(7), Period.ofDays(7), "1W"},
@@ -85,7 +85,7 @@ public class TenorTest {
   }
 
   @DataProvider(name = "ofMonths")
-  static Object[][] data_ofMonths() {
+  public static Object[][] data_ofMonths() {
     return new Object[][] {
         {1, Period.ofMonths(1), "1M"},
         {2, Period.ofMonths(2), "2M"},
@@ -103,7 +103,7 @@ public class TenorTest {
   }
 
   @DataProvider(name = "ofYears")
-  static Object[][] data_ofYears() {
+  public static Object[][] data_ofYears() {
     return new Object[][] {
         {1, Period.ofYears(1), "1Y"},
         {2, Period.ofYears(2), "2Y"},
@@ -154,7 +154,7 @@ public class TenorTest {
   }
 
   @DataProvider(name = "parseGood")
-  static Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"2D", TENOR_2D},
         {"2W", TENOR_2W},
@@ -177,7 +177,7 @@ public class TenorTest {
   }
 
   @DataProvider(name = "parseBad")
-  static Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {""},
         {"2"},
@@ -201,7 +201,7 @@ public class TenorTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "normalized")
-  static Object[][] data_normalized() {
+  public static Object[][] data_normalized() {
     return new Object[][] {
         {Period.ofDays(1), Period.ofDays(1)},
         {Period.ofDays(7), Period.ofDays(7)},
@@ -225,7 +225,7 @@ public class TenorTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "based")
-  static Object[][] data_based() {
+  public static Object[][] data_based() {
     return new Object[][] {
         {Tenor.ofDays(1), false, false},
         {Tenor.ofDays(2), false, false},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNameTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNameTest.java
@@ -41,7 +41,7 @@ public class FloatingRateNameTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "nameType")
-  static Object[][] data_name_type() {
+  public static Object[][] data_name_type() {
     return new Object[][] {
         {"GBP-LIBOR", "GBP-LIBOR-", FloatingRateType.IBOR},
         {"GBP-LIBOR-BBA", "GBP-LIBOR-", FloatingRateType.IBOR},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateTypeTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateTypeTest.java
@@ -49,7 +49,7 @@ public class FloatingRateTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FloatingRateType.IBOR, "Ibor"},
         {FloatingRateType.OVERNIGHT_AVERAGED, "OvernightAveraged"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FxIndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FxIndexTest.java
@@ -38,7 +38,7 @@ public class FxIndexTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FxIndices.EUR_CHF_ECB, "EUR/CHF-ECB"},
         {FxIndices.EUR_GBP_ECB, "EUR/GBP-ECB"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/IborIndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/IborIndexTest.java
@@ -579,7 +579,7 @@ public class IborIndexTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
         {IborIndices.CHF_LIBOR_6M, "CHF-LIBOR-6M"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/IndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/IndexTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 public class IndexTest {
 
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
         {IborIndices.CHF_LIBOR_6M, "CHF-LIBOR-6M"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/OvernightIndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/OvernightIndexTest.java
@@ -261,7 +261,7 @@ public class OvernightIndexTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {OvernightIndices.GBP_SONIA, "GBP-SONIA"},
         {OvernightIndices.CHF_TOIS, "CHF-TOIS"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/PriceIndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/PriceIndexTest.java
@@ -50,7 +50,7 @@ public class PriceIndexTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PriceIndices.GB_HICP, "GB-HICP"},
         {PriceIndices.GB_RPI, "GB-RPI"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/location/CountryTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/location/CountryTest.java
@@ -98,7 +98,7 @@ public class CountryTest {
   }
 
   @DataProvider(name = "ofBad")
-  Object[][] data_ofBad() {
+  public static Object[][] data_ofBad() {
     return new Object[][] {
         {""},
         {"A"},
@@ -135,7 +135,7 @@ public class CountryTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {""},
         {"A"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/FrequencyTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/FrequencyTest.java
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableList;
 public class FrequencyTest {
 
   @DataProvider(name = "create")
-  static Object[][] data_create() {
+  public static Object[][] data_create() {
     return new Object[][] {
         {Frequency.ofDays(1), Period.ofDays(1), "P1D"},
         {Frequency.ofDays(2), Period.ofDays(2), "P2D"},
@@ -138,7 +138,7 @@ public class FrequencyTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "ofMonths")
-  static Object[][] data_ofMonths() {
+  public static Object[][] data_ofMonths() {
     return new Object[][] {
         {1, Period.ofMonths(1), "P1M"},
         {2, Period.ofMonths(2), "P2M"},
@@ -159,7 +159,7 @@ public class FrequencyTest {
   }
 
   @DataProvider(name = "ofYears")
-  static Object[][] data_ofYears() {
+  public static Object[][] data_ofYears() {
     return new Object[][] {
         {1, Period.ofYears(1), "P1Y"},
         {2, Period.ofYears(2), "P2Y"},
@@ -175,7 +175,7 @@ public class FrequencyTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "normalized")
-  static Object[][] data_normalized() {
+  public static Object[][] data_normalized() {
     return new Object[][] {
         {Period.ofDays(1), Period.ofDays(1)},
         {Period.ofDays(7), Period.ofDays(7)},
@@ -199,7 +199,7 @@ public class FrequencyTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "based")
-  static Object[][] data_based() {
+  public static Object[][] data_based() {
     return new Object[][] {
         {Frequency.ofDays(1), false, false, false},
         {Frequency.ofDays(2), false, false, false},
@@ -234,7 +234,7 @@ public class FrequencyTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "events")
-  static Object[][] data_events() {
+  public static Object[][] data_events() {
     return new Object[][] {
         {Frequency.P1D, 364},
         {Frequency.P1W, 52},
@@ -287,7 +287,7 @@ public class FrequencyTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "exactDivide")
-  static Object[][] data_exactDivide() {
+  public static Object[][] data_exactDivide() {
     return new Object[][] {
         {Frequency.P1D, Frequency.P1D, 1},
         {Frequency.P1W, Frequency.P1D, 7},
@@ -345,7 +345,7 @@ public class FrequencyTest {
   }
 
   @DataProvider(name = "parseGood")
-  static Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"1D", Frequency.ofDays(1)},
         {"2D", Frequency.ofDays(2)},
@@ -374,7 +374,7 @@ public class FrequencyTest {
   }
 
   @DataProvider(name = "parseBad")
-  static Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {""},
         {"2"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -218,7 +218,7 @@ public class PeriodicScheduleTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "generation")
-  Object[][] data_generation() {
+  public static Object[][] data_generation() {
     return new Object[][] {
         // stub null
         {JUN_17, SEP_17, P1M, null, null, BDA, null, null, null,

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/RollConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/RollConventionTest.java
@@ -60,7 +60,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "types")
-  static Object[][] data_types() {
+  public static Object[][] data_types() {
     RollConvention[] conv = StandardRollConventions.values();
     Object[][] result = new Object[conv.length][];
     for (int i = 0; i < conv.length; i++) {
@@ -88,7 +88,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "adjust")
-  static Object[][] data_adjust() {
+  public static Object[][] data_adjust() {
     return new Object[][] {
         {EOM, date(2014, AUGUST, 1), date(2014, AUGUST, 31)},
         {EOM, date(2014, AUGUST, 30), date(2014, AUGUST, 31)},
@@ -157,7 +157,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "matches")
-  static Object[][] data_matches() {
+  public static Object[][] data_matches() {
     return new Object[][] {
         {EOM, date(2014, AUGUST, 1), false},
         {EOM, date(2014, AUGUST, 30), false},
@@ -190,7 +190,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "next")
-  static Object[][] data_next() {
+  public static Object[][] data_next() {
     return new Object[][] {
         {EOM, date(2014, AUGUST, 1), P1M, date(2014, SEPTEMBER, 30)},
         {EOM, date(2014, AUGUST, 30), P1M, date(2014, SEPTEMBER, 30)},
@@ -268,7 +268,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "previous")
-  static Object[][] data_previous() {
+  public static Object[][] data_previous() {
     return new Object[][] {
         {EOM, date(2014, OCTOBER, 1), P1M, date(2014, SEPTEMBER, 30)},
         {EOM, date(2014, OCTOBER, 31), P1M, date(2014, SEPTEMBER, 30)},
@@ -551,7 +551,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {NONE, "None"},
         {EOM, "EOM"},
@@ -600,7 +600,7 @@ public class RollConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "lenient")
-  static Object[][] data_lenient() {
+  public static Object[][] data_lenient() {
     return new Object[][] {
         {"2", DAY_2},
         {"30", DAY_30},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
@@ -50,7 +50,7 @@ public class StubConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "types")
-  static Object[][] data_types() {
+  public static Object[][] data_types() {
     StubConvention[] conv = StubConvention.values();
     Object[][] result = new Object[conv.length][];
     for (int i = 0; i < conv.length; i++) {
@@ -68,7 +68,7 @@ public class StubConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "roll")
-  static Object[][] data_roll() {
+  public static Object[][] data_roll() {
     return new Object[][] {
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, false, DAY_14},
         {NONE, date(2014, JANUARY, 14), date(2014, AUGUST, 16), P1M, true, DAY_14},
@@ -140,7 +140,7 @@ public class StubConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "implicit")
-  static Object[][] data_implicit() {
+  public static Object[][] data_implicit() {
     return new Object[][] {
         {NONE, false, false, NONE},
         {NONE, true, false, null},
@@ -229,7 +229,7 @@ public class StubConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {NONE, "None"},
         {SHORT_INITIAL, "ShortInitial"},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/HalfUpRoundingTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/HalfUpRoundingTest.java
@@ -95,7 +95,7 @@ public class HalfUpRoundingTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "round")
-  Object[][] data_round() {
+  public static Object[][] data_round() {
     return new Object[][] {
         {HalfUpRounding.ofDecimalPlaces(2), 12.3449, 12.34},
         {HalfUpRounding.ofDecimalPlaces(2), 12.3450, 12.35},

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueAdjustmentTypeTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueAdjustmentTypeTest.java
@@ -32,7 +32,7 @@ public class ValueAdjustmentTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {ValueAdjustmentType.DELTA_AMOUNT, "DeltaAmount"},
         {ValueAdjustmentType.DELTA_MULTIPLIER, "DeltaMultiplier"},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/DoubleArrayMathTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/DoubleArrayMathTest.java
@@ -199,7 +199,7 @@ public class DoubleArrayMathTest {
 
   //-------------------------------------------------------------------------
   @AfterMethod
-  private void assertInputsUnchanged() {
+  public void assertInputsUnchanged() {
     assertThat(ARRAY_0_0).containsExactly(-1e-4, 1e-3);
     assertThat(ARRAY_1_2).containsExactly(1d, 2d);
     assertThat(ARRAY_1_2B).containsExactly(1 - 1e-4, 2 + 1e-3);

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MessagesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MessagesTest.java
@@ -24,7 +24,7 @@ import com.opengamma.strata.collect.tuple.Pair;
 public class MessagesTest {
 
   @DataProvider(name = "formatMessageSingle")
-  Object[][] data_formatMessageSingle() {
+  public static Object[][] data_formatMessageSingle() {
     return new Object[][] {
         // null template
         {null, null, "", " - [null]"},
@@ -68,7 +68,7 @@ public class MessagesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "formatMessage")
-  Object[][] data_formatMessage() {
+  public static Object[][] data_formatMessage() {
     return new Object[][] {
         // null template
         {null, null, "", ""},
@@ -139,7 +139,7 @@ public class MessagesTest {
   }
 
   @DataProvider(name = "formatMessageWithAttributes")
-  Object[][] data_formatMessageWithAttributes() {
+  public static Object[][] data_formatMessageWithAttributes() {
     return new Object[][]{
         // null template
         {null, null, Pair.of("", ImmutableMap.of())},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureReasonTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureReasonTest.java
@@ -24,7 +24,7 @@ public class FailureReasonTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FailureReason.CALCULATION_FAILED, "CALCULATION_FAILED"},
         {FailureReason.CURRENCY_CONVERSION, "CURRENCY_CONVERSION"},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -345,7 +345,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "subSeries")
-  Object[][] data_subSeries() {
+  public static Object[][] data_subSeries() {
     return new Object[][] {
         // start = end -> empty
         {DATE_2011_01_01, DATE_2011_01_01, new int[] {}},
@@ -424,7 +424,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "headSeries")
-  Object[][] data_headSeries() {
+  public static Object[][] data_headSeries() {
     return new Object[][] {
         {0, new int[] {}},
         {1, new int[] {0}},
@@ -467,7 +467,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "tailSeries")
-  Object[][] data_tailSeries() {
+  public static Object[][] data_tailSeries() {
     return new Object[][] {
         {0, new int[] {}},
         {1, new int[] {4}},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/SparseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/SparseLocalDateDoubleTimeSeriesTest.java
@@ -267,7 +267,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "subSeries")
-  Object[][] data_subSeries() {
+  public static Object[][] data_subSeries() {
     return new Object[][] {
         // start = end -> empty
         {DATE_2011_01_01, DATE_2011_01_01, new int[] {}},
@@ -313,7 +313,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "headSeries")
-  Object[][] data_headSeries() {
+  public static Object[][] data_headSeries() {
     return new Object[][] {
         {0, new int[] {}},
         {1, new int[] {0}},
@@ -352,7 +352,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "tailSeries")
-  Object[][] data_tailSeries() {
+  public static Object[][] data_tailSeries() {
     return new Object[][] {
         {0, new int[] {}},
         {1, new int[] {4}},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/DoublesPairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/DoublesPairTest.java
@@ -26,7 +26,7 @@ public class DoublesPairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {1.2d, 2.5d},
         {-100.1d, 200.2d},
@@ -73,7 +73,7 @@ public class DoublesPairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "parseGood")
-  Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"[1.2, 2.5]", 1.2d, 2.5d},
         {"[1.2,2.5]", 1.2d, 2.5d},
@@ -92,7 +92,7 @@ public class DoublesPairTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {null},
         {""},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/IntDoublePairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/IntDoublePairTest.java
@@ -26,7 +26,7 @@ public class IntDoublePairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {1, 2.5d},
         {-100, 200.2d},
@@ -73,7 +73,7 @@ public class IntDoublePairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "parseGood")
-  Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"[1, 2.5]", 1, 2.5d},
         {"[1,2.5]", 1, 2.5d},
@@ -92,7 +92,7 @@ public class IntDoublePairTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {null},
         {""},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/LongDoublePairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/LongDoublePairTest.java
@@ -26,7 +26,7 @@ public class LongDoublePairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {1L, 2.5d},
         {-100L, 200.2d},
@@ -73,7 +73,7 @@ public class LongDoublePairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "parseGood")
-  Object[][] data_parseGood() {
+  public static Object[][] data_parseGood() {
     return new Object[][] {
         {"[1, 2.5]", 1L, 2.5d},
         {"[1,2.5]", 1L, 2.5d},
@@ -92,7 +92,7 @@ public class LongDoublePairTest {
   }
 
   @DataProvider(name = "parseBad")
-  Object[][] data_parseBad() {
+  public static Object[][] data_parseBad() {
     return new Object[][] {
         {null},
         {""},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjDoublePairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjDoublePairTest.java
@@ -24,7 +24,7 @@ public class ObjDoublePairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {"A", 2.5d},
         {"B", 200.2d},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjIntPairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjIntPairTest.java
@@ -24,7 +24,7 @@ public class ObjIntPairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {"A", 2},
         {"B", 200},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/PairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/PairTest.java
@@ -22,7 +22,7 @@ public class PairTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {"A", "B"},
         {"A", 200.2d},
@@ -51,7 +51,7 @@ public class PairTest {
   }
 
   @DataProvider(name = "factoryNull")
-  Object[][] data_factoryNull() {
+  public static Object[][] data_factoryNull() {
     return new Object[][] {
         {null, null},
         {null, "B"},

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/TripleTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/TripleTest.java
@@ -22,7 +22,7 @@ public class TripleTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
-  Object[][] data_factory() {
+  public static Object[][] data_factory() {
     return new Object[][] {
         {"A", "B", "C"},
         {"A", 200.2d, 6L},
@@ -51,7 +51,7 @@ public class TripleTest {
   }
 
   @DataProvider(name = "factoryNull")
-  Object[][] data_factoryNull() {
+  public static Object[][] data_factoryNull() {
     return new Object[][] {
         {null, null, null},
         {null, "B", "C"},

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlDocumentParserTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlDocumentParserTest.java
@@ -1432,7 +1432,7 @@ public class FpmlDocumentParserTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "parse")
-  Object[][] data_parse() {
+  public static Object[][] data_parse() {
     return new Object[][] {
         {"classpath:com/opengamma/strata/loader/fpml/cd-ex01-long-asia-corp-fixreg.xml"},
         {"classpath:com/opengamma/strata/loader/fpml/cd-ex02-2003-short-asia-corp-fixreg.xml"},

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveNodeClashActionTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/CurveNodeClashActionTest.java
@@ -22,7 +22,7 @@ public class CurveNodeClashActionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CurveNodeClashAction.DROP_THIS, "DropThis"},
         {CurveNodeClashAction.DROP_OTHER, "DropOther"},

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveExtrapolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveExtrapolatorTest.java
@@ -28,7 +28,7 @@ public class CurveExtrapolatorTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CurveExtrapolators.EXCEPTION, "Exception"},
         {CurveExtrapolators.EXPONENTIAL, "Exponential"},

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveInterpolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveInterpolatorTest.java
@@ -39,7 +39,7 @@ public class CurveInterpolatorTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {LINEAR, "Linear"},
         {LOG_LINEAR, "LogLinear"},

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/PenaltyMatrixGeneratorTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/PenaltyMatrixGeneratorTest.java
@@ -217,7 +217,7 @@ public class PenaltyMatrixGeneratorTest {
   }
 
   @DataProvider
-  Object[][] data() {
+  public static Object[][] data() {
     Object[][] obj = new Object[1][4];
     double[] x = new double[] {0.0, 0.3, 0.7, 0.8, 1.2, 2.0};
     obj[0][0] = x;

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxSingleBarrierOptionMethodTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxSingleBarrierOptionMethodTest.java
@@ -32,7 +32,7 @@ public class FxSingleBarrierOptionMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FxSingleBarrierOptionMethod.BLACK, "Black"},
         {FxSingleBarrierOptionMethod.TRINOMIAL_TREE, "TrinomialTree"},

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxVanillaOptionMethodTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxVanillaOptionMethodTest.java
@@ -32,7 +32,7 @@ public class FxVanillaOptionMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FxVanillaOptionMethod.BLACK, "Black"},
         {FxVanillaOptionMethod.VANNA_VOLGA, "VannaVolga"},

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/CompoundedRateTypeTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/CompoundedRateTypeTest.java
@@ -22,7 +22,7 @@ public class CompoundedRateTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CompoundedRateType.PERIODIC, "Periodic"},
         {CompoundedRateType.CONTINUOUS, "Continuous"},

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/common/PriceTypeTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/common/PriceTypeTest.java
@@ -22,7 +22,7 @@ public class PriceTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PriceType.CLEAN, "Clean"},
         {PriceType.DIRTY, "Dirty"}

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/credit/AccrualOnDefaultFormulaTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/credit/AccrualOnDefaultFormulaTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 public class AccrualOnDefaultFormulaTest {
 
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {AccrualOnDefaultFormula.ORIGINAL_ISDA, "OriginalISDA"},
         {AccrualOnDefaultFormula.MARKIT_FIX, "MarkitFix"},

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/swap/DiscountingRatePaymentPeriodPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/swap/DiscountingRatePaymentPeriodPricerTest.java
@@ -457,7 +457,7 @@ public class DiscountingRatePaymentPeriodPricerTest {
 
   // test forecast value sensitivity for ibor, with straight, flat and exclusive compounding.
   @DataProvider(name = "compoundingRatePaymentPeriod")
-  Object[][] data_forecastValueSensitivity_ibor_compounding() {
+  public static Object[][] data_forecastValueSensitivity_ibor_compounding() {
     return new Object[][] {
         {PAYMENT_PERIOD_COMPOUNDING_STRAIGHT},
         {PAYMENT_PERIOD_COMPOUNDING_FLAT},

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondYieldConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/CapitalIndexedBondYieldConventionTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 public class CapitalIndexedBondYieldConventionTest {
 
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CapitalIndexedBondYieldConvention.US_IL_REAL, "US-I/L-Real"},
         {CapitalIndexedBondYieldConvention.GB_IL_FLOAT, "GB-I/L-Float"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/bond/FixedCouponBondYieldConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/bond/FixedCouponBondYieldConventionTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 public class FixedCouponBondYieldConventionTest {
 
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FixedCouponBondYieldConvention.GB_BUMP_DMO, "GB-Bump-DMO"},
         {FixedCouponBondYieldConvention.US_STREET, "US-Street"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/cms/CmsPeriodTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/cms/CmsPeriodTypeTest.java
@@ -22,7 +22,7 @@ public class CmsPeriodTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CmsPeriodType.COUPON, "Coupon"},
         {CmsPeriodType.CAPLET, "Caplet"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/common/BuySellTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/common/BuySellTest.java
@@ -52,7 +52,7 @@ public class BuySellTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {BuySell.BUY, "Buy"},
         {BuySell.SELL, "Sell"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/common/LongShortTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/common/LongShortTest.java
@@ -45,7 +45,7 @@ public class LongShortTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {LongShort.LONG, "Long"},
         {LongShort.SHORT, "Short"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/common/PayReceiveTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/common/PayReceiveTest.java
@@ -61,7 +61,7 @@ public class PayReceiveTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PayReceive.PAY, "Pay"},
         {PayReceive.RECEIVE, "Receive"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/common/PutCallTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/common/PutCallTest.java
@@ -40,7 +40,7 @@ public class PutCallTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PutCall.PUT, "Put"},
         {PutCall.CALL, "Call"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/common/SettlementTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/common/SettlementTypeTest.java
@@ -24,7 +24,7 @@ public class SettlementTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {SettlementType.CASH, "Cash"},
         {SettlementType.PHYSICAL, "Physical"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/PaymentOnDefaultTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/PaymentOnDefaultTest.java
@@ -22,7 +22,7 @@ public class PaymentOnDefaultTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PaymentOnDefault.NONE, "None"},
         {PaymentOnDefault.ACCRUED_PREMIUM, "AccruedPremium"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/ProtectionStartOfDayTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/ProtectionStartOfDayTest.java
@@ -22,7 +22,7 @@ public class ProtectionStartOfDayTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {ProtectionStartOfDay.NONE, "None"},
         {ProtectionStartOfDay.BEGINNING, "Beginning"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/type/AccrualStartTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/type/AccrualStartTest.java
@@ -22,7 +22,7 @@ public class AccrualStartTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {AccrualStart.NEXT_DAY, "NextDay"},
         {AccrualStart.IMM_DATE, "ImmDate"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/type/CdsConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/type/CdsConventionTest.java
@@ -173,7 +173,7 @@ public class CdsConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CdsConventions.USD_STANDARD, "USD-STANDARD"},
         {CdsConventions.JPY_US_GB_STANDARD, "JPY-US-GB-STANDARD"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/type/CdsConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/type/CdsConventionsTest.java
@@ -37,7 +37,7 @@ public class CdsConventionsTest {
   private static final HolidayCalendarId GBLO_EUTA = GBLO.combinedWith(EUTA);
 
   @DataProvider(name = "currency")
-  static Object[][] data_currency() {
+  public static Object[][] data_currency() {
     return new Object[][] {
         {CdsConventions.EUR_GB_STANDARD, EUR},
         {CdsConventions.EUR_STANDARD, EUR},
@@ -56,7 +56,7 @@ public class CdsConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "common")
-  static Object[][] data_common() {
+  public static Object[][] data_common() {
     return new Object[][] {
         {CdsConventions.EUR_GB_STANDARD,},
         {CdsConventions.EUR_STANDARD,},
@@ -80,7 +80,7 @@ public class CdsConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "businessDayAdjustment")
-  static Object[][] data_businessDayAdjustment() {
+  public static Object[][] data_businessDayAdjustment() {
     return new Object[][] {
         {CdsConventions.EUR_GB_STANDARD, BusinessDayAdjustment.of(FOLLOWING, GBLO_EUTA)},
         {CdsConventions.EUR_STANDARD, BusinessDayAdjustment.of(FOLLOWING, EUTA)},
@@ -101,7 +101,7 @@ public class CdsConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "string")
-  static Object[][] data_string() {
+  public static Object[][] data_string() {
     return new Object[][] {
         {CdsConventions.EUR_GB_STANDARD, "EUR-GB-STANDARD"},
         {CdsConventions.EUR_STANDARD, "EUR-STANDARD"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/credit/type/CdsQuoteConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/credit/type/CdsQuoteConventionTest.java
@@ -22,7 +22,7 @@ public class CdsQuoteConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CdsQuoteConvention.PAR_SPREAD, "ParSpread"},
         {CdsQuoteConvention.POINTS_UPFRONT, "PointsUpfront"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/deposit/type/IborFixingDepositConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/deposit/type/IborFixingDepositConventionTest.java
@@ -131,7 +131,7 @@ public class IborFixingDepositConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {ImmutableIborFixingDepositConvention.of(GBP_LIBOR_3M), "GBP-LIBOR-3M"},
         {ImmutableIborFixingDepositConvention.of(USD_LIBOR_3M), "USD-LIBOR-3M"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/deposit/type/TermDepositConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/deposit/type/TermDepositConventionTest.java
@@ -106,7 +106,7 @@ public class TermDepositConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {TermDepositConventions.USD_DEPOSIT_T2, "USD-Deposit-T2"},
         {TermDepositConventions.EUR_DEPOSIT_T2, "EUR-Deposit-T2"},
@@ -146,7 +146,7 @@ public class TermDepositConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "spotAndConv")
-  static Object[][] data_spotAndConv() {
+  public static Object[][] data_spotAndConv() {
     return new Object[][] {
         {TermDepositConventions.GBP_DEPOSIT_T0, 0, BusinessDayConventions.MODIFIED_FOLLOWING},
         {TermDepositConventions.GBP_SHORT_DEPOSIT_T0, 0, BusinessDayConventions.FOLLOWING},

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdOptionTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdOptionTypeTest.java
@@ -22,7 +22,7 @@ public class EtdOptionTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {EtdOptionType.AMERICAN, "American"},
         {EtdOptionType.EUROPEAN, "European"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdSettlementTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdSettlementTypeTest.java
@@ -22,7 +22,7 @@ public class EtdSettlementTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {EtdSettlementType.CASH, "Cash"},
         {EtdSettlementType.PHYSICAL, "Physical"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdStyleTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdStyleTypeTest.java
@@ -22,7 +22,7 @@ public class EtdStyleTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {EtdExpiryType.MONTHLY, "Monthly"},
         {EtdExpiryType.WEEKLY, "Weekly"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdTypeTest.java
@@ -22,7 +22,7 @@ public class EtdTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {EtdType.FUTURE, "Future"},
         {EtdType.OPTION, "Option"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/fra/FraDiscountingMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fra/FraDiscountingMethodTest.java
@@ -24,7 +24,7 @@ public class FraDiscountingMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FraDiscountingMethod.NONE, "None"},
         {FraDiscountingMethod.ISDA, "ISDA"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fra/type/FraConventionTest.java
@@ -307,7 +307,7 @@ public class FraConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {ImmutableFraConvention.of(GBP_LIBOR_3M), "GBP-LIBOR-3M"},
         {ImmutableFraConvention.of(USD_LIBOR_3M), "USD-LIBOR-3M"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/fx/type/FxSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/fx/type/FxSwapConventionsTest.java
@@ -26,7 +26,7 @@ public class FxSwapConventionsTest {
   private static final HolidayCalendarId GBLO_USNY = GBLO.combinedWith(USNY);
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {FxSwapConventions.EUR_USD, 2},
         {FxSwapConventions.EUR_GBP, 2},
@@ -40,7 +40,7 @@ public class FxSwapConventionsTest {
   }
 
   @DataProvider(name = "currencyPair")
-  static Object[][] data_currency_pair() {
+  public static Object[][] data_currency_pair() {
     return new Object[][] {
         {FxSwapConventions.EUR_USD, CurrencyPair.of(EUR, USD)},
         {FxSwapConventions.EUR_GBP, CurrencyPair.of(EUR, GBP)},
@@ -54,7 +54,7 @@ public class FxSwapConventionsTest {
   }
 
   @DataProvider(name = "calendar")
-  static Object[][] data_calendar() {
+  public static Object[][] data_calendar() {
     return new Object[][] {
         {FxSwapConventions.EUR_USD, EUTA_USNY},
         {FxSwapConventions.EUR_GBP, GBLO_EUTA},

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/type/IborFutureConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/type/IborFutureConventionTest.java
@@ -88,7 +88,7 @@ public class IborFutureConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborFutureConventions.USD_LIBOR_3M_QUARTERLY_IMM, "USD-LIBOR-3M-Quarterly-IMM"},
         {IborFutureConventions.USD_LIBOR_3M_MONTHLY_IMM, "USD-LIBOR-3M-Monthly-IMM"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/option/BarrierTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/option/BarrierTypeTest.java
@@ -28,7 +28,7 @@ public class BarrierTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {BarrierType.UP, "Up"},
         {BarrierType.DOWN, "Down"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/option/FutureOptionPremiumStyleTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/option/FutureOptionPremiumStyleTest.java
@@ -22,7 +22,7 @@ public class FutureOptionPremiumStyleTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FutureOptionPremiumStyle.DAILY_MARGIN, "DailyMargin"},
         {FutureOptionPremiumStyle.UPFRONT_PREMIUM, "UpfrontPremium"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/option/KnockTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/option/KnockTypeTest.java
@@ -28,7 +28,7 @@ public class KnockTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {KnockType.KNOCK_IN, "KnockIn"},
         {KnockType.KNOCK_OUT, "KnockOut"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/CompoundingMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/CompoundingMethodTest.java
@@ -22,7 +22,7 @@ public class CompoundingMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {CompoundingMethod.NONE, "None"},
         {CompoundingMethod.STRAIGHT, "Straight"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/FixingRelativeToTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/FixingRelativeToTest.java
@@ -27,7 +27,7 @@ public class FixingRelativeToTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FixingRelativeTo.PERIOD_START, "PeriodStart"},
         {FixingRelativeTo.PERIOD_END, "PeriodEnd"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/FxResetFixingRelativeToTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/FxResetFixingRelativeToTest.java
@@ -27,7 +27,7 @@ public class FxResetFixingRelativeToTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FxResetFixingRelativeTo.PERIOD_START, "PeriodStart"},
         {FxResetFixingRelativeTo.PERIOD_END, "PeriodEnd"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateResetMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateResetMethodTest.java
@@ -22,7 +22,7 @@ public class IborRateResetMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborRateResetMethod.WEIGHTED, "Weighted"},
         {IborRateResetMethod.UNWEIGHTED, "Unweighted"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/NegativeRateMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/NegativeRateMethodTest.java
@@ -47,7 +47,7 @@ public class NegativeRateMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {NegativeRateMethod.ALLOW_NEGATIVE, "AllowNegative"},
         {NegativeRateMethod.NOT_NEGATIVE, "NotNegative"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/OvernightAccrualMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/OvernightAccrualMethodTest.java
@@ -22,7 +22,7 @@ public class OvernightAccrualMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {OvernightAccrualMethod.AVERAGED, "Averaged"},
         {OvernightAccrualMethod.COMPOUNDED, "Compounded"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/PaymentRelativeToTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/PaymentRelativeToTest.java
@@ -27,7 +27,7 @@ public class PaymentRelativeToTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PaymentRelativeTo.PERIOD_START, "PeriodStart"},
         {PaymentRelativeTo.PERIOD_END, "PeriodEnd"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/PriceIndexCalculationMethodTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/PriceIndexCalculationMethodTest.java
@@ -22,7 +22,7 @@ public class PriceIndexCalculationMethodTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {PriceIndexCalculationMethod.MONTHLY, "Monthly"},
         {PriceIndexCalculationMethod.INTERPOLATED, "Interpolated"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapIndexTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapIndexTest.java
@@ -107,7 +107,7 @@ public class SwapIndexTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "indexName")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
         {OvernightIndices.GBP_SONIA, "GBP-SONIA"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapLegTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/SwapLegTypeTest.java
@@ -22,7 +22,7 @@ public class SwapLegTypeTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {SwapLegType.FIXED, "Fixed"},
         {SwapLegType.IBOR, "Ibor"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedIborSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedIborSwapConventionTest.java
@@ -135,7 +135,7 @@ public class FixedIborSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, "USD-FIXED-1Y-LIBOR-3M"},
         {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, "USD-FIXED-6M-LIBOR-3M"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedIborSwapConventionsTest.java
@@ -40,7 +40,7 @@ public class FixedIborSwapConventionsTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, 2},
         {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, 2},
@@ -63,7 +63,7 @@ public class FixedIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "period")
-  static Object[][] data_period() {
+  public static Object[][] data_period() {
     return new Object[][] {
         {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, Frequency.P6M},
         {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, Frequency.P12M},
@@ -86,7 +86,7 @@ public class FixedIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayCount")
-  static Object[][] data_day_count() {
+  public static Object[][] data_day_count() {
     return new Object[][] {
         {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, DayCounts.THIRTY_U_360},
         {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, DayCounts.ACT_360},
@@ -109,7 +109,7 @@ public class FixedIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "floatLeg")
-  static Object[][] data_float_leg() {
+  public static Object[][] data_float_leg() {
     return new Object[][] {
         {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, IborIndices.USD_LIBOR_3M},
         {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, IborIndices.USD_LIBOR_3M},
@@ -141,7 +141,7 @@ public class FixedIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayConvention")
-  static Object[][] data_day_convention() {
+  public static Object[][] data_day_convention() {
     return new Object[][] {
         {FixedIborSwapConventions.USD_FIXED_6M_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
         {FixedIborSwapConventions.USD_FIXED_1Y_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
@@ -164,7 +164,7 @@ public class FixedIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "stubIbor")
-  static Object[][] data_stub_ibor() {
+  public static Object[][] data_stub_ibor() {
     return new Object[][] {
         {FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_3M, Tenor.TENOR_18M},
         {FixedIborSwapConventions.EUR_FIXED_1Y_EURIBOR_6M, Tenor.TENOR_18M},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionTest.java
@@ -119,7 +119,7 @@ public class FixedInflationSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_HCIP, "GBP-FIXED-ZC-GB-HCIP"},
         {FixedInflationSwapConventions.USD_FIXED_ZC_US_CPI, "USD-FIXED-ZC-US-CPI"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionsTest.java
@@ -22,7 +22,7 @@ public class FixedInflationSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "floatLeg")
-  static Object[][] data_float_leg() {
+  public static Object[][] data_float_leg() {
     return new Object[][] {
         {FixedInflationSwapConventions.CHF_FIXED_ZC_CH_CPI, PriceIndices.CH_CPI},
         {FixedInflationSwapConventions.EUR_FIXED_ZC_EU_AI_CPI, PriceIndices.EU_AI_CPI},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedOvernightSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedOvernightSwapConventionTest.java
@@ -132,7 +132,7 @@ public class FixedOvernightSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, "USD-FIXED-1Y-FED-FUND-OIS"},
         {FixedOvernightSwapConventions.USD_FIXED_TERM_FED_FUND_OIS, "USD-FIXED-TERM-FED-FUND-OIS"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedOvernightSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedOvernightSwapConventionsTest.java
@@ -40,7 +40,7 @@ public class FixedOvernightSwapConventionsTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_TERM_FED_FUND_OIS, 2},
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, 2},
@@ -60,7 +60,7 @@ public class FixedOvernightSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "period")
-  static Object[][] data_period() {
+  public static Object[][] data_period() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_TERM_FED_FUND_OIS, Frequency.TERM},
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, Frequency.P12M},
@@ -85,7 +85,7 @@ public class FixedOvernightSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayCount")
-  static Object[][] data_day_count() {
+  public static Object[][] data_day_count() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_TERM_FED_FUND_OIS, DayCounts.ACT_360},
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, DayCounts.ACT_360},
@@ -105,7 +105,7 @@ public class FixedOvernightSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "floatLeg")
-  static Object[][] data_float_leg() {
+  public static Object[][] data_float_leg() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_TERM_FED_FUND_OIS, OvernightIndices.USD_FED_FUND},
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, OvernightIndices.USD_FED_FUND},
@@ -125,7 +125,7 @@ public class FixedOvernightSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayConvention")
-  static Object[][] data_day_convention() {
+  public static Object[][] data_day_convention() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_TERM_FED_FUND_OIS, BusinessDayConventions.MODIFIED_FOLLOWING},
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, BusinessDayConventions.MODIFIED_FOLLOWING},
@@ -145,7 +145,7 @@ public class FixedOvernightSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "stubOn")
-  static Object[][] data_stub_on() {
+  public static Object[][] data_stub_on() {
     return new Object[][] {
         {FixedOvernightSwapConventions.USD_FIXED_1Y_FED_FUND_OIS, Tenor.TENOR_18M},
         {FixedOvernightSwapConventions.EUR_FIXED_1Y_EONIA_OIS, Tenor.TENOR_18M},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/IborIborSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/IborIborSwapConventionTest.java
@@ -120,7 +120,7 @@ public class IborIborSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, "USD-LIBOR-1M-LIBOR-3M"},
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, "USD-LIBOR-3M-LIBOR-6M"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/IborIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/IborIborSwapConventionsTest.java
@@ -39,7 +39,7 @@ public class IborIborSwapConventionsTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, 2},
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, 2},
@@ -61,7 +61,7 @@ public class IborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "period")
-  static Object[][] data_period() {
+  public static Object[][] data_period() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, Frequency.P6M},
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, Frequency.P3M},
@@ -83,7 +83,7 @@ public class IborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayCount")
-  static Object[][] data_day_count() {
+  public static Object[][] data_day_count() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, CompoundingMethod.FLAT},
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, CompoundingMethod.FLAT},
@@ -105,7 +105,7 @@ public class IborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "spreadLeg")
-  static Object[][] data_spread_leg() {
+  public static Object[][] data_spread_leg() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, IborIndices.USD_LIBOR_3M},
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, IborIndices.USD_LIBOR_1M},
@@ -127,7 +127,7 @@ public class IborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "flatLeg")
-  static Object[][] data_flat_leg() {
+  public static Object[][] data_flat_leg() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, IborIndices.USD_LIBOR_6M},
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, IborIndices.USD_LIBOR_3M},
@@ -149,7 +149,7 @@ public class IborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayConvention")
-  static Object[][] data_day_convention() {
+  public static Object[][] data_day_convention() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, BusinessDayConventions.MODIFIED_FOLLOWING},
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
@@ -171,7 +171,7 @@ public class IborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "stubIbor")
-  static Object[][] data_stub_ibor() {
+  public static Object[][] data_stub_ibor() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, Tenor.TENOR_8M},
         {IborIborSwapConventions.JPY_LIBOR_1M_LIBOR_6M, Tenor.TENOR_8M},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionTest.java
@@ -132,7 +132,7 @@ public class OvernightIborSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, "USD-FED-FUND-AA-LIBOR-3M"},
     };

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightIborSwapConventionsTest.java
@@ -40,7 +40,7 @@ public class OvernightIborSwapConventionsTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, 2},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, 0},
@@ -55,7 +55,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "periodOn")
-  static Object[][] data_period_on() {
+  public static Object[][] data_period_on() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P12M},
@@ -74,7 +74,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "periodIbor")
-  static Object[][] data_period_ibor() {
+  public static Object[][] data_period_ibor() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P3M},
@@ -93,7 +93,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayCount")
-  static Object[][] data_day_count() {
+  public static Object[][] data_day_count() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, DayCounts.ACT_360},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, DayCounts.ACT_365F},
@@ -108,7 +108,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "onLeg")
-  static Object[][] data_float_leg() {
+  public static Object[][] data_float_leg() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, OvernightIndices.USD_FED_FUND},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, OvernightIndices.GBP_SONIA},
@@ -122,7 +122,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "iborLeg")
-  static Object[][] data_ibor_leg() {
+  public static Object[][] data_ibor_leg() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, IborIndices.USD_LIBOR_3M},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, IborIndices.GBP_LIBOR_3M},
@@ -136,7 +136,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayConvention")
-  static Object[][] data_day_convention() {
+  public static Object[][] data_day_convention() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
@@ -150,7 +150,7 @@ public class OvernightIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "stubOn")
-  static Object[][] data_stub_on() {
+  public static Object[][] data_stub_on() {
     return new Object[][] {
         {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
         {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Tenor.of(Period.ofMonths(13))},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/ThreeLegBasisSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/ThreeLegBasisSwapConventionTest.java
@@ -136,7 +136,7 @@ public class ThreeLegBasisSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, "EUR-FIXED-1Y-EURIBOR-3M-EURIBOR-6M"},
     };

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/ThreeLegBasisSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/ThreeLegBasisSwapConventionsTest.java
@@ -36,7 +36,7 @@ public class ThreeLegBasisSwapConventionsTest {
   private static final ReferenceData REF_DATA = ReferenceData.standard();
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, 2}
     };
@@ -49,7 +49,7 @@ public class ThreeLegBasisSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "period")
-  static Object[][] data_period() {
+  public static Object[][] data_period() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, Frequency.P3M},
     };
@@ -62,7 +62,7 @@ public class ThreeLegBasisSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayCount")
-  static Object[][] data_day_count() {
+  public static Object[][] data_day_count() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, CompoundingMethod.NONE}
     };
@@ -75,7 +75,7 @@ public class ThreeLegBasisSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "spreadFloatingLeg")
-  static Object[][] data_spread_floating_leg() {
+  public static Object[][] data_spread_floating_leg() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, IborIndices.EUR_EURIBOR_3M}
     };
@@ -88,7 +88,7 @@ public class ThreeLegBasisSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "flatFloatingLeg")
-  static Object[][] data_flat_floating_leg() {
+  public static Object[][] data_flat_floating_leg() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, IborIndices.EUR_EURIBOR_6M}
     };
@@ -101,7 +101,7 @@ public class ThreeLegBasisSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayConvention")
-  static Object[][] data_day_convention() {
+  public static Object[][] data_day_convention() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, BusinessDayConventions.MODIFIED_FOLLOWING}
     };
@@ -114,7 +114,7 @@ public class ThreeLegBasisSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "stubIbor")
-  static Object[][] data_stub_ibor() {
+  public static Object[][] data_stub_ibor() {
     return new Object[][] {
         {ThreeLegBasisSwapConventions.EUR_FIXED_1Y_EURIBOR_3M_EURIBOR_6M, Tenor.TENOR_8M}
     };

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/XCcyIborIborSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/XCcyIborIborSwapConventionTest.java
@@ -141,7 +141,7 @@ public class XCcyIborIborSwapConventionTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
-  static Object[][] data_name() {
+  public static Object[][] data_name() {
     return new Object[][] {
         {IborIborSwapConventions.USD_LIBOR_1M_LIBOR_3M, "USD-LIBOR-1M-LIBOR-3M"},
         {IborIborSwapConventions.USD_LIBOR_3M_LIBOR_6M, "USD-LIBOR-3M-LIBOR-6M"},

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/XCcyIborIborSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/XCcyIborIborSwapConventionsTest.java
@@ -34,7 +34,7 @@ public class XCcyIborIborSwapConventionsTest {
   private static final HolidayCalendarId EUTA_GBLO = EUTA.combinedWith(GBLO);
 
   @DataProvider(name = "spotLag")
-  static Object[][] data_spot_lag() {
+  public static Object[][] data_spot_lag() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, 2},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, 2},
@@ -49,7 +49,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "period")
-  static Object[][] data_period() {
+  public static Object[][] data_period() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, Frequency.P3M},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, Frequency.P3M},
@@ -64,7 +64,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "spreadLegIndex")
-  static Object[][] data_spread_leg() {
+  public static Object[][] data_spread_leg() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, IborIndices.EUR_EURIBOR_3M},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, IborIndices.GBP_LIBOR_3M},
@@ -79,7 +79,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "spreadLegBda")
-  static Object[][] data_spread_leg_bda() {
+  public static Object[][] data_spread_leg_bda() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA_USNY)},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO_USNY)},
@@ -94,7 +94,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "flatLegIndex")
-  static Object[][] data_flat_leg() {
+  public static Object[][] data_flat_leg() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, IborIndices.USD_LIBOR_3M},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, IborIndices.USD_LIBOR_3M},
@@ -109,7 +109,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "flatLegBda")
-  static Object[][] data_flat_leg_bda() {
+  public static Object[][] data_flat_leg_bda() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA_USNY)},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO_USNY)},
@@ -124,7 +124,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "dayConvention")
-  static Object[][] data_day_convention() {
+  public static Object[][] data_day_convention() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
@@ -139,7 +139,7 @@ public class XCcyIborIborSwapConventionsTest {
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "notionalExchange")
-  static Object[][] data_notional_exchange() {
+  public static Object[][] data_notional_exchange() {
     return new Object[][] {
         {XCcyIborIborSwapConventions.EUR_EURIBOR_3M_USD_LIBOR_3M, true},
         {XCcyIborIborSwapConventions.GBP_LIBOR_3M_USD_LIBOR_3M, true},


### PR DESCRIPTION
In Java 9, setAccessible no longer works the same way thus TestNG cannot access these methods.
Changing them to public has no effect on the test cases.

(This was a search and replace, that I've double checked afterwards)