### PR TITLE
Add Attributes.hasAttribute() shorthand method

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/Attributes.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/Attributes.java
@@ -68,7 +68,7 @@ public interface Attributes {
    * @param type  the type to find
    * @return true if a matching attribute is present
    */
-  public default <T> boolean hasAttribute(AttributeType<T> type) {
+  public default <T> boolean containsAttribute(AttributeType<T> type) {
     return findAttribute(type).isPresent();
   }
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/Attributes.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/Attributes.java
@@ -62,6 +62,17 @@ public interface Attributes {
   }
 
   /**
+   * Determines if an attribute associated with the specified type is present.
+   *
+   * @param <T>  the type of the attribute value
+   * @param type  the type to find
+   * @return true if a matching attribute is present
+   */
+  public default <T> boolean hasAttribute(AttributeType<T> type) {
+    return findAttribute(type).isPresent();
+  }
+
+  /**
    * Finds the attribute associated with the specified type.
    * <p>
    * This method obtains the specified attribute.

--- a/modules/product/src/test/java/com/opengamma/strata/product/AttributesTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/AttributesTest.java
@@ -27,7 +27,7 @@ public class AttributesTest {
   public void test_empty() {
     Attributes test = Attributes.empty();
     assertEquals(test.findAttribute(AttributeType.DESCRIPTION), Optional.empty());
-    assertFalse(test.hasAttribute(AttributeType.DESCRIPTION));
+    assertFalse(test.containsAttribute(AttributeType.DESCRIPTION));
     assertThrows(IllegalArgumentException.class, () -> test.getAttribute(AttributeType.DESCRIPTION));
 
     Attributes test2 = test.withAttribute(AttributeType.NAME, "world");
@@ -38,12 +38,12 @@ public class AttributesTest {
     Attributes test = Attributes.of(AttributeType.DESCRIPTION, "hello");
     assertEquals(test.findAttribute(AttributeType.DESCRIPTION), Optional.of("hello"));
     assertEquals(test.getAttribute(AttributeType.DESCRIPTION), "hello");
-    assertTrue(test.hasAttribute(AttributeType.DESCRIPTION));
+    assertTrue(test.containsAttribute(AttributeType.DESCRIPTION));
 
     Attributes test2 = test.withAttribute(AttributeType.NAME, "world");
     assertEquals(test2.getAttribute(AttributeType.DESCRIPTION), "hello");
     assertEquals(test2.getAttribute(AttributeType.NAME), "world");
-    assertTrue(test2.hasAttribute(AttributeType.DESCRIPTION));
+    assertTrue(test2.containsAttribute(AttributeType.DESCRIPTION));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/test/java/com/opengamma/strata/product/AttributesTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/AttributesTest.java
@@ -9,7 +9,9 @@ import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Optional;
 
@@ -25,6 +27,7 @@ public class AttributesTest {
   public void test_empty() {
     Attributes test = Attributes.empty();
     assertEquals(test.findAttribute(AttributeType.DESCRIPTION), Optional.empty());
+    assertFalse(test.hasAttribute(AttributeType.DESCRIPTION));
     assertThrows(IllegalArgumentException.class, () -> test.getAttribute(AttributeType.DESCRIPTION));
 
     Attributes test2 = test.withAttribute(AttributeType.NAME, "world");
@@ -35,10 +38,12 @@ public class AttributesTest {
     Attributes test = Attributes.of(AttributeType.DESCRIPTION, "hello");
     assertEquals(test.findAttribute(AttributeType.DESCRIPTION), Optional.of("hello"));
     assertEquals(test.getAttribute(AttributeType.DESCRIPTION), "hello");
+    assertTrue(test.hasAttribute(AttributeType.DESCRIPTION));
 
     Attributes test2 = test.withAttribute(AttributeType.NAME, "world");
     assertEquals(test2.getAttribute(AttributeType.DESCRIPTION), "hello");
     assertEquals(test2.getAttribute(AttributeType.NAME), "world");
+    assertTrue(test2.hasAttribute(AttributeType.DESCRIPTION));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Add a simple helper method to Attributes - `thing.hasAttribute(foo)` reads more clearly than `thing.findAttribute(foo).isPresent()` and is also nicer to use in functional code.