### PR TITLE
Add MapStream method to NodalCurve, similar to CurrencyParameterSensitivity

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/NodalCurve.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/NodalCurve.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.market.curve;
 
+import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.ParameterPerturbation;
@@ -90,6 +91,18 @@ public interface NodalCurve
    * @return the new curve
    */
   public abstract NodalCurve withValues(DoubleArray xValues, DoubleArray yValues);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Converts this instance to a stream of y-values, keyed by the x-values.
+   * <p>
+   * This returns a {@link MapStream} keyed by the x-values.
+   *
+   * @return a map stream containing the x-values and the y-values
+   */
+  public default MapStream<Double, Double> values() {
+    return MapStream.zip(getXValues().stream().boxed(), getYValues().stream().boxed());
+  }
 
   //-------------------------------------------------------------------------
   @Override

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/ConstantNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/ConstantNodalCurveTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.param.ParameterMetadata;
@@ -90,6 +91,7 @@ public class ConstantNodalCurveTest {
     assertThat(test.yValueParameterSensitivity(10.2421).getMarketDataName()).isEqualTo(CURVE_NAME);
     assertThat(test.yValueParameterSensitivity(10.2421).getSensitivity()).isEqualTo(DoubleArray.of(1d));
     assertThat(test.firstDerivative(10.2421)).isEqualTo(0d);
+    assertThat(test.values().toMap()).isEqualTo(ImmutableMap.of(XVALUE, YVALUE));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/InflationNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/InflationNodalCurveTest.java
@@ -9,6 +9,7 @@ import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static java.time.temporal.ChronoUnit.MONTHS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 import java.time.LocalDate;
@@ -17,6 +18,7 @@ import java.util.function.DoubleBinaryOperator;
 
 import org.testng.annotations.Test;
 
+import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.ShiftType;
 import com.opengamma.strata.market.curve.interpolator.CurveInterpolator;
@@ -197,6 +199,7 @@ public class InflationNodalCurveTest {
         .of(CURVE2_NOFIX, VAL_DATE_2, LAST_FIX_MONTH_2, LAST_FIX_VALUE + 1.0d,
             SEASONALITY_ADDITIVE_DEF);
     coverBeanEquals(test, test2);
+    assertThat(test.values().toMap()).isEqualTo(MapStream.zip(TIMES.stream().boxed(), VALUES.stream().boxed()).toMap());
   }
 
   public void test_serialization() {

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.market.ValueType;
@@ -249,6 +250,7 @@ public class InterpolatedNodalCurveTest {
         .extrapolatorRight(CurveExtrapolators.LOG_LINEAR)
         .build();
     coverBeanEquals(test, test2);
+    assertThat(test.values().toMap()).isEqualTo(ImmutableMap.of(1d, 5d, 2d, 7d, 3d, 8d));
   }
 
   public void test_serialization() {


### PR DESCRIPTION
What's a better name than `values()`?