### PR TITLE
Additional methods for formatted doubles in CSV

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -10,6 +10,7 @@ import static com.opengamma.strata.collect.Guavate.zipWithIndex;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -461,6 +462,11 @@ public final class CsvOutput {
      * @throws UncheckedIOException if an IO exception occurs
      */
     public CsvRowOutputWithHeaders writeCell(String header, Object value) {
+      if (value instanceof Double) {
+        return writeCell(header, ((Double) value).doubleValue());
+      } else if (value instanceof Float) {
+        return writeCell(header, ((Float) value).doubleValue());
+      }
       return writeCell(header, JodaBeanUtils.stringConverter().convertToString(value));
     }
 
@@ -479,7 +485,8 @@ public final class CsvOutput {
      * @throws UncheckedIOException if an IO exception occurs
      */
     public CsvRowOutputWithHeaders writeCell(String header, double value) {
-      return writeCell(header, Double.valueOf(value));
+      String str = BigDecimal.valueOf(value).toPlainString();
+      return writeCell(header, str.endsWith(".0") ? str.substring(0, str.length() - 2) : str);
     }
 
     /**

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
@@ -153,6 +153,21 @@ public class CsvOutputTest {
     assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "a,b,c" + LINE_SEP);
   }
 
+  public void test_withHeaders_writeCells_numbers() {
+    List<String> headers = Arrays.asList("h1", "h2", "h3");
+    StringBuilder buf = new StringBuilder();
+    CsvRowOutputWithHeaders csv = CsvOutput.standard(buf).withHeaders(headers, false);
+    csv.writeCell("h1", 1.23d);
+    csv.writeCell("h2", 123d);
+    csv.writeCell("h3", 123L);
+    csv.writeNewLine();
+    csv.writeCell("h1", Double.valueOf(123d));
+    csv.writeCell("h2", Float.valueOf(123f));
+    csv.writeCell("h3", Long.valueOf(123L));
+    csv.writeNewLine();
+    assertEquals(buf.toString(), "h1,h2,h3" + LINE_SEP + "1.23,123,123" + LINE_SEP + "123,123,123" + LINE_SEP);
+  }
+
   public void test_withHeaders_writeLine() {
     List<String> headers = Arrays.asList("h1", "h2", "h3");
     StringBuilder buf = new StringBuilder();

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvLoaderUtils.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvLoaderUtils.java
@@ -8,6 +8,7 @@ package com.opengamma.strata.loader.csv;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
 import static com.opengamma.strata.collect.Guavate.toImmutableMap;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.Locale;
@@ -364,6 +365,33 @@ public final class CsvLoaderUtils {
     double amount = LoaderUtils.parseDouble(row.getValue(amountField));
     PayReceive direction = LoaderUtils.parsePayReceive(row.getValue(directionField));
     return CurrencyAmount.of(currency, direction.normalize(amount));
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns a value formatted as a percentage.
+   * <p>
+   * Using this method avoids nasty effects from floating point arithmetic.
+   * 
+   * @param value  the value in decimal format (to be multiplied by 100)
+   * @return the formatted percentage value
+   */
+  public static String formattedPercentage(double value) {
+    String str = BigDecimal.valueOf(value).movePointRight(2).toPlainString();
+    return str.endsWith(".0") ? str.substring(0, str.length() - 2) : str;
+  }
+
+  /**
+   * Returns a value formatted as a double.
+   * <p>
+   * Using this method avoids nasty effects from floating point arithmetic.
+   * 
+   * @param value  the value
+   * @return the formatted value
+   */
+  public static String formattedDouble(double value) {
+    String str = BigDecimal.valueOf(value).toPlainString();
+    return str.endsWith(".0") ? str.substring(0, str.length() - 2) : str;
   }
 
 }

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/CsvLoaderUtilsTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/CsvLoaderUtilsTest.java
@@ -160,4 +160,19 @@ public class CsvLoaderUtilsTest {
     assertThrowsIllegalArg(() -> CsvLoaderUtils.parseCurrencyAmountWithDirection(row, "CCX", "AMT", "DIR"));
   }
 
+  //-------------------------------------------------------------------------
+  public void test_formattedDouble() {
+    assertEquals(CsvLoaderUtils.formattedDouble(123.45d), "123.45");
+    assertEquals(CsvLoaderUtils.formattedDouble(0.7d), "0.7");
+    assertEquals(CsvLoaderUtils.formattedDouble(0.08d), "0.08");
+    assertEquals(CsvLoaderUtils.formattedDouble(789d), "789");
+  }
+
+  public void test_formattedPercentage() {
+    assertEquals(CsvLoaderUtils.formattedPercentage(1.2345d), "123.45");
+    assertEquals(CsvLoaderUtils.formattedPercentage(0.007d), "0.7");
+    assertEquals(CsvLoaderUtils.formattedPercentage(0.08d), "8");
+    assertEquals(CsvLoaderUtils.formattedPercentage(7.89d), "789");
+  }
+
 }


### PR DESCRIPTION
Use BigDecimal for clearer CSV formatting
No need for trailing ".0"