### PR TITLE
Additional FailureItem method

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItem.java
@@ -236,6 +236,20 @@ public final class FailureItem
   }
 
   /**
+   * Returns an instance with the specified attributes added.
+   * <p>
+   * If the attribute map of this instance has any of the new attribute keys, the values are replaced.
+   *
+   * @param attributes  the new attributes to add
+   * @return the new failure item
+   */
+  public FailureItem withAttributes(Map<String, String> attributes) {
+    Map<String, String> newAttributes = new HashMap<>(this.attributes);
+    newAttributes.putAll(attributes);
+    return new FailureItem(reason, message, newAttributes, stackTrace, causeType);
+  }
+
+  /**
    * Returns a string summary of the failure, as a single line excluding the stack trace.
    * 
    * @return the summary string

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
@@ -105,10 +105,24 @@ public class FailureItemTest {
     assertEquals(test.toString(), "INVALID: failure: error: java.lang.IllegalArgumentException: exmsg");
   }
 
-  public void test_withAttributes() {
+  public void test_withAttribute() {
     FailureItem test = FailureItem.of(FailureReason.INVALID, "my {one} {two} failure", "big", "bad");
     test = test.withAttribute("foo", "bar");
     assertEquals(test.getAttributes(), ImmutableMap.of("one", "big", "two", "bad", "foo", "bar"));
+    assertEquals(test.getReason(), FailureReason.INVALID);
+    assertEquals(test.getMessage(), "my big bad failure");
+    assertEquals(test.getCauseType().isPresent(), false);
+    assertEquals(test.getStackTrace().contains(".FailureItem.of("), false);
+    assertEquals(test.getStackTrace().contains(".Failure.of("), false);
+    assertEquals(test.getStackTrace().startsWith("com.opengamma.strata.collect.result.FailureItem: my big bad failure"), true);
+    assertEquals(test.getStackTrace().contains(".test_withAttribute("), true);
+    assertEquals(test.toString(), "INVALID: my big bad failure");
+  }
+
+  public void test_withAttributes() {
+    FailureItem test = FailureItem.of(FailureReason.INVALID, "my {one} {two} failure", "big", "bad");
+    test = test.withAttributes(ImmutableMap.of("foo", "bar", "two", "good"));
+    assertEquals(test.getAttributes(), ImmutableMap.of("one", "big", "two", "good", "foo", "bar"));
     assertEquals(test.getReason(), FailureReason.INVALID);
     assertEquals(test.getMessage(), "my big bad failure");
     assertEquals(test.getCauseType().isPresent(), false);


### PR DESCRIPTION
Add `FailureItem#withAttributes(Map<String, String>)` to complement `#withAttribute(String, String)`