### PR TITLE
Additional MapStream methods

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
@@ -134,6 +134,25 @@ public final class MapStream<K, V>
 
   //-------------------------------------------------------------------------
   /**
+   * Returns the keys as a stream, dropping the values.
+   *
+   * @return a stream of the keys
+   */
+  public Stream<K> keys() {
+    return underlying.map(e -> e.getKey());
+  }
+
+  /**
+   * Returns the values as a stream, dropping the keys.
+   *
+   * @return a stream of the values
+   */
+  public Stream<V> values() {
+    return underlying.map(e -> e.getValue());
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Filters the stream by applying the predicate function to each key and value.
    * <p>
    * Entries are included in the returned stream if the predicate function returns true.
@@ -158,6 +177,21 @@ public final class MapStream<K, V>
   }
 
   /**
+   * Filters the stream checking the type of each key.
+   * <p>
+   * Entries are included in the returned stream if the key is an instance of the specified type.
+   *
+   * @param <R>  the type to filter to
+   * @param castToClass  the class to filter the keys to
+   * @return a stream including only those entries where the key is an instance of the specified type
+   */
+  public <R> MapStream<R, V> filterKeys(Class<R> castToClass) {
+    return wrap(underlying
+        .filter(e -> castToClass.isInstance(e.getKey()))
+        .map(e -> entry(castToClass.cast(e.getKey()), e.getValue())));
+  }
+
+  /**
    * Filters the stream by applying the predicate function to each value.
    * <p>
    * Entries are included in the returned stream if the predicate function returns true.
@@ -169,6 +203,22 @@ public final class MapStream<K, V>
     return wrap(underlying.filter(e -> predicate.test(e.getValue())));
   }
 
+  /**
+   * Filters the stream checking the type of each value.
+   * <p>
+   * Entries are included in the returned stream if the value is an instance of the specified type.
+   *
+   * @param <R>  the type to filter to
+   * @param castToClass  the class to filter the values to
+   * @return a stream including only those entries where the value is an instance of the specified type
+   */
+  public <R> MapStream<K, R> filterValues(Class<R> castToClass) {
+    return wrap(underlying
+        .filter(e -> castToClass.isInstance(e.getValue()))
+        .map(e -> entry(e.getKey(), castToClass.cast(e.getValue()))));
+  }
+
+  //-------------------------------------------------------------------------
   /**
    * Transforms the keys in the stream by applying a mapper function to each key.
    * <p>
@@ -232,6 +282,7 @@ public final class MapStream<K, V>
     return underlying.map(e -> mapper.apply(e.getKey(), e.getValue()));
   }
 
+  //-------------------------------------------------------------------------
   /**
    * Returns an immutable map built from the entries in the stream.
    * <p>

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.collect;
 
+import static com.opengamma.strata.collect.Guavate.toImmutableList;
 import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +30,17 @@ public class MapStreamTest {
 
   private final Map<String, Integer> map = ImmutableMap.of("one", 1, "two", 2, "three", 3, "four", 4);
 
+  public void keys() {
+    List<String> result = MapStream.of(map).keys().collect(toImmutableList());
+    assertThat(result).isEqualTo(ImmutableList.of("one", "two", "three", "four"));
+  }
+
+  public void values() {
+    List<Integer> result = MapStream.of(map).values().collect(toImmutableList());
+    assertThat(result).isEqualTo(ImmutableList.of(1, 2, 3, 4));
+  }
+
+  //-------------------------------------------------------------------------
   public void filter() {
     Map<String, Integer> expected = ImmutableMap.of("one", 1, "two", 2);
     Map<String, Integer> result = MapStream.of(map).filter((k, v) -> k.equals("one") || v == 2).toMap();
@@ -41,10 +53,22 @@ public class MapStreamTest {
     assertThat(result).isEqualTo(expected);
   }
 
+  public void filterKeys_byClass() {
+    Map<Number, Number> map = ImmutableMap.of(1, 11, 2d, 22d, 3, 33d);
+    Map<Integer, Number> result = MapStream.of(map).filterKeys(Integer.class).toMap();
+    assertThat(result).isEqualTo(ImmutableMap.of(1, 11, 3, 33d));
+  }
+
   public void filterValues() {
     Map<String, Integer> expected = ImmutableMap.of("one", 1, "two", 2);
     Map<String, Integer> result = MapStream.of(map).filterValues(v -> v < 3).toMap();
     assertThat(result).isEqualTo(expected);
+  }
+
+  public void filterValues_byClass() {
+    Map<Number, Number> map = ImmutableMap.of(1, 11, 2d, 22, 3, 33d);
+    Map<Number, Integer> result = MapStream.of(map).filterValues(Integer.class).toMap();
+    assertThat(result).isEqualTo(ImmutableMap.of(1, 11, 2d, 22));
   }
 
   public void mapKeysToKeys() {


### PR DESCRIPTION
Get a stream of just the keys, or values.
Filter by type, casting the result.