### PR TITLE
Avoid warnings in tests

### DIFF
--- a/modules/basics/src/test/java/com/opengamma/strata/basics/StandardIdTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/StandardIdTest.java
@@ -21,6 +21,7 @@ public class StandardIdTest {
 
   private static final String SCHEME = "Scheme";
   private static final String OTHER_SCHEME = "Other";
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_factory_String_String() {
@@ -147,7 +148,7 @@ public class StandardIdTest {
     assertEquals((Object) d3.equals(d1a), false);
     assertEquals((Object) d3.equals(d2), false);
     assertEquals((Object) d3.equals(d3), true);
-    assertEquals((Object) d1b.equals("d1"), false);
+    assertEquals((Object) d1b.equals(ANOTHER_TYPE), false);
     assertEquals((Object) d1b.equals(null), false);
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyAmountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyAmountTest.java
@@ -27,6 +27,7 @@ public class CurrencyAmountTest {
   private static final double AMT2 = 200;
   private static final CurrencyAmount CCY_AMOUNT = CurrencyAmount.of(CCY1, AMT1);
   private static final CurrencyAmount CCY_AMOUNT_NEGATIVE = CurrencyAmount.of(CCY1, -AMT1);
+  private static final Object ANOTHER_TYPE = "";
 
   public void test_fixture() {
     assertEquals(CCY_AMOUNT.getCurrency(), CCY1);
@@ -204,7 +205,7 @@ public class CurrencyAmountTest {
   }
 
   public void test_equals_bad() {
-    assertFalse(CCY_AMOUNT.equals(""));
+    assertFalse(CCY_AMOUNT.equals(ANOTHER_TYPE));
     assertFalse(CCY_AMOUNT.equals(null));
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyPairTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyPairTest.java
@@ -34,6 +34,8 @@ import com.google.common.collect.ImmutableSet;
 @Test
 public class CurrencyPairTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-----------------------------------------------------------------------
   public void test_getAvailable() {
     Set<CurrencyPair> available = CurrencyPair.getAvailablePairs();
@@ -268,7 +270,7 @@ public class CurrencyPairTest {
 
   public void test_equals_bad() {
     CurrencyPair test = CurrencyPair.of(AUD, GBP);
-    assertFalse(test.equals(""));
+    assertFalse(test.equals(ANOTHER_TYPE));
     assertFalse(test.equals(null));
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxMatrixTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxMatrixTest.java
@@ -40,6 +40,7 @@ public class FxMatrixTest {
 
   private static final double TOLERANCE = 1e-6;
   public static final Offset<Double> TOL = offset(TOLERANCE);
+  private static final Object ANOTHER_TYPE = "";
 
   public void emptyMatrixCanHandleTrivialRate() {
     FxMatrix matrix = FxMatrix.empty();
@@ -548,7 +549,7 @@ public class FxMatrixTest {
     FxMatrix test = FxMatrix.builder()
         .addRate(USD, GBP, 1.4)
         .build();
-    assertThat(test.equals("")).isFalse();
+    assertThat(test.equals(ANOTHER_TYPE)).isFalse();
     assertThat(test.equals(null)).isFalse();
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRateTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/FxRateTest.java
@@ -25,6 +25,7 @@ public class FxRateTest {
   private static final Currency EUR = Currency.EUR;
   private static final Currency GBP = Currency.GBP;
   private static final Currency USD = Currency.USD;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_of_CurrencyCurrencyDouble() {
@@ -230,7 +231,7 @@ public class FxRateTest {
 
   public void test_equals_bad() {
     FxRate test = FxRate.of(AUD, GBP, 1.25d);
-    assertFalse(test.equals(""));
+    assertFalse(test.equals(ANOTHER_TYPE));
     assertFalse(test.equals(null));
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/Business252DayCountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/Business252DayCountTest.java
@@ -28,6 +28,7 @@ import com.opengamma.strata.basics.ReferenceData;
 public class Business252DayCountTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_factory_name() {
@@ -91,7 +92,7 @@ public class Business252DayCountTest {
     DayCount b = DayCount.of("Bus/252 GBLO");
     assertEquals(a.equals(a), true);
     assertEquals(a.equals(b), false);
-    assertEquals(a.equals("Rubbish"), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
     assertEquals(a.equals(null), false);
     assertEquals(a.hashCode(), a.hashCode());
   }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/HolidayCalendarIdTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/HolidayCalendarIdTest.java
@@ -29,6 +29,8 @@ import com.opengamma.strata.basics.currency.Currency;
 @Test
 public class HolidayCalendarIdTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of_single() {
     HolidayCalendarId test = HolidayCalendarId.of("GB");
     assertEquals(test.getName(), "GB");
@@ -136,7 +138,7 @@ public class HolidayCalendarIdTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals("Rubbish"), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/HolidayCalendarTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/HolidayCalendarTest.java
@@ -51,6 +51,7 @@ public class HolidayCalendarTest {
 
   private static final LocalDate WED_2014_07_30 = LocalDate.of(2014, 7, 30);
   private static final LocalDate THU_2014_07_31 = LocalDate.of(2014, 7, 31);
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_NO_HOLIDAYS() {
@@ -575,7 +576,7 @@ public class HolidayCalendarTest {
     assertEquals(test.toString(), "HolidayCalendar[Fri/Sat+Mock]");
     assertEquals(test.getName(), "Fri/Sat+Mock");
     assertEquals(test.equals(base1.combinedWith(base2)), true);
-    assertEquals(test.equals(""), false);
+    assertEquals(test.equals(ANOTHER_TYPE), false);
     assertEquals(test.equals(null), false);
     assertEquals(test.hashCode(), base1.combinedWith(base2).hashCode());
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/TenorTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/TenorTest.java
@@ -59,6 +59,8 @@ import com.google.common.collect.ImmutableList;
 @Test
 public class TenorTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   @DataProvider(name = "ofPeriod")
   public static Object[][] data_ofPeriod() {
     return new Object[][] {
@@ -328,7 +330,7 @@ public class TenorTest {
 
   public void test_equals_bad() {
     assertEquals(TENOR_3D.equals(null), false);
-    assertEquals(TENOR_3D.equals("String"), false);
+    assertEquals(TENOR_3D.equals(ANOTHER_TYPE), false);
     assertEquals(TENOR_3D.equals(new Object()), false);
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/location/CountryTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/location/CountryTest.java
@@ -22,6 +22,8 @@ import org.testng.annotations.Test;
 @Test
 public class CountryTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-----------------------------------------------------------------------
   public void test_constants() {
     assertEquals(Country.of("EU"), Country.EU);
@@ -198,7 +200,7 @@ public class CountryTest {
   public void test_equals_bad() {
     Country a = Country.GB;
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals("String"), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
     assertEquals(a.equals(new Object()), false);
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/FrequencyTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/FrequencyTest.java
@@ -38,6 +38,8 @@ import com.google.common.collect.ImmutableList;
 @Test
 public class FrequencyTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   @DataProvider(name = "create")
   public static Object[][] data_create() {
     return new Object[][] {
@@ -436,7 +438,7 @@ public class FrequencyTest {
 
   public void test_equals_bad() {
     assertEquals(P3M.equals(null), false);
-    assertEquals(P3M.equals("String"), false);
+    assertEquals(P3M.equals(ANOTHER_TYPE), false);
     assertEquals(P3M.equals(new Object()), false);
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/TypedStringTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/TypedStringTest.java
@@ -18,6 +18,8 @@ import org.testng.annotations.Test;
 @Test
 public class TypedStringTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of() {
     SampleType test = SampleType.of("A");
     assertEquals(test.toString(), "A");
@@ -47,7 +49,7 @@ public class TypedStringTest {
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(null), false);
-    assertEquals(a1.equals("A"), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/array/DoubleArrayTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/array/DoubleArrayTest.java
@@ -30,6 +30,8 @@ import com.google.common.collect.ImmutableList;
 @Test
 public class DoubleArrayTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   private static final double DELTA = 1e-14;
 
   public void test_EMPTY() {
@@ -451,7 +453,7 @@ public class DoubleArrayTest {
     assertEquals(a1.equals(a1), true);
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.equals(null), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/array/DoubleMatrixTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/array/DoubleMatrixTest.java
@@ -23,6 +23,8 @@ import org.testng.annotations.Test;
 @Test
 public class DoubleMatrixTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_EMPTY() {
     assertMatrix(DoubleMatrix.EMPTY);
   }
@@ -306,7 +308,7 @@ public class DoubleMatrixTest {
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(c), false);
     assertEquals(a1.equals(d), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.equals(null), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/array/IntArrayTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/array/IntArrayTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 public class IntArrayTest {
 
   private static final int[] EMPTY_INT_ARRAY = new int[0];
+  private static final Object ANOTHER_TYPE = "";
 
   public void test_EMPTY() {
     assertContent(IntArray.EMPTY);
@@ -197,13 +198,13 @@ public class IntArrayTest {
     assertEquals(list.get(2).intValue(), 3);
     assertEquals(list.contains(2), true);
     assertEquals(list.contains(5), false);
-    assertEquals(list.contains(""), false);
+    assertEquals(list.contains(ANOTHER_TYPE), false);
     assertEquals(list.indexOf(2), 1);
     assertEquals(list.indexOf(5), -1);
-    assertEquals(list.indexOf(""), -1);
+    assertEquals(list.indexOf(ANOTHER_TYPE), -1);
     assertEquals(list.lastIndexOf(3), 2);
     assertEquals(list.lastIndexOf(5), -1);
-    assertEquals(list.lastIndexOf(""), -1);
+    assertEquals(list.lastIndexOf(ANOTHER_TYPE), -1);
 
     assertThrows(() -> list.clear(), UnsupportedOperationException.class);
     assertThrows(() -> list.set(0, 3), UnsupportedOperationException.class);
@@ -427,7 +428,7 @@ public class IntArrayTest {
     assertEquals(a1.equals(a1), true);
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.equals(null), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvFileTest.java
@@ -32,6 +32,8 @@ import com.google.common.io.Files;
 @Test
 public class CsvFileTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   private final String CSV1 = "" +
       "h1,h2\n" +
       "r11,r12\n" +
@@ -418,7 +420,7 @@ public class CsvFileTest {
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(c), false);
     assertEquals(a1.equals(null), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.hashCode(), a2.hashCode());
     assertNotNull(a1.toString());
     // row
@@ -426,7 +428,7 @@ public class CsvFileTest {
     assertEquals(a1.row(0).equals(a2.row(0)), true);
     assertEquals(a1.row(0).equals(b.row(0)), false);
     assertEquals(c.row(0).equals(c.row(1)), false);
-    assertEquals(a1.row(0).equals(""), false);
+    assertEquals(a1.row(0).equals(ANOTHER_TYPE), false);
     assertEquals(a1.row(0).equals(null), false);
     assertEquals(a1.row(0).hashCode(), a2.row(0).hashCode());
     assertNotNull(a1.row(0).toString());

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/IniFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/IniFileTest.java
@@ -51,6 +51,7 @@ public class IniFileTest {
   private final String INI4 = "" +
       "[section]\n" +
       "a=d= = x\n";
+  private static final Object ANOTHER_TYPE = "";
 
   public void test_of_noLists() {
     IniFile test = IniFile.of(CharSource.wrap(INI1));
@@ -179,7 +180,7 @@ public class IniFileTest {
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(null), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }
 
@@ -192,7 +193,7 @@ public class IniFileTest {
     assertEquals(a1.section("name").equals(a2.section("name")), true);
     assertEquals(a1.section("name").equals(b.section("section")), false);
     assertEquals(a1.section("name").equals(null), false);
-    assertEquals(a1.section("name").equals(""), false);
+    assertEquals(a1.section("name").equals(ANOTHER_TYPE), false);
     assertEquals(a1.section("name").hashCode(), a2.section("name").hashCode());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertiesFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertiesFileTest.java
@@ -37,6 +37,7 @@ public class PropertiesFileTest {
       "a = y\n";
   private final String FILE3 = "" +
       "a=d= = x\n";
+  private static final Object ANOTHER_TYPE = "";
 
   public void test_of_noLists() {
     PropertiesFile test = PropertiesFile.of(CharSource.wrap(FILE1));
@@ -95,7 +96,7 @@ public class PropertiesFileTest {
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(null), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertySetTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/PropertySetTest.java
@@ -25,6 +25,8 @@ import com.google.common.collect.Multimap;
 @Test
 public class PropertySetTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_empty() {
     PropertySet test = PropertySet.empty();
 
@@ -124,7 +126,7 @@ public class PropertySetTest {
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(null), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
@@ -27,6 +27,8 @@ import com.google.common.io.Resources;
 @Test
 public class ResourceLocatorTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of_filePrefixed() throws Exception {
     ResourceLocator test = ResourceLocator.of("file:src/test/resources/com/opengamma/strata/collect/io/TestFile.txt");
     assertEquals(test.getLocator(), "file:src/test/resources/com/opengamma/strata/collect/io/TestFile.txt");
@@ -167,7 +169,7 @@ public class ResourceLocatorTest {
     assertEquals(a1.equals(a2), true);
     assertEquals(a1.equals(b), false);
     assertEquals(a1.equals(null), false);
-    assertEquals(a1.equals(""), false);
+    assertEquals(a1.equals(ANOTHER_TYPE), false);
     assertEquals(a1.hashCode(), a2.hashCode());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/XmlFileTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/XmlFileTest.java
@@ -63,6 +63,7 @@ public class XmlFileTest {
   private static final XmlElement LEAF2A = XmlElement.ofContent("leaf2", ATTR_MAP_EMPTY, "a");
   private static final XmlElement LEAF2B = XmlElement.ofContent("leaf2", ATTR_MAP_EMPTY, "b");
   private static final List<XmlElement> CHILD_LIST_MULTI = ImmutableList.of(LEAF1, LEAF2A, LEAF2B);
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_of_ByteSource() {
@@ -136,7 +137,7 @@ public class XmlFileTest {
     XmlFile test = XmlFile.of(source);
     XmlFile test2 = XmlFile.of(source);
     assertFalse(test.equals(null));
-    assertFalse(test.equals(""));
+    assertFalse(test.equals(ANOTHER_TYPE));
     assertEquals(test, test);
     assertEquals(test, test2);
     assertEquals(test.hashCode(), test2.hashCode());

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -42,6 +42,7 @@ import com.opengamma.strata.collect.tuple.Pair;
 public class DenseLocalDateDoubleTimeSeriesTest {
 
   private static final double TOLERANCE = 1e-5;
+  private static final Object ANOTHER_TYPE = "";
 
   private static final LocalDate DATE_2015_06_01 = date(2015, 6, 1);
   private static final LocalDate DATE_2014_06_01 = date(2014, 6, 1);
@@ -784,7 +785,7 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
   public void test_equals_bad() {
     LocalDateDoubleTimeSeries test = LocalDateDoubleTimeSeries.of(DATE_2014_01_01, 1d);
-    assertEquals(test.equals(""), false);
+    assertEquals(test.equals(ANOTHER_TYPE), false);
     assertEquals(test.equals(null), false);
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/LocalDateDoublePointTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/LocalDateDoublePointTest.java
@@ -22,6 +22,7 @@ public class LocalDateDoublePointTest {
   private static final LocalDate DATE_2012_06_30 = LocalDate.of(2012, 6, 30);
   private static final LocalDate DATE_2012_07_01 = LocalDate.of(2012, 7, 1);
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_of() {
@@ -102,7 +103,7 @@ public class LocalDateDoublePointTest {
 
   public void test_equalsBad() {
     LocalDateDoublePoint a = LocalDateDoublePoint.of(DATE_2012_06_29, 1d);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
     assertEquals(a.equals(null), false);
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/SparseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/SparseLocalDateDoubleTimeSeriesTest.java
@@ -57,6 +57,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
       DATE_2010_01_01, DATE_2011_01_01, DATE_2012_01_01);
   private static final ImmutableList<Double> VALUES_10_12 = values(10, 11, 12);
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_emptySeries() {
@@ -581,7 +582,7 @@ public class SparseLocalDateDoubleTimeSeriesTest {
 
   public void test_equals_bad() {
     LocalDateDoubleTimeSeries test = LocalDateDoubleTimeSeries.of(DATE_2014_01_01, 1d);
-    assertEquals(test.equals(""), false);
+    assertEquals(test.equals(ANOTHER_TYPE), false);
     assertEquals(test.equals(null), false);
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/DoublesPairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/DoublesPairTest.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.collect.TestHelper;
 public class DoublesPairTest {
 
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
@@ -162,8 +163,9 @@ public class DoublesPairTest {
   public void test_equals_bad() {
     DoublesPair a = DoublesPair.of(1.1d, 1.7d);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
-    assertEquals(a.equals(Pair.of(Double.valueOf(1.1d), Double.valueOf(1.7d))), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
+    Object unrelatedPair = Pair.of(Double.valueOf(1.1d), Double.valueOf(1.7d));
+    assertEquals(a.equals(unrelatedPair), false);
   }
 
   public void test_hashCode() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/IntDoublePairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/IntDoublePairTest.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.collect.TestHelper;
 public class IntDoublePairTest {
 
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
@@ -162,8 +163,9 @@ public class IntDoublePairTest {
   public void test_equals_bad() {
     IntDoublePair a = IntDoublePair.of(1, 1.7d);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
-    assertEquals(a.equals(Pair.of(Integer.valueOf(1), Double.valueOf(1.7d))), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
+    Object unrelatdPair = Pair.of(Integer.valueOf(1), Double.valueOf(1.7d));
+    assertEquals(a.equals(unrelatdPair), false);
   }
 
   public void test_hashCode() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/LongDoublePairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/LongDoublePairTest.java
@@ -23,6 +23,7 @@ import com.opengamma.strata.collect.TestHelper;
 public class LongDoublePairTest {
 
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
@@ -162,8 +163,9 @@ public class LongDoublePairTest {
   public void test_equals_bad() {
     LongDoublePair a = LongDoublePair.of(1L, 1.7d);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
-    assertEquals(a.equals(Pair.of(Long.valueOf(1L), Double.valueOf(1.7d))), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
+    Object unrelatedType = Pair.of(Long.valueOf(1L), Double.valueOf(1.7d));
+    assertEquals(a.equals(unrelatedType), false);
   }
 
   public void test_hashCode() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjDoublePairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjDoublePairTest.java
@@ -21,6 +21,7 @@ import com.opengamma.strata.collect.TestHelper;
 public class ObjDoublePairTest {
 
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
@@ -128,8 +129,9 @@ public class ObjDoublePairTest {
   public void test_equals_bad() {
     ObjDoublePair<String> a = ObjDoublePair.of("1", 1.7d);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
-    assertEquals(a.equals(Pair.of(Integer.valueOf(1), Double.valueOf(1.7d))), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
+    Object unrelatedType = Pair.of(Integer.valueOf(1), Double.valueOf(1.7d));
+    assertEquals(a.equals(unrelatedType), false);
   }
 
   public void test_hashCode() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjIntPairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/ObjIntPairTest.java
@@ -21,6 +21,7 @@ import com.opengamma.strata.collect.TestHelper;
 public class ObjIntPairTest {
 
   private static final double TOLERANCE = 0.00001d;
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
@@ -128,8 +129,9 @@ public class ObjIntPairTest {
   public void test_equals_bad() {
     ObjIntPair<String> a = ObjIntPair.of("1", 1);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
-    assertEquals(a.equals(Pair.of(Integer.valueOf(1), Integer.valueOf(1))), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
+    Object unrelatedType = Pair.of(Integer.valueOf(1), Integer.valueOf(1));
+    assertEquals(a.equals(unrelatedType), false);
   }
 
   public void test_hashCode() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/PairTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/PairTest.java
@@ -20,6 +20,8 @@ import com.opengamma.strata.collect.TestHelper;
 @Test
 public class PairTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
   public static Object[][] data_factory() {
@@ -124,7 +126,7 @@ public class PairTest {
   public void test_equals_bad() {
     Pair<Integer, String> a = Pair.of(1, "Hello");
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
   public void test_hashCode() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/TripleTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/tuple/TripleTest.java
@@ -20,6 +20,8 @@ import com.opengamma.strata.collect.TestHelper;
 @Test
 public class TripleTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-------------------------------------------------------------------------
   @DataProvider(name = "factory")
   public static Object[][] data_factory() {
@@ -142,7 +144,7 @@ public class TripleTest {
   public void test_equals_bad() {
     Triple<Integer, String, String> a = Triple.of(1, "Hello", "Triple");
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
   public void test_hashCode() {

--- a/modules/data/src/test/java/com/opengamma/strata/data/MarketDataNameTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/MarketDataNameTest.java
@@ -15,6 +15,8 @@ import org.testng.annotations.Test;
 @Test
 public class MarketDataNameTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of() {
     TestingName test = new TestingName("Foo");
     assertEquals(test.getName(), "Foo");
@@ -28,7 +30,7 @@ public class MarketDataNameTest {
     assertEquals(test.hashCode(), test.hashCode());
     assertEquals(test.equals(new TestingName("Eoo")), false);
     assertEquals(test.equals(new TestingName("Foo")), true);
-    assertEquals(test.equals("Foo"), false);
+    assertEquals(test.equals(ANOTHER_TYPE), false);
     assertEquals(test.equals(null), false);
     assertEquals(test.compareTo(new TestingName("Eoo")) > 0, true);
     assertEquals(test.compareTo(new TestingName("Foo")) == 0, true);

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveExtrapolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveExtrapolatorTest.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableMap;
 @Test
 public class CurveExtrapolatorTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
   public static Object[][] data_name() {
@@ -75,7 +77,7 @@ public class CurveExtrapolatorTest {
     coverPrivateConstructor(CurveExtrapolators.class);
     coverPrivateConstructor(StandardCurveExtrapolators.class);
     assertFalse(FLAT.equals(null));
-    assertFalse(FLAT.equals(""));
+    assertFalse(FLAT.equals(ANOTHER_TYPE));
   }
 
   public void test_serialization() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveInterpolatorTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/interpolator/CurveInterpolatorTest.java
@@ -37,6 +37,8 @@ import com.opengamma.strata.collect.array.DoubleArray;
 @Test
 public class CurveInterpolatorTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-------------------------------------------------------------------------
   @DataProvider(name = "name")
   public static Object[][] data_name() {
@@ -136,7 +138,7 @@ public class CurveInterpolatorTest {
     coverPrivateConstructor(CurveInterpolators.class);
     coverPrivateConstructor(StandardCurveInterpolators.class);
     assertFalse(LINEAR.equals(null));
-    assertFalse(LINEAR.equals(""));
+    assertFalse(LINEAR.equals(ANOTHER_TYPE));
   }
 
   public void test_serialization() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/MutablePointSensitivitiesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/MutablePointSensitivitiesTest.java
@@ -28,6 +28,7 @@ public class MutablePointSensitivitiesTest {
   private static final PointSensitivity CS2 = DummyPointSensitivity.of(GBP, date(2015, 7, 30), 22d);
   private static final PointSensitivity CS3 = DummyPointSensitivity.of(GBP, date(2015, 8, 30), 32d);
   private static final PointSensitivity CS3B = DummyPointSensitivity.of(GBP, date(2015, 8, 30), 3d);
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_size_add_getSensitivities() {
@@ -177,7 +178,7 @@ public class MutablePointSensitivitiesTest {
     assertEquals(test.equals(test), true);
     assertEquals(test.equals(test2), true);
     assertEquals(test.equals(test3), false);
-    assertEquals(test.equals("Bad"), false);
+    assertEquals(test.equals(ANOTHER_TYPE), false);
     assertEquals(test.equals(null), false);
     assertEquals(test.hashCode(), test2.hashCode());
   }

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/PiecewisePolynomialResultTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/PiecewisePolynomialResultTest.java
@@ -17,9 +17,8 @@ import com.opengamma.strata.collect.array.DoubleMatrix;
  */
 public class PiecewisePolynomialResultTest {
 
-  /**
-   * 
-   */
+  private static final Object ANOTHER_TYPE = "";
+
   @Test
   public void hashCodeEqualsTest() {
     final double[] knots1 = new double[] {1., 2., 3., 4. };
@@ -66,7 +65,7 @@ public class PiecewisePolynomialResultTest {
     assertTrue(!(res6.equals(res1)));
 
     assertTrue(!(res1.equals(null)));
-    assertTrue(!(res1.equals(DoubleArray.copyOf(knots1))));
+    assertTrue(!(res1.equals(ANOTHER_TYPE)));
 
     final DoubleMatrix[] sense1 = new DoubleMatrix[] {DoubleMatrix.copyOf(matrix1), DoubleMatrix.copyOf(matrix1)};
     final DoubleMatrix[] sense2 =
@@ -83,7 +82,7 @@ public class PiecewisePolynomialResultTest {
             DoubleArray.copyOf(knots1), DoubleMatrix.copyOf(matrix1), order, 1, sense2);
     assertTrue(resSen1.equals(resSen1));
 
-    assertTrue(!(resSen1.equals(DoubleArray.copyOf(knots1))));
+    assertTrue(!(resSen1.equals(ANOTHER_TYPE)));
 
     assertTrue(!(resSen1.equals(res5)));
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/AttributeTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/AttributeTypeTest.java
@@ -16,6 +16,8 @@ import org.testng.annotations.Test;
 @Test
 public class AttributeTypeTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-------------------------------------------------------------------------
   public void test_constant_description() {
     AttributeType<String> test = AttributeType.DESCRIPTION;
@@ -42,7 +44,7 @@ public class AttributeTypeTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
   public void test_jodaConvert() throws Exception {

--- a/modules/product/src/test/java/com/opengamma/strata/product/ProductTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/ProductTypeTest.java
@@ -15,6 +15,8 @@ import org.testng.annotations.Test;
 @Test
 public class ProductTypeTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   //-------------------------------------------------------------------------
   public void test_constants() {
     assertEquals(ProductType.SECURITY.toString(), "Security");
@@ -40,7 +42,7 @@ public class ProductTypeTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
 }

--- a/modules/product/src/test/java/com/opengamma/strata/product/SecurityIdTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/SecurityIdTest.java
@@ -18,6 +18,7 @@ import com.opengamma.strata.basics.StandardId;
 public class SecurityIdTest {
 
   private static final StandardId STANDARD_ID = StandardId.of("A", "1");
+  private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
   public void test_of_strings() {
@@ -50,7 +51,7 @@ public class SecurityIdTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
 }

--- a/modules/product/src/test/java/com/opengamma/strata/product/common/ExchangeIdTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/common/ExchangeIdTest.java
@@ -17,6 +17,8 @@ import org.testng.annotations.Test;
 @Test
 public class ExchangeIdTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of() {
     ExchangeId test = ExchangeId.of("GB");
     assertEquals(test.getName(), "GB");
@@ -33,7 +35,7 @@ public class ExchangeIdTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals("Rubbish"), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdContractCodeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdContractCodeTest.java
@@ -15,7 +15,8 @@ import org.testng.annotations.Test;
 @Test
 public class EtdContractCodeTest {
 
-  //-------------------------------------------------------------------------
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of() {
     EtdContractCode test = EtdContractCode.of("test");
     assertEquals(test.toString(), "test");
@@ -30,7 +31,7 @@ public class EtdContractCodeTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals(""), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
 }

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdContractSpecIdTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdContractSpecIdTest.java
@@ -18,6 +18,8 @@ import com.opengamma.strata.basics.StandardId;
 @Test
 public class EtdContractSpecIdTest {
 
+  private static final Object ANOTHER_TYPE = "";
+
   public void test_of() {
     EtdContractSpecId test = EtdContractSpecId.of(StandardId.of("A", "B"));
     assertEquals(test.getStandardId(), StandardId.of("A", "B"));
@@ -41,7 +43,7 @@ public class EtdContractSpecIdTest {
     assertEquals(a.equals(a2), true);
     assertEquals(a.equals(b), false);
     assertEquals(a.equals(null), false);
-    assertEquals(a.equals("Rubbish"), false);
+    assertEquals(a.equals(ANOTHER_TYPE), false);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Passing a string directly to equals() causes a warning in Eclipse, and probably IntelliJ too