### PR TITLE
Short-circuit lookups via ScenarioFxRateProvider

### DIFF
--- a/modules/data/src/main/java/com/opengamma/strata/data/scenario/ScenarioFxRateProvider.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/scenario/ScenarioFxRateProvider.java
@@ -60,6 +60,9 @@ public interface ScenarioFxRateProvider {
    * @throws IllegalArgumentException if either of the currencies aren't included in the currency pair of this rate
    */
   public default double convert(double amount, Currency fromCurrency, Currency toCurrency, int scenarioIndex) {
+    if (fromCurrency.equals(toCurrency)) {
+      return amount;
+    }
     return amount * fxRate(fromCurrency, toCurrency, scenarioIndex);
   }
 
@@ -77,6 +80,9 @@ public interface ScenarioFxRateProvider {
    * @throws RuntimeException if no FX rate could be found
    */
   public default double fxRate(Currency baseCurrency, Currency counterCurrency, int scenarioIndex) {
+    if (baseCurrency.equals(counterCurrency)) {
+      return 1;
+    }
     return fxRateProvider(scenarioIndex).fxRate(baseCurrency, counterCurrency);
   }
 

--- a/modules/data/src/test/java/com/opengamma/strata/data/scenario/ScenarioFxRateProviderTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/scenario/ScenarioFxRateProviderTest.java
@@ -38,11 +38,13 @@ public class ScenarioFxRateProviderTest {
 
   @Test
   public void convert() {
+    assertThat(fxRateProvider.convert(2, Currency.GBP, Currency.GBP, 0)).isEqualTo(2d);
     assertThat(fxRateProvider.convert(10, Currency.GBP, Currency.USD, 0)).isEqualTo(14d);
   }
 
   @Test
   public void fxRate() {
+    assertThat(fxRateProvider.fxRate(Currency.GBP, Currency.GBP, 0)).isEqualTo(1d);
     assertThat(fxRateProvider.fxRate(Currency.GBP, Currency.USD, 0)).isEqualTo(1.4d);
   }
 


### PR DESCRIPTION
Short-circuit lookups via the ScenarioFxRateProvider interface to avoid fetching/constructing the underlying FxRateProvider unnecessarily.