### PR TITLE
Do not check that (non-overridden) effective date is before first regular start date when the effective date is overridden.

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -355,18 +355,24 @@ public final class PeriodicSchedule
   private void validate() {
     ArgChecker.inOrderNotEqual(
         startDate, endDate, "startDate", "endDate");
+    
     if (firstRegularStartDate != null) {
-      ArgChecker.inOrderOrEqual(
-          startDate, firstRegularStartDate, "unadjusted", "firstRegularStartDate");
+     
       if (lastRegularEndDate != null) {
         ArgChecker.inOrderNotEqual(
             firstRegularStartDate, lastRegularEndDate, "firstRegularStartDate", "lastRegularEndDate");
       }
+      
+      // Check override start date if present, otherwise use regular start date
       if (overrideStartDate != null) {
         ArgChecker.inOrderNotEqual(
             overrideStartDate.getUnadjusted(), firstRegularStartDate, "overrideStartDate", "firstRegularStartDate");
+      } else {
+        ArgChecker.inOrderOrEqual(
+            startDate, firstRegularStartDate, "unadjusted", "firstRegularStartDate");
       }
     }
+    
     if (lastRegularEndDate != null) {
       ArgChecker.inOrderOrEqual(
           lastRegularEndDate, endDate, "lastRegularEndDate", "endDate");

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -355,14 +355,11 @@ public final class PeriodicSchedule
   private void validate() {
     ArgChecker.inOrderNotEqual(
         startDate, endDate, "startDate", "endDate");
-    
     if (firstRegularStartDate != null) {
-     
       if (lastRegularEndDate != null) {
         ArgChecker.inOrderNotEqual(
             firstRegularStartDate, lastRegularEndDate, "firstRegularStartDate", "lastRegularEndDate");
       }
-      
       // Check override start date if present, otherwise use regular start date
       if (overrideStartDate != null) {
         ArgChecker.inOrderNotEqual(
@@ -372,7 +369,6 @@ public final class PeriodicSchedule
             startDate, firstRegularStartDate, "unadjusted", "firstRegularStartDate");
       }
     }
-    
     if (lastRegularEndDate != null) {
       ArgChecker.inOrderOrEqual(
           lastRegularEndDate, endDate, "lastRegularEndDate", "endDate");

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -184,6 +184,39 @@ public class PeriodicScheduleTest {
     assertEquals(test.calculatedStartDate(), AdjustableDate.of(JUN_04, BDA));
     assertEquals(test.calculatedEndDate(), AdjustableDate.of(SEP_17, BDA));
   }
+  
+  public void test_firstPaymentDate_before_effectiveDate() {
+  
+    // Schedule where the combination of override start date and regular first period start date produce a first
+    // payment date which is before the (non-overridden) start date
+  
+    LocalDate startDate = LocalDate.of(2018, 7, 26);
+    LocalDate endDate = LocalDate.of(2019, 6, 20);
+    LocalDate overrideStartDate = LocalDate.of(2018, 3, 20);
+    LocalDate firstRegularStartDate = LocalDate.of(2018, 6, 20);
+    
+    PeriodicSchedule scheduleDefinition = PeriodicSchedule.builder()
+        .startDate(startDate)
+        .endDate(endDate)
+        .frequency(Frequency.P3M)
+        .businessDayAdjustment(BDA)
+        .firstRegularStartDate(firstRegularStartDate)
+        .overrideStartDate(AdjustableDate.of(overrideStartDate))
+        .build();
+  
+    Schedule schedule = scheduleDefinition.createSchedule(REF_DATA);
+    assertEquals(schedule.size(), 5);
+    
+    for (int i = 0; i < schedule.size(); i++) {
+
+      LocalDate expectedStart = overrideStartDate.plusMonths(3 * i);
+      LocalDate expectedEnd = expectedStart.plusMonths(3);
+      SchedulePeriod expectedPeriod = SchedulePeriod.of(expectedStart, expectedEnd);
+  
+      SchedulePeriod actualPeriod = schedule.getPeriod(i);
+      assertEquals(expectedPeriod, actualPeriod);
+    }
+  }
 
   public void test_of_LocalDateRoll_null() {
     assertThrowsIllegalArg(() -> PeriodicSchedule.of(null, SEP_17, P1M, BDA, SHORT_INITIAL, DAY_17));


### PR DESCRIPTION
We have seen valid production CDS trades with this schedule setup.