### PR TITLE
Output CSV using headers

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -185,7 +185,9 @@ public final class CsvOutput {
    * cells to be written by header name.
    * <p>
    * This writes the header line to the underlying.
-   * The returned instance should then be used to write additional rows.
+   * This is normally called once when the {@code CsvOutput} instance is created
+   * with only the returned instance used to write additional rows.
+   * While it is possible to write rows through both instances, this is likely to get confusing.
    *
    * @param headers  the list of headers
    * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -18,6 +18,8 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import org.joda.beans.JodaBeanUtils;
+
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.tuple.ObjIntPair;
@@ -424,6 +426,60 @@ public final class CsvOutput {
       }
       mutableValueList.set(index, value);
       return this;
+    }
+
+    /**
+     * Writes a single cell by header, with the cell only being output when {@code writeNewLine()} is called.
+     * <p>
+     * The header must exactly match the header passed into the constructor of this instance.
+     * An exception is thrown if the header is not known.
+     * <p>
+     * Note that if {@link #writeNewLine()} is not called, the cell will never be output.
+     *
+     * @param header  the header to write
+     * @param value  the value to write
+     * @return this, for method chaining
+     * @throws IllegalArgumentException if one of the headers does not match
+     * @throws UncheckedIOException if an IO exception occurs
+     */
+    public CsvRowOutputWithHeaders writeCell(String header, Object value) {
+      return writeCell(header, JodaBeanUtils.stringConverter().convertToString(value));
+    }
+
+    /**
+     * Writes a single cell by header, with the cell only being output when {@code writeNewLine()} is called.
+     * <p>
+     * The header must exactly match the header passed into the constructor of this instance.
+     * An exception is thrown if the header is not known.
+     * <p>
+     * Note that if {@link #writeNewLine()} is not called, the cell will never be output.
+     *
+     * @param header  the header to write
+     * @param value  the value to write
+     * @return this, for method chaining
+     * @throws IllegalArgumentException if one of the headers does not match
+     * @throws UncheckedIOException if an IO exception occurs
+     */
+    public CsvRowOutputWithHeaders writeCell(String header, double value) {
+      return writeCell(header, Double.valueOf(value));
+    }
+
+    /**
+     * Writes a single cell by header, with the cell only being output when {@code writeNewLine()} is called.
+     * <p>
+     * The header must exactly match the header passed into the constructor of this instance.
+     * An exception is thrown if the header is not known.
+     * <p>
+     * Note that if {@link #writeNewLine()} is not called, the cell will never be output.
+     *
+     * @param header  the header to write
+     * @param value  the value to write
+     * @return this, for method chaining
+     * @throws IllegalArgumentException if one of the headers does not match
+     * @throws UncheckedIOException if an IO exception occurs
+     */
+    public CsvRowOutputWithHeaders writeCell(String header, long value) {
+      return writeCell(header, Long.valueOf(value));
     }
 
     /**

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
@@ -15,6 +15,9 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
+
 /**
  * Test {@link CsvOutput}.
  */
@@ -120,6 +123,46 @@ public class CsvOutputTest {
         .writeCell("b")
         .writeLine(row);
     assertEquals(buf.toString(), "a,b,x,y\n");
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_withHeaders_writeCell() {
+    List<String> headers = Arrays.asList("h1", "h2", "h3");
+    StringBuilder buf = new StringBuilder();
+    CsvRowOutputWithHeaders csv = CsvOutput.standard(buf).withHeaders(headers, false);
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP);
+    csv.writeCell("h1", "a");
+    csv.writeCell("h3", "c");
+    csv.writeCell("h1", "A");
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP);
+    csv.writeNewLine();
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "A,,c" + LINE_SEP);
+    assertThrows(IllegalArgumentException.class, () -> csv.writeCell("H1", "x"));
+  }
+
+  public void test_withHeaders_writeCells() {
+    List<String> headers = Arrays.asList("h1", "h2", "h3");
+    StringBuilder buf = new StringBuilder();
+    CsvRowOutputWithHeaders csv = CsvOutput.standard(buf).withHeaders(headers, false);
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP);
+    csv.writeCells(ImmutableMap.of("h1", "a", "h2", "b"));
+    csv.writeCell("h3", "c");
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP);
+    csv.writeNewLine();
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "a,b,c" + LINE_SEP);
+  }
+
+  public void test_withHeaders_writeLine() {
+    List<String> headers = Arrays.asList("h1", "h2", "h3");
+    StringBuilder buf = new StringBuilder();
+    CsvRowOutputWithHeaders csv = CsvOutput.standard(buf).withHeaders(headers, false);
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP);
+    csv.writeLine(ImmutableMap.of("h1", "a", "h2", "b"));
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "a,b," + LINE_SEP);
+    csv.writeCell("h3", "c");
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "a,b," + LINE_SEP);
+    csv.writeNewLine();
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "a,b," + LINE_SEP + ",,c" + LINE_SEP);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Provide a more convenient way to output CSV files using headers.

Note that this change includes some mutability (!), but that is fairly typical of IO code.