### PR TITLE
Add ObjDoubleToDoubleFunction

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/function/ObjDoubleToDoubleFunction.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/function/ObjDoubleToDoubleFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.collect.function;
+
+import java.util.Objects;
+import java.util.function.DoubleUnaryOperator;
+
+/**
+ * A function of two arguments - one object and one {@code double} - that returns a {@code double}.
+ * <p>
+ * This takes two arguments and returns an object result.
+ *
+ * @param <T> the type of the object parameter
+ */
+@FunctionalInterface
+public interface ObjDoubleToDoubleFunction<T> {
+
+  /**
+   * Applies the function.
+   *
+   * @param obj  the first argument
+   * @param value  the second argument
+   * @return the result of the function
+   */
+  public abstract double apply(T obj, double value);
+
+  /**
+   * Returns a new function that composes this function and the specified function.
+   * <p>
+   * This returns a composed function that applies the input to this function
+   * and then converts the result using the specified function.
+   *
+   * @param other  the second function
+   * @return the combined function, "this AND_THEN that"
+   * @throws NullPointerException if the other function is null
+   */
+  public default ObjDoubleToDoubleFunction<T> andThen(DoubleUnaryOperator other) {
+    Objects.requireNonNull(other);
+    return (obj, value) -> other.applyAsDouble(apply(obj, value));
+  }
+
+}

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/function/ObjDoubleToDoubleFunctionTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/function/ObjDoubleToDoubleFunctionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.collect.function;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link ObjDoubleToDoubleFunction}.
+ */
+@Test
+public class ObjDoubleToDoubleFunctionTest {
+
+  public void test_andThen() {
+    ObjDoubleToDoubleFunction<String> fn1 = (a, b) -> Double.parseDouble(a) + b;
+    ObjDoubleToDoubleFunction<String> fn2 = fn1.andThen(val -> val + 4);
+    assertEquals(fn1.apply("2", 3.2d), 5.2d, 0d);
+    assertEquals(fn2.apply("2", 3.2d), 9.2d, 0d);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void test_andThen_null() {
+    ObjDoubleToDoubleFunction<String> fn1 = (a, b) -> 6d;
+    fn1.andThen(null);
+  }
+
+}


### PR DESCRIPTION
An additional functional interface that allows an `Object` and a `double` to be operated on, producing a `double`.