### PR TITLE
Fix bond pricer dirty price after new issue

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingFixedCouponBondProductPricer.java
@@ -804,6 +804,9 @@ public class DiscountingFixedCouponBondProductPricer {
     int couponIndex = couponIndex(bond.getPeriodicPayments(), settlementDate);
     double factorSpot = accruedYearFraction(bond, settlementDate);
     double factorPeriod = bond.getPeriodicPayments().get(couponIndex).getYearFraction();
+    if (bond.getYieldConvention().equals(GB_BUMP_DMO)) {
+      return (factorPeriod - factorSpot) * ((double) bond.getFrequency().eventsPerYear());
+    }
     return (factorPeriod - factorSpot) / factorPeriod;
   }
 


### PR DESCRIPTION
Adjust by eventsPerYear

See [forum](https://forums.opengamma.com/t/yield-duration-diff-on-new-issue-gilts-vs-bloomberg/912) post.