### PR TITLE
Fix Japanese holiday calendar rules

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
@@ -494,6 +494,7 @@ final class GlobalHolidayCalendars {
   // http://www.nao.ac.jp/faq/a0301.html (equinox)
   // http://eco.mtk.nao.ac.jp/koyomi/faq/holiday.html.en
   // https://www.jpx.co.jp/english/announce/market-holidays.html
+  // https://www.loc.gov/law/foreign-news/article/japan-three-holidays-to-be-moved-to-ease-2020-olympic-ceremony-traffic/
   static ImmutableHolidayCalendar generateTokyo() {
     List<LocalDate> holidays = new ArrayList<>(2000);
     for (int year = 1950; year <= 2099; year++) {
@@ -538,14 +539,20 @@ final class GlobalHolidayCalendars {
         holidays.add(bumpSunToMon(date(year, 5, 5)));
       }
       // marine
-      if (year >= 2003) {
+      if (year == 2020) {
+        // moved because of the Olympics (day prior to opening ceremony)
+        holidays.add(date(year, 7, 23));
+      } else if (year >= 2003) {
         holidays.add(date(year, 7, 1).with(dayOfWeekInMonth(3, MONDAY)));
       } else if (year >= 1996) {
         holidays.add(bumpSunToMon(date(year, 7, 20)));
       }
       // mountain
-      if (year >= 2016) {
-        holidays.add(bumpSunAndTueToMon(date(year, 8, 11)));
+      if (year == 2020) {
+        // moved because of the Olympics (day after closing ceremony)
+        holidays.add(date(year, 8, 10));
+      } else if (year >= 2016) {
+        holidays.add(bumpSunToMon(date(year, 8, 11)));
       }
       // aged
       if (year >= 2003) {
@@ -562,7 +569,10 @@ final class GlobalHolidayCalendars {
       citizensDay(holidays, date(year, 9, 20), date(year, 9, 22));
       citizensDay(holidays, date(year, 9, 21), date(year, 9, 23));
       // health-sports
-      if (year >= 2000) {
+      if (year == 2020) {
+        // moved because of the Olympics (day of opening ceremony)
+        holidays.add(date(2020, 7, 24));
+      } else if (year >= 2000) {
         holidays.add(date(year, 10, 1).with(dayOfWeekInMonth(2, MONDAY)));
       } else if (year >= 1966) {
         holidays.add(bumpSunToMon(date(year, 10, 10)));
@@ -574,8 +584,7 @@ final class GlobalHolidayCalendars {
       // emperor (current emporer birthday)
       if (year >= 1990 && year < 2019) {
         holidays.add(bumpSunToMon(date(year, 12, 23)));
-      }
-      if (year >= 2020) {
+      } else if (year >= 2020) {
         holidays.add(bumpSunToMon(date(year, 2, 23)));
       }
       // new years eve - bank of Japan, but not national holiday
@@ -1246,17 +1255,6 @@ final class GlobalHolidayCalendars {
   private static LocalDate bumpSunToMon(LocalDate date) {
     if (date.getDayOfWeek() == SUNDAY) {
       return date.plusDays(1);
-    }
-    return date;
-  }
-
-  // bump Sunday & Tuesday to the Monday
-  private static LocalDate bumpSunAndTueToMon(LocalDate date) {
-    if (date.getDayOfWeek() == SUNDAY) {
-      return date.plusDays(1);
-    }
-    if (date.getDayOfWeek() == TUESDAY) {
-      return date.minusDays(1);
     }
     return date;
   }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
@@ -624,6 +624,7 @@ public class GlobalHolidayCalendarsTest {
     return new Object[][] {
         // https://www.boj.or.jp/en/about/outline/holi.htm/
         // http://web.archive.org/web/20110513190217/http://www.boj.or.jp/en/about/outline/holi.htm/
+        // https://www.japanspecialist.co.uk/travel-tips/national-holidays-in-japan/
         {1999, mds(1999, md(1, 1), md(1, 2), md(1, 3), md(1, 15), md(2, 11), md(3, 22), md(4, 29), md(5, 3), md(5, 4), md(5, 5),
             md(7, 20), md(9, 15), md(9, 23), md(10, 11), md(11, 3), md(11, 23), md(12, 23), md(12, 31))},
         {2000, mds(2000, md(1, 1), md(1, 2), md(1, 3), md(1, 10), md(2, 11), md(3, 20), md(4, 29), md(5, 3), md(5, 4), md(5, 5),
@@ -653,6 +654,18 @@ public class GlobalHolidayCalendarsTest {
         {2015, mds(2015, md(1, 1), md(1, 2), md(1, 3), md(1, 12), md(2, 11), md(3, 21), md(4, 29),
             md(5, 3), md(5, 4), md(5, 5), md(5, 6),
             md(7, 20), md(9, 21), md(9, 22), md(9, 23), md(10, 12), md(11, 3), md(11, 23), md(12, 23), md(12, 31))},
+        {2018, mds(2018, md(1, 1), md(1, 2), md(1, 3), md(1, 8), md(2, 12), md(3, 21), md(4, 30),
+            md(5, 3), md(5, 4), md(5, 5), md(7, 16), md(8, 11), md(9, 17), md(9, 24),
+            md(10, 8), md(11, 3), md(11, 23), md(12, 23), md(12, 24), md(12, 31))},
+        {2019, mds(2019, md(1, 1), md(1, 2), md(1, 3), md(1, 14), md(2, 11), md(3, 21), md(4, 29), md(4, 30),
+            md(5, 1), md(5, 2), md(5, 3), md(5, 4), md(5, 5), md(5, 6), md(7, 15), md(8, 12), md(9, 16), md(9, 23),
+            md(10, 14), md(10, 22), md(11, 4), md(11, 23), md(12, 31))},
+        {2020, mds(2020, md(1, 1), md(1, 2), md(1, 3), md(1, 13), md(2, 11), md(2, 24), md(3, 20), md(4, 29),
+            md(5, 3), md(5, 4), md(5, 5), md(5, 6), md(7, 23), md(7, 24), md(8, 10), md(9, 21), md(9, 22),
+            md(11, 3), md(11, 23), md(12, 31))},
+        {2021, mds(2021, md(1, 1), md(1, 11), md(2, 11), md(2, 23), md(3, 20), md(4, 29),
+            md(5, 3), md(5, 4), md(5, 5), md(7, 19), md(8, 11), md(9, 20), md(9, 23),
+            md(10, 11), md(11, 3), md(11, 23), md(12, 31))},
     };
   }
 


### PR DESCRIPTION
Three holidays in 2020 are moved (Marine, Sports & Mountain)
Thus bumpSunAndTueToMon was the wrong rule to apply
Fixes #1962 