### PR TITLE
Simpler check for FpML

### DIFF
--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/not-fpml.xml
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/not-fpml.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<root>
-</root>


### PR DESCRIPTION
Performance checks show old way was little faster than a full parse
New check is simple enough and should still be catch valid FpML