### PR TITLE
Deprecate CHF-TOIS

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/IborIndexCsvLookup.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/IborIndexCsvLookup.java
@@ -99,13 +99,14 @@ final class IborIndexCsvLookup
   private static ImmutableMap<String, IborIndex> loadFromCsv() {
     List<ResourceLocator> resources = ResourceConfig.orderedResources("IborIndexData.csv");
     Map<String, IborIndex> map = new HashMap<>();
+    // files are ordered lowest priority to highest, thus Map::put is used
     for (ResourceLocator resource : resources) {
       try {
         CsvFile csv = CsvFile.of(resource.getCharSource(), true);
         for (CsvRow row : csv.rows()) {
           IborIndex parsed = parseIborIndex(row);
           map.put(parsed.getName(), parsed);
-          map.putIfAbsent(parsed.getName().toUpperCase(Locale.ENGLISH), parsed);
+          map.put(parsed.getName().toUpperCase(Locale.ENGLISH), parsed);
         }
       } catch (RuntimeException ex) {
         log.log(Level.SEVERE, "Error processing resource as Ibor Index CSV file: " + resource, ex);

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/OvernightIndexCsvLookup.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/OvernightIndexCsvLookup.java
@@ -71,13 +71,14 @@ final class OvernightIndexCsvLookup
   private static ImmutableMap<String, OvernightIndex> loadFromCsv() {
     List<ResourceLocator> resources = ResourceConfig.orderedResources("OvernightIndexData.csv");
     Map<String, OvernightIndex> map = new HashMap<>();
+    // files are ordered lowest priority to highest, thus Map::put is used
     for (ResourceLocator resource : resources) {
       try {
         CsvFile csv = CsvFile.of(resource.getCharSource(), true);
         for (CsvRow row : csv.rows()) {
           OvernightIndex parsed = parseOvernightIndex(row);
           map.put(parsed.getName(), parsed);
-          map.putIfAbsent(parsed.getName().toUpperCase(Locale.ENGLISH), parsed);
+          map.put(parsed.getName().toUpperCase(Locale.ENGLISH), parsed);
         }
       } catch (RuntimeException ex) {
         log.log(Level.SEVERE, "Error processing resource as Overnight Index CSV file: " + resource, ex);

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/OvernightIndices.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/OvernightIndices.java
@@ -40,7 +40,10 @@ public final class OvernightIndices {
    * The TOIS index for CHF.
    * <p>
    * The Tomorrow/Next Overnight Indexed Swaps (TOIS) index, which is a "Tomorrow/Next" index.
+   * 
+   * @deprecated TOIS was replaced by SARON at the end of 2017
    */
+  @Deprecated
   public static final OvernightIndex CHF_TOIS = OvernightIndex.of("CHF-TOIS");
   /**
    * The EONIA index for EUR.

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/PriceIndexCsvLookup.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/PriceIndexCsvLookup.java
@@ -68,13 +68,14 @@ final class PriceIndexCsvLookup
   private static ImmutableMap<String, PriceIndex> loadFromCsv() {
     List<ResourceLocator> resources = ResourceConfig.orderedResources("PriceIndexData.csv");
     Map<String, PriceIndex> map = new HashMap<>();
+    // files are ordered lowest priority to highest, thus Map::put is used
     for (ResourceLocator resource : resources) {
       try {
         CsvFile csv = CsvFile.of(resource.getCharSource(), true);
         for (CsvRow row : csv.rows()) {
           PriceIndex parsed = parsePriceIndex(row);
           map.put(parsed.getName(), parsed);
-          map.putIfAbsent(parsed.getName().toUpperCase(Locale.ENGLISH), parsed);
+          map.put(parsed.getName().toUpperCase(Locale.ENGLISH), parsed);
         }
       } catch (RuntimeException ex) {
         log.log(Level.SEVERE, "Error processing resource as Price Index CSV file: " + resource, ex);

--- a/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/OvernightIndexData.csv
+++ b/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/OvernightIndexData.csv
@@ -2,7 +2,7 @@ Name,Currency,Active,Day Count,Fixing Calendar,Publication Offset Days,Effective
 ,,,,,,
 GBP-SONIA,GBP,true,Act/365F,GBLO,0,0,Act/365F
 CHF-SARON,CHF,true,Act/360,CHZU,0,0,Act/360
-CHF-TOIS,CHF,true,Act/360,CHZU,0,1,Act/360
+CHF-TOIS,CHF,false,Act/360,CHZU,0,1,Act/360
 EUR-EONIA,EUR,true,Act/360,EUTA,0,0,Act/360
 JPY-TONAR,JPY,true,Act/365F,JPTO,1,0,Act/365F
 USD-FED-FUND,USD,true,Act/360,USNY,1,0,Act/360


### PR DESCRIPTION
TOIS has been replaced by SARON.
Ensure that override CSV data correctly replaces the Strata data.