### PR TITLE
Add codec methods to `ArrayByteSource`

### DIFF
--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
@@ -12,9 +12,12 @@ import static org.testng.Assert.assertThrows;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 
 import org.testng.annotations.Test;
 
+import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteSource;
 import com.opengamma.strata.collect.function.CheckedSupplier;
 
@@ -154,6 +157,50 @@ public class ArrayByteSourceTest {
     assertEquals(test.readUtf8UsingBom(), "ABC");
     assertEquals(test.asCharSourceUtf8UsingBom().read(), "ABC");
     assertEquals(test.toString(), "ArrayByteSource[3 bytes]");
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_md5() {
+    byte[] bytes = new byte[] {65, 66, 67, 99};
+    @SuppressWarnings("deprecation")
+    byte[] hash = Hashing.md5().hashBytes(bytes).asBytes();
+    ArrayByteSource test = ArrayByteSource.copyOf(bytes);
+    assertEquals(test.toMd5(), ArrayByteSource.ofUnsafe(hash));
+  }
+
+  public void test_sha512() {
+    byte[] bytes = new byte[] {65, 66, 67, 99};
+    byte[] hash = Hashing.sha512().hashBytes(bytes).asBytes();
+    ArrayByteSource test = ArrayByteSource.copyOf(bytes);
+    assertEquals(test.toSha512(), ArrayByteSource.ofUnsafe(hash));
+  }
+
+  public void test_base64() {
+    byte[] bytes = new byte[] {65, 66, 67, 99};
+    @SuppressWarnings("deprecation")
+    byte[] base64 = BaseEncoding.base64().encode(bytes).getBytes(StandardCharsets.UTF_8);
+    ArrayByteSource test = ArrayByteSource.copyOf(bytes);
+    assertEquals(test.toBase64(), ArrayByteSource.ofUnsafe(base64));
+  }
+
+  public void test_base64String() {
+    byte[] bytes = new byte[] {65, 66, 67, 99};
+    @SuppressWarnings("deprecation")
+    String base64 = BaseEncoding.base64().encode(bytes);
+    ArrayByteSource test = ArrayByteSource.copyOf(bytes);
+    assertEquals(test.toBase64String(), base64);
+    ArrayByteSource roundtrip = ArrayByteSource.fromBase64(base64);
+    assertEquals(roundtrip, test);
+    assertEquals(test.toBase64String(), test.toBase64().readUtf8());
+  }
+
+  public void test_hexString() {
+    byte[] bytes = new byte[] {65, 66, 67, 99};
+    String hex = "41424363";
+    ArrayByteSource test = ArrayByteSource.copyOf(bytes);
+    assertEquals(test.toHexString(), hex);
+    ArrayByteSource roundtrip = ArrayByteSource.fromHex(hex);
+    assertEquals(roundtrip, test);
   }
 
 }


### PR DESCRIPTION
Directly handle codec conversions on `ArrayByteSource`
Handles our use cases, but wouldn't scale to all possible conversions