### PR TITLE
Add helper methods to CsvOutput to bridge writing CSV Files and Iterators

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -223,22 +223,6 @@ public final class CsvOutput {
   }
 
   /**
-   * Writes multiple {@code CsvRow}s to the underlying.
-   * <p>
-   * The boolean flag controls whether each entry is always quoted or only quoted when necessary.
-   *
-   * @param rows  the rows to write
-   * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
-   * @throws UncheckedIOException if an IO exception occurs
-   */
-  public void writeRows(Iterable<CsvRow> rows, boolean alwaysQuote) {
-    ArgChecker.notNull(rows, "rows");
-    for (CsvRow row : rows) {
-      writeRow(row, alwaysQuote);
-    }
-  }
-
-  /**
    * Writes a single CSV line to the underlying, only quoting if needed.
    * <p>
    * This can be used as a method reference from a {@code Stream} pipeline from
@@ -272,6 +256,22 @@ public final class CsvOutput {
       writeCell(cell, alwaysQuote);
     }
     writeNewLine();
+  }
+
+  /**
+   * Writes multiple {@code CsvRow}s to the underlying.
+   * <p>
+   * The boolean flag controls whether each entry is always quoted or only quoted when necessary.
+   *
+   * @param rows  the rows to write
+   * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeRows(Iterable<CsvRow> rows, boolean alwaysQuote) {
+    ArgChecker.notNull(rows, "rows");
+    for (CsvRow row : rows) {
+      writeRow(row, alwaysQuote);
+    }
   }
 
   /**

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -174,6 +174,218 @@ public final class CsvOutput {
     return new CsvOutput(underlying, newLine, separator, true);
   }
 
+  /**
+   * Writes the provided {@code CsvFile} to the underlying, using the system default line separator and using a
+   * comma separator.
+   * <p>
+   * See the standard quoting rules in the class-level documentation.
+   *
+   * @param file  the file whose contents to output
+   * @param underlying  the destination to write to
+   */
+  public static void writeStandard(CsvFile file, Appendable underlying) {
+    writeStandard(file, underlying, NEW_LINE, COMMA);
+  }
+
+  /**
+   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled and
+   * using a comma separator.
+   * <p>
+   * See the standard quoting rules in the class-level documentation.
+   *
+   * @param file  the file whose contents to output
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   */
+  public static void writeStandard(CsvFile file, Appendable underlying, String newLine) {
+    writeStandard(file, underlying, newLine, COMMA);
+  }
+
+  /**
+   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled,
+   * specifying the separator.
+   * <p>
+   * See the standard quoting rules in the class-level documentation.
+   *
+   * @param file  the file whose contents to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
+   */
+  public static void writeStandard(CsvFile file, Appendable underlying, String newLine, String separator) {
+    CsvOutput output = new CsvOutput(underlying, newLine, separator, false);
+    output.writeLine(file.headers(), false);
+    output.writeRows(file.rows(), false);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying, using the system default line
+   * separator and using a comma separator.
+   * <p>
+   * See the standard quoting rules in the class-level documentation.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param underlying  the destination to write to
+   */
+  public static void writeStandard(CsvIterator iterator, Appendable underlying) {
+    writeStandard(iterator, underlying, NEW_LINE, COMMA);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to
+   * be controlled and using a comma separator.
+   * <p>
+   * See the standard quoting rules in the class-level documentation.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   */
+  public static void writeStandard(CsvIterator iterator, Appendable underlying, String newLine) {
+    writeStandard(iterator, underlying, newLine, COMMA);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to
+   * be controlled, specifying the separator.
+   * <p>
+   * See the standard quoting rules in the class-level documentation.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
+   */
+  public static void writeStandard(CsvIterator iterator, Appendable underlying, String newLine, String separator) {
+    CsvOutput output = new CsvOutput(underlying, newLine, separator, false);
+    output.writeLine(iterator.headers(), false);
+    iterator.asStream().forEachOrdered(output::writeRow);
+  }
+
+  /**
+   * Writes the provided {@code CsvFile} to the underlying, using the system default line separator and using a
+   * comma separator.
+   * <p>
+   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
+   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
+   * will be quoted and the quote section will be preceeded by equals.
+   * Thus, the string '=Foo' will be written as '="=Foo"'.
+   * This avoids the string being treated as an expression by tools like Excel.
+   * Simple numbers are not quoted.
+   * Thus, the number '-1234' will still be written as '-1234'.
+   *
+   * @param file  the file whose contents to write
+   * @param underlying  the destination to write to
+   */
+  public static void writeSafe(CsvFile file, Appendable underlying) {
+    writeSafe(file, underlying, NEW_LINE, COMMA);
+  }
+
+  /**
+   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled and
+   * using a comma separator.
+   * <p>
+   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
+   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
+   * will be quoted and the quote section will be preceeded by equals.
+   * Thus, the string '=Foo' will be written as '="=Foo"'.
+   * This avoids the string being treated as an expression by tools like Excel.
+   * Simple numbers are not quoted.
+   * Thus, the number '-1234' will still be written as '-1234'.
+   *
+   * @param file  the file whose contents to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   */
+  public static void writeSafe(CsvFile file, Appendable underlying, String newLine) {
+    writeSafe(file, underlying, newLine, COMMA);
+  }
+
+  /**
+   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled,
+   * specifying the separator.
+   * <p>
+   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
+   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
+   * will be quoted and the quote section will be preceeded by equals.
+   * Thus, the string '=Foo' will be written as '="=Foo"'.
+   * This avoids the string being treated as an expression by tools like Excel.
+   * Simple numbers are not quoted.
+   * Thus, the number '-1234' will still be written as '-1234'.
+   *
+   * @param file  the file whose contents to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
+   */
+  public static void writeSafe(CsvFile file, Appendable underlying, String newLine, String separator) {
+    CsvOutput output = new CsvOutput(underlying, newLine, separator, true);
+    output.writeLine(file.headers(), false);
+    output.writeRows(file.rows(), false);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying, using the system default line separator
+   * and using a comma separator.
+   * <p>
+   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
+   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
+   * will be quoted and the quote section will be preceeded by equals.
+   * Thus, the string '=Foo' will be written as '="=Foo"'.
+   * This avoids the string being treated as an expression by tools like Excel.
+   * Simple numbers are not quoted.
+   * Thus, the number '-1234' will still be written as '-1234'.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param underlying  the destination to write to
+   */
+  public static void writeSafe(CsvIterator iterator, Appendable underlying) {
+    writeSafe(iterator, underlying, NEW_LINE, COMMA);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to be
+   * controlled and using a comma separator.
+   * <p>
+   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
+   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
+   * will be quoted and the quote section will be preceeded by equals.
+   * Thus, the string '=Foo' will be written as '="=Foo"'.
+   * This avoids the string being treated as an expression by tools like Excel.
+   * Simple numbers are not quoted.
+   * Thus, the number '-1234' will still be written as '-1234'.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   */
+  public static void writeSafe(CsvIterator iterator, Appendable underlying, String newLine) {
+    writeSafe(iterator, underlying, newLine, COMMA);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to
+   * be controlled, specifying the separator.
+   * <p>
+   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
+   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
+   * will be quoted and the quote section will be preceeded by equals.
+   * Thus, the string '=Foo' will be written as '="=Foo"'.
+   * This avoids the string being treated as an expression by tools like Excel.
+   * Simple numbers are not quoted.
+   * Thus, the number '-1234' will still be written as '-1234'.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param underlying  the destination to write to
+   * @param newLine  the new line string
+   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
+   */
+  public static void writeSafe(CsvIterator iterator, Appendable underlying, String newLine, String separator) {
+    CsvOutput output = new CsvOutput(underlying, newLine, separator, true);
+    output.writeLine(iterator.headers(), false);
+    iterator.asStream().forEachOrdered(output::writeRow);
+  }
+
   //-------------------------------------------------------------------------
   // creates an instance
   private CsvOutput(Appendable underlying, String newLine, String separator, boolean safeExpressions) {
@@ -223,6 +435,22 @@ public final class CsvOutput {
   }
 
   /**
+   * Writes multiple {@code CsvRow}s to the underlying.
+   * <p>
+   * The boolean flag controls whether each entry is always quoted or only quoted when necessary.
+   *
+   * @param rows  the rows to write
+   * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeRows(Iterable<? extends CsvRow> rows, boolean alwaysQuote) {
+    ArgChecker.notNull(rows, "rows");
+    for (CsvRow row : rows) {
+      writeRow(row, alwaysQuote);
+    }
+  }
+
+  /**
    * Writes a single CSV line to the underlying, only quoting if needed.
    * <p>
    * This can be used as a method reference from a {@code Stream} pipeline from
@@ -236,6 +464,22 @@ public final class CsvOutput {
    */
   public void writeLine(List<String> line) {
     writeLine(line, false);
+  }
+
+  /**
+   * Writes a single {@code CsvRow} to the underlying, only quoting if needed.
+   * <p>
+   * This can be used as a method reference from a {@code Stream} pipeline from
+   * {@link Stream#forEachOrdered(Consumer)}.
+   * <p>
+   * This method writes each field in the specified row to the underlying, followed by
+   * a new line character.
+   *
+   * @param row  the row to write
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeRow(CsvRow row) {
+    writeRow(row, false);
   }
 
   /**
@@ -253,6 +497,26 @@ public final class CsvOutput {
   public void writeLine(List<String> line, boolean alwaysQuote) {
     ArgChecker.notNull(line, "line");
     for (String cell : line) {
+      writeCell(cell, alwaysQuote);
+    }
+    writeNewLine();
+  }
+
+  /**
+   * Writes a single {@code CsvRow} to the underlying.
+   * <p>
+   * The boolean flag controls whether each entry is always quoted or only quoted when necessary.
+   * <p>
+   * This method writes each field in the specified row to the underlying, followed by
+   * a new line character.
+   *
+   * @param row  the row to write
+   * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeRow(CsvRow row, boolean alwaysQuote) {
+    ArgChecker.notNull(row, "row");
+    for (String cell : row.fields()) {
       writeCell(cell, alwaysQuote);
     }
     writeNewLine();

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/CsvOutput.java
@@ -174,218 +174,6 @@ public final class CsvOutput {
     return new CsvOutput(underlying, newLine, separator, true);
   }
 
-  /**
-   * Writes the provided {@code CsvFile} to the underlying, using the system default line separator and using a
-   * comma separator.
-   * <p>
-   * See the standard quoting rules in the class-level documentation.
-   *
-   * @param file  the file whose contents to output
-   * @param underlying  the destination to write to
-   */
-  public static void writeStandard(CsvFile file, Appendable underlying) {
-    writeStandard(file, underlying, NEW_LINE, COMMA);
-  }
-
-  /**
-   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled and
-   * using a comma separator.
-   * <p>
-   * See the standard quoting rules in the class-level documentation.
-   *
-   * @param file  the file whose contents to output
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   */
-  public static void writeStandard(CsvFile file, Appendable underlying, String newLine) {
-    writeStandard(file, underlying, newLine, COMMA);
-  }
-
-  /**
-   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled,
-   * specifying the separator.
-   * <p>
-   * See the standard quoting rules in the class-level documentation.
-   *
-   * @param file  the file whose contents to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
-   */
-  public static void writeStandard(CsvFile file, Appendable underlying, String newLine, String separator) {
-    CsvOutput output = new CsvOutput(underlying, newLine, separator, false);
-    output.writeLine(file.headers(), false);
-    output.writeRows(file.rows(), false);
-  }
-
-  /**
-   * Writes the output of the provided {@code CsvIterator} to the underlying, using the system default line
-   * separator and using a comma separator.
-   * <p>
-   * See the standard quoting rules in the class-level documentation.
-   *
-   * @param iterator  the iterator whose output to write
-   * @param underlying  the destination to write to
-   */
-  public static void writeStandard(CsvIterator iterator, Appendable underlying) {
-    writeStandard(iterator, underlying, NEW_LINE, COMMA);
-  }
-
-  /**
-   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to
-   * be controlled and using a comma separator.
-   * <p>
-   * See the standard quoting rules in the class-level documentation.
-   *
-   * @param iterator  the iterator whose output to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   */
-  public static void writeStandard(CsvIterator iterator, Appendable underlying, String newLine) {
-    writeStandard(iterator, underlying, newLine, COMMA);
-  }
-
-  /**
-   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to
-   * be controlled, specifying the separator.
-   * <p>
-   * See the standard quoting rules in the class-level documentation.
-   *
-   * @param iterator  the iterator whose output to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
-   */
-  public static void writeStandard(CsvIterator iterator, Appendable underlying, String newLine, String separator) {
-    CsvOutput output = new CsvOutput(underlying, newLine, separator, false);
-    output.writeLine(iterator.headers(), false);
-    iterator.asStream().forEachOrdered(output::writeRow);
-  }
-
-  /**
-   * Writes the provided {@code CsvFile} to the underlying, using the system default line separator and using a
-   * comma separator.
-   * <p>
-   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
-   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
-   * will be quoted and the quote section will be preceeded by equals.
-   * Thus, the string '=Foo' will be written as '="=Foo"'.
-   * This avoids the string being treated as an expression by tools like Excel.
-   * Simple numbers are not quoted.
-   * Thus, the number '-1234' will still be written as '-1234'.
-   *
-   * @param file  the file whose contents to write
-   * @param underlying  the destination to write to
-   */
-  public static void writeSafe(CsvFile file, Appendable underlying) {
-    writeSafe(file, underlying, NEW_LINE, COMMA);
-  }
-
-  /**
-   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled and
-   * using a comma separator.
-   * <p>
-   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
-   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
-   * will be quoted and the quote section will be preceeded by equals.
-   * Thus, the string '=Foo' will be written as '="=Foo"'.
-   * This avoids the string being treated as an expression by tools like Excel.
-   * Simple numbers are not quoted.
-   * Thus, the number '-1234' will still be written as '-1234'.
-   *
-   * @param file  the file whose contents to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   */
-  public static void writeSafe(CsvFile file, Appendable underlying, String newLine) {
-    writeSafe(file, underlying, newLine, COMMA);
-  }
-
-  /**
-   * Writes the provided {@code CsvFile} to the underlying, allowing the new line character to be controlled,
-   * specifying the separator.
-   * <p>
-   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
-   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
-   * will be quoted and the quote section will be preceeded by equals.
-   * Thus, the string '=Foo' will be written as '="=Foo"'.
-   * This avoids the string being treated as an expression by tools like Excel.
-   * Simple numbers are not quoted.
-   * Thus, the number '-1234' will still be written as '-1234'.
-   *
-   * @param file  the file whose contents to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
-   */
-  public static void writeSafe(CsvFile file, Appendable underlying, String newLine, String separator) {
-    CsvOutput output = new CsvOutput(underlying, newLine, separator, true);
-    output.writeLine(file.headers(), false);
-    output.writeRows(file.rows(), false);
-  }
-
-  /**
-   * Writes the output of the provided {@code CsvIterator} to the underlying, using the system default line separator
-   * and using a comma separator.
-   * <p>
-   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
-   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
-   * will be quoted and the quote section will be preceeded by equals.
-   * Thus, the string '=Foo' will be written as '="=Foo"'.
-   * This avoids the string being treated as an expression by tools like Excel.
-   * Simple numbers are not quoted.
-   * Thus, the number '-1234' will still be written as '-1234'.
-   *
-   * @param iterator  the iterator whose output to write
-   * @param underlying  the destination to write to
-   */
-  public static void writeSafe(CsvIterator iterator, Appendable underlying) {
-    writeSafe(iterator, underlying, NEW_LINE, COMMA);
-  }
-
-  /**
-   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to be
-   * controlled and using a comma separator.
-   * <p>
-   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
-   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
-   * will be quoted and the quote section will be preceeded by equals.
-   * Thus, the string '=Foo' will be written as '="=Foo"'.
-   * This avoids the string being treated as an expression by tools like Excel.
-   * Simple numbers are not quoted.
-   * Thus, the number '-1234' will still be written as '-1234'.
-   *
-   * @param iterator  the iterator whose output to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   */
-  public static void writeSafe(CsvIterator iterator, Appendable underlying, String newLine) {
-    writeSafe(iterator, underlying, newLine, COMMA);
-  }
-
-  /**
-   * Writes the output of the provided {@code CsvIterator} to the underlying, allowing the new line character to
-   * be controlled, specifying the separator.
-   * <p>
-   * This applies the standard quoting rules from the class-level documentation, plus an additional rule.
-   * If an entry starts with an expression character, '=', '@', '+' or '-', the entry
-   * will be quoted and the quote section will be preceeded by equals.
-   * Thus, the string '=Foo' will be written as '="=Foo"'.
-   * This avoids the string being treated as an expression by tools like Excel.
-   * Simple numbers are not quoted.
-   * Thus, the number '-1234' will still be written as '-1234'.
-   *
-   * @param iterator  the iterator whose output to write
-   * @param underlying  the destination to write to
-   * @param newLine  the new line string
-   * @param separator  the separator used to separate each field, typically a comma, but a tab is sometimes used
-   */
-  public static void writeSafe(CsvIterator iterator, Appendable underlying, String newLine, String separator) {
-    CsvOutput output = new CsvOutput(underlying, newLine, separator, true);
-    output.writeLine(iterator.headers(), false);
-    iterator.asStream().forEachOrdered(output::writeRow);
-  }
-
   //-------------------------------------------------------------------------
   // creates an instance
   private CsvOutput(Appendable underlying, String newLine, String separator, boolean safeExpressions) {
@@ -443,7 +231,7 @@ public final class CsvOutput {
    * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
    * @throws UncheckedIOException if an IO exception occurs
    */
-  public void writeRows(Iterable<? extends CsvRow> rows, boolean alwaysQuote) {
+  public void writeRows(Iterable<CsvRow> rows, boolean alwaysQuote) {
     ArgChecker.notNull(rows, "rows");
     for (CsvRow row : rows) {
       writeRow(row, alwaysQuote);
@@ -467,22 +255,6 @@ public final class CsvOutput {
   }
 
   /**
-   * Writes a single {@code CsvRow} to the underlying, only quoting if needed.
-   * <p>
-   * This can be used as a method reference from a {@code Stream} pipeline from
-   * {@link Stream#forEachOrdered(Consumer)}.
-   * <p>
-   * This method writes each field in the specified row to the underlying, followed by
-   * a new line character.
-   *
-   * @param row  the row to write
-   * @throws UncheckedIOException if an IO exception occurs
-   */
-  public void writeRow(CsvRow row) {
-    writeRow(row, false);
-  }
-
-  /**
    * Writes a single CSV line to the underlying.
    * <p>
    * The boolean flag controls whether each entry is always quoted or only quoted when necessary.
@@ -503,6 +275,22 @@ public final class CsvOutput {
   }
 
   /**
+   * Writes a single {@code CsvRow} to the underlying, only quoting if needed.
+   * <p>
+   * This can be used as a method reference from a {@code Stream} pipeline from
+   * {@link Stream#forEachOrdered(Consumer)}.
+   * <p>
+   * This method writes each field in the specified row to the underlying, followed by
+   * a new line character.
+   *
+   * @param row  the row to write
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeRow(CsvRow row) {
+    writeRow(row, false);
+  }
+
+  /**
    * Writes a single {@code CsvRow} to the underlying.
    * <p>
    * The boolean flag controls whether each entry is always quoted or only quoted when necessary.
@@ -520,6 +308,30 @@ public final class CsvOutput {
       writeCell(cell, alwaysQuote);
     }
     writeNewLine();
+  }
+
+  /**
+   * Writes the provided {@code CsvFile} to the underlying.
+   *
+   * @param file  the file whose contents to write
+   * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeCsvFile(CsvFile file, boolean alwaysQuote) {
+    this.writeLine(file.headers(), alwaysQuote);
+    this.writeRows(file.rows(), alwaysQuote);
+  }
+
+  /**
+   * Writes the output of the provided {@code CsvIterator} to the underlying.
+   *
+   * @param iterator  the iterator whose output to write
+   * @param alwaysQuote  when true, each column will be quoted, when false, quoting is selective
+   * @throws UncheckedIOException if an IO exception occurs
+   */
+  public void writeCsvIterator(CsvIterator iterator, boolean alwaysQuote) {
+    this.writeLine(iterator.headers(), alwaysQuote);
+    iterator.asStream().forEachOrdered(row -> writeRow(row, alwaysQuote));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
@@ -209,35 +209,36 @@ public class CsvOutputTest {
   }
 
   //-------------------------------------------------------------------------
-  public void test_write_csv_file_standard() throws IOException {
+  public void test_write_csv_file() throws IOException {
     CsvFile file = CsvFile.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
+
     try (StringWriter underlying = new StringWriter()) {
-      CsvOutput.writeStandard(file, underlying, "\n", ",");
+      CsvOutput.standard(underlying, "\n", ",").writeCsvFile(file, false);
       assertEquals(underlying.toString(), "a,b,c\n1,\"=2\",3\n");
     }
   }
 
-  public void test_write_csv_file_safe() throws IOException {
+  public void test_write_csv_file_always_quote() throws IOException {
     CsvFile file = CsvFile.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
     try (StringWriter underlying = new StringWriter()) {
-      CsvOutput.writeSafe(file, underlying, "\n", ",");
-      assertEquals(underlying.toString(), "a,b,c\n1,=\"=2\",3\n");
+      CsvOutput.standard(underlying, "\n", ",").writeCsvFile(file, true);
+      assertEquals(underlying.toString(), "\"a\",\"b\",\"c\"\n\"1\",\"=2\",\"3\"\n");
     }
   }
 
-  public void test_write_csv_iterator_standard() throws IOException {
+  public void test_write_csv_iterator() throws IOException {
     CsvIterator iterator = CsvIterator.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
     try (StringWriter underlying = new StringWriter()) {
-      CsvOutput.writeStandard(iterator, underlying, "\n", ",");
+      CsvOutput.standard(underlying, "\n", ",").writeCsvIterator(iterator, false);
       assertEquals(underlying.toString(), "a,b,c\n1,\"=2\",3\n");
     }
   }
 
-  public void test_write_csv_iterator_safe() throws IOException {
+  public void test_write_csv_iterator_always_quote() throws IOException {
     CsvIterator iterator = CsvIterator.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
     try (StringWriter underlying = new StringWriter()) {
-      CsvOutput.writeSafe(iterator, underlying, "\n", ",");
-      assertEquals(underlying.toString(), "a,b,c\n1,=\"=2\",3\n");
+      CsvOutput.standard(underlying, "\n", ",").writeCsvIterator(iterator, true);
+      assertEquals(underlying.toString(), "\"a\",\"b\",\"c\"\n\"1\",\"=2\",\"3\"\n");
     }
   }
 }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/CsvOutputTest.java
@@ -9,10 +9,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 
+import com.google.common.io.CharSource;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -206,4 +208,36 @@ public class CsvOutputTest {
     assertThrows(UncheckedIOException.class, () -> output.writeNewLine());
   }
 
+  //-------------------------------------------------------------------------
+  public void test_write_csv_file_standard() throws IOException {
+    CsvFile file = CsvFile.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
+    try (StringWriter underlying = new StringWriter()) {
+      CsvOutput.writeStandard(file, underlying, "\n", ",");
+      assertEquals(underlying.toString(), "a,b,c\n1,\"=2\",3\n");
+    }
+  }
+
+  public void test_write_csv_file_safe() throws IOException {
+    CsvFile file = CsvFile.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
+    try (StringWriter underlying = new StringWriter()) {
+      CsvOutput.writeSafe(file, underlying, "\n", ",");
+      assertEquals(underlying.toString(), "a,b,c\n1,=\"=2\",3\n");
+    }
+  }
+
+  public void test_write_csv_iterator_standard() throws IOException {
+    CsvIterator iterator = CsvIterator.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
+    try (StringWriter underlying = new StringWriter()) {
+      CsvOutput.writeStandard(iterator, underlying, "\n", ",");
+      assertEquals(underlying.toString(), "a,b,c\n1,\"=2\",3\n");
+    }
+  }
+
+  public void test_write_csv_iterator_safe() throws IOException {
+    CsvIterator iterator = CsvIterator.of(CharSource.wrap("a,b,c\n1,=2,3"), true);
+    try (StringWriter underlying = new StringWriter()) {
+      CsvOutput.writeSafe(iterator, underlying, "\n", ",");
+      assertEquals(underlying.toString(), "a,b,c\n1,=\"=2\",3\n");
+    }
+  }
 }


### PR DESCRIPTION
Sometimes you already have an instance of a CsvFile or CsvIterator that you want to write out somewhere. This PR adds some static helper methods to CsvOutput to help support that.