### PR TITLE
Short-circuit in TradeInfo#from and PositionInfo#from

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/PositionInfo.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/PositionInfo.java
@@ -90,6 +90,9 @@ public final class PositionInfo
    * @return the position information
    */
   public static PositionInfo from(PortfolioItemInfo info) {
+    if (info instanceof PositionInfo) {
+      return ((PositionInfo) info);
+    }
     return empty().combinedWith(info);
   }
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/TradeInfo.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/TradeInfo.java
@@ -120,6 +120,9 @@ public final class TradeInfo
    * @return the trade information
    */
   public static TradeInfo from(PortfolioItemInfo info) {
+    if (info instanceof TradeInfo) {
+      return ((TradeInfo) info);
+    }
     return empty().combinedWith(info);
   }
 


### PR DESCRIPTION
Where the supplied PortfolioItemInfo is already of the required type (which should be the common case) simply return it immediately to avoid re-building the object from scratch.