### PR TITLE
Extend the CSV trade loader

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvInfoResolver.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvInfoResolver.java
@@ -433,8 +433,28 @@ public interface TradeCsvInfoResolver {
     return CdsTradeCsvPlugin.parseCdsIndex(row, info, this);
   }
 
+  //-------------------------------------------------------------------------
   /**
-   * Parses any other kind of trade from CSV.
+   * Parses any kind of trade from CSV before standard matching.
+   * <p>
+   * This is called before the standard matching on the 'Product Type' column.
+   * As such, it allows the standard parsing to be replaced for a given type.
+   * 
+   * @param typeUpper  the upper case product type column
+   * @param row  the CSV row to parse
+   * @param info  the trade info
+   * @return the trade, empty if the product type is not known, or if standard parsing should occur
+   * @throws RuntimeException if the product type is known but the row contains invalid data
+   */
+  public default Optional<Trade> overrideParseTrade(String typeUpper, CsvRow row, TradeInfo info) {
+    return Optional.empty();
+  }
+
+  /**
+   * Parses any kind of trade from CSV after standard matching.
+   * <p>
+   * This is called after the standard matching on the 'Product Type' column.
+   * As such, it allows non-matched rows to be captured.
    * 
    * @param typeUpper  the upper case product type column
    * @param row  the CSV row to parse

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
@@ -459,6 +459,15 @@ public final class TradeCsvLoader {
         String typeRaw = row.getField(TYPE_FIELD);
         TradeInfo info = parseTradeInfo(row);
         String typeUpper = typeRaw.toUpperCase(Locale.ENGLISH);
+        // allow type matching to be overridden
+        Optional<Trade> overrideOpt = resolver.overrideParseTrade(typeUpper, row, info);
+        if (overrideOpt.isPresent()) {
+          if (tradeType.isInstance(overrideOpt.get())) {
+            trades.add(tradeType.cast(overrideOpt.get()));
+          }
+          continue;
+        }
+        // standard type matching
         switch (typeUpper) {
           case "FRA":
             if (tradeType == FraTrade.class || tradeType == Trade.class) {
@@ -508,7 +517,7 @@ public final class TradeCsvLoader {
           case "VARIABLE":
             failures.add(FailureItem.of(
                 FailureReason.PARSING,
-                "CSV file contained a 'Variable' type at line {lineNumber} that was not preceeded by a 'Swap'",
+                "CSV file contained a 'Variable' type at line {lineNumber} that was not preceeded by a 'Swap' or 'Swaption'",
                 row.lineNumber()));
             break;
           case "FX":
@@ -542,6 +551,7 @@ public final class TradeCsvLoader {
             }
             break;
           default:
+            // type is not a standard one
             Optional<Trade> parsedOpt = resolver.parseOtherTrade(typeUpper, row, info);
             if (parsedOpt.isPresent()) {
               if (tradeType.isInstance(parsedOpt.get())) {

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
@@ -2029,6 +2029,37 @@ public class TradeCsvLoaderTest {
   }
 
   @Test
+  public void test_load_overrideTypeViaResolver() {
+    Trade trade = new Trade() {
+      @Override
+      public Trade withInfo(TradeInfo info) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public TradeInfo getInfo() {
+        return TradeInfo.empty();
+      }
+    };
+    TradeCsvLoader test = TradeCsvLoader.of(new TradeCsvInfoResolver() {
+      @Override
+      public ReferenceData getReferenceData() {
+        return ReferenceData.standard();
+      }
+
+      @Override
+      public Optional<Trade> overrideParseTrade(String typeUpper, CsvRow row, TradeInfo info) {
+        return Optional.of(trade);
+      }
+    });
+    ValueWithFailures<List<Trade>> trades = test.parse(ImmutableList.of(CharSource.wrap("Strata Trade Type\nFRA")));
+
+    assertThat(trades.getFailures()).hasSize(0);
+    assertThat(trades.getValue()).hasSize(1);
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
   public void test_load_invalidFra() {
     TradeCsvLoader test = TradeCsvLoader.standard();
     ValueWithFailures<List<Trade>> trades = test.parse(ImmutableList.of(CharSource.wrap("Strata Trade Type,Buy Sell\nFra,Buy")));


### PR DESCRIPTION
Allow the standard parsing to be overridden for a given product type