### PR TITLE
Filter out empty sensitivities during CurrencyParameterSensitivities builder filtering

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivitiesBuilder.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivitiesBuilder.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.market.param;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -127,8 +128,12 @@ public final class CurrencyParameterSensitivitiesBuilder {
    * @return this, for chaining
    */
   public CurrencyParameterSensitivitiesBuilder filterSensitivity(DoublePredicate predicate) {
-    for (CurrencyParameterSensitivityBuilder builder : data.values()) {
+    for (Iterator<CurrencyParameterSensitivityBuilder> it = data.values().iterator(); it.hasNext();) {
+      CurrencyParameterSensitivityBuilder builder = it.next();
       builder.filterSensitivity(predicate);
+      if (builder.isEmpty()) {
+        it.remove();
+      }
     }
     return this;
   }

--- a/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivitiesBuilder.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivitiesBuilder.java
@@ -123,6 +123,8 @@ public final class CurrencyParameterSensitivitiesBuilder {
    * Filters the sensitivity values.
    * <p>
    * For example, this could be used to remove sensitivities near to zero.
+   * <p>
+   * If the filter removes all the values for a market data name, the name will not be present in the result.
    * 
    * @param predicate  the predicate to test the value, return true to retain the value
    * @return this, for chaining

--- a/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivityBuilder.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/param/CurrencyParameterSensitivityBuilder.java
@@ -94,6 +94,15 @@ final class CurrencyParameterSensitivityBuilder {
     return this;
   }
 
+  /**
+   * Returns whether this sensitivity builder has any values.
+   *
+   * @return whether the sensitivity is empty
+   */
+  boolean isEmpty() {
+    return sensitivity.isEmpty();
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Builds the sensitivity from the provided data.

--- a/modules/market/src/test/java/com/opengamma/strata/market/param/CurrencyParameterSensitivitiesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/param/CurrencyParameterSensitivitiesTest.java
@@ -173,6 +173,16 @@ public class CurrencyParameterSensitivitiesTest {
     assertEquals(test.getSensitivities().get(0), expected);
   }
 
+  public void test_builder_filterSensitivity_remove() {
+    CurrencyParameterSensitivity entry1 =
+        CurrencyParameterSensitivity.of(NAME1, METADATA1B, USD, DoubleArray.of(1, 1, 1, 1));
+    CurrencyParameterSensitivities test = CurrencyParameterSensitivities.builder()
+        .add(entry1)
+        .filterSensitivity(v -> v != 1)
+        .build();
+    assertEquals(test.getSensitivities().size(), 0);
+  }
+
   //-------------------------------------------------------------------------
   public void test_getSensitivity() {
     CurrencyParameterSensitivities test = CurrencyParameterSensitivities.of(ENTRY_USD);


### PR DESCRIPTION
This came up with LCH sensitivities parsing - I had to manually remove empty sensitivities that were produced in a object -> CSV -> object conversion