### PR TITLE
Provide a way to determine the caller class

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -129,6 +129,8 @@ public final class Guavate {
   //-------------------------------------------------------------------------
   /**
    * Creates a single {@code Map.Entry}.
+   * <p>
+   * The entry is immutable.
    * 
    * @param <K>  the type of the key
    * @param <V>  the type of the value
@@ -899,6 +901,29 @@ public final class Guavate {
       }
     } catch (RuntimeException ex) {
       resultFuture.completeExceptionally(ex);
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Finds the caller class.
+   * <p>
+   * This takes an argument which is the number of stack levels to look back.
+   * This will be 2 to return the caller of this method, 3 to return the caller of the caller, and so on.
+   * 
+   * @param callStackDepth  the depth of the stack to look back
+   * @return the caller class
+   */
+  public static Class<?> callerClass(int callStackDepth) {
+    return CallerClassSecurityManager.INSTANCE.callerClass(callStackDepth);
+  }
+
+  // on Java 9 or later could use StackWalker, but this is a good choice for Java 8
+  static class CallerClassSecurityManager extends SecurityManager {
+    private static final CallerClassSecurityManager INSTANCE = new CallerClassSecurityManager();
+
+    Class<?> callerClass(int callStackDepth) {
+      return getClassContext()[callStackDepth];
     }
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -548,6 +548,13 @@ public class GuavateTest {
   }
 
   //-------------------------------------------------------------------------
+  public void test_callerClass() {
+    assertEquals(Guavate.callerClass(0), Guavate.CallerClassSecurityManager.class);
+    assertEquals(Guavate.callerClass(1), Guavate.class);
+    assertEquals(Guavate.callerClass(2), GuavateTest.class);
+  }
+
+  //-------------------------------------------------------------------------
   public void test_validUtilityClass() {
     assertUtilityClass(Guavate.class);
   }


### PR DESCRIPTION
Adds a simple utility to find the caller class
The fast way to do this is via JDK internal `Reflection.getCallerClass`
This uses a suitable alternative
Java 9 has `StackWalker` but using that from Java 8 is painful