### PR TITLE
Rename more rates-specific classes

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/blog/multicurve1/CalibrationPV01Example.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/blog/multicurve1/CalibrationPV01Example.java
@@ -25,7 +25,7 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.sensitivity.MarketQuoteSensitivityCalculator;
 import com.opengamma.strata.pricer.swap.DiscountingSwapTradePricer;
@@ -80,7 +80,7 @@ public class CalibrationPV01Example {
       ImmutableMarketData.builder(VALUATION_DATE).values(MAP_MQ).build();
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
 
   private static final DiscountingSwapTradePricer PRICER_SWAP = DiscountingSwapTradePricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;

--- a/examples/src/main/java/com/opengamma/strata/examples/blog/multicurve1/CalibrationPVPerformanceExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/blog/multicurve1/CalibrationPVPerformanceExample.java
@@ -25,7 +25,7 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.sensitivity.MarketQuoteSensitivityCalculator;
 import com.opengamma.strata.pricer.swap.DiscountingSwapTradePricer;
@@ -78,7 +78,7 @@ public class CalibrationPVPerformanceExample {
       ImmutableMarketData.builder(VALUATION_DATE).values(MAP_MQ).build();
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
 
   private static final DiscountingSwapTradePricer PRICER_SWAP = DiscountingSwapTradePricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;

--- a/examples/src/main/java/com/opengamma/strata/examples/blog/multicurve2/CalibrationInterpolationExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/blog/multicurve2/CalibrationInterpolationExample.java
@@ -26,7 +26,7 @@ import com.opengamma.strata.market.curve.CurveGroupName;
 import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.sensitivity.MarketQuoteSensitivityCalculator;
 import com.opengamma.strata.pricer.swap.DiscountingSwapTradePricer;
@@ -83,7 +83,7 @@ public class CalibrationInterpolationExample {
   private static final ImmutableMarketData MARKET_QUOTES =
       ImmutableMarketData.builder(VALUATION_DATE).values(MAP_MQ).build();
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.standard();
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.standard();
 
   private static final DiscountingSwapTradePricer PRICER_SWAP = DiscountingSwapTradePricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SabrSwaptionCubeCalibrationExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SabrSwaptionCubeCalibrationExample.java
@@ -42,7 +42,7 @@ import com.opengamma.strata.market.surface.SurfaceMetadata;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.impl.option.NormalFormulaRepository;
 import com.opengamma.strata.pricer.option.RawOptionData;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
@@ -82,7 +82,7 @@ public class SabrSwaptionCubeCalibrationExample {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final RatesProvider MULTICURVE =
       CALIBRATOR.calibrate(CONFIGS, MARKET_QUOTES, REF_DATA);
 

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SabrSwaptionCubePvRiskExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SabrSwaptionCubePvRiskExample.java
@@ -47,7 +47,7 @@ import com.opengamma.strata.market.surface.SurfaceMetadata;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.option.RawOptionData;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -90,7 +90,7 @@ public class SabrSwaptionCubePvRiskExample {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
 
   private static final SabrSwaptionPhysicalProductPricer SWAPTION_PRICER = SabrSwaptionPhysicalProductPricer.DEFAULT;
 

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoader.java
@@ -283,7 +283,7 @@ public final class RatesCalibrationCsvLoader {
       Collection<CharSource> curveNodeCharSources) {
 
     // load curve groups and settings
-    List<RatesCurveGroupDefinition> curveGroups = CurveGroupDefinitionCsvLoader.parseCurveGroupDefinitions(groupsCharSource);
+    List<RatesCurveGroupDefinition> curveGroups = RatesCurveGroupDefinitionCsvLoader.parseCurveGroupDefinitions(groupsCharSource);
     Map<CurveName, LoadedCurveSettings> settingsMap = RatesCurvesCsvLoader.parseCurveSettings(settingsCharSource);
 
     // load curve definitions

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurveGroupDefinitionCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurveGroupDefinitionCsvLoader.java
@@ -64,7 +64,7 @@ import com.opengamma.strata.market.curve.RatesCurveGroupEntry;
  *
  * @see RatesCurveGroupDefinition
  */
-public final class CurveGroupDefinitionCsvLoader {
+public final class RatesCurveGroupDefinitionCsvLoader {
 
   // Column headers
   private static final String GROUPS_NAME = "Group Name";
@@ -293,7 +293,7 @@ public final class CurveGroupDefinitionCsvLoader {
 
   //-------------------------------------------------------------------------
   // This class only has static methods
-  private CurveGroupDefinitionCsvLoader() {
+  private RatesCurveGroupDefinitionCsvLoader() {
   }
 
   //-------------------------------------------------------------------------

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCurvesCsvLoader.java
@@ -209,7 +209,7 @@ public final class RatesCurvesCsvLoader {
       CharSource settingsCharSource,
       Collection<CharSource> curveValueCharSources) {
 
-    List<RatesCurveGroupDefinition> curveGroups = CurveGroupDefinitionCsvLoader.parseCurveGroupDefinitions(groupsCharSource);
+    List<RatesCurveGroupDefinition> curveGroups = RatesCurveGroupDefinitionCsvLoader.parseCurveGroupDefinitions(groupsCharSource);
     Map<LocalDate, Map<CurveName, Curve>> curves =
         parseCurves(datePredicate, settingsCharSource, curveValueCharSources);
     ImmutableListMultimap.Builder<LocalDate, RatesCurveGroup> builder = ImmutableListMultimap.builder();

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCurveGroupDefinitionCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/RatesCurveGroupDefinitionCsvLoaderTest.java
@@ -18,16 +18,16 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.opengamma.strata.collect.io.ResourceLocator;
+import com.opengamma.strata.market.curve.CurveName;
 import com.opengamma.strata.market.curve.RatesCurveGroup;
 import com.opengamma.strata.market.curve.RatesCurveGroupDefinition;
 import com.opengamma.strata.market.curve.RatesCurveGroupEntry;
-import com.opengamma.strata.market.curve.CurveName;
 
 /**
- * Test {@link CurveGroupDefinitionCsvLoader}.
+ * Test {@link RatesCurveGroupDefinitionCsvLoader}.
  */
 @Test
-public class CurveGroupDefinitionCsvLoaderTest {
+public class RatesCurveGroupDefinitionCsvLoaderTest {
 
   private static final String GROUPS_1 = "classpath:com/opengamma/strata/loader/csv/groups.csv";
   private static final String SETTINGS_1 = "classpath:com/opengamma/strata/loader/csv/settings.csv";
@@ -37,7 +37,8 @@ public class CurveGroupDefinitionCsvLoaderTest {
 
   //-------------------------------------------------------------------------
   public void test_loadCurveGroupDefinition() {
-    List<RatesCurveGroupDefinition> defns = CurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.of(GROUPS_1));
+    List<RatesCurveGroupDefinition> defns =
+        RatesCurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.of(GROUPS_1));
     assertEquals(defns.size(), 1);
     RatesCurveGroupDefinition defn = defns.get(0);
     assertEquals(defn.getEntries().get(0), RatesCurveGroupEntry.builder()
@@ -52,9 +53,10 @@ public class CurveGroupDefinitionCsvLoaderTest {
 
   //-------------------------------------------------------------------------
   public void test_writeCurveGroupDefinition() {
-    RatesCurveGroupDefinition defn = CurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.of(GROUPS_1)).get(0);
+    RatesCurveGroupDefinition defn =
+        RatesCurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.of(GROUPS_1)).get(0);
     Appendable underlying = new StringBuilder();
-    CurveGroupDefinitionCsvLoader.writeCurveGroupDefinition(underlying, defn);
+    RatesCurveGroupDefinitionCsvLoader.writeCurveGroupDefinition(underlying, defn);
     String created = underlying.toString();
     String expected =
         "Group Name,Curve Type,Reference,Curve Name" + System.lineSeparator() +
@@ -71,7 +73,7 @@ public class CurveGroupDefinitionCsvLoaderTest {
         ResourceLocator.of(SETTINGS_1),
         ImmutableList.of(ResourceLocator.of(CURVES_1), ResourceLocator.of(CURVES_2)));
     Appendable underlying = new StringBuilder();
-    CurveGroupDefinitionCsvLoader.writeCurveGroup(underlying, curveGroups.get(0));
+    RatesCurveGroupDefinitionCsvLoader.writeCurveGroup(underlying, curveGroups.get(0));
     String created = underlying.toString();
     String expected =
         "Group Name,Curve Type,Reference,Curve Name" + System.lineSeparator() +
@@ -81,16 +83,17 @@ public class CurveGroupDefinitionCsvLoaderTest {
   }
 
   public void test_test_writeCurveGroupDefinition_roundtrip() throws Exception {
-    List<RatesCurveGroupDefinition> defn = CurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.of(GROUPS_1));
+    List<RatesCurveGroupDefinition> defn =
+        RatesCurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.of(GROUPS_1));
     File tempFile = File.createTempFile("TestCurveGroupLoading", "csv");
     tempFile.deleteOnExit();
-    CurveGroupDefinitionCsvLoader.writeCurveGroupDefinition(tempFile, defn.get(0));
-    assertEquals(CurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.ofFile(tempFile)), defn);
+    RatesCurveGroupDefinitionCsvLoader.writeCurveGroupDefinition(tempFile, defn.get(0));
+    assertEquals(RatesCurveGroupDefinitionCsvLoader.loadCurveGroupDefinitions(ResourceLocator.ofFile(tempFile)), defn);
   }
 
   //-------------------------------------------------------------------------
   public void coverage() {
-    coverPrivateConstructor(CurveGroupDefinitionCsvLoader.class);
+    coverPrivateConstructor(RatesCurveGroupDefinitionCsvLoader.class);
   }
 
 }

--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/RatesCurveGroupMarketDataFunction.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/RatesCurveGroupMarketDataFunction.java
@@ -37,7 +37,7 @@ import com.opengamma.strata.market.curve.RatesCurveInputsId;
 import com.opengamma.strata.market.observable.IndexQuoteId;
 import com.opengamma.strata.measure.curve.RootFinderConfig;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 
 /**
@@ -108,7 +108,7 @@ public class RatesCurveGroupMarketDataFunction implements MarketDataFunction<Rat
 
     // create the calibrator, using the configured RootFinderConfig if found
     RootFinderConfig rfc = marketDataConfig.find(RootFinderConfig.class).orElse(RootFinderConfig.standard());
-    CurveCalibrator calibrator = CurveCalibrator.of(
+    RatesCurveCalibrator calibrator = RatesCurveCalibrator.of(
         rfc.getAbsoluteTolerance(), rfc.getRelativeTolerance(), rfc.getMaximumSteps(), calibrationMeasures);
 
     // calibrate
@@ -135,7 +135,7 @@ public class RatesCurveGroupMarketDataFunction implements MarketDataFunction<Rat
    */
   MarketDataBox<RatesCurveGroup> buildCurveGroup(
       RatesCurveGroupDefinition configuredGroup,
-      CurveCalibrator calibrator,
+      RatesCurveCalibrator calibrator,
       ScenarioMarketData marketData,
       ReferenceData refData,
       ObservableSource obsSource) {
@@ -170,7 +170,7 @@ public class RatesCurveGroupMarketDataFunction implements MarketDataFunction<Rat
   // calibrates when there are multiple groups
   private MarketDataBox<RatesCurveGroup> buildMultipleCurveGroups(
       RatesCurveGroupDefinition configuredGroup,
-      CurveCalibrator calibrator,
+      RatesCurveCalibrator calibrator,
       MarketDataBox<LocalDate> valuationDateBox,
       List<MarketDataBox<RatesCurveInputs>> inputBoxes,
       Map<ObservableId, LocalDateDoubleTimeSeries> fixings,
@@ -199,7 +199,7 @@ public class RatesCurveGroupMarketDataFunction implements MarketDataFunction<Rat
   // calibrates when there is a single group
   private MarketDataBox<RatesCurveGroup> buildSingleCurveGroup(
       RatesCurveGroupDefinition configuredGroup,
-      CurveCalibrator calibrator,
+      RatesCurveCalibrator calibrator,
       LocalDate valuationDate,
       List<MarketDataBox<RatesCurveInputs>> inputBoxes,
       Map<ObservableId, LocalDateDoubleTimeSeries> fixings,
@@ -251,7 +251,7 @@ public class RatesCurveGroupMarketDataFunction implements MarketDataFunction<Rat
 
   private RatesCurveGroup buildGroup(
       RatesCurveGroupDefinition groupDefn,
-      CurveCalibrator calibrator,
+      RatesCurveCalibrator calibrator,
       MarketData marketData,
       ReferenceData refData) {
 

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxOptionVolatilitiesMarketDataFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/fxopt/FxOptionVolatilitiesMarketDataFunctionTest.java
@@ -91,7 +91,7 @@ import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.measure.StandardComponents;
 import com.opengamma.strata.measure.ValuationZoneTimeDefinition;
 import com.opengamma.strata.measure.rate.RatesMarketDataLookup;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.fxopt.BlackFxOptionSmileVolatilities;
 import com.opengamma.strata.pricer.fxopt.BlackFxOptionSurfaceVolatilities;
 import com.opengamma.strata.pricer.fxopt.BlackFxVanillaOptionTradePricer;
@@ -298,7 +298,7 @@ public class FxOptionVolatilitiesMarketDataFunctionTest {
   private static final MarketDataRequirements REQUIREMENTS = MarketDataRequirements.of(RULES, TARGETS, COLUMN, REF_DATA);
   private static final CalculationRunner CALC_RUNNER = CalculationRunner.ofMultiThreaded();
 
-  private static final CurveCalibrator CURVE_CALIBRATOR = CurveCalibrator.standard();
+  private static final RatesCurveCalibrator CURVE_CALIBRATOR = RatesCurveCalibrator.standard();
   private static final RatesProvider EXP_RATES = CURVE_CALIBRATOR.calibrate(CURVE_GROUP_DEFINITION, MARKET_DATA, REF_DATA);
   private static final RatesProvider EXP_RATES_1 = CURVE_CALIBRATOR.calibrate(
       CURVE_GROUP_DEFINITION, SCENARIO_MARKET_DATA.scenario(1), REF_DATA);

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesCurveGroupMarketDataFunctionTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/rate/RatesCurveGroupMarketDataFunctionTest.java
@@ -62,7 +62,7 @@ import com.opengamma.strata.market.observable.IndexQuoteId;
 import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.measure.curve.TestMarketDataMap;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.fra.DiscountingFraTradePricer;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.swap.DiscountingSwapTradePricer;
@@ -78,7 +78,7 @@ import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 public class RatesCurveGroupMarketDataFunctionTest {
 
   /** The calibrator. */
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.standard();
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.standard();
   /** The maximum allowable PV when round-tripping an instrument used to calibrate a curve. */
   private static final double PV_TOLERANCE = 5e-10;
   /** The reference data. */

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/RatesCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/RatesCurveCalibrator.java
@@ -37,7 +37,7 @@ import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.product.ResolvedTrade;
 
 /**
- * Curve calibrator.
+ * Curve calibrator for rates curves.
  * <p>
  * This calibrator takes an abstract curve definition and produces real curves.
  * <p>
@@ -52,13 +52,13 @@ import com.opengamma.strata.product.ResolvedTrade;
  * Once calibrated, the curves are then available for use.
  * Each node in the curve definition becomes a parameter in the matching output curve.
  */
-public final class CurveCalibrator {
+public final class RatesCurveCalibrator {
 
   /**
    * The standard curve calibrator.
    */
-  private static final CurveCalibrator STANDARD =
-      CurveCalibrator.of(1e-9, 1e-9, 1000, CalibrationMeasures.PAR_SPREAD, CalibrationMeasures.PRESENT_VALUE);
+  private static final RatesCurveCalibrator STANDARD =
+      RatesCurveCalibrator.of(1e-9, 1e-9, 1000, CalibrationMeasures.PAR_SPREAD, CalibrationMeasures.PRESENT_VALUE);
   /**
    * The matrix algebra used for matrix inversion.
    */
@@ -88,8 +88,8 @@ public final class CurveCalibrator {
    *
    * @return the standard curve calibrator
    */
-  public static CurveCalibrator standard() {
-    return CurveCalibrator.STANDARD;
+  public static RatesCurveCalibrator standard() {
+    return RatesCurveCalibrator.STANDARD;
   }
 
   /**
@@ -103,7 +103,7 @@ public final class CurveCalibrator {
    * @param stepMaximum  the maximum steps
    * @return the curve calibrator
    */
-  public static CurveCalibrator of(
+  public static RatesCurveCalibrator of(
       double toleranceAbs,
       double toleranceRel,
       int stepMaximum) {
@@ -123,7 +123,7 @@ public final class CurveCalibrator {
    * @param measures  the calibration measures, used to compute the function for which the root is found
    * @return the curve calibrator
    */
-  public static CurveCalibrator of(
+  public static RatesCurveCalibrator of(
       double toleranceAbs,
       double toleranceRel,
       int stepMaximum,
@@ -145,7 +145,7 @@ public final class CurveCalibrator {
    *   stored in the metadata
    * @return the curve calibrator
    */
-  public static CurveCalibrator of(
+  public static RatesCurveCalibrator of(
       double toleranceAbs,
       double toleranceRel,
       int stepMaximum,
@@ -153,7 +153,7 @@ public final class CurveCalibrator {
       CalibrationMeasures pvMeasures) {
 
     NewtonVectorRootFinder rootFinder = NewtonVectorRootFinder.broyden(toleranceAbs, toleranceRel, stepMaximum);
-    return new CurveCalibrator(rootFinder, measures, pvMeasures);
+    return new RatesCurveCalibrator(rootFinder, measures, pvMeasures);
   }
 
   /**
@@ -165,17 +165,17 @@ public final class CurveCalibrator {
    *   stored in the metadata
    * @return the curve calibrator
    */
-  public static CurveCalibrator of(
+  public static RatesCurveCalibrator of(
       NewtonVectorRootFinder rootFinder,
       CalibrationMeasures measures,
       CalibrationMeasures pvMeasures) {
 
-    return new CurveCalibrator(rootFinder, measures, pvMeasures);
+    return new RatesCurveCalibrator(rootFinder, measures, pvMeasures);
   }
 
   //-------------------------------------------------------------------------
   // restricted constructor
-  private CurveCalibrator(
+  private RatesCurveCalibrator(
       NewtonVectorRootFinder rootFinder,
       CalibrationMeasures measures,
       CalibrationMeasures pvMeasures) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticRatesCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/SyntheticRatesCurveCalibrator.java
@@ -45,20 +45,20 @@ import com.opengamma.strata.product.ResolvedTrade;
  * This curve transformation is often used to have a different risk view or to standardize
  * all risk to a common set of instruments, even if they are not the most liquid in a market.
  */
-public final class SyntheticCurveCalibrator {
+public final class SyntheticRatesCurveCalibrator {
 
   /**
    * The standard synthetic curve calibrator.
    * <p>
-   * This uses the standard {@link CurveCalibrator} and {@link CalibrationMeasures}.
+   * This uses the standard {@link RatesCurveCalibrator} and {@link CalibrationMeasures}.
    */
-  private static final SyntheticCurveCalibrator STANDARD = SyntheticCurveCalibrator.of(
-      CurveCalibrator.standard(), CalibrationMeasures.MARKET_QUOTE);
+  private static final SyntheticRatesCurveCalibrator STANDARD = SyntheticRatesCurveCalibrator.of(
+      RatesCurveCalibrator.standard(), CalibrationMeasures.MARKET_QUOTE);
 
   /**
    * The curve calibrator.
    */
-  private final CurveCalibrator calibrator;
+  private final RatesCurveCalibrator calibrator;
   /**
    * The market-quotes measures used to produce the synthetic quotes.
    */
@@ -69,11 +69,11 @@ public final class SyntheticCurveCalibrator {
    * The standard synthetic curve calibrator.
    * <p>
    * The {@link CalibrationMeasures#MARKET_QUOTE} measures are used for calibration.
-   * The underlying calibrator is {@link CurveCalibrator#standard()}.
+   * The underlying calibrator is {@link RatesCurveCalibrator#standard()}.
    *
    * @return the standard synthetic curve calibrator
    */
-  public static SyntheticCurveCalibrator standard() {
+  public static SyntheticRatesCurveCalibrator standard() {
     return STANDARD;
   }
 
@@ -84,12 +84,12 @@ public final class SyntheticCurveCalibrator {
    * @param marketQuotesMeasures  the measures used to compute the market quotes
    * @return the synthetic curve calibrator
    */
-  public static SyntheticCurveCalibrator of(CurveCalibrator calibrator, CalibrationMeasures marketQuotesMeasures) {
-    return new SyntheticCurveCalibrator(calibrator, marketQuotesMeasures);
+  public static SyntheticRatesCurveCalibrator of(RatesCurveCalibrator calibrator, CalibrationMeasures marketQuotesMeasures) {
+    return new SyntheticRatesCurveCalibrator(calibrator, marketQuotesMeasures);
   }
 
   // restricted constructor
-  private SyntheticCurveCalibrator(CurveCalibrator calibrator, CalibrationMeasures marketQuotesMeasures) {
+  private SyntheticRatesCurveCalibrator(RatesCurveCalibrator calibrator, CalibrationMeasures marketQuotesMeasures) {
     this.measures = marketQuotesMeasures;
     this.calibrator = calibrator;
   }
@@ -109,7 +109,7 @@ public final class SyntheticCurveCalibrator {
    * 
    * @return the calibrator
    */
-  public CurveCalibrator getCalibrator() {
+  public RatesCurveCalibrator getCalibrator() {
     return calibrator;
   }
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/package-info.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/curve/package-info.java
@@ -7,6 +7,6 @@
 /**
  * Provides the ability to calibrate curves.
  * <p>
- * The main class is {@link com.opengamma.strata.pricer.curve.CurveCalibrator}.
+ * The main class is {@link com.opengamma.strata.pricer.curve.RatesCurveCalibrator}.
  */
 package com.opengamma.strata.pricer.curve;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountFactorUsd2FomcDatesOisIrsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountFactorUsd2FomcDatesOisIrsTest.java
@@ -278,7 +278,7 @@ public class CalibrationDiscountFactorUsd2FomcDatesOisIrsTest {
       DiscountingTermDepositProductPricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountingSimple1Test.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountingSimple1Test.java
@@ -158,7 +158,7 @@ public class CalibrationDiscountingSimple1Test {
   private static final DiscountingSwapProductPricer SWAP_PRICER =
       DiscountingSwapProductPricer.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountingSimpleEurStdTenorsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountingSimpleEurStdTenorsTest.java
@@ -159,7 +159,7 @@ public class CalibrationDiscountingSimpleEurStdTenorsTest {
   private static final DiscountingSwapProductPricer SWAP_PRICER =
       DiscountingSwapProductPricer.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountingSmithWilsonTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationDiscountingSmithWilsonTest.java
@@ -130,7 +130,7 @@ public class CalibrationDiscountingSmithWilsonTest {
     CURVES_METADATA.add(groupMetadata);
   }
   private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   /** Test with CurveGroupDefinition */
   private static final String CURVE_GROUP_NAME_STR = "GBP-SINGLE-CURVE";

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationEurStandard.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationEurStandard.java
@@ -87,7 +87,7 @@ public class CalibrationEurStandard {
   private static final CurveInterpolator INTERPOLATOR_LINEAR = CurveInterpolators.LINEAR;
   private static final CurveExtrapolator EXTRAPOLATOR_FLAT = CurveExtrapolators.FLAT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   public static RatesProvider calibrateEurStandard(
       LocalDate valuationDate,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationInflationUsdTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationInflationUsdTest.java
@@ -200,7 +200,7 @@ public class CalibrationInflationUsdTest {
   private static final DiscountingTermDepositProductPricer DEPO_PRICER =
       DiscountingTermDepositProductPricer.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationNotionalEquivalentTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationNotionalEquivalentTest.java
@@ -54,7 +54,7 @@ import com.opengamma.strata.product.swap.type.ThreeLegBasisSwapConventions;
 
 /**
  * Test the notional equivalent computation based on present value sensitivity to quote in 
- * the calibrated curves by {@link CurveCalibrator}.
+ * the calibrated curves by {@link RatesCurveCalibrator}.
  */  
 @Test
 public class CalibrationNotionalEquivalentTest {
@@ -70,7 +70,7 @@ public class CalibrationNotionalEquivalentTest {
   private static final String QUOTES_FILE = "quotes/quotes-20160229-eur.csv";
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final CalibrationMeasures PV_MEASURES = CalibrationMeasures.of(
       "PresentValue",
       PresentValueCalibrationMeasure.FRA_PV,

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateAndDiscountFactorUsd2OisIrsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateAndDiscountFactorUsd2OisIrsTest.java
@@ -248,7 +248,7 @@ public class CalibrationZeroRateAndDiscountFactorUsd2OisIrsTest {
       DiscountingSwapProductPricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsd2OisFuturesHWIrsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsd2OisFuturesHWIrsTest.java
@@ -274,7 +274,7 @@ public class CalibrationZeroRateUsd2OisFuturesHWIrsTest {
       IBOR_FUT_PAR_SPREAD_HW, TradeCalibrationMeasure.FRA_PAR_SPREAD, TradeCalibrationMeasure.SWAP_PAR_SPREAD,
       TradeCalibrationMeasure.FX_SWAP_PAR_SPREAD, TradeCalibrationMeasure.IBOR_FIXING_DEPOSIT_PAR_SPREAD,
       TradeCalibrationMeasure.TERM_DEPOSIT_PAR_SPREAD);
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, HW_PAR_SPREAD);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, HW_PAR_SPREAD);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsd2OisFuturesIrsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsd2OisFuturesIrsTest.java
@@ -248,7 +248,7 @@ public class CalibrationZeroRateUsd2OisFuturesIrsTest {
       DiscountingTermDepositProductPricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsd3OisIrsBsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsd3OisIrsBsTest.java
@@ -302,7 +302,7 @@ public class CalibrationZeroRateUsd3OisIrsBsTest {
       DiscountingTermDepositProductPricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsdEur2OisFxTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsdEur2OisFxTest.java
@@ -183,7 +183,7 @@ public class CalibrationZeroRateUsdEur2OisFxTest {
       DiscountingFxSwapProductPricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;
   
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsdOisIrsEurFxXCcyIrsTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/CalibrationZeroRateUsdOisIrsEurFxXCcyIrsTest.java
@@ -297,7 +297,7 @@ public class CalibrationZeroRateUsdOisIrsEurFxXCcyIrsTest {
       DiscountingFxSwapProductPricer.DEFAULT;
   private static final MarketQuoteSensitivityCalculator MQC = MarketQuoteSensitivityCalculator.DEFAULT;
 
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100);
 
   // Constants
   private static final double TOLERANCE_PV = 1.0E-6;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/RatesCurveCalibratorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/RatesCurveCalibratorTest.java
@@ -10,13 +10,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.annotations.Test;
 
 /**
- * Tests {@link CurveCalibrator}.
+ * Tests {@link RatesCurveCalibrator}.
  */
 @Test
-public class CurveCalibratorTest {
+public class RatesCurveCalibratorTest {
 
   public void test_toString() {
-    assertThat(CurveCalibrator.standard().toString()).isEqualTo("CurveCalibrator[ParSpread]");
+    assertThat(RatesCurveCalibrator.standard().toString()).isEqualTo("CurveCalibrator[ParSpread]");
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/SyntheticRatesCurveCalibratorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/curve/SyntheticRatesCurveCalibratorTest.java
@@ -43,10 +43,10 @@ import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapLegType;
 
 /**
- * Tests {@link SyntheticCurveCalibrator}.
+ * Tests {@link SyntheticRatesCurveCalibrator}.
  */
 @Test 
-public class SyntheticCurveCalibratorTest {
+public class SyntheticRatesCurveCalibratorTest {
 
   private static final ReferenceData REF_DATA = ReferenceData.standard();
   private static final LocalDate VALUATION_DATE = LocalDate.of(2015, 11, 20);
@@ -113,10 +113,10 @@ public class SyntheticCurveCalibratorTest {
         .addTimeSeries(IndexQuoteId.of(EUR_EURIBOR_6M), tsEur6)
         .build();
   }
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.standard();
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.standard();
   private static final CalibrationMeasures MQ_MEASURES = CalibrationMeasures.MARKET_QUOTE;
-  private static final SyntheticCurveCalibrator CALIBRATOR_SYNTHETIC = 
-      SyntheticCurveCalibrator.of(CALIBRATOR, MQ_MEASURES);
+  private static final SyntheticRatesCurveCalibrator CALIBRATOR_SYNTHETIC = 
+      SyntheticRatesCurveCalibrator.of(CALIBRATOR, MQ_MEASURES);
   
   private static final ImmutableRatesProvider MULTICURVE_INPUT_EUR_TSEMPTY =
       CALIBRATOR.calibrate(GROUPS_IN_EUR, MARKET_QUOTES_EUR_INPUT, REF_DATA);
@@ -129,7 +129,7 @@ public class SyntheticCurveCalibratorTest {
 
   //-------------------------------------------------------------------------
   public void test_of() {
-    SyntheticCurveCalibrator test = SyntheticCurveCalibrator.of(CALIBRATOR, MQ_MEASURES);
+    SyntheticRatesCurveCalibrator test = SyntheticRatesCurveCalibrator.of(CALIBRATOR, MQ_MEASURES);
     assertEquals(test.getMeasures(), MQ_MEASURES);
     assertEquals(test.getCalibrator(), CALIBRATOR);
     assertEquals(test.toString(), "SyntheticCurveCalibrator[CurveCalibrator[ParSpread], MarketQuote]");
@@ -196,7 +196,7 @@ public class SyntheticCurveCalibratorTest {
 
   // Check synthetic calibration in the case of existing time-series with fixing on the valuation date
   public void calibrate_ts_vd() {
-    SyntheticCurveCalibrator calibratorDefault = SyntheticCurveCalibrator.standard();
+    SyntheticRatesCurveCalibrator calibratorDefault = SyntheticRatesCurveCalibrator.standard();
     MarketData mad = calibratorDefault.marketData(GROUPS_SYN_EUR, MULTICURVE_INPUT_EUR_TSLARGE, REF_DATA);
     RatesProvider multicurveSyn = CALIBRATOR_SYNTHETIC.calibrate(GROUPS_SYN_EUR, MULTICURVE_INPUT_EUR_TSLARGE, REF_DATA);
     for (CurveDefinition entry : GROUPS_SYN_EUR.getCurveDefinitions()) {

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtilsJacobianTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/sensitivity/CurveSensitivityUtilsJacobianTest.java
@@ -46,7 +46,7 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.TenorParameterMetadata;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.deposit.DiscountingIborFixingDepositProductPricer;
 import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -71,7 +71,7 @@ public class CurveSensitivityUtilsJacobianTest {
   private static final String QUOTES_PATH = "src/test/resources/quotes/";
 
   // Quotes
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.standard();  
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.standard();  
   private static final String QUOTES_FILE = "quotes-20151120-eur.csv";
   private static final Map<QuoteId, Double> MQ_INPUT = 
       QuotesCsvLoader.load(VALUATION_DATE, ImmutableList.of(ResourceLocator.of(QUOTES_PATH + QUOTES_FILE)));

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeBlackCleanDataTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeBlackCleanDataTest.java
@@ -48,7 +48,7 @@ import com.opengamma.strata.market.surface.SurfaceMetadata;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.impl.option.BlackFormulaRepository;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -85,7 +85,7 @@ public class SabrSwaptionCalibratorCubeBlackCleanDataTest {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final RatesProvider MULTICURVE = CALIBRATOR.calibrate(CONFIGS, MARKET_QUOTES, REF_DATA);
 
   private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeBlackExtremeDataTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeBlackExtremeDataTest.java
@@ -39,7 +39,7 @@ import com.opengamma.strata.market.surface.Surface;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.impl.option.BlackFormulaRepository;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
 import com.opengamma.strata.pricer.rate.RatesProvider;
@@ -75,7 +75,7 @@ public class SabrSwaptionCalibratorCubeBlackExtremeDataTest {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final RatesProvider MULTICURVE = CALIBRATOR.calibrate(CONFIGS, MARKET_QUOTES, REF_DATA);
 
   private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalSimpleDataTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalSimpleDataTest.java
@@ -52,7 +52,7 @@ import com.opengamma.strata.market.surface.SurfaceMetadata;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.impl.option.BlackFormulaRepository;
 import com.opengamma.strata.pricer.impl.option.NormalFormulaRepository;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
@@ -90,7 +90,7 @@ public class SabrSwaptionCalibratorCubeNormalSimpleDataTest {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final RatesProvider MULTICURVE = CALIBRATOR.calibrate(CONFIGS, MARKET_QUOTES, REF_DATA);
 
   private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCalibratorCubeNormalTest.java
@@ -38,7 +38,7 @@ import com.opengamma.strata.market.surface.Surface;
 import com.opengamma.strata.market.surface.interpolator.GridSurfaceInterpolator;
 import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.impl.option.BlackFormulaRepository;
 import com.opengamma.strata.pricer.impl.option.NormalFormulaRepository;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
@@ -76,7 +76,7 @@ public class SabrSwaptionCalibratorCubeNormalTest {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final RatesProvider MULTICURVE = CALIBRATOR.calibrate(CONFIGS, MARKET_QUOTES, REF_DATA);
 
   private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionRawDataSensitivityCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionRawDataSensitivityCalculatorTest.java
@@ -54,7 +54,7 @@ import com.opengamma.strata.market.surface.interpolator.SurfaceInterpolator;
 import com.opengamma.strata.pricer.cms.SabrExtrapolationReplicationCmsLegPricer;
 import com.opengamma.strata.pricer.cms.SabrExtrapolationReplicationCmsPeriodPricer;
 import com.opengamma.strata.pricer.curve.CalibrationMeasures;
-import com.opengamma.strata.pricer.curve.CurveCalibrator;
+import com.opengamma.strata.pricer.curve.RatesCurveCalibrator;
 import com.opengamma.strata.pricer.option.TenorRawOptionData;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.product.cms.CmsLeg;
@@ -91,7 +91,7 @@ public class SabrSwaptionRawDataSensitivityCalculatorTest {
   private static final ImmutableMarketData MARKET_QUOTES = ImmutableMarketData.of(CALIBRATION_DATE, MAP_MQ);
 
   private static final CalibrationMeasures CALIBRATION_MEASURES = CalibrationMeasures.PAR_SPREAD;
-  private static final CurveCalibrator CALIBRATOR = CurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
+  private static final RatesCurveCalibrator CALIBRATOR = RatesCurveCalibrator.of(1e-9, 1e-9, 100, CALIBRATION_MEASURES);
   private static final RatesProvider MULTICURVE = CALIBRATOR.calibrate(CONFIGS, MARKET_QUOTES, REF_DATA);
 
   private static final TenorRawOptionData DATA_RAW_FULL = SabrSwaptionCalibratorSmileTestUtils


### PR DESCRIPTION
`CurveCalibrator` to `RatesCurveCalibrator`
`SyntheticCurveCalibrator` to `SyntheticRatesCurveCalibrator`
`CurveGroupDefinitionCsvLoader` to `RatesCurveGroupDefinitionCsvLoader`

What about the other classes in the package?
Maybe these should move to the `rate` package?