### PR TITLE
Adding two methods on Result: ifSuccess and ifFailure

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -10,7 +10,9 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -583,6 +585,10 @@ public final class Result<T>
     return value != null;
   }
 
+  public void ifSuccess(Consumer<? super T> consumer) {
+    consumer.accept(value);
+  }
+
   /**
    * Indicates if this result represents a failure.
    * <p>
@@ -592,6 +598,10 @@ public final class Result<T>
    */
   public boolean isFailure() {
     return failure != null;
+  }
+
+  public void ifFailure(BiConsumer<? super T, Failure> consumer) {
+    consumer.accept(value, failure);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -585,8 +585,17 @@ public final class Result<T>
     return value != null;
   }
 
+  /**
+   * Executes the given consumer if the result represents a successful call and has a result available.
+   *
+   * This is the opposite of {@link #ifFailure(BiConsumer)}.
+   *
+   * @param consumer the consumer to be decorated
+   */
   public void ifSuccess(Consumer<? super T> consumer) {
-    consumer.accept(value);
+    if (value != null) {
+      consumer.accept(value);
+    }
   }
 
   /**
@@ -600,8 +609,17 @@ public final class Result<T>
     return failure != null;
   }
 
+  /**
+   * Executes the given consumer if the result represents a failure.
+   *
+   * This is the opposite of {@link #ifSuccess(Consumer)}.
+   *
+   * @param consumer the consumer to be decorated
+   */
   public void ifFailure(BiConsumer<? super T, Failure> consumer) {
-    consumer.accept(value, failure);
+    if (failure != null) {
+      consumer.accept(value, failure);
+    }
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -588,8 +587,6 @@ public final class Result<T>
   /**
    * Executes the given consumer if the result represents a successful call and has a result available.
    *
-   * This is the opposite of {@link #ifFailure(BiConsumer)}.
-   *
    * @param consumer the consumer to be decorated
    */
   public void ifSuccess(Consumer<? super T> consumer) {
@@ -612,13 +609,11 @@ public final class Result<T>
   /**
    * Executes the given consumer if the result represents a failure.
    *
-   * This is the opposite of {@link #ifSuccess(Consumer)}.
-   *
    * @param consumer the consumer to be decorated
    */
-  public void ifFailure(BiConsumer<? super T, Failure> consumer) {
+  public void ifFailure(Consumer<Failure> consumer) {
     if (failure != null) {
-      consumer.accept(value, failure);
+      consumer.accept(failure);
     }
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
@@ -56,7 +56,7 @@ public class ResultTest {
 
   public void ifSuccess() {
     Result<String> test = Result.success("success");
-    test.ifSuccess(value -> assertEquals(value, "success"));;
+    test.ifSuccess(value -> assertEquals(value, "success"));
   }
 
   public void ifFailure() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
@@ -13,7 +13,6 @@ import static com.opengamma.strata.collect.result.FailureReason.ERROR;
 import static com.opengamma.strata.collect.result.FailureReason.MISSING_DATA;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -62,8 +61,7 @@ public class ResultTest {
 
   public void ifFailure() {
     Result<String> test = Result.failure(FailureReason.INVALID, "no success");
-    test.ifFailure((value, failure) -> {
-      assertNull(value);
+    test.ifFailure((failure) -> {
       assertEquals(
           failure.getReason(),
           FailureReason.INVALID);

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
@@ -11,9 +11,9 @@ import static com.opengamma.strata.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.strata.collect.result.FailureReason.CALCULATION_FAILED;
 import static com.opengamma.strata.collect.result.FailureReason.ERROR;
 import static com.opengamma.strata.collect.result.FailureReason.MISSING_DATA;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -53,6 +53,22 @@ public class ResultTest {
     assertEquals(test.getValueOrElse("blue"), "success");
     assertThrowsIllegalArg(() -> test.getValueOrElse(null));
     assertThrowsIllegalArg(() -> test.getValueOrElseApply(null));
+  }
+
+  public void ifSuccess() {
+    Result<String> test = Result.success("success");
+    test.ifSuccess(value -> assertEquals(value, "success"));
+  }
+
+  public void ifFailure() {
+    Result<String> test = Result.failure(FailureReason.INVALID, "no success");
+    test.ifFailure((value, failure) -> {
+      assertNull(value);
+      assertEquals(
+          failure.getReason(),
+          FailureReason.INVALID);
+      assertEquals(failure.getMessage(), "no success");
+    });
   }
 
   public void success_getFailure() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
@@ -57,7 +57,7 @@ public class ResultTest {
 
   public void ifSuccess() {
     Result<String> test = Result.success("success");
-    test.ifSuccess(value -> assertEquals(value, "success"));
+    test.ifSuccess(value -> assertEquals(value, "success"));;
   }
 
   public void ifFailure() {


### PR DESCRIPTION
The consumer in `ifSuccess` will receive the value of the Result. It will only execute if the Result is successful.

The BiConsumer in `ifFailure` will receive both the value and the failure of the Result. It will only execute if the Result has a failure.