### PR TITLE
Support more cash settlement methods from FpML

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/SwaptionFpmlParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/SwaptionFpmlParserPlugin.java
@@ -161,15 +161,19 @@ final class SwaptionFpmlParserPlugin implements FpmlParserPlugin {
   }
 
   private CashSwaptionSettlementMethod parseCashSettlementMethod(XmlElement cashSettlementEl) {
-    if (cashSettlementEl.findChild("cashPriceAlternateMethod").isPresent()) {
+    if (cashSettlementEl.findChild("cashPriceMethod").isPresent() ||
+        cashSettlementEl.findChild("cashPriceAlternateMethod").isPresent()) {
       return CashSwaptionSettlementMethod.CASH_PRICE;
 
     } else if (cashSettlementEl.findChild("parYieldCurveUnadjustedMethod").isPresent() ||
-        cashSettlementEl.findChild("parYieldCurveAadjustedMethod").isPresent()) {
+        cashSettlementEl.findChild("parYieldCurveAdjustedMethod").isPresent()) {
       return CashSwaptionSettlementMethod.PAR_YIELD;
 
     } else if (cashSettlementEl.findChild("zeroCouponYieldAdjustedMethod").isPresent()) {
       return CashSwaptionSettlementMethod.ZERO_COUPON_YIELD;
+
+    } else if (cashSettlementEl.findChild("collateralizedCashPriceMethod").isPresent()) {
+      return CashSwaptionSettlementMethod.COLLATERALIZED_CASH_PRICE;
 
     } else {
       throw new FpmlParseException("Invalid swaption cash settlement method: " + cashSettlementEl);

--- a/modules/product/src/main/java/com/opengamma/strata/product/swaption/CashSwaptionSettlementMethod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swaption/CashSwaptionSettlementMethod.java
@@ -22,18 +22,21 @@ public enum CashSwaptionSettlementMethod implements NamedEnum {
    * The cash price method
    * <p>
    * If exercised, the value of the underlying swap is exchanged at the cash settlement date.
+   * Defined by the 2006 ISDA definitions 18.3a and 18.3b.
    */
   CASH_PRICE,
   /**
    * The par yield curve method.
    * <p>
    * The settlement amount is computed with cash-settled annuity using the pre-agreed strike swap rate.
+   * Defined by the 2006 ISDA definitions 18.3c and 18.3e.
    */
   PAR_YIELD,
   /**
    * The zero coupon yield method.
    * <p>
    * The settlement amount is computed with the discount factor based on the agreed zero coupon curve.
+   * Defined by the 2006 ISDA definitions 18.3d.
    */
   ZERO_COUPON_YIELD,
   /**


### PR DESCRIPTION
FpML parsing is extended to support two more cash settlement methods
`cashPriceMethod` is merged with `cashPriceAlternateMethod`
`collateralizedCashPriceMethod` is connected to new code in Strata
Fix spelling of `parYieldCurveAdjustedMethod`
Fixes #1903