### PR TITLE
Change behaviour of `ResourceLoacator.ofClasspath`

### DIFF
--- a/examples/src/test/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilderTest.java
+++ b/examples/src/test/java/com/opengamma/strata/examples/marketdata/ExampleMarketDataBuilderTest.java
@@ -11,17 +11,9 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarOutputStream;
 
 import org.testng.annotations.Test;
 
@@ -93,33 +85,6 @@ public class ExampleMarketDataBuilderTest {
     assertBuilder(builder);
   }
 
-  public void test_classpath_jar() throws Exception {
-
-    // Create a JAR file containing the example market data
-    File tempFile = File.createTempFile(ExampleMarketDataBuilderTest.class.getSimpleName(), ".jar");
-    try (FileOutputStream tempFileOut = new FileOutputStream(tempFile)) {
-      try (JarOutputStream zipFileOut = new JarOutputStream(tempFileOut)) {
-        File diskRoot = new File(EXAMPLE_MARKET_DATA_DIRECTORY_ROOT);
-        appendToJar(diskRoot, "zip-data", diskRoot, zipFileOut);
-      }
-    }
-
-    // Obtain a classloader which can see this JAR
-    ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
-    try (URLClassLoader classLoader = URLClassLoader.newInstance(new URL[] {tempFile.toURI().toURL()})) {
-      // Test automatically finding the resource inside the JAR
-      Thread.currentThread().setContextClassLoader(classLoader);
-      assertBuilder(ExampleMarketDataBuilder.ofResource("zip-data", classLoader));
-    } finally {
-      Thread.currentThread().setContextClassLoader(originalContextClassLoader);
-      try {
-        Files.deleteIfExists(tempFile.toPath());
-      } catch (IOException ex) {
-        // ignore
-      }
-    }
-  }
-
   public void test_ofPath() {
     Path rootPath = new File(EXAMPLE_MARKET_DATA_DIRECTORY_ROOT).toPath();
     ExampleMarketDataBuilder builder = ExampleMarketDataBuilder.ofPath(rootPath);
@@ -175,39 +140,6 @@ public class ExampleMarketDataBuilderTest {
     assertEquals(snapshot.getValues().size(), VALUES.size(),
         Messages.format("Snapshot contained unexpected market data: {}",
             Sets.difference(snapshot.getValues().keySet(), VALUES)));
-  }
-
-  //-------------------------------------------------------------------------
-  // build jar file
-  // jar files use forward-slash on all operating systems
-  // directories always have a trailing forward-slash
-  // there must be no slash at the root
-  private void appendToJar(File sourceRootDir, String destRootPath, File currentFile, JarOutputStream jarOutput)
-      throws IOException {
-    if (currentFile.isDirectory()) {
-      String entryName = getEntryName(sourceRootDir, destRootPath, currentFile) + '/';
-      jarOutput.putNextEntry(new JarEntry(entryName));
-      jarOutput.closeEntry();
-      for (File content : currentFile.listFiles()) {
-        appendToJar(sourceRootDir, destRootPath, content, jarOutput);
-      }
-    } else {
-      String entryName = getEntryName(sourceRootDir, destRootPath, currentFile);
-      jarOutput.putNextEntry(new JarEntry(entryName));
-      try (FileInputStream fileIn = new FileInputStream(currentFile)) {
-        byte[] b = new byte[1024];
-        int len;
-        while ((len = fileIn.read(b)) != -1) {
-          jarOutput.write(b, 0, len);
-        }
-      }
-      jarOutput.closeEntry();
-    }
-  }
-
-  private String getEntryName(File sourceRootDir, String destRootPath, File currentFile) {
-    String relativePath = currentFile.getAbsolutePath().substring(sourceRootDir.getAbsolutePath().length());
-    return destRootPath + relativePath.replace('\\', '/');
   }
 
 }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceLocator.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/ResourceLocator.java
@@ -139,15 +139,22 @@ public final class ResourceLocator {
 
   /**
    * Creates a resource from a fully qualified resource name.
+   * <p>
+   * If the resource name does not start with a slash '/', one will be prepended.
+   * Use {@link #ofClasspath(Class, String)} to get a relative resource.
+   * <p>
+   * This method uses {@code ResourceLocator.class.getResource(String)} to find the resource.
+   * It avoids using {@link ClassLoader#getResource(String)} which works poorly with modules.
    * 
-   * @param resourceName  the classpath resource name
+   * @param resourceName  the resource name, which will have a slash '/' prepended if missing
    * @return the resource locator
    */
   public static ResourceLocator ofClasspath(String resourceName) {
     ArgChecker.notNull(resourceName, "classpathLocator");
-    URL url = classLoader().getResource(resourceName);
+    String searchName = resourceName.startsWith("/") ? resourceName : "/" + resourceName;
+    URL url = ResourceLocator.class.getResource(searchName);
     if (url == null) {
-      throw new IllegalArgumentException("Resource not found: " + resourceName);
+      throw new IllegalArgumentException("Resource not found: " + searchName);
     }
     return ofClasspathUrl(url);
   }
@@ -161,7 +168,7 @@ public final class ResourceLocator {
    *   <li>Otherwise the resource name is treated as a path relative to the package containing the class</li>
    * </ul>
    *
-   * @param cls  the class
+   * @param cls  the class used to find the resource
    * @param resourceName  the resource name
    * @return the resource locator
    */

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ResourceLocatorTest.java
@@ -123,7 +123,18 @@ public class ResourceLocatorTest {
     assertEquals(test.toString(), locator);
   }
 
-  public void test_ofClasspath() throws Exception {
+  public void test_ofClasspath_absolute() throws Exception {
+    ResourceLocator test = ResourceLocator.ofClasspath("/com/opengamma/strata/collect/io/TestFile.txt");
+    assertEquals(test.getLocator().startsWith("classpath"), true);
+    assertEquals(test.getLocator().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
+    assertEquals(test.getByteSource().read()[0], 'H');
+    assertEquals(test.getCharSource().readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.getCharSource(StandardCharsets.UTF_8).readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.toString().startsWith("classpath"), true);
+    assertEquals(test.toString().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
+  }
+
+  public void test_ofClasspath_relativeConvertedToAbsolute() throws Exception {
     ResourceLocator test = ResourceLocator.ofClasspath("com/opengamma/strata/collect/io/TestFile.txt");
     assertEquals(test.getLocator().startsWith("classpath"), true);
     assertEquals(test.getLocator().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
@@ -134,7 +145,19 @@ public class ResourceLocatorTest {
     assertEquals(test.toString().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
   }
 
-  public void test_ofClasspath_relative() throws Exception {
+  public void test_ofClasspath_withClass_absolute() throws Exception {
+    ResourceLocator test =
+        ResourceLocator.ofClasspath(ResourceLocator.class, "/com/opengamma/strata/collect/io/TestFile.txt");
+    assertEquals(test.getLocator().startsWith("classpath"), true);
+    assertEquals(test.getLocator().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
+    assertEquals(test.getByteSource().read()[0], 'H');
+    assertEquals(test.getCharSource().readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.getCharSource(StandardCharsets.UTF_8).readLines(), ImmutableList.of("HelloWorld"));
+    assertEquals(test.toString().startsWith("classpath"), true);
+    assertEquals(test.toString().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);
+  }
+
+  public void test_ofClasspath_withClass_relative() throws Exception {
     ResourceLocator test = ResourceLocator.ofClasspath(ResourceLocator.class, "TestFile.txt");
     assertEquals(test.getLocator().startsWith("classpath"), true);
     assertEquals(test.getLocator().endsWith("com/opengamma/strata/collect/io/TestFile.txt"), true);


### PR DESCRIPTION
Java 9 modules have caused `ClassLoader.getResource` to be less useful.
Change to use `Class.getResource`.
Users can use `ofClasspath(Class, String)` if there is a problem.