### PR TITLE
Enhance performance by avoiding Math.pow

### DIFF
--- a/modules/math/src/main/java/com/opengamma/strata/math/MathUtils.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/MathUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.math;
+
+/**
+ * Simple utilities for maths.
+ */
+public final class MathUtils {
+
+  /**
+   * Returns the power of 2 (square).
+   * 
+   * @param value  the value to check
+   * @return {@code value * value}
+   */
+  public static double pow2(double value) {
+    return value * value;
+  }
+
+  /**
+   * Returns the power of 3 (cube).
+   * 
+   * @param value  the value to check
+   * @return {@code value * value * value}
+   */
+  public static double pow3(double value) {
+    return value * value * value;
+  }
+
+  /**
+   * Returns the power of 4.
+   * 
+   * @param value  the value to check
+   * @return {@code value * value * value * value}
+   */
+  public static double pow4(double value) {
+    return value * value * value * value;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Checks if a number is near zero.
+   * <p>
+   * NaN and infinity are not near zero.
+   * 
+   * @param value  the value to check
+   * @param tolerance  the tolerance, must be positive and not NaN/Infinite (not validated)
+   * @return true if near zero
+   */
+  public static boolean nearZero(double value, double tolerance) {
+    return value >= -tolerance && value <= tolerance;
+  }
+
+  /**
+   * Checks if a number is near one.
+   * <p>
+   * NaN and infinity are not near one.
+   * 
+   * @param value  the value to check
+   * @param tolerance  the tolerance, must be positive and not NaN/Infinite (not validated)
+   * @return true if near one
+   */
+  public static boolean nearOne(double value, double tolerance) {
+    return value >= 1 - tolerance && value <= 1 + tolerance;
+  }
+
+  //-------------------------------------------------------------------------
+  // restricted constructor
+  private MathUtils() {
+  }
+
+}

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/FunctionUtils.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/FunctionUtils.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.math.MathUtils;
 
 /**
  * A collection of basic useful maths functions.
@@ -22,13 +23,14 @@ public final class FunctionUtils {
   private FunctionUtils() {
   }
 
-  //-------------------------------------------------------------------------
   /**
    * Returns the square of a number.
    * 
    * @param x  the number to square
    * @return x*x
+   * @deprecated Use {@link MathUtils#pow2(double)}
    */
+  @Deprecated
   public static double square(double x) {
     return x * x;
   }
@@ -38,7 +40,9 @@ public final class FunctionUtils {
    * 
    * @param x  the number to cube
    * @return x*x*x
+   * @deprecated Use {@link MathUtils#pow3(double)}
    */
+  @Deprecated
   public static double cube(double x) {
     return x * x * x;
   }

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/PiecewiseCubicHermiteSplineInterpolatorWithSensitivity.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/PiecewiseCubicHermiteSplineInterpolatorWithSensitivity.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.math.impl.interpolation;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
+
 import java.util.Arrays;
 
 import com.google.common.primitives.Doubles;
@@ -12,7 +14,6 @@ import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.DoubleArrayMath;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
-import com.opengamma.strata.math.impl.FunctionUtils;
 
 /**
  * C1 cubic interpolation preserving monotonicity based on 
@@ -191,7 +192,7 @@ public class PiecewiseCubicHermiteSplineInterpolatorWithSensitivity extends Piec
         double w1 = 2. * h[i] + h[i - 1];
         double w2 = h[i] + 2. * h[i - 1];
         double w12 = w1 + w2;
-        double z2 = 0.5 * w12 / FunctionUtils.square(w1 * delta[i] + w2 * delta[i - 1]);
+        double z2 = 0.5 * w12 / pow2(w1 * delta[i] + w2 * delta[i - 1]);
         jac[i][i - 1] = -w1 * invH[i - 1] * delta[i] * delta[i] * z2;
         jac[i][i] = (w1 * invH[i - 1] * delta[i] * delta[i] - w2 * invH[i] * delta[i - 1] * delta[i - 1]) * z2;
         jac[i][i + 1] = w2 * invH[i] * delta[i - 1] * delta[i - 1] * z2;

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/leastsquare/GeneralizedLeastSquare.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/leastsquare/GeneralizedLeastSquare.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.math.impl.statistics.leastsquare;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
 import static org.apache.commons.math3.util.CombinatoricsUtils.binomialCoefficient;
 
 import java.util.List;
@@ -16,7 +17,6 @@ import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.DoubleArrayMath;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
-import com.opengamma.strata.math.impl.FunctionUtils;
 import com.opengamma.strata.math.impl.linearalgebra.SVDecompositionCommons;
 import com.opengamma.strata.math.impl.matrix.CommonsMatrixAlgebra;
 import com.opengamma.strata.math.impl.matrix.MatrixAlgebra;
@@ -228,7 +228,7 @@ public class GeneralizedLeastSquare {
       for (k = 0; k < m; k++) {
         temp += w.get(k) * f[k][i];
       }
-      chiSq += FunctionUtils.square(y.get(i) - temp) * invSigmaSqr[i];
+      chiSq += pow2(y.get(i) - temp) * invSigmaSqr[i];
     }
 
     return new GeneralizedLeastSquareResults<>(basisFunctions, chiSq, w, covar);
@@ -292,7 +292,7 @@ public class GeneralizedLeastSquare {
       for (k = 0; k < m; k++) {
         temp += w.get(k) * f[k][i];
       }
-      chiSq += FunctionUtils.square(y.get(i) - temp) * invSigmaSqr[i];
+      chiSq += pow2(y.get(i) - temp) * invSigmaSqr[i];
     }
 
     return new GeneralizedLeastSquareResults<>(basisFunctions, chiSq, w, covar);
@@ -305,7 +305,7 @@ public class GeneralizedLeastSquare {
     for (int i = 0; i < m; i++) {
       double sum = 0;
       for (int k = 0; k < n; k++) {
-        sum += FunctionUtils.square(funcMatrix[i][k]) * invSigmaSqr[k];
+        sum += pow2(funcMatrix[i][k]) * invSigmaSqr[k];
       }
       a[i][i] = sum;
       for (int j = i + 1; j < m; j++) {

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/leastsquare/NonLinearLeastSquare.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/leastsquare/NonLinearLeastSquare.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.math.impl.statistics.leastsquare;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
+
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -14,7 +16,6 @@ import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
 import com.opengamma.strata.math.MathException;
-import com.opengamma.strata.math.impl.FunctionUtils;
 import com.opengamma.strata.math.impl.differentiation.VectorFieldFirstOrderDifferentiator;
 import com.opengamma.strata.math.impl.differentiation.VectorFieldSecondOrderDifferentiator;
 import com.opengamma.strata.math.impl.function.ParameterizedFunction;
@@ -680,7 +681,7 @@ public class NonLinearLeastSquare {
     for (int i = 0; i < m; i++) {
       double sum = 0.0;
       for (int k = 0; k < n; k++) {
-        sum += FunctionUtils.square(jacobian.get(k, i));
+        sum += pow2(jacobian.get(k, i));
       }
       alpha[i] = sum;
     }

--- a/modules/math/src/test/java/com/opengamma/strata/math/MathUtilsTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/MathUtilsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.math;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link MathUtils}.
+ */
+public class MathUtilsTest {
+
+  @Test
+  public void test_pow2() {
+    assertThat(MathUtils.pow2(3)).isEqualTo(9);
+    assertThat(MathUtils.pow2(2)).isEqualTo(4);
+    assertThat(MathUtils.pow2(1)).isEqualTo(1);
+    assertThat(MathUtils.pow2(0)).isEqualTo(0);
+    assertThat(MathUtils.pow2(-1)).isEqualTo(1);
+    assertThat(MathUtils.pow2(-2)).isEqualTo(4);
+    assertThat(MathUtils.pow2(-3)).isEqualTo(9);
+    assertThat(MathUtils.pow2(Double.POSITIVE_INFINITY)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(MathUtils.pow2(Double.NEGATIVE_INFINITY)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(MathUtils.pow2(Double.NaN)).isNaN();
+    assertThat(MathUtils.pow2(Double.POSITIVE_INFINITY)).isEqualTo(Math.pow(Double.POSITIVE_INFINITY, 2));
+    assertThat(MathUtils.pow2(Double.NEGATIVE_INFINITY)).isEqualTo(Math.pow(Double.NEGATIVE_INFINITY, 2));
+    assertThat(MathUtils.pow2(Double.NaN)).isEqualTo(Math.pow(Double.NaN, 2));
+  }
+
+  @Test
+  public void test_pow3() {
+    assertThat(MathUtils.pow3(3)).isEqualTo(27);
+    assertThat(MathUtils.pow3(2)).isEqualTo(8);
+    assertThat(MathUtils.pow3(1)).isEqualTo(1);
+    assertThat(MathUtils.pow3(0)).isEqualTo(0);
+    assertThat(MathUtils.pow3(-1)).isEqualTo(-1);
+    assertThat(MathUtils.pow3(-2)).isEqualTo(-8);
+    assertThat(MathUtils.pow3(-3)).isEqualTo(-27);
+    assertThat(MathUtils.pow3(Double.POSITIVE_INFINITY)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(MathUtils.pow3(Double.NEGATIVE_INFINITY)).isEqualTo(Double.NEGATIVE_INFINITY);
+    assertThat(MathUtils.pow3(Double.NaN)).isNaN();
+    assertThat(MathUtils.pow3(Double.POSITIVE_INFINITY)).isEqualTo(Math.pow(Double.POSITIVE_INFINITY, 3));
+    assertThat(MathUtils.pow3(Double.NEGATIVE_INFINITY)).isEqualTo(Math.pow(Double.NEGATIVE_INFINITY, 3));
+    assertThat(MathUtils.pow3(Double.NaN)).isEqualTo(Math.pow(Double.NaN, 3));
+  }
+
+  @Test
+  public void test_pow4() {
+    assertThat(MathUtils.pow4(3)).isEqualTo(81);
+    assertThat(MathUtils.pow4(2)).isEqualTo(16);
+    assertThat(MathUtils.pow4(1)).isEqualTo(1);
+    assertThat(MathUtils.pow4(0)).isEqualTo(0);
+    assertThat(MathUtils.pow4(-1)).isEqualTo(1);
+    assertThat(MathUtils.pow4(-2)).isEqualTo(16);
+    assertThat(MathUtils.pow4(-3)).isEqualTo(81);
+    assertThat(MathUtils.pow4(Double.POSITIVE_INFINITY)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(MathUtils.pow4(Double.NEGATIVE_INFINITY)).isEqualTo(Double.POSITIVE_INFINITY);
+    assertThat(MathUtils.pow4(Double.NaN)).isNaN();
+    assertThat(MathUtils.pow4(Double.POSITIVE_INFINITY)).isEqualTo(Math.pow(Double.POSITIVE_INFINITY, 4));
+    assertThat(MathUtils.pow4(Double.NEGATIVE_INFINITY)).isEqualTo(Math.pow(Double.NEGATIVE_INFINITY, 4));
+    assertThat(MathUtils.pow4(Double.NaN)).isEqualTo(Math.pow(Double.NaN, 4));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_nearZero() {
+    assertThat(MathUtils.nearZero(0, 0)).isTrue();
+    assertThat(MathUtils.nearZero(-0, 0)).isTrue();
+
+    assertThat(MathUtils.nearZero(0, 0.5)).isTrue();
+    assertThat(MathUtils.nearZero(-0, 0.5)).isTrue();
+
+    assertThat(MathUtils.nearZero(0.5, 0.5)).isTrue();
+    assertThat(MathUtils.nearZero(Math.nextAfter(0.5, -1000d), 0.5)).isTrue();
+    assertThat(MathUtils.nearZero(Math.nextAfter(0.5, 1000d), 0.5)).isFalse();
+
+    assertThat(MathUtils.nearZero(-0.5, 0.5)).isTrue();
+    assertThat(MathUtils.nearZero(Math.nextAfter(-0.5, -1000d), 0.5)).isFalse();
+    assertThat(MathUtils.nearZero(Math.nextAfter(-0.5, 1000d), 0.5)).isTrue();
+
+    assertThat(MathUtils.nearZero(Double.POSITIVE_INFINITY, 0.5)).isFalse();
+    assertThat(MathUtils.nearZero(Double.NEGATIVE_INFINITY, 0.5)).isFalse();
+    assertThat(MathUtils.nearZero(Double.NaN, 0.5)).isFalse();
+  }
+
+  @Test
+  public void test_nearOne() {
+    assertThat(MathUtils.nearOne(1, 0)).isTrue();
+    assertThat(MathUtils.nearOne(1, 0.5)).isTrue();
+
+    assertThat(MathUtils.nearOne(1.5, 0.5)).isTrue();
+    assertThat(MathUtils.nearOne(Math.nextAfter(1.5, -1000d), 0.5)).isTrue();
+    assertThat(MathUtils.nearOne(Math.nextAfter(1.5, 1000d), 0.5)).isFalse();
+
+    assertThat(MathUtils.nearOne(0.5, 0.5)).isTrue();
+    assertThat(MathUtils.nearOne(Math.nextAfter(0.5, -1000d), 0.5)).isFalse();
+    assertThat(MathUtils.nearOne(Math.nextAfter(0.5, 1000d), 0.5)).isTrue();
+
+    assertThat(MathUtils.nearOne(Double.POSITIVE_INFINITY, 0.5)).isFalse();
+    assertThat(MathUtils.nearOne(Double.NEGATIVE_INFINITY, 0.5)).isFalse();
+    assertThat(MathUtils.nearOne(Double.NaN, 0.5)).isFalse();
+  }
+
+}

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/FunctionUtilsTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/FunctionUtilsTest.java
@@ -19,6 +19,7 @@ public class FunctionUtilsTest {
   private static final double EPS = 1e-15;
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testSquare() {
     for (int i = 0; i < 100; i++) {
       final double x = Math.random();
@@ -27,6 +28,7 @@ public class FunctionUtilsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testCube() {
     for (int i = 0; i < 100; i++) {
       final double x = Math.random();

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/PenaltyMatrixGeneratorTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/PenaltyMatrixGeneratorTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.math.impl.interpolation;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
 import static org.testng.AssertJUnit.assertEquals;
 
 import org.testng.annotations.DataProvider;
@@ -12,7 +13,6 @@ import org.testng.annotations.Test;
 
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
-import com.opengamma.strata.math.impl.FunctionUtils;
 import com.opengamma.strata.math.impl.matrix.MatrixAlgebra;
 import com.opengamma.strata.math.impl.matrix.OGMatrixAlgebra;
 import com.opengamma.strata.math.impl.util.AssertMatrix;
@@ -254,7 +254,7 @@ public class PenaltyMatrixGeneratorTest {
     double expected = 0.0;
     for (int i = 0; i < n; i++) {
       if (i > 0 && i < (n - 1)) { // we not not use the end points
-        expected += FunctionUtils.square(d2ydx2.get(i));
+        expected += pow2(d2ydx2.get(i));
       }
     }
     double scale = Math.pow(2.0, 4); //((2.0-0.0)^2^2)
@@ -397,12 +397,12 @@ public class PenaltyMatrixGeneratorTest {
 
         //The penalty matrix does not use end points, so don't include them here 
         if (i != 0 & i != (nx - 1)) {
-          dzdxSum += FunctionUtils.square(dzdx.get(index));
-          d2zdx2Sum += FunctionUtils.square(d2zdx2.get(index));
+          dzdxSum += pow2(dzdx.get(index));
+          d2zdx2Sum += pow2(d2zdx2.get(index));
         }
         if (j != 0 & j != (ny - 1)) {
-          dzdySum += FunctionUtils.square(dzdy.get(index));
-          d2zdy2Sum += FunctionUtils.square(d2zdy2.get(index));
+          dzdySum += pow2(dzdy.get(index));
+          d2zdy2Sum += pow2(d2zdy2.get(index));
         }
 
       }

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/minimization/MinimizationTestFunctions.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/minimization/MinimizationTestFunctions.java
@@ -5,10 +5,11 @@
  */
 package com.opengamma.strata.math.impl.minimization;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
+
 import java.util.function.Function;
 
 import com.opengamma.strata.collect.array.DoubleArray;
-import com.opengamma.strata.math.impl.FunctionUtils;
 
 /**
  * 
@@ -18,7 +19,7 @@ public abstract class MinimizationTestFunctions {
 
     @Override
     public Double apply(DoubleArray x) {
-      return FunctionUtils.square(1 - x.get(0)) + 100 * FunctionUtils.square(x.get(1) - FunctionUtils.square(x.get(0)));
+      return pow2(1 - x.get(0)) + 100 * pow2(x.get(1) - pow2(x.get(0)));
     }
   };
 
@@ -27,8 +28,8 @@ public abstract class MinimizationTestFunctions {
         @Override
         public DoubleArray apply(DoubleArray x) {
           return DoubleArray.of(
-              2 * (x.get(0) - 1) + 400 * x.get(0) * (FunctionUtils.square(x.get(0)) - x.get(1)),
-              200 * (x.get(1) - FunctionUtils.square(x.get(0))));
+              2 * (x.get(0) - 1) + 400 * x.get(0) * (pow2(x.get(0)) - x.get(1)),
+              200 * (x.get(1) - pow2(x.get(0))));
         }
       };
 
@@ -42,7 +43,8 @@ public abstract class MinimizationTestFunctions {
       }
       double sum = 0;
       for (int i = 0; i < n / 2; i++) {
-        sum += FunctionUtils.square(1 - x.get(2 * i)) + 100 * FunctionUtils.square(x.get(2 * i + 1) - FunctionUtils.square(x.get(2 * i)));
+        sum +=
+            pow2(1 - x.get(2 * i)) + 100 * pow2(x.get(2 * i + 1) - pow2(x.get(2 * i)));
       }
       return sum;
     }
@@ -56,7 +58,7 @@ public abstract class MinimizationTestFunctions {
 
       double sum = 0;
       for (int i = 0; i < n - 1; i++) {
-        sum += FunctionUtils.square(1 - x.get(i)) + 100 * FunctionUtils.square(x.get(i + 1) - FunctionUtils.square(x.get(i)));
+        sum += pow2(1 - x.get(i)) + 100 * pow2(x.get(i + 1) - pow2(x.get(i)));
       }
       return sum;
     }
@@ -69,11 +71,11 @@ public abstract class MinimizationTestFunctions {
       int n = x.size();
 
       double[] res = new double[n];
-      res[0] = 2 * (x.get(0) - 1) + 400 * x.get(0) * (FunctionUtils.square(x.get(0)) - x.get(1));
-      res[n - 1] = 200 * (x.get(n - 1) - FunctionUtils.square(x.get(n - 2)));
+      res[0] = 2 * (x.get(0) - 1) + 400 * x.get(0) * (pow2(x.get(0)) - x.get(1));
+      res[n - 1] = 200 * (x.get(n - 1) - pow2(x.get(n - 2)));
       for (int i = 1; i < n - 1; i++) {
-        res[i] = 2 * (x.get(i) - 1) + 400 * x.get(i) * (FunctionUtils.square(x.get(i)) - x.get(i + 1)) + 200
-            * (x.get(i) - FunctionUtils.square(x.get(i - 1)));
+        res[i] = 2 * (x.get(i) - 1) + 400 * x.get(i) * (pow2(x.get(i)) - x.get(i + 1)) +
+            200 * (x.get(i) - pow2(x.get(i - 1)));
       }
           return DoubleArray.copyOf(res);
     }

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/minimization/ParabolicMinimumBracketerTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/minimization/ParabolicMinimumBracketerTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.math.impl.minimization;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.function.Function;
@@ -12,7 +13,6 @@ import java.util.function.Function;
 import org.testng.annotations.Test;
 
 import com.opengamma.strata.math.MathException;
-import com.opengamma.strata.math.impl.FunctionUtils;
 
 /**
  * Test.
@@ -48,7 +48,7 @@ public class ParabolicMinimumBracketerTest extends MinimumBracketerTestCase {
 
     @Override
     public Double apply(final Double x) {
-      return FunctionUtils.square((x - 50) / 50.0);
+      return pow2((x - 50) / 50.0);
     }
   };
 

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.pricer.bond;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
 import static com.opengamma.strata.product.bond.FixedCouponBondYieldConvention.DE_BONDS;
 import static com.opengamma.strata.product.bond.FixedCouponBondYieldConvention.GB_BUMP_DMO;
 import static com.opengamma.strata.product.bond.FixedCouponBondYieldConvention.JP_SIMPLE;
@@ -755,7 +756,7 @@ public class DiscountingFixedCouponBondProductPricer {
       double num = 1d + bond.getFixedRate() * maturity;
       double den = 1d + yield * maturity;
       double dirtyPrice = dirtyPriceFromCleanPrice(bond, settlementDate, num / den);
-      return 2d * num * Math.pow(maturity, 2) * Math.pow(den, -3) / dirtyPrice;
+      return 2d * num * pow2(maturity) * Math.pow(den, -3) / dirtyPrice;
     }
     throw new UnsupportedOperationException("The convention " + yieldConv.name() + " is not supported.");
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackBarrierPriceFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackBarrierPriceFormulaRepository.java
@@ -5,7 +5,8 @@
  */
 package com.opengamma.strata.pricer.impl.option;
 
-import com.google.common.math.DoubleMath;
+import static com.opengamma.strata.math.MathUtils.nearZero;
+
 import com.opengamma.strata.basics.value.ValueDerivatives;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -66,7 +67,7 @@ public class BlackBarrierPriceFormulaRepository {
     double df2 = Math.exp(-rate * timeToExpiry);
     double sigmaSq = lognormalVol * lognormalVol;
     double sigmaT = lognormalVol * Math.sqrt(timeToExpiry);
-    if (DoubleMath.fuzzyEquals(Math.min(timeToExpiry, sigmaSq), 0d, SMALL)) {
+    if (nearZero(Math.min(timeToExpiry, sigmaSq), SMALL)) {
       if (isKnockIn) {
         return 0d;
       }
@@ -149,7 +150,7 @@ public class BlackBarrierPriceFormulaRepository {
     double df2 = Math.exp(-rate * timeToExpiry);
     double lognormalVolSq = lognormalVol * lognormalVol;
     double lognormalVolT = lognormalVol * Math.sqrt(timeToExpiry);
-    if (DoubleMath.fuzzyEquals(Math.min(timeToExpiry, lognormalVolSq), 0d, SMALL)) {
+    if (nearZero(Math.min(timeToExpiry, lognormalVolSq), SMALL)) {
       if (isKnockIn) {
         return ValueDerivatives.of(0d, DoubleArray.filled(7));
       }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackOneTouchAssetPriceFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackOneTouchAssetPriceFormulaRepository.java
@@ -5,7 +5,8 @@
  */
 package com.opengamma.strata.pricer.impl.option;
 
-import com.google.common.math.DoubleMath;
+import static com.opengamma.strata.math.MathUtils.nearZero;
+
 import com.opengamma.strata.basics.value.ValueDerivatives;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -62,7 +63,7 @@ public class BlackOneTouchAssetPriceFormulaRepository {
     double df1 = Math.exp(timeToExpiry * (costOfCarry - rate));
     double lognormalVolSq = lognormalVol * lognormalVol;
     double lognormalVolT = lognormalVol * Math.sqrt(timeToExpiry);
-    if (DoubleMath.fuzzyEquals(Math.min(timeToExpiry, lognormalVolSq), 0d, SMALL)) {
+    if (nearZero(Math.min(timeToExpiry, lognormalVolSq), SMALL)) {
       return isKnockIn ? 0d : spot * df1;
     }
     double mu = (costOfCarry - 0.5 * lognormalVolSq) / lognormalVolSq;
@@ -112,7 +113,7 @@ public class BlackOneTouchAssetPriceFormulaRepository {
     double df1 = Math.exp(timeToExpiry * (costOfCarry - rate));
     double lognormalVolSq = lognormalVol * lognormalVol;
     double lognormalVolT = lognormalVol * Math.sqrt(timeToExpiry);
-    if (DoubleMath.fuzzyEquals(Math.min(timeToExpiry, lognormalVolSq), 0d, SMALL)) {
+    if (nearZero(Math.min(timeToExpiry, lognormalVolSq), SMALL)) {
       if (isKnockIn) {
         return ValueDerivatives.of(0d, DoubleArray.filled(6));
       }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackOneTouchCashPriceFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackOneTouchCashPriceFormulaRepository.java
@@ -5,7 +5,8 @@
  */
 package com.opengamma.strata.pricer.impl.option;
 
-import com.google.common.math.DoubleMath;
+import static com.opengamma.strata.math.MathUtils.nearZero;
+
 import com.opengamma.strata.basics.value.ValueDerivatives;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
@@ -62,7 +63,7 @@ public class BlackOneTouchCashPriceFormulaRepository {
     double df2 = Math.exp(-rate * timeToExpiry);
     double lognormalVolSq = lognormalVol * lognormalVol;
     double lognormalVolT = lognormalVol * Math.sqrt(timeToExpiry);
-    if (DoubleMath.fuzzyEquals(Math.min(timeToExpiry, lognormalVolSq), 0d, SMALL)) {
+    if (nearZero(Math.min(timeToExpiry, lognormalVolSq), SMALL)) {
       return isKnockIn ? 0d : df2;
     }
     double mu = (costOfCarry - 0.5 * lognormalVolSq) / lognormalVolSq;
@@ -112,7 +113,7 @@ public class BlackOneTouchCashPriceFormulaRepository {
     double df2 = Math.exp(-rate * timeToExpiry);
     double lognormalVolSq = lognormalVol * lognormalVol;
     double lognormalVolT = lognormalVol * Math.sqrt(timeToExpiry);
-    if (DoubleMath.fuzzyEquals(Math.min(timeToExpiry, lognormalVolSq), 0d, SMALL)) {
+    if (nearZero(Math.min(timeToExpiry, lognormalVolSq), SMALL)) {
       if (isKnockIn) {
         return ValueDerivatives.of(0d, DoubleArray.filled(6));
       }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/tree/CoxRossRubinsteinLatticeSpecification.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/tree/CoxRossRubinsteinLatticeSpecification.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.pricer.impl.tree;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
+
 import com.opengamma.strata.collect.array.DoubleArray;
 
 /**
@@ -20,8 +22,8 @@ public final class CoxRossRubinsteinLatticeSpecification implements LatticeSpeci
     double factor1 = Math.exp(0.5 * interestRate * dt);
     double factor2 = Math.exp(0.5 * dx);
     double factor3 = Math.exp(-0.5 * dx);
-    double upProbability = Math.pow((factor1 - factor3) / (factor3 - factor2), 2);
-    double downProbability = Math.pow((factor2 - factor1) / (factor3 - factor2), 2);
+    double upProbability = pow2((factor1 - factor3) / (factor3 - factor2));
+    double downProbability = pow2((factor2 - factor1) / (factor3 - factor2));
     double middleProbability = 1d - upProbability - downProbability;
     return DoubleArray.of(upFactor, 1d, downFactor, upProbability, middleProbability, downProbability);
   }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/local/DupireLocalVolatilityCalculator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/local/DupireLocalVolatilityCalculator.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.pricer.impl.volatility.local;
 
+import static com.opengamma.strata.math.MathUtils.pow2;
+
 import java.util.function.Function;
 
 import com.opengamma.strata.basics.value.ValueDerivatives;
@@ -79,7 +81,8 @@ public class DupireLocalVolatilityCalculator implements LocalVolatilityCalculato
           }
           localVol = Math.sqrt(var);
           localVolSensi = volSensi.multipliedBy(localVol * k * h2 * divK * (1d + 0.5 * k * h2 * divK) / vol / den +
-              0.5 * localVol * Math.pow(k * h1 * divK, 2) / vol / den + (vol + divT * t + rq * t * k * divK) / (localVol * den) -
+              0.5 * localVol * pow2(k * h1 * divK) / vol / den +
+              (vol + divT * t + rq * t * k * divK) / (localVol * den) -
               0.5 * divK2 * localVol * k * k * t / den)
               .plus(divKSensi.multipliedBy((vol * t * rq * k / localVol - localVol * k * h1 * (1d + k * h2 * divK)) / den))
               .plus(divTSensi.multipliedBy(vol * t / (localVol * den)))

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/local/ImpliedTrinomialTreeLocalVolatilityCalculator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/volatility/local/ImpliedTrinomialTreeLocalVolatilityCalculator.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.pricer.impl.volatility.local;
 
 import static com.opengamma.strata.market.curve.interpolator.CurveInterpolators.LINEAR;
 import static com.opengamma.strata.market.curve.interpolator.CurveInterpolators.TIME_SQUARE;
+import static com.opengamma.strata.math.MathUtils.pow2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -292,8 +293,8 @@ public class ImpliedTrinomialTreeLocalVolatilityCalculator implements LocalVolat
     double fwd = spot * fwdFactor;
     timeRes[nTotal - 1] = dt;
     spotRes[nTotal - 1] = spot;
-    double var = (dwProb * Math.pow(assetPrice[0] - fwd, 2) + midProb * Math.pow(assetPrice[1] - fwd, 2) +
-        upProb * Math.pow(assetPrice[2] - fwd, 2)) / (fwd * fwd * dt);
+    double var = (dwProb * pow2(assetPrice[0] - fwd) + midProb * pow2(assetPrice[1] - fwd) +
+        upProb * pow2(assetPrice[2] - fwd)) / (fwd * fwd * dt);
     volRes[nTotal - 1] = Math.sqrt(0.5 * (var + volRes[nTotal - 2] * volRes[nTotal - 2]));
     probability.add(0, DoubleMatrix.ofUnsafe(new double[][] {{dwProb, midProb, upProb}}));
     df[0] = discountFactor;
@@ -365,8 +366,8 @@ public class ImpliedTrinomialTreeLocalVolatilityCalculator implements LocalVolat
       double[] varBare = new double[nNodes];
       for (int k = 0; k < nNodes; ++k) {
         double fwd = assetPriceLocal[k] * fwdFactor;
-        varBare[k] = (prob[k][0] * Math.pow(assetPrice[k] - fwd, 2) + prob[k][1] * Math.pow(assetPrice[k + 1] - fwd, 2) +
-            prob[k][2] * Math.pow(assetPrice[k + 2] - fwd, 2)) / (fwd * fwd * dt);
+        varBare[k] = (prob[k][0] * pow2(assetPrice[k] - fwd) + prob[k][1] * pow2(assetPrice[k + 1] - fwd) +
+            prob[k][2] * pow2(assetPrice[k + 2] - fwd)) / (fwd * fwd * dt);
         if (varBare[k] < 0d) {
           throw new IllegalArgumentException("Negative variance");
         }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/volatility/smile/SabrPerformance.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/volatility/smile/SabrPerformance.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2019 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.impl.volatility.smile;
+
+import java.util.stream.IntStream;
+
+import com.opengamma.strata.basics.value.ValueDerivatives;
+
+/**
+ * Test performance.
+ */
+public class SabrPerformance {
+
+  public static void main(String[] args) {
+    double[] betas = new double[] {0.5, 0.75, 1.0, 1.25, 1.5};
+    for (int i = 0; i < betas.length; i++) {
+      double beta = betas[i];
+      System.out.println("Beta = " + beta);
+      for (int j = 0; j < 5; j++) {
+        double time = sabrVolatility(beta);
+        System.out.println(time + "ms");
+      }
+      double hot1 = IntStream.range(0, 1000)
+          .mapToDouble(index -> sabrVolatility(beta))
+          .average()
+          .getAsDouble();
+      System.out.println(hot1 + "ms (hot)");
+      System.out.println();
+    }
+
+    for (int i = 0; i < betas.length; i++) {
+      double beta = betas[i];
+      System.out.println("Beta = " + beta);
+      for (int j = 0; j < 5; j++) {
+        double time = sabrAdjoint(beta);
+        System.out.println(time + "ms");
+      }
+      double hot1 = IntStream.range(0, 1000)
+          .mapToDouble(index -> sabrAdjoint(beta))
+          .average()
+          .getAsDouble();
+      System.out.println(hot1 + "ms (hot)");
+      System.out.println();
+    }
+  }
+
+  private static double sabrVolatility(double beta) {
+    SabrHaganVolatilityFunctionProvider provider = SabrHaganVolatilityFunctionProvider.DEFAULT;
+    Data cp = new Data();
+    double total = 0;
+    long start = System.nanoTime();
+    for (int i = 0; i < cp.strikes.length; i++) {
+      double strike = cp.strikes[i];
+      double eval = provider.volatility(cp.forward, strike, cp.tau, cp.alpha, beta, cp.rho, cp.nu);
+      total += eval;
+    }
+    long end = System.nanoTime();
+    if (total == 0) {
+      return -1;
+    }
+    return (end - start) / 1_000_000d;
+  }
+
+  private static double sabrAdjoint(double beta) {
+    SabrHaganVolatilityFunctionProvider provider = SabrHaganVolatilityFunctionProvider.DEFAULT;
+    Data cp = new Data();
+    double total = 0;
+    long start = System.nanoTime();
+    for (int i = 0; i < cp.strikes.length; i++) {
+      double strike = cp.strikes[i];
+      ValueDerivatives eval = provider.volatilityAdjoint(cp.forward, strike, cp.tau, cp.alpha, beta, cp.rho, cp.nu);
+      total += eval.getValue();
+    }
+    long end = System.nanoTime();
+    if (total == 0) {
+      return -1;
+    }
+    return (end - start) / 1_000_000d;
+  }
+
+  static class Data {
+    int cnt = 10;
+    double forward = 100.4456433578360;
+    double tau = 0.01917808219;
+    double strikeLb = 99.1;
+    double strikeUb = 101.7;
+    double[] strikes = createStrikes(strikeLb, strikeUb, 1 << cnt);
+    double alpha = 0.11535269852484416;
+    double nu = 4.249484906629612;
+    double rho = -0.08280305920343885;
+
+    double[] createStrikes(double lb, double ub, int cnt) {
+      double incr = (ub - lb) / cnt;
+      double[] res = new double[cnt];
+      int i = 0;
+      while (i < cnt) {
+        res[i] = lb + incr * i;
+        i += 1;
+      }
+      return res;
+    }
+  }
+}


### PR DESCRIPTION
Math.pow is slow when the power is a small integer
This particularly affects SABR volatility adjoint