### PR TITLE
Guavate.concatToList to use <? extends T> generics

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -73,7 +73,7 @@ public final class Guavate {
    * @return the list that combines the inputs
    */
   @SafeVarargs
-  public static <T> ImmutableList<T> concatToList(Iterable<T>... iterables) {
+  public static <T> ImmutableList<T> concatToList(Iterable<? extends T>... iterables) {
     return ImmutableList.copyOf(Iterables.concat(iterables));
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -58,6 +58,13 @@ public class GuavateTest {
     assertEquals(test, ImmutableList.of("a", "b", "c", "d", "e", "f"));
   }
 
+  public void test_concatToList_differentTypes() {
+    Iterable<Integer> iterable1 = Arrays.asList(1, 2, 3);
+    Iterable<Double> iterable2 = Arrays.asList(10d, 20d, 30d);
+    ImmutableList<Number> test = Guavate.concatToList(iterable1, iterable2);
+    assertEquals(test, ImmutableList.of(1, 2, 3, 10d, 20d, 30d));
+  }
+
   //-------------------------------------------------------------------------
   public void test_firstNonEmpty_supplierMatch1() {
     Optional<Number> test = Guavate.firstNonEmpty(


### PR DESCRIPTION
Matches the generics used in ImmutableList.copyOf() and Iterables.concat()