### PR TITLE
Optimise CurrencyAmount#parse

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -50,6 +50,9 @@ public final class CurrencyAmount
   /** Serialization version. */
   private static final long serialVersionUID = 1L;
 
+  /** Splitter on single space for parsing from string. */
+  private static final Splitter WHITESPACE_SPLITTER = Splitter.on(' ');
+
   /**
    * The currency.
    * <p>
@@ -118,7 +121,7 @@ public final class CurrencyAmount
   @FromString
   public static CurrencyAmount parse(String amountStr) {
     ArgChecker.notNull(amountStr, "amountStr");
-    List<String> split = Splitter.on(' ').splitToList(amountStr);
+    List<String> split = WHITESPACE_SPLITTER.splitToList(amountStr);
     if (split.size() != 2) {
       throw new IllegalArgumentException("Unable to parse amount, invalid format: " + amountStr);
     }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -115,6 +115,7 @@ public final class CurrencyAmount
    */
   @FromString
   public static CurrencyAmount parse(String amountStr) {
+    // this method has had some performance optimizations applied
     if (amountStr == null || amountStr.length() <= 4 || amountStr.charAt(3) != ' ') {
       throw new IllegalArgumentException("Unable to parse amount, invalid format: " + amountStr);
     }

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -121,13 +121,13 @@ public final class CurrencyAmount
   @FromString
   public static CurrencyAmount parse(String amountStr) {
     ArgChecker.notNull(amountStr, "amountStr");
-    List<String> split = WHITESPACE_SPLITTER.splitToList(amountStr);
-    if (split.size() != 2) {
-      throw new IllegalArgumentException("Unable to parse amount, invalid format: " + amountStr);
-    }
+    ArgChecker.isTrue(
+        amountStr.length() > 4 && amountStr.charAt(3) == ' ',
+        "Unable to parse amount, invalid format: {}",
+        amountStr);
     try {
-      Currency cur = Currency.parse(split.get(0));
-      double amount = Double.parseDouble(split.get(1));
+      Currency cur = Currency.parse(amountStr.substring(0, 3));
+      double amount = Double.parseDouble(amountStr.substring(4));
       return new CurrencyAmount(cur, amount);
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("Unable to parse amount: " + amountStr, ex);

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -119,10 +119,11 @@ public final class CurrencyAmount
         amountStr != null && amountStr.length() > 4 && amountStr.charAt(3) == ' ',
         "Unable to parse amount, invalid format: {}",
         amountStr);
+    String currencyCode = amountStr.substring(0, 3);
+    String doubleString = amountStr.substring(4);
+    ArgChecker.isTrue(doubleString.indexOf(' ') == -1, "Unable to parse amount, invalid format: {}", amountStr);
     try {
-      Currency cur = Currency.parse(amountStr.substring(0, 3));
-      String doubleString = amountStr.substring(4);
-      ArgChecker.isTrue(doubleString.indexOf(' ') == -1, "Unable to parse amount, invalid format: {}", amountStr);
+      Currency cur = Currency.parse(currencyCode);
       double amount = Double.parseDouble(doubleString);
       return new CurrencyAmount(cur, amount);
     } catch (RuntimeException ex) {

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -115,7 +115,7 @@ public final class CurrencyAmount
    */
   @FromString
   public static CurrencyAmount parse(String amountStr) {
-    if (amountStr == null || amountStr.length() <= 4 || amountStr.charAt(3) == ' ') {
+    if (amountStr == null || amountStr.length() <= 4 || amountStr.charAt(3) != ' ') {
       throw new IllegalArgumentException("Unable to parse amount, invalid format: " + amountStr);
     }
 

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -115,14 +115,15 @@ public final class CurrencyAmount
    */
   @FromString
   public static CurrencyAmount parse(String amountStr) {
-    ArgChecker.notNull(amountStr, "amountStr");
     ArgChecker.isTrue(
-        amountStr.length() > 4 && amountStr.charAt(3) == ' ',
+        amountStr != null && amountStr.length() > 4 && amountStr.charAt(3) == ' ',
         "Unable to parse amount, invalid format: {}",
         amountStr);
     try {
       Currency cur = Currency.parse(amountStr.substring(0, 3));
-      double amount = Double.parseDouble(amountStr.substring(4));
+      String doubleString = amountStr.substring(4);
+      ArgChecker.isTrue(doubleString.indexOf(' ') == -1, "Unable to parse amount, invalid format: {}", amountStr);
+      double amount = Double.parseDouble(doubleString);
       return new CurrencyAmount(cur, amount);
     } catch (RuntimeException ex) {
       throw new IllegalArgumentException("Unable to parse amount: " + amountStr, ex);

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -7,14 +7,12 @@ package com.opengamma.strata.basics.currency;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.function.DoubleUnaryOperator;
 
 import org.joda.beans.JodaBeanUtils;
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.math.DoubleMath;
 import com.opengamma.strata.collect.ArgChecker;
@@ -49,9 +47,6 @@ public final class CurrencyAmount
 
   /** Serialization version. */
   private static final long serialVersionUID = 1L;
-
-  /** Splitter on single space for parsing from string. */
-  private static final Splitter WHITESPACE_SPLITTER = Splitter.on(' ');
 
   /**
    * The currency.

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -115,13 +115,16 @@ public final class CurrencyAmount
    */
   @FromString
   public static CurrencyAmount parse(String amountStr) {
-    ArgChecker.isTrue(
-        amountStr != null && amountStr.length() > 4 && amountStr.charAt(3) == ' ',
-        "Unable to parse amount, invalid format: {}",
-        amountStr);
+    if (amountStr == null || amountStr.length() <= 4 || amountStr.charAt(3) == ' ') {
+      throw new IllegalArgumentException("Unable to parse amount, invalid format: " + amountStr);
+    }
+
     String currencyCode = amountStr.substring(0, 3);
     String doubleString = amountStr.substring(4);
-    ArgChecker.isTrue(doubleString.indexOf(' ') == -1, "Unable to parse amount, invalid format: {}", amountStr);
+    if (doubleString.indexOf(' ') != -1) {
+      throw new IllegalArgumentException("Unable to parse amount, invalid format: " + amountStr);
+    }
+
     try {
       Currency cur = Currency.parse(currencyCode);
       double amount = Double.parseDouble(doubleString);


### PR DESCRIPTION
Using Splitter requires us to traverse the string twice, but since we know the format should always be an ISO 3 letter code then a double we can take a shortcut and split ourselves and then let Currency.parse() or Double.parse() throw if they have any issues.