### PR TITLE
Let Result and Failure use Throwable for cause instead of Exception

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Failure.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Failure.java
@@ -85,7 +85,7 @@ public final class Failure
   }
 
   /**
-   * Obtains a failure from a reason, message and exception.
+   * Obtains a failure from a reason, message and throwable.
    * <p>
    * The message is produced using a template that contains zero to many "{}" placeholders.
    * Each placeholder is replaced by the next available argument.
@@ -105,13 +105,46 @@ public final class Failure
   }
 
   /**
-   * Obtains a failure from a reason and exception.
+   * Obtains a failure from a reason, message and exception.
+   * <p>
+   * The message is produced using a template that contains zero to many "{}" placeholders.
+   * Each placeholder is replaced by the next available argument.
+   * If there are too few arguments, then the message will be left with placeholders.
+   * If there are too many arguments, then the excess arguments are appended to the
+   * end of the message. No attempt is made to format the arguments.
+   * See {@link Messages#format(String, Object...)} for more details.
+   * 
+   * @param reason  the reason
+   * @param cause  the cause
+   * @param message  the failure message, possibly containing placeholders, formatted using {@link Messages#format}
+   * @param messageArgs  arguments used to create the failure message
+   * @return the failure
+   */
+  public static Failure of(FailureReason reason, Exception cause, String message, Object... messageArgs) {
+    // this method is retained to ensure binary compatibility
+    return Failure.of(FailureItem.of(reason, cause, message, messageArgs));
+  }
+
+  /**
+   * Obtains a failure from a reason and throwable.
    * 
    * @param reason  the reason
    * @param cause  the cause
    * @return the failure
    */
   public static Failure of(FailureReason reason, Throwable cause) {
+    return Failure.of(FailureItem.of(reason, cause));
+  }
+
+  /**
+   * Obtains a failure from a reason and exception.
+   * 
+   * @param reason  the reason
+   * @param cause  the cause
+   * @return the failure
+   */
+  public static Failure of(FailureReason reason, Exception cause) {
+    // this method is retained to ensure binary compatibility
     return Failure.of(FailureItem.of(reason, cause));
   }
 

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Failure.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Failure.java
@@ -100,7 +100,7 @@ public final class Failure
    * @param messageArgs  arguments used to create the failure message
    * @return the failure
    */
-  public static Failure of(FailureReason reason, Exception cause, String message, Object... messageArgs) {
+  public static Failure of(FailureReason reason, Throwable cause, String message, Object... messageArgs) {
     return Failure.of(FailureItem.of(reason, cause, message, messageArgs));
   }
 
@@ -111,7 +111,7 @@ public final class Failure
    * @param cause  the cause
    * @return the failure
    */
-  public static Failure of(FailureReason reason, Exception cause) {
+  public static Failure of(FailureReason reason, Throwable cause) {
     return Failure.of(FailureItem.of(reason, cause));
   }
 

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -168,6 +168,20 @@ public final class Result<T>
   }
 
   /**
+   * Creates a failed result caused by an exception.
+   * <p>
+   * The failure will have a reason of {@code ERROR}.
+   *
+   * @param <R> the expected type of the result
+   * @param cause  the cause of the failure
+   * @return a failure result
+   */
+  public static <R> Result<R> failure(Exception cause) {
+    // this method is retained to ensure binary compatibility
+    return new Result<>(Failure.of(FailureReason.ERROR, cause));
+  }
+
+  /**
    * Creates a failed result caused by a throwable.
    * <p>
    * The failure will have a reason of {@code ERROR}.
@@ -190,6 +204,29 @@ public final class Result<T>
   }
 
   /**
+   * Creates a failed result caused by an exception.
+   * <p>
+   * The failure will have a reason of {@code ERROR}.
+   * <p>
+   * The message is produced using a template that contains zero to many "{}" placeholders.
+   * Each placeholder is replaced by the next available argument.
+   * If there are too few arguments, then the message will be left with placeholders.
+   * If there are too many arguments, then the excess arguments are appended to the
+   * end of the message. No attempt is made to format the arguments.
+   * See {@link Messages#format(String, Object...)} for more details.
+   *
+   * @param <R> the expected type of the result
+   * @param cause  the cause of the failure
+   * @param message  a message explaining the failure, uses "{}" for inserting {@code messageArgs}
+   * @param messageArgs  the arguments for the message
+   * @return a failure result
+   */
+  public static <R> Result<R> failure(Exception cause, String message, Object... messageArgs) {
+    // this method is retained to ensure binary compatibility
+    return new Result<>(Failure.of(FailureReason.ERROR, cause, message, messageArgs));
+  }
+
+  /**
    * Creates a failed result caused by a throwable with a specified reason.
    *
    * @param <R> the expected type of the result
@@ -198,6 +235,19 @@ public final class Result<T>
    * @return a failure result
    */
   public static <R> Result<R> failure(FailureReason reason, Throwable cause) {
+    return new Result<>(Failure.of(reason, cause));
+  }
+
+  /**
+   * Creates a failed result caused by an exception with a specified reason.
+   *
+   * @param <R> the expected type of the result
+   * @param reason  the result reason
+   * @param cause  the cause of the failure
+   * @return a failure result
+   */
+  public static <R> Result<R> failure(FailureReason reason, Exception cause) {
+    // this method is retained to ensure binary compatibility
     return new Result<>(Failure.of(reason, cause));
   }
 
@@ -224,6 +274,33 @@ public final class Result<T>
       String message,
       Object... messageArgs) {
 
+    return new Result<>(Failure.of(reason, cause, message, messageArgs));
+  }
+
+  /**
+   * Creates a failed result caused by an exception with a specified reason and message.
+   * <p>
+   * The message is produced using a template that contains zero to many "{}" placeholders.
+   * Each placeholder is replaced by the next available argument.
+   * If there are too few arguments, then the message will be left with placeholders.
+   * If there are too many arguments, then the excess arguments are appended to the
+   * end of the message. No attempt is made to format the arguments.
+   * See {@link Messages#format(String, Object...)} for more details.
+   *
+   * @param <R> the expected type of the result
+   * @param reason  the result reason
+   * @param cause  the cause of the failure
+   * @param message  a message explaining the failure, uses "{}" for inserting {@code messageArgs}
+   * @param messageArgs  the arguments for the message
+   * @return a failure result
+   */
+  public static <R> Result<R> failure(
+      FailureReason reason,
+      Exception cause,
+      String message,
+      Object... messageArgs) {
+
+    // this method is retained to ensure binary compatibility
     return new Result<>(Failure.of(reason, cause, message, messageArgs));
   }
 

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -155,20 +155,20 @@ public final class Result<T>
   }
 
   /**
-   * Creates a failed result caused by an exception.
+   * Creates a failed result caused by a throwable.
    * <p>
    * The failure will have a reason of {@code ERROR}.
    *
    * @param <R> the expected type of the result
-   * @param exception  the cause of the failure
+   * @param cause  the cause of the failure
    * @return a failure result
    */
-  public static <R> Result<R> failure(Exception exception) {
-    return new Result<>(Failure.of(FailureReason.ERROR, exception));
+  public static <R> Result<R> failure(Throwable cause) {
+    return new Result<>(Failure.of(FailureReason.ERROR, cause));
   }
 
   /**
-   * Creates a failed result caused by an exception.
+   * Creates a failed result caused by a throwable.
    * <p>
    * The failure will have a reason of {@code ERROR}.
    * <p>
@@ -180,29 +180,29 @@ public final class Result<T>
    * See {@link Messages#format(String, Object...)} for more details.
    *
    * @param <R> the expected type of the result
-   * @param exception  the cause of the failure
+   * @param cause  the cause of the failure
    * @param message  a message explaining the failure, uses "{}" for inserting {@code messageArgs}
    * @param messageArgs  the arguments for the message
    * @return a failure result
    */
-  public static <R> Result<R> failure(Exception exception, String message, Object... messageArgs) {
-    return new Result<>(Failure.of(FailureReason.ERROR, exception, message, messageArgs));
+  public static <R> Result<R> failure(Throwable cause, String message, Object... messageArgs) {
+    return new Result<>(Failure.of(FailureReason.ERROR, cause, message, messageArgs));
   }
 
   /**
-   * Creates a failed result caused by an exception with a specified reason.
+   * Creates a failed result caused by a throwable with a specified reason.
    *
    * @param <R> the expected type of the result
    * @param reason  the result reason
-   * @param exception  the cause of the failure
+   * @param cause  the cause of the failure
    * @return a failure result
    */
-  public static <R> Result<R> failure(FailureReason reason, Exception exception) {
-    return new Result<>(Failure.of(reason, exception));
+  public static <R> Result<R> failure(FailureReason reason, Throwable cause) {
+    return new Result<>(Failure.of(reason, cause));
   }
 
   /**
-   * Creates a failed result caused by an exception with a specified reason and message.
+   * Creates a failed result caused by a throwable with a specified reason and message.
    * <p>
    * The message is produced using a template that contains zero to many "{}" placeholders.
    * Each placeholder is replaced by the next available argument.
@@ -213,18 +213,18 @@ public final class Result<T>
    *
    * @param <R> the expected type of the result
    * @param reason  the result reason
-   * @param exception  the cause of the failure
+   * @param cause  the cause of the failure
    * @param message  a message explaining the failure, uses "{}" for inserting {@code messageArgs}
    * @param messageArgs  the arguments for the message
    * @return a failure result
    */
   public static <R> Result<R> failure(
       FailureReason reason,
-      Exception exception,
+      Throwable cause,
       String message,
       Object... messageArgs) {
 
-    return new Result<>(Failure.of(reason, exception, message, messageArgs));
+    return new Result<>(Failure.of(reason, cause, message, messageArgs));
   }
 
   /**

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/ResultTest.java
@@ -173,6 +173,28 @@ public class ResultTest {
     assertThat(item.getMessage()).isEqualTo("failure");
     assertThat(item.getCauseType().get()).isEqualTo(ex.getClass());
     assertThat(item.getStackTrace()).isEqualTo(Throwables.getStackTraceAsString(ex).replace(System.lineSeparator(), "\n"));
+  }  
+
+  @Test
+  public void failure_error() {
+    Error ex = new Error("failure");
+    Result<String> test = Result.failure(ex);
+    assertThat(test.isSuccess()).isEqualTo(false);
+    assertThat(test.isFailure()).isEqualTo(true);
+    assertThat(test.get()).isEmpty();
+    assertThat(test.getValueOrElse("blue")).isEqualTo("blue");
+    assertThat(test.getValueOrElseApply(f -> "blue")).isEqualTo("blue");
+    assertThat(test.getValueOrElseApply(Failure::getMessage)).isEqualTo("failure");
+    assertThat(test.getValueOrElse(null)).isNull();
+    assertThatIllegalArgumentException().isThrownBy(() -> test.getValueOrElseApply(null));
+    assertThat(test.getFailure().getReason()).isEqualTo(ERROR);
+    assertThat(test.getFailure().getMessage()).isEqualTo("failure");
+    assertThat(test.getFailure().getItems().size()).isEqualTo(1);
+    FailureItem item = test.getFailure().getFirstItem();
+    assertThat(item.getReason()).isEqualTo(ERROR);
+    assertThat(item.getMessage()).isEqualTo("failure");
+    assertThat(item.getCauseType().get()).isEqualTo(ex.getClass());
+    assertThat(item.getStackTrace()).isEqualTo(Throwables.getStackTraceAsString(ex).replace(System.lineSeparator(), "\n"));
   }
 
   @Test


### PR DESCRIPTION
Leftover from when FailureItem required Exception, but can now be extended