### PR TITLE
Allow combining empty sensitivities

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivity.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivity.java
@@ -204,6 +204,9 @@ public final class CurrencyParameterSensitivity
    * Combines two or more instances to form a single sensitivity instance.
    * <p>
    * The result will store information about the separate instances allowing it to be {@link #split()} later.
+   * <p>
+   * If a single sensitivity is supplied and refers to the same market data then it will be returned unmodified.
+   * Otherwise a new instance will be returned with a single parameter split (the original sensitivity).
    * 
    * @param marketDataName  the combined name of the market data that the sensitivity refers to
    * @param sensitivities  the sensitivity instances to combine, two or more
@@ -214,25 +217,39 @@ public final class CurrencyParameterSensitivity
       CurrencyParameterSensitivity... sensitivities) {
 
     ArgChecker.notEmpty(sensitivities, "sensitivities");
-    if (sensitivities.length < 2) {
-      throw new IllegalArgumentException("At least two sensitivity instances must be specified");
-    }
     Currency currency = Stream.of(sensitivities).map(s -> s.getCurrency()).distinct().reduce(ensureOnlyOne()).get();
     int size = Stream.of(sensitivities).mapToInt(s -> s.getParameterCount()).sum();
+
+    if (sensitivities.length == 1) {
+      CurrencyParameterSensitivity first = sensitivities[0];
+      if (first.getMarketDataName().equals(marketDataName)) {
+        return first;
+      }
+    }
+
     double[] combinedSensitivities = new double[size];
     ImmutableList.Builder<ParameterMetadata> combinedMeta = ImmutableList.builder();
     ImmutableList.Builder<ParameterSize> split = ImmutableList.builder();
     int count = 0;
     for (int i = 0; i < sensitivities.length; i++) {
       CurrencyParameterSensitivity sens = sensitivities[i];
+      if (sens.getParameterCount() == 0) {
+        // Discard empty sensitivities
+        continue;
+      }
       System.arraycopy(sens.getSensitivity().toArrayUnsafe(), 0, combinedSensitivities, count, sens.getParameterCount());
       combinedMeta.addAll(sens.getParameterMetadata());
       split.add(ParameterSize.of(sens.getMarketDataName(), sens.getParameterCount()));
       count += sens.getParameterCount();
     }
 
+    List<ParameterSize> parameterSplit = split.build();
     return new CurrencyParameterSensitivity(
-        marketDataName, combinedMeta.build(), currency, DoubleArray.ofUnsafe(combinedSensitivities), split.build());
+        marketDataName,
+        combinedMeta.build(),
+        currency,
+        DoubleArray.ofUnsafe(combinedSensitivities),
+        parameterSplit.isEmpty() ? null : parameterSplit);
   }
 
   @ImmutableValidator


### PR DESCRIPTION
Make combining instances of CurrencyParameterSensitivity more lenient so that combining a single instance is allowed, as is combining with empty sensitivities.