### PR TITLE
Unicode BOM conversion was ignoring charset

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/UnicodeBom.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/UnicodeBom.java
@@ -80,11 +80,6 @@ public final class UnicodeBom {
     return new CharSource() {
 
       @Override
-      public ByteSource asByteSource(Charset charset) {
-        return byteSource;
-      }
-
-      @Override
       public Reader openStream() throws IOException {
         return toReader(byteSource.openStream());
       }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/UnicodeBomTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/UnicodeBomTest.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.collect.io;
 
 import static com.opengamma.strata.collect.TestHelper.assertUtilityClass;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -61,7 +62,7 @@ public class UnicodeBomTest {
     CharSource charSource = UnicodeBom.toCharSource(byteSource);
     String str = charSource.read();
     assertEquals(str, "Hello");
-    assertEquals(charSource.asByteSource(StandardCharsets.UTF_8), byteSource);
+    assertTrue(charSource.asByteSource(StandardCharsets.UTF_8).contentEquals(byteSource));
     assertEquals(charSource.toString().startsWith("UnicodeBom"), true);
   }
 


### PR DESCRIPTION
This was an unnecessary optimisation. To do the job properly would be complex with two inner classes and the use cases here don't justify that complexity.