### PR TITLE
MapStream factory method from collection only

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
@@ -94,7 +94,18 @@ public final class MapStream<K, V>
    * @return a stream of map entries derived from the values in the collection
    */
   public static <V> MapStream<V, V> of(Collection<V> collection) {
-    return of(collection.stream(), key -> key);
+    return of(collection.stream());
+  }
+
+  /**
+   * Returns a stream of map entries where the keys and values are taken from a stream.
+   *
+   * @param <V>  the key and value type
+   * @param stream  the stream
+   * @return a stream of map entries derived from the values in the stream
+   */
+  public static <V> MapStream<V, V> of(Stream<V> stream) {
+    return of(stream, key -> key);
   }
 
   /**
@@ -110,7 +121,6 @@ public final class MapStream<K, V>
   public static <K, V> MapStream<K, V> of(Collection<V> collection, Function<? super V, ? extends K> keyFunction) {
     return of(collection.stream(), keyFunction);
   }
-
 
   /**
    * Returns a stream of map entries where the keys and values are extracted from a

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/MapStream.java
@@ -87,6 +87,17 @@ public final class MapStream<K, V>
   }
 
   /**
+   * Returns a stream of map entries where the keys and values are taken from a collection.
+   *
+   * @param <V>  the key and value type
+   * @param collection  the collection
+   * @return a stream of map entries derived from the values in the collection
+   */
+  public static <V> MapStream<V, V> of(Collection<V> collection) {
+    return of(collection.stream(), key -> key);
+  }
+
+  /**
    * Returns a stream of map entries where the values are taken from a collection
    * and the keys are created by applying a function to each value.
    *
@@ -99,6 +110,7 @@ public final class MapStream<K, V>
   public static <K, V> MapStream<K, V> of(Collection<V> collection, Function<? super V, ? extends K> keyFunction) {
     return of(collection.stream(), keyFunction);
   }
+
 
   /**
    * Returns a stream of map entries where the keys and values are extracted from a

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
@@ -63,6 +63,16 @@ public class MapStreamTest {
     assertThat(result).isEqualTo(list);
   }
 
+  public void keys_fromStream() {
+    List<String> result = MapStream.of(list.stream()).keys().collect(toImmutableList());
+    assertThat(result).isEqualTo(list);
+  }
+
+  public void values_fromStream() {
+    List<String> result = MapStream.of(list.stream()).values().collect(toImmutableList());
+    assertThat(result).isEqualTo(list);
+  }
+
   //-------------------------------------------------------------------------
   public void filter() {
     Map<String, Integer> expected = ImmutableMap.of("one", 1, "two", 2);

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MapStreamTest.java
@@ -40,6 +40,7 @@ import com.opengamma.strata.collect.tuple.Pair;
 public class MapStreamTest {
 
   private final Map<String, Integer> map = ImmutableMap.of("one", 1, "two", 2, "three", 3, "four", 4);
+  private final List<String> list = ImmutableList.of("one", "two", "three", "four");
 
   //-------------------------------------------------------------------------
   public void keys() {
@@ -50,6 +51,16 @@ public class MapStreamTest {
   public void values() {
     List<Integer> result = MapStream.of(map).values().collect(toImmutableList());
     assertThat(result).isEqualTo(ImmutableList.of(1, 2, 3, 4));
+  }
+
+  public void keys_fromList() {
+    List<String> result = MapStream.of(list).keys().collect(toImmutableList());
+    assertThat(result).isEqualTo(list);
+  }
+
+  public void values_fromList() {
+    List<String> result = MapStream.of(list).values().collect(toImmutableList());
+    assertThat(result).isEqualTo(list);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Caters to the common use-case of creating a MapStream from a collection and operating on the values while retaining the original object as a key. 