### PR TITLE
Remove JavaFX as a Maven dependency

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -72,13 +72,6 @@
     
     <!-- External dependencies -->
     <dependency>
-      <groupId>javafx</groupId>
-      <artifactId>javafx</artifactId>
-      <version>8.0</version>
-      <scope>system</scope>
-      <systemPath>${javafx.jar.path}</systemPath>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
@@ -184,8 +177,6 @@
     <!-- Not installed/deployed -->
     <maven.install.skip>true</maven.install.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <!-- JavaFX -->
-    <javafx.jar.path>${java.home}/lib/ext/jfxrt.jar</javafx.jar.path>
     <!-- Properties for maven-javadoc-plugin -->
     <windowtitle>OpenGamma Strata Examples</windowtitle>
     <doctitle><![CDATA[<h1>OpenGamma Strata Examples</h1>]]></doctitle>


### PR DESCRIPTION
Does not work in Eclipse when running on Java 10 and is not a recommended solution.

Work is ongoing in JavaFX to produce a module in maven central. Eventually (ie Java 11) that will be the solution.

After this PR, the JavaFX code still works fine on Java 8, and is still not compiled when it is not available. So this change has zero effect provided if use Oracle JDK 8 with JavaFX in it.