### PR TITLE
Refactor codec methods

### DIFF
--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
@@ -260,7 +260,6 @@ public class ArrayByteSourceTest {
   @Test
   public void test_toHash() {
     byte[] bytes = new byte[] {65, 66, 67, 99};
-    @SuppressWarnings("deprecation")
     HashCode hash = Hashing.crc32().hashBytes(bytes);
     ArrayByteSource test = ArrayByteSource.copyOf(bytes);
     assertThat(test.toHash(Hashing.crc32())).isEqualTo(ArrayByteSource.ofUnsafe(hash.asBytes()));

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import org.joda.beans.ser.JodaBeanSer;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteSource;
@@ -257,6 +258,17 @@ public class ArrayByteSourceTest {
 
   //-------------------------------------------------------------------------
   @Test
+  public void test_toHash() {
+    byte[] bytes = new byte[] {65, 66, 67, 99};
+    @SuppressWarnings("deprecation")
+    HashCode hash = Hashing.crc32().hashBytes(bytes);
+    ArrayByteSource test = ArrayByteSource.copyOf(bytes);
+    assertThat(test.toHash(Hashing.crc32())).isEqualTo(ArrayByteSource.ofUnsafe(hash.asBytes()));
+    assertThat(test.toHashString(Hashing.crc32())).isEqualTo(hash.toString());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
   public void test_md5() {
     byte[] bytes = new byte[] {65, 66, 67, 99};
     @SuppressWarnings("deprecation")
@@ -266,6 +278,7 @@ public class ArrayByteSourceTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void test_sha512() {
     byte[] bytes = new byte[] {65, 66, 67, 99};
     byte[] hash = Hashing.sha512().hashBytes(bytes).asBytes();

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/FileByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/FileByteSourceTest.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import org.joda.beans.ser.JodaBeanSer;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.hash.Hashing;
+
 /**
  * Test {@link FileByteSource}.
  */
@@ -44,6 +46,22 @@ public class FileByteSourceTest {
     assertThat(test.size()).isGreaterThan(100);
     assertThat(test.sizeIfKnown().isPresent()).isTrue();
     assertThat(test.read()[0]).isEqualTo((byte) '<');
+  }
+
+  @Test
+  public void test_of_hash() {
+    FileByteSource test = FileByteSource.of(new File("pom.xml").toPath());
+    ArrayByteSource loaded = test.load();
+    assertThat(test.toHash(Hashing.sha256())).isEqualTo(loaded.toHash(Hashing.sha256()));
+    assertThat(test.toHashString(Hashing.sha256())).isEqualTo(loaded.toHashString(Hashing.sha256()));
+  }
+
+  @Test
+  public void test_of_base64() {
+    FileByteSource test = FileByteSource.of(new File("pom.xml").toPath());
+    ArrayByteSource loaded = test.load();
+    assertThat(test.toBase64()).isEqualTo(loaded.toBase64());
+    assertThat(test.toBase64String()).isEqualTo(loaded.toBase64String());
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Move base-64 methods up to `BeanByteSource`
Add hashing methods to `BeanByteSource` taking parameter for flexibility
Deprecate overly specific SHA-512 and MD5 methods