### PR TITLE
Make Messages.formatWithAttributes() append additional arguments

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Messages.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Messages.java
@@ -138,7 +138,7 @@ public final class Messages {
    * The message template contains zero to many "{name}" placeholders.
    * Each placeholder is replaced by the next available argument.
    * If there are too few arguments, then the message will be left with placeholders.
-   * If there are too many arguments, then the excess arguments are ignored.
+   * If there are too many arguments, then the excess arguments are appended to the message.
    * No attempt is made to format the arguments.
    * <p>
    * This method is null tolerant to ensure that use in exception construction will
@@ -177,6 +177,18 @@ public final class Messages {
       argIndex++;
     }
     matcher.appendTail(outputMessageBuffer);
+
+    // append remaining args
+    if (argIndex < args.length) {
+      outputMessageBuffer.append(" - [");
+      for (int i = argIndex; i < args.length; i++) {
+        if (i > argIndex) {
+          outputMessageBuffer.append(", ");
+        }
+        outputMessageBuffer.append(args[i]);
+      }
+      outputMessageBuffer.append(']');
+    }
 
     return Pair.of(outputMessageBuffer.toString(), ImmutableMap.copyOf(attributes));
   }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -97,7 +97,7 @@ public final class FailureItem
    * If there are too few arguments, then the message will be left with placeholders.
    * If there are too many arguments, then the excess arguments are appended to the
    * end of the message. No attempt is made to format the arguments.
-   * See {@link Messages#format(String, Object...)} for more details.
+   * See {@link Messages#formatWithAttributes(String, Object...)} for more details.
    * <p>
    * An exception will be created internally to obtain a stack trace.
    * The cause type will not be present in the resulting failure.
@@ -181,7 +181,7 @@ public final class FailureItem
    * If there are too few arguments, then the message will be left with placeholders.
    * If there are too many arguments, then the excess arguments are appended to the
    * end of the message. No attempt is made to format the arguments.
-   * See {@link Messages#format(String, Object...)} for more details.
+   * See {@link Messages#formatWithAttributes(String, Object...)} for more details.
    * 
    * @param reason  the reason
    * @param cause  the cause

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MessagesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MessagesTest.java
@@ -144,7 +144,7 @@ public class MessagesTest {
         // null template
         {null, null, Pair.of("", ImmutableMap.of())},
         {null, new Object[] {}, Pair.of("", ImmutableMap.of())},
-        {"", new Object[] {"testValueMissingKey"}, Pair.of("", ImmutableMap.of())},
+        {"", new Object[] {"testValueMissingKey"}, Pair.of(" - [testValueMissingKey]", ImmutableMap.of())},
         {"{}", new Object[] {"testValue"}, Pair.of("testValue", ImmutableMap.of())},
         {"{}", new Object[] {null}, Pair.of("null", ImmutableMap.of())},
         {"{a}", new Object[] {"testValue"}, Pair.of("testValue", ImmutableMap.of("a", "testValue"))},
@@ -152,8 +152,8 @@ public class MessagesTest {
         {"Test {abc} test2 {def} test3", new Object[] {"abcValue", 123456}, Pair.of("Test abcValue test2 123456 test3", ImmutableMap.of("abc", "abcValue", "def", "123456"))},
         {"Test {abc} test2 {} test3", new Object[] {"abcValue", 123456}, Pair.of("Test abcValue test2 123456 test3", ImmutableMap.of("abc", "abcValue"))},
         {"Test {abc} test2 {} test3 {} test4", new Object[] {"abcValue", 123456, 789}, Pair.of("Test abcValue test2 123456 test3 789 test4", ImmutableMap.of("abc", "abcValue"))},
-        {"Test {abc} test2 {def} test3", new Object[] {"abcValue", 123456, 789}, Pair.of("Test abcValue test2 123456 test3", ImmutableMap.of("abc", "abcValue", "def", "123456"))},
-        {"Test {abc} test2 {abc} test3", new Object[] {"abcValue", 123456, 789}, Pair.of("Test abcValue test2 123456 test3", ImmutableMap.of("abc", "123456"))},
+        {"Test {abc} test2 {def} test3", new Object[] {"abcValue", 123456, 789}, Pair.of("Test abcValue test2 123456 test3 - [789]", ImmutableMap.of("abc", "abcValue", "def", "123456"))},
+        {"Test {abc} test2 {abc} test3", new Object[] {"abcValue", 123456, 789}, Pair.of("Test abcValue test2 123456 test3 - [789]", ImmutableMap.of("abc", "123456"))},
         {"Test {abc} test2 {def} test3", new Object[] {"abcValue"}, Pair.of("Test abcValue test2 {def} test3", ImmutableMap.of("abc", "abcValue"))},
         {"{a} bcd", new Object[] {"$testValue"}, Pair.of("$testValue bcd", ImmutableMap.of("a", "\\$testValue"))}, //The $ must be escaped
         {"Test {abc} test2 {def} test3 {ghi} test4", new Object[] {"abcValue"}, Pair.of("Test abcValue test2 {def} test3 {ghi} test4", ImmutableMap.of("abc", "abcValue"))}


### PR DESCRIPTION
Currently `Messages.format()` appends additional arguments to the end of the message, while 
`Messages.formatWithAttributes()` discards them. This meant that the JavaDoc on several `FailureItem.of()` methods was incorrect, and is inconsistent in the class.
Now additional arguments without a placeholder will be appended to the message (and continue to be left out of the attributes).