### PR TITLE
Remove N^2 uniqueness checks in interpolators

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/ArgChecker.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/ArgChecker.java
@@ -732,12 +732,10 @@ public final class ArgChecker {
   public static double[] noDuplicatesSorted(double[] argument, String name) {
     notNull(argument, name);
     for (int i = 1; i < argument.length; i++) {
-      if (argument[i] <= argument[i - 1]) {
-        if (argument[i] == argument[i - 1]) {
-          throw new IllegalArgumentException(noDuplicatesArrayMsg(name));
-        } else {
-          throw new IllegalArgumentException(noDuplicatesSortedArrayMsg(name));
-        }
+      if (argument[i] == argument[i - 1]) {
+        throw new IllegalArgumentException(noDuplicatesArrayMsg(name));
+      } else if (argument[i] < argument[i - 1]) {
+        throw new IllegalArgumentException(noDuplicatesSortedArrayMsg(name));
       }
     }
     return argument;

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/ArgChecker.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/ArgChecker.java
@@ -6,10 +6,11 @@
 package com.opengamma.strata.collect;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.DoubleStream;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.math.DoubleMath;
@@ -704,8 +705,13 @@ public final class ArgChecker {
    */
   public static double[] noDuplicates(double[] argument, String name) {
     notNull(argument, name);
-    if (argument.length > 0 && DoubleStream.of(argument).distinct().count() != argument.length) {
-      throw new IllegalArgumentException(noDuplicatesArrayMsg(name));
+    if (argument.length > 1) {
+      Set<Double> seen = new LinkedHashSet<>();
+      for (double v : argument) {
+        if (!seen.add(v)) {
+          throw new IllegalArgumentException(noDuplicatesArrayMsg(name));
+        }
+      }
     }
     return argument;
   }
@@ -721,7 +727,7 @@ public final class ArgChecker {
    * Given the input argument, this returns only if it is non-null, sorted, and does not contain duplicate values.
    * For example, in a constructor:
    * <pre>
-   *  this.values = ArgChecker.noDuplicates(values, "values");
+   *  this.values = ArgChecker.noDuplicatesSorted(values, "values");
    * </pre>
    *
    * @param argument  the argument to check, null, out of order or duplicate values throws an exception

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/ArgChecker.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/ArgChecker.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
+import java.util.stream.DoubleStream;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.math.DoubleMath;
@@ -681,6 +682,70 @@ public final class ArgChecker {
       }
     }
     return argument;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Checks that the specified argument array is non-null and does not contain any duplicate values.
+   * <p>
+   * Given the input argument, this returns only if it is non-null and does not contain duplicate values.
+   * For example, in a constructor:
+   * <pre>
+   *  this.values = ArgChecker.noDuplicates(values, "values");
+   * </pre>
+   * <p>
+   * If you know the argument is sorted increasing then {@link #noDuplicatesSorted(double[], String)} might be more
+   * performant.
+   *
+   * @param argument  the argument to check, null or duplicate values throws an exception
+   * @param name  the name of the argument to use in the error message, not null
+   * @return the input {@code argument}, not null
+   * @throws IllegalArgumentException if the input is null or contains duplicate values
+   */
+  public static double[] noDuplicates(double[] argument, String name) {
+    notNull(argument, name);
+    if (argument.length > 0 && DoubleStream.of(argument).distinct().count() != argument.length) {
+      throw new IllegalArgumentException(noDuplicatesArrayMsg(name));
+    }
+    return argument;
+  }
+
+  // extracted to aid inlining performance
+  private static String noDuplicatesArrayMsg(String name) {
+    return "Argument array '" + name + "' must not contain duplicates";
+  }
+
+  /**
+   * Checks that the specified argument array is non-null, sorted, and does not contain any duplicate values.
+   * <p>
+   * Given the input argument, this returns only if it is non-null, sorted, and does not contain duplicate values.
+   * For example, in a constructor:
+   * <pre>
+   *  this.values = ArgChecker.noDuplicates(values, "values");
+   * </pre>
+   *
+   * @param argument  the argument to check, null, out of order or duplicate values throws an exception
+   * @param name  the name of the argument to use in the error message, not null
+   * @return the input {@code argument}, not null
+   * @throws IllegalArgumentException if the input is null, unsorted, or contains duplicate values
+   */
+  public static double[] noDuplicatesSorted(double[] argument, String name) {
+    notNull(argument, name);
+    for (int i = 1; i < argument.length; i++) {
+      if (argument[i] <= argument[i - 1]) {
+        if (argument[i] == argument[i - 1]) {
+          throw new IllegalArgumentException(noDuplicatesArrayMsg(name));
+        } else {
+          throw new IllegalArgumentException(noDuplicatesSortedArrayMsg(name));
+        }
+      }
+    }
+    return argument;
+  }
+
+  // extracted to aid inlining performance
+  private static String noDuplicatesSortedArrayMsg(String name) {
+    return "Argument array '" + name + "' must be sorted and not contain duplicates";
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
@@ -448,7 +448,7 @@ public final class DoubleArrayMath {
     double[] result = new double[len1];
     for (int i = 0; i < len1; i++) {
       int key = positions[i];
-      ArgChecker.inRange(key, 0, len1, "key must be in range: 0 <= key < length");
+      ArgChecker.inRange(key, 0, len1, "key");
       result[i] = values[key];
     }
     return result;

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
@@ -35,7 +35,7 @@ public final class DoubleArrayMath {
   //-------------------------------------------------------------------------
   /**
    * Converts a {@code double} array to a {@code Double} array.
-   * 
+   *
    * @param array  the array to convert
    * @return the converted array
    */
@@ -54,7 +54,7 @@ public final class DoubleArrayMath {
    * Converts a {@code Double} array to a {@code double} array.
    * <p>
    * Throws an exception if null is found.
-   * 
+   *
    * @param array  the array to convert
    * @return the converted array
    * @throws NullPointerException if null found
@@ -75,7 +75,7 @@ public final class DoubleArrayMath {
    * Calculates the sum total of all the elements in the array.
    * <p>
    * The input array is not mutated.
-   * 
+   *
    * @param array  the array to sum
    * @return the sum total of all the elements
    */
@@ -92,7 +92,7 @@ public final class DoubleArrayMath {
    * Applies an addition to each element in the array, returning a new array.
    * <p>
    * The result is always a new array. The input array is not mutated.
-   * 
+   *
    * @param array  the input array, not mutated
    * @param valueToAdd  the value to add
    * @return the resulting array
@@ -109,7 +109,7 @@ public final class DoubleArrayMath {
    * Applies a multiplication to each element in the array, returning a new array.
    * <p>
    * The result is always a new array. The input array is not mutated.
-   * 
+   *
    * @param array  the input array, not mutated
    * @param valueToMultiplyBy  the value to multiply by
    * @return the resulting array
@@ -126,7 +126,7 @@ public final class DoubleArrayMath {
    * Applies an operator to each element in the array, returning a new array.
    * <p>
    * The result is always a new array. The input array is not mutated.
-   * 
+   *
    * @param array  the input array, not mutated
    * @param operator  the operator to use
    * @return the resulting array
@@ -144,7 +144,7 @@ public final class DoubleArrayMath {
    * Adds a constant value to each element in the array by mutation.
    * <p>
    * The input array is mutated.
-   * 
+   *
    * @param array  the array to mutate
    * @param valueToAdd  the value to add
    */
@@ -174,7 +174,7 @@ public final class DoubleArrayMath {
    * Multiplies each element in the array by a value by mutation.
    * <p>
    * The input array is mutated.
-   * 
+   *
    * @param array  the array to mutate
    * @param valueToMultiplyBy  the value to multiply by
    */
@@ -204,7 +204,7 @@ public final class DoubleArrayMath {
    * Mutates each element in the array using an operator by mutation.
    * <p>
    * The input array is mutated.
-   * 
+   *
    * @param array  the array to mutate
    * @param operator  the operator to use to perform the mutation
    */
@@ -230,7 +230,7 @@ public final class DoubleArrayMath {
    * </pre>
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   * 
+   *
    * @param array1  the first array
    * @param array2  the second array
    * @return an array combining the two input arrays using the plus operator
@@ -254,7 +254,7 @@ public final class DoubleArrayMath {
    * </pre>
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   * 
+   *
    * @param array1  the first array
    * @param array2  the second array
    * @return an array combining the two input arrays using the multiply operator
@@ -270,7 +270,7 @@ public final class DoubleArrayMath {
    * input arrays using the operator. The two input arrays must have the same length.
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   * 
+   *
    * @param array1  the first array
    * @param array2  the second array
    * @param operator  the operator to use when combining values
@@ -294,7 +294,7 @@ public final class DoubleArrayMath {
    * Where one array is longer than the other, the values from the longer array will be used.
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   * 
+   *
    * @param array1  the first array
    * @param array2  the second array
    * @param operator  the operator to use when combining values
@@ -329,7 +329,7 @@ public final class DoubleArrayMath {
    * An empty array returns true;
    * <p>
    * The input array is not mutated.
-   * 
+   *
    * @param array  the array to check
    * @param tolerance  the tolerance to use
    * @return true if the array is effectively equal to zero
@@ -349,7 +349,7 @@ public final class DoubleArrayMath {
    * If the arrays differ in length, false is returned.
    * <p>
    * The input arrays are not mutated.
-   * 
+   *
    * @param array1  the first array to check
    * @param array2  the second array to check
    * @param tolerance  the tolerance to use
@@ -420,6 +420,92 @@ public final class DoubleArrayMath {
     values[second] = t;
   }
 
+  /**
+   * Returns a copy of the first array in the order defined by the position values of the second array.
+   * <p>
+   * The two arrays must be the same size.
+   * The order is determined by the array of positions.
+   * The result value at each entry is changed to the value at the position of the positions entry.
+   * It is not checked that the positions array does not contain duplicates.
+   * <p>
+   * The result is a new array. The input arrays are not mutated.
+   * <p>
+   * e.g
+   * <pre>{@code double[] values = { 1d, 5d, 10d };
+   * double[] positions = { 2, 0, 1 };
+   * reorderedCopy(values, positions); // returns [10d, 1d, 5d]
+   * }</pre>
+   *
+   * @param values  the array of values
+   * @param positions  the array of positions
+   * @throws IllegalArgumentException if any of the positions do not correspond to an index in the values
+   */
+  public static double[] reorderedCopy(double[] values, int[] positions) {
+    int len1 = positions.length;
+    if (len1 != values.length) {
+      throw new IllegalArgumentException("Value array cannot be reordered as they differ in length");
+    }
+    double[] result = new double[len1];
+    for (int i = 0; i < len1; i++) {
+      int key = positions[i];
+      ArgChecker.inRange(key, 0, len1, "key must be in range: 0 <= key < length");
+      result[i] = values[key];
+    }
+    return result;
+  }
+
+  /**
+   * Sorts the two arrays, retaining the associated values with the sorted keys.
+   * <p>
+   * The two arrays must be the same size and represent a pair of key to value.
+   * The sort order is determined by the array of keys.
+   * The position of each value is changed to match that of the sorted keys.
+   * <p>
+   * The input arrays are mutated.
+   *
+   * @param keys  the array of keys to sort
+   * @param values  the array of associated values to retain
+   */
+  public static void sortPairs(double[] keys, int[] values) {
+    int len1 = keys.length;
+    if (len1 != values.length) {
+      throw new IllegalArgumentException("Arrays cannot be sorted as they differ in length");
+    }
+    dualArrayQuickSort(keys, values, 0, len1 - 1);
+  }
+
+  private static void dualArrayQuickSort(double[] keys, int[] values, int left, int right) {
+    if (right > left) {
+      int pivot = (left + right) >> 1;
+      int pivotNewIndex = partition(keys, values, left, right, pivot);
+      dualArrayQuickSort(keys, values, left, pivotNewIndex - 1);
+      dualArrayQuickSort(keys, values, pivotNewIndex + 1, right);
+    }
+  }
+
+  private static int partition(double[] keys, int[] values, int left, int right, int pivot) {
+    double pivotValue = keys[pivot];
+    swap(keys, values, pivot, right);
+    int storeIndex = left;
+    for (int i = left; i < right; i++) {
+      if (keys[i] <= pivotValue) {
+        swap(keys, values, i, storeIndex);
+        storeIndex++;
+      }
+    }
+    swap(keys, values, storeIndex, right);
+    return storeIndex;
+  }
+
+  private static void swap(double[] keys, int[] values, int first, int second) {
+    double t = keys[first];
+    keys[first] = keys[second];
+    keys[second] = t;
+    int t2 = values[first];
+    values[first] = values[second];
+    values[second] = t2;
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Sorts the two arrays, retaining the associated values with the sorted keys.
@@ -429,7 +515,7 @@ public final class DoubleArrayMath {
    * The position of each value is changed to match that of the sorted keys.
    * <p>
    * The input arrays are mutated.
-   * 
+   *
    * @param <V>  the type of the values
    * @param keys  the array of keys to sort
    * @param values  the array of associated values to retain
@@ -476,6 +562,10 @@ public final class DoubleArrayMath {
 
   /**
    * Return the array lengths if they are the same, otherwise throws an {@code IllegalArgumentException}.
+   *
+   * @param array1 the first array
+   * @param array2 the second array
+   * @return the length of both arrays
    */
   private static int length(double[] array1, double[] array2) {
     int len1 = array1.length;

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
@@ -560,13 +560,7 @@ public final class DoubleArrayMath {
     values[second] = t;
   }
 
-  /**
-   * Return the array lengths if they are the same, otherwise throws an {@code IllegalArgumentException}.
-   *
-   * @param array1 the first array
-   * @param array2 the second array
-   * @return the length of both arrays
-   */
+  // return the array lengths if they are the same, otherwise throws an IllegalArgumentException
   private static int length(double[] array1, double[] array2) {
     int len1 = array1.length;
     int len2 = array2.length;

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/DoubleArrayMath.java
@@ -35,7 +35,7 @@ public final class DoubleArrayMath {
   //-------------------------------------------------------------------------
   /**
    * Converts a {@code double} array to a {@code Double} array.
-   *
+   * 
    * @param array  the array to convert
    * @return the converted array
    */
@@ -54,7 +54,7 @@ public final class DoubleArrayMath {
    * Converts a {@code Double} array to a {@code double} array.
    * <p>
    * Throws an exception if null is found.
-   *
+   * 
    * @param array  the array to convert
    * @return the converted array
    * @throws NullPointerException if null found
@@ -75,7 +75,7 @@ public final class DoubleArrayMath {
    * Calculates the sum total of all the elements in the array.
    * <p>
    * The input array is not mutated.
-   *
+   * 
    * @param array  the array to sum
    * @return the sum total of all the elements
    */
@@ -92,7 +92,7 @@ public final class DoubleArrayMath {
    * Applies an addition to each element in the array, returning a new array.
    * <p>
    * The result is always a new array. The input array is not mutated.
-   *
+   * 
    * @param array  the input array, not mutated
    * @param valueToAdd  the value to add
    * @return the resulting array
@@ -109,7 +109,7 @@ public final class DoubleArrayMath {
    * Applies a multiplication to each element in the array, returning a new array.
    * <p>
    * The result is always a new array. The input array is not mutated.
-   *
+   * 
    * @param array  the input array, not mutated
    * @param valueToMultiplyBy  the value to multiply by
    * @return the resulting array
@@ -126,7 +126,7 @@ public final class DoubleArrayMath {
    * Applies an operator to each element in the array, returning a new array.
    * <p>
    * The result is always a new array. The input array is not mutated.
-   *
+   * 
    * @param array  the input array, not mutated
    * @param operator  the operator to use
    * @return the resulting array
@@ -144,7 +144,7 @@ public final class DoubleArrayMath {
    * Adds a constant value to each element in the array by mutation.
    * <p>
    * The input array is mutated.
-   *
+   * 
    * @param array  the array to mutate
    * @param valueToAdd  the value to add
    */
@@ -174,7 +174,7 @@ public final class DoubleArrayMath {
    * Multiplies each element in the array by a value by mutation.
    * <p>
    * The input array is mutated.
-   *
+   * 
    * @param array  the array to mutate
    * @param valueToMultiplyBy  the value to multiply by
    */
@@ -204,7 +204,7 @@ public final class DoubleArrayMath {
    * Mutates each element in the array using an operator by mutation.
    * <p>
    * The input array is mutated.
-   *
+   * 
    * @param array  the array to mutate
    * @param operator  the operator to use to perform the mutation
    */
@@ -230,7 +230,7 @@ public final class DoubleArrayMath {
    * </pre>
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   *
+   * 
    * @param array1  the first array
    * @param array2  the second array
    * @return an array combining the two input arrays using the plus operator
@@ -254,7 +254,7 @@ public final class DoubleArrayMath {
    * </pre>
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   *
+   * 
    * @param array1  the first array
    * @param array2  the second array
    * @return an array combining the two input arrays using the multiply operator
@@ -270,7 +270,7 @@ public final class DoubleArrayMath {
    * input arrays using the operator. The two input arrays must have the same length.
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   *
+   * 
    * @param array1  the first array
    * @param array2  the second array
    * @param operator  the operator to use when combining values
@@ -294,7 +294,7 @@ public final class DoubleArrayMath {
    * Where one array is longer than the other, the values from the longer array will be used.
    * <p>
    * The result is always a new array. The input arrays are not mutated.
-   *
+   * 
    * @param array1  the first array
    * @param array2  the second array
    * @param operator  the operator to use when combining values
@@ -329,7 +329,7 @@ public final class DoubleArrayMath {
    * An empty array returns true;
    * <p>
    * The input array is not mutated.
-   *
+   * 
    * @param array  the array to check
    * @param tolerance  the tolerance to use
    * @return true if the array is effectively equal to zero
@@ -349,7 +349,7 @@ public final class DoubleArrayMath {
    * If the arrays differ in length, false is returned.
    * <p>
    * The input arrays are not mutated.
-   *
+   * 
    * @param array1  the first array to check
    * @param array2  the second array to check
    * @param tolerance  the tolerance to use
@@ -515,7 +515,7 @@ public final class DoubleArrayMath {
    * The position of each value is changed to match that of the sorted keys.
    * <p>
    * The input arrays are mutated.
-   *
+   * 
    * @param <V>  the type of the values
    * @param keys  the array of keys to sort
    * @param values  the array of associated values to retain

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/ArgCheckerTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/ArgCheckerTest.java
@@ -761,6 +761,42 @@ public class ArgCheckerTest {
         .withMessageMatching(".*array.*'name'.*empty.*");
   }
 
+  //-----------------------------------------------------------------------
+  public void test_double_noDuplicates() {
+    double[] values = {0d, 1d, 10d, 5d};
+    assertEquals(ArgChecker.noDuplicates(values, "name"), values);
+  }
+
+  public void test_double_noDuplicates_NaN() {
+    double[] values = {0d, 1d, 10d, Double.NaN};
+    assertEquals(ArgChecker.noDuplicates(values, "name"), values);
+  }
+
+  public void test_double_noDuplicates_hasDuplicates() {
+    double[] values = {0d, 1d, 10d, 5d, 1d};
+    assertThrowsIllegalArg(() -> ArgChecker.noDuplicates(values, "name"));
+  }
+
+  public void test_double_noDuplicatesSorted() {
+    double[] values = {0d, 1d, 5d, 10d};
+    assertEquals(ArgChecker.noDuplicatesSorted(values, "name"), values);
+  }
+
+  public void test_double_noDuplicatesSorted_Nan() {
+    double[] values = {0d, 1d, 5d, Double.NaN, 10d};
+    assertEquals(ArgChecker.noDuplicatesSorted(values, "name"), values);
+  }
+
+  public void test_double_noDuplicatesSorted_hasDuplicates() {
+    double[] values = {0d, 1d, 5d, 5d, 10d};
+    assertThrowsIllegalArg(() -> ArgChecker.noDuplicatesSorted(values, "name"));
+  }
+
+  public void test_double_noDuplicatesSorted_notSorted() {
+    double[] values = {0d, 1d, 5d, 10d, 4d};
+    assertThrowsIllegalArg(() -> ArgChecker.noDuplicatesSorted(values, "name"));
+  }
+
   //-------------------------------------------------------------------------
   @Test
   public void test_inOrderNotEqual_true() {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/ArgCheckerTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/ArgCheckerTest.java
@@ -764,37 +764,37 @@ public class ArgCheckerTest {
   //-----------------------------------------------------------------------
   public void test_double_noDuplicates() {
     double[] values = {0d, 1d, 10d, 5d};
-    assertEquals(ArgChecker.noDuplicates(values, "name"), values);
+    assertThat(ArgChecker.noDuplicates(values, "name")).containsExactly(values);
   }
 
   public void test_double_noDuplicates_NaN() {
     double[] values = {0d, 1d, 10d, Double.NaN};
-    assertEquals(ArgChecker.noDuplicates(values, "name"), values);
+    assertThat(ArgChecker.noDuplicates(values, "name")).containsExactly(values);
   }
 
   public void test_double_noDuplicates_hasDuplicates() {
     double[] values = {0d, 1d, 10d, 5d, 1d};
-    assertThrowsIllegalArg(() -> ArgChecker.noDuplicates(values, "name"));
+    assertThatIllegalArgumentException().isThrownBy(() -> ArgChecker.noDuplicates(values, "name"));
   }
 
   public void test_double_noDuplicatesSorted() {
     double[] values = {0d, 1d, 5d, 10d};
-    assertEquals(ArgChecker.noDuplicatesSorted(values, "name"), values);
+    assertThat(ArgChecker.noDuplicatesSorted(values, "name")).containsExactly(values);
   }
 
   public void test_double_noDuplicatesSorted_Nan() {
     double[] values = {0d, 1d, 5d, Double.NaN, 10d};
-    assertEquals(ArgChecker.noDuplicatesSorted(values, "name"), values);
+    assertThat(ArgChecker.noDuplicatesSorted(values, "name")).containsExactly(values);
   }
 
   public void test_double_noDuplicatesSorted_hasDuplicates() {
     double[] values = {0d, 1d, 5d, 5d, 10d};
-    assertThrowsIllegalArg(() -> ArgChecker.noDuplicatesSorted(values, "name"));
+    assertThatIllegalArgumentException().isThrownBy(() -> ArgChecker.noDuplicatesSorted(values, "name"));
   }
 
   public void test_double_noDuplicatesSorted_notSorted() {
     double[] values = {0d, 1d, 5d, 10d, 4d};
-    assertThrowsIllegalArg(() -> ArgChecker.noDuplicatesSorted(values, "name"));
+    assertThatIllegalArgumentException().isThrownBy(() -> ArgChecker.noDuplicatesSorted(values, "name"));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/DoubleArrayMathTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/DoubleArrayMathTest.java
@@ -222,6 +222,32 @@ public class DoubleArrayMathTest {
 
   //-------------------------------------------------------------------------
   @Test
+  public void test_sortPairs_doubleint_1() {
+    double[] keys = {3d, 5d, 2d, 4d};
+    int[] values = {6, 10, 4, 8};
+    DoubleArrayMath.sortPairs(keys, values);
+    assertThat(keys).containsExactly(2d, 3d, 4d, 5d);
+    assertThat(values).containsExactly(4, 6, 8, 10);
+  }
+
+  @Test
+  public void test_sortPairs_doubleint_2() {
+    double[] keys = {3d, 2d, 5d, 4d};
+    int[] values = {6, 4, 10, 8};
+    DoubleArrayMath.sortPairs(keys, values);
+    assertThat(keys).containsExactly(2d, 3d, 4d, 5d);
+    assertThat(values).containsExactly(4, 6, 8, 10);
+  }
+
+  @Test
+  public void test_sortPairs_doubleint_sizeDifferent() {
+    double[] keys = {3d, 2d, 5d, 4d};
+    int[] values = {6, 4};
+    assertThatIllegalArgumentException().isThrownBy(() -> DoubleArrayMath.sortPairs(keys, values));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
   public void coverage() {
     coverPrivateConstructor(DoubleArrayMath.class);
   }

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/ConstrainedCubicSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/ConstrainedCubicSplineInterpolator.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.math.impl.interpolation;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import com.google.common.primitives.Doubles;
 import com.opengamma.strata.collect.ArgChecker;
@@ -39,15 +40,10 @@ public class ConstrainedCubicSplineInterpolator extends PiecewisePolynomialInter
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yValues containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts - 1; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
-
     double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
     double[] yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     final double[] intervals = _solver.intervalsCalculator(xValuesSrt);
     final double[] slopes = _solver.slopesCalculator(yValuesSrt, intervals);
@@ -90,19 +86,15 @@ public class ConstrainedCubicSplineInterpolator extends PiecewisePolynomialInter
         ArgChecker.isFalse(Double.isInfinite(yValuesMatrix[j][i]), "yValuesMatrix containing Infinity");
       }
     }
-    for (int i = 0; i < nDataPts; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
 
-    double[] xValuesSrt = new double[nDataPts];
     DoubleMatrix[] coefMatrix = new DoubleMatrix[dim];
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    int[] sortedPositions = IntStream.range(0, nDataPts).toArray();
+    DoubleArrayMath.sortPairs(xValuesSrt, sortedPositions);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     for (int i = 0; i < dim; ++i) {
-      xValuesSrt = Arrays.copyOf(xValues, nDataPts);
-      double[] yValuesSrt = Arrays.copyOf(yValuesMatrix[i], nDataPts);
-      DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+      double[] yValuesSrt = DoubleArrayMath.reorderedCopy(yValuesMatrix[i], sortedPositions);
 
       final double[] intervals = _solver.intervalsCalculator(xValuesSrt);
       final double[] slopes = _solver.slopesCalculator(yValuesSrt, intervals);
@@ -152,11 +144,7 @@ public class ConstrainedCubicSplineInterpolator extends PiecewisePolynomialInter
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yValues containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts - 1; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
+    ArgChecker.noDuplicates(xValues, "xValues");
 
     final double[] intervals = _solver.intervalsCalculator(xValues);
     final double[] slopes = _solver.slopesCalculator(yValues, intervals);

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/CubicSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/CubicSplineInterpolator.java
@@ -6,10 +6,13 @@
 package com.opengamma.strata.math.impl.interpolation;
 
 import java.util.Arrays;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
 
 import com.google.common.primitives.Doubles;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.DoubleArrayMath;
+import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
 
 /**
@@ -47,16 +50,8 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yData containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "Data should be distinct");
-      }
-    }
-
-    double[] xValuesSrt = new double[nDataPts];
-    double[] yValuesSrt = new double[nDataPts];
-
-    xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    double[] yValuesSrt;
 
     if (xValues.length + 2 == yValues.length) {
       _solver = new CubicSplineClampedSolver(yValues[0], yValues[nDataPts + 1]);
@@ -66,18 +61,20 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     }
     DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     final DoubleMatrix coefMatrix = _solver.solve(xValuesSrt, yValuesSrt);
     final int nCoefs = coefMatrix.columnCount();
 
-    for (int i = 0; i < _solver.getKnotsMat1D(xValuesSrt).size() - 1; ++i) {
+    DoubleArray knotsMat1D = _solver.getKnotsMat1D(xValuesSrt);
+    for (int i = 0; i < knotsMat1D.size() - 1; ++i) {
       for (int j = 0; j < nCoefs; ++j) {
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }
     }
 
-    return new PiecewisePolynomialResult(_solver.getKnotsMat1D(xValuesSrt), coefMatrix, nCoefs, 1);
+    return new PiecewisePolynomialResult(knotsMat1D, coefMatrix, nCoefs, 1);
 
   }
 
@@ -113,17 +110,12 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       }
     }
 
-    for (int k = 0; k < dim; ++k) {
-      for (int i = 0; i < nDataPts; ++i) {
-        for (int j = i + 1; j < nDataPts; ++j) {
-          ArgChecker.isFalse(xValues[i] == xValues[j], "Data should be distinct");
-        }
-      }
-    }
-
-    double[] xValuesSrt = new double[nDataPts];
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
     double[][] yValuesMatrixSrt = new double[dim][nDataPts];
 
+    int[] sortedPositions = IntStream.range(0, nDataPts).toArray();
+    DoubleArrayMath.sortPairs(xValuesSrt, sortedPositions);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
     if (xValues.length + 2 == yValuesMatrix[0].length) {
       double[] iniConds = new double[dim];
       double[] finConds = new double[dim];
@@ -132,22 +124,14 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
         finConds[i] = yValuesMatrix[i][nDataPts + 1];
       }
       _solver = new CubicSplineClampedSolver(iniConds, finConds);
-
       for (int i = 0; i < dim; ++i) {
-        xValuesSrt = Arrays.copyOf(xValues, nDataPts);
         double[] yValuesSrt = Arrays.copyOfRange(yValuesMatrix[i], 1, nDataPts + 1);
-        DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
-
-        yValuesMatrixSrt[i] = Arrays.copyOf(yValuesSrt, nDataPts);
+        yValuesMatrixSrt[i] = DoubleArrayMath.reorderedCopy(yValuesSrt, sortedPositions);
       }
     } else {
       _solver = new CubicSplineNakSolver();
       for (int i = 0; i < dim; ++i) {
-        xValuesSrt = Arrays.copyOf(xValues, nDataPts);
-        double[] yValuesSrt = Arrays.copyOf(yValuesMatrix[i], nDataPts);
-        DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
-
-        yValuesMatrixSrt[i] = Arrays.copyOf(yValuesSrt, nDataPts);
+        yValuesMatrixSrt[i] = DoubleArrayMath.reorderedCopy(yValuesMatrix[i], sortedPositions);
       }
     }
 
@@ -193,13 +177,11 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yData containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "Data should be distinct");
-      }
+    if (DoubleStream.of(xValues).distinct().count() != xValues.length) {
+      throw new IllegalArgumentException("Data should be distinct");
     }
 
-    double[] yValuesSrt = new double[nDataPts];
+    double[] yValuesSrt;
 
     if (xValues.length + 2 == yValues.length) {
       _solver = new CubicSplineClampedSolver(yValues[0], yValues[nDataPts + 1]);

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/CubicSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/CubicSplineInterpolator.java
@@ -50,7 +50,7 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yData containing Infinity");
     }
 
-    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    double[] xValuesSrt = xValues.clone();
     double[] yValuesSrt;
 
     if (xValues.length + 2 == yValues.length) {
@@ -177,9 +177,7 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yData containing Infinity");
     }
 
-    if (DoubleStream.of(xValues).distinct().count() != xValues.length) {
-      throw new IllegalArgumentException("Data should be distinct");
-    }
+    ArgChecker.noDuplicates(xValues, "xValues");
 
     double[] yValuesSrt;
 

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/CubicSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/CubicSplineInterpolator.java
@@ -50,7 +50,7 @@ public class CubicSplineInterpolator extends PiecewisePolynomialInterpolator {
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yData containing Infinity");
     }
 
-    double[] xValuesSrt = xValues.clone();
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
     double[] yValuesSrt;
 
     if (xValues.length + 2 == yValues.length) {

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/NonnegativityPreservingCubicSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/NonnegativityPreservingCubicSplineInterpolator.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.math.impl.interpolation;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import com.google.common.primitives.Doubles;
 import com.opengamma.strata.collect.ArgChecker;
@@ -58,20 +59,17 @@ public class NonnegativityPreservingCubicSplineInterpolator extends PiecewisePol
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yValues containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts - 1; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
 
     double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
-    double[] yValuesSrt = new double[nDataPts];
+    double[] yValuesSrt;
     if (nDataPts == yValuesLen) {
       yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     } else {
       yValuesSrt = Arrays.copyOfRange(yValues, 1, nDataPts + 1);
     }
     DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     final double[] intervals = _solver.intervalsCalculator(xValuesSrt);
     final double[] slopes = _solver.slopesCalculator(yValuesSrt, intervals);
@@ -116,24 +114,23 @@ public class NonnegativityPreservingCubicSplineInterpolator extends PiecewisePol
         ArgChecker.isFalse(Double.isInfinite(yValuesMatrix[j][i]), "yValuesMatrix containing Infinity");
       }
     }
-    for (int i = 0; i < nDataPts; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
 
-    double[] xValuesSrt = new double[nDataPts];
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    int[] sortedPositions = IntStream.range(0, nDataPts).toArray();
+    DoubleArrayMath.sortPairs(xValuesSrt, sortedPositions);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
+
     DoubleMatrix[] coefMatrix = new DoubleMatrix[dim];
 
     for (int i = 0; i < dim; ++i) {
-      xValuesSrt = Arrays.copyOf(xValues, nDataPts);
-      double[] yValuesSrt = new double[nDataPts];
+      double[] yValuesSrt;
       if (nDataPts == yValuesLen) {
-        yValuesSrt = Arrays.copyOf(yValuesMatrix[i], nDataPts);
+        yValuesSrt = DoubleArrayMath.reorderedCopy(yValuesMatrix[i], sortedPositions);
       } else {
-        yValuesSrt = Arrays.copyOfRange(yValuesMatrix[i], 1, nDataPts + 1);
+        yValuesSrt = DoubleArrayMath.reorderedCopy(
+            Arrays.copyOfRange(yValuesMatrix[i], 1, nDataPts + 1),
+            sortedPositions);
       }
-      DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
 
       final double[] intervals = _solver.intervalsCalculator(xValuesSrt);
       final double[] slopes = _solver.slopesCalculator(yValuesSrt, intervals);
@@ -187,13 +184,9 @@ public class NonnegativityPreservingCubicSplineInterpolator extends PiecewisePol
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yValues containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts - 1; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
+    ArgChecker.noDuplicates(xValues, "xValues");
 
-    double[] yValuesSrt = new double[nDataPts];
+    double[] yValuesSrt;
     if (nDataPts == yValuesLen) {
       yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     } else {

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/PiecewiseCubicHermiteSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/PiecewiseCubicHermiteSplineInterpolator.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.math.impl.interpolation;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.DoubleArrayMath;
@@ -43,9 +44,7 @@ public class PiecewiseCubicHermiteSplineInterpolator extends PiecewisePolynomial
     double[] yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
 
-    for (int i = 1; i < nDataPts; ++i) {
-      ArgChecker.isFalse(xValuesSrt[i - 1] == xValuesSrt[i], "xValues should be distinct");
-    }
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     final DoubleMatrix coefMatrix = solve(xValuesSrt, yValuesSrt);
 
@@ -80,19 +79,14 @@ public class PiecewiseCubicHermiteSplineInterpolator extends PiecewisePolynomial
       }
     }
 
-    for (int i = 0; i < nDataPts; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
-
-    double[] xValuesSrt = new double[nDataPts];
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    int[] sortedPositions = IntStream.range(0, nDataPts).toArray();
+    DoubleArrayMath.sortPairs(xValuesSrt, sortedPositions);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
     DoubleMatrix[] coefMatrix = new DoubleMatrix[dim];
 
     for (int i = 0; i < dim; ++i) {
-      xValuesSrt = Arrays.copyOf(xValues, nDataPts);
-      double[] yValuesSrt = Arrays.copyOf(yValuesMatrix[i], nDataPts);
-      DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+      double[] yValuesSrt = DoubleArrayMath.reorderedCopy(yValuesMatrix[i], sortedPositions);
 
       coefMatrix[i] = solve(xValuesSrt, yValuesSrt);
     }

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/PiecewiseCubicHermiteSplineInterpolatorWithSensitivity.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/PiecewiseCubicHermiteSplineInterpolatorWithSensitivity.java
@@ -44,9 +44,7 @@ public class PiecewiseCubicHermiteSplineInterpolatorWithSensitivity extends Piec
     double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
     double[] yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
-    for (int i = 1; i < nDataPts; ++i) {
-      ArgChecker.isFalse(xValuesSrt[i - 1] == xValuesSrt[i], "xValues should be distinct");
-    }
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     DoubleMatrix[] temp = solve(xValuesSrt, yValuesSrt);
     // check the matrices

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/SemiLocalCubicSplineInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/SemiLocalCubicSplineInterpolator.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.math.impl.interpolation;
 
 import java.util.Arrays;
+import java.util.stream.IntStream;
 
 import com.google.common.primitives.Doubles;
 import com.opengamma.strata.collect.ArgChecker;
@@ -43,15 +44,10 @@ public class SemiLocalCubicSplineInterpolator extends PiecewisePolynomialInterpo
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yValues containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts - 1; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
-
     double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
     double[] yValuesSrt = Arrays.copyOf(yValues, nDataPts);
     DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
 
     double[] intervals = _solver.intervalsCalculator(xValuesSrt);
     double[] slopes = _solver.slopesCalculator(yValuesSrt, intervals);
@@ -96,19 +92,15 @@ public class SemiLocalCubicSplineInterpolator extends PiecewisePolynomialInterpo
         ArgChecker.isFalse(Double.isInfinite(yValuesMatrix[j][i]), "yValuesMatrix containing Infinity");
       }
     }
-    for (int i = 0; i < nDataPts; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
 
-    double[] xValuesSrt = new double[nDataPts];
+    double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
+    int[] sortedPositions = IntStream.range(0, nDataPts).toArray();
+    DoubleArrayMath.sortPairs(xValuesSrt, sortedPositions);
+    ArgChecker.noDuplicatesSorted(xValuesSrt, "xValues");
     DoubleMatrix[] coefMatrix = new DoubleMatrix[dim];
 
     for (int i = 0; i < dim; ++i) {
-      xValuesSrt = Arrays.copyOf(xValues, nDataPts);
-      double[] yValuesSrt = Arrays.copyOf(yValuesMatrix[i], nDataPts);
-      DoubleArrayMath.sortPairs(xValuesSrt, yValuesSrt);
+      double[] yValuesSrt = DoubleArrayMath.reorderedCopy(yValuesMatrix[i], sortedPositions);
 
       double[] intervals = _solver.intervalsCalculator(xValuesSrt);
       double[] slopes = _solver.slopesCalculator(yValuesSrt, intervals);
@@ -159,11 +151,7 @@ public class SemiLocalCubicSplineInterpolator extends PiecewisePolynomialInterpo
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yValues containing Infinity");
     }
 
-    for (int i = 0; i < nDataPts - 1; ++i) {
-      for (int j = i + 1; j < nDataPts; ++j) {
-        ArgChecker.isFalse(xValues[i] == xValues[j], "xValues should be distinct");
-      }
-    }
+    ArgChecker.noDuplicates(xValues, "xValues");
 
     double[] intervals = _solver.intervalsCalculator(xValues);
     double[] slopes = _solver.slopesCalculator(yValues, intervals);

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/linearalgebra/CholeskyDecompositionOpenGammaResult.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/linearalgebra/CholeskyDecompositionOpenGammaResult.java
@@ -49,11 +49,6 @@ public class CholeskyDecompositionOpenGammaResult implements CholeskyDecompositi
   }
 
   @Override
-  public DoubleArray solve(DoubleArray b) {
-    return b;
-  }
-
-  @Override
   public double[] solve(double[] b) {
     int dim = b.length;
     ArgChecker.isTrue(dim == _lArray.length, "b array of incorrect size");

--- a/modules/math/src/main/java/com/opengamma/strata/math/linearalgebra/DecompositionResult.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/linearalgebra/DecompositionResult.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.math.linearalgebra;
 
+import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.array.DoubleMatrix;
 
@@ -22,7 +23,11 @@ public interface DecompositionResult {
    * @param input  the vector to calculate with
    * @return the vector x
    */
-  public abstract DoubleArray solve(DoubleArray input);
+  public default DoubleArray solve(DoubleArray input) {
+    ArgChecker.notNull(input, "input");
+    double[] result = solve(input.toArrayUnsafe());
+    return DoubleArray.ofUnsafe(result);
+  }
 
   /**
    * Solves $\mathbf{A}x = b$ where $\mathbf{A}$ is a (decomposed) matrix and $b$ is a vector.

--- a/modules/math/src/main/java/com/opengamma/strata/math/linearalgebra/DecompositionResult.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/linearalgebra/DecompositionResult.java
@@ -26,7 +26,7 @@ public interface DecompositionResult {
   public default DoubleArray solve(DoubleArray input) {
     ArgChecker.notNull(input, "input");
     double[] result = solve(input.toArrayUnsafe());
-    return DoubleArray.ofUnsafe(result);
+    return DoubleArray.copyOf(result);
   }
 
   /**

--- a/modules/math/src/main/java/com/opengamma/strata/math/linearalgebra/DecompositionResult.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/linearalgebra/DecompositionResult.java
@@ -25,7 +25,7 @@ public interface DecompositionResult {
    */
   public default DoubleArray solve(DoubleArray input) {
     ArgChecker.notNull(input, "input");
-    double[] result = solve(input.toArrayUnsafe());
+    double[] result = solve(input.toArray());
     return DoubleArray.copyOf(result);
   }
 


### PR DESCRIPTION
Not sure this is the best implementation - still seems a little boilerplatey.
Could definitely be streamlined with more ArgChecker methods, potentially ones that assert that a double array is sorted, unique, and doesn't contain NaN or infinity, but maybe that's overstepping what ArgChecker is responsible for.