### PR TITLE
Add Guavate.tryCatchToOptional

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -140,6 +140,25 @@ public final class Guavate {
 
   //-------------------------------------------------------------------------
   /**
+   * Wraps a try-catch block around an expression, avoiding exceptions.
+   * <p>
+   * This converts an exception throwing method into an optional returning one by discarding the exception.
+   * In most cases it is better to add a `findXxx()` method to the code you want to call.
+   * 
+   * @param <T> the type of the result
+   * @param supplier the supplier that might throw an exception
+   * @return the value wrapped in an exception, empty if the method returns null or an exception is thrown
+   */
+  public static <T> Optional<T> tryCatchToOptional(Supplier<T> supplier) {
+    try {
+      return Optional.ofNullable(supplier.get());
+    } catch (RuntimeException ex) {
+      return Optional.empty();
+    }
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Uses a number of suppliers to create a single optional result.
    * <p>
    * This invokes each supplier in turn until a non empty optional is returned.

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -145,9 +145,9 @@ public final class Guavate {
    * This converts an exception throwing method into an optional returning one by discarding the exception.
    * In most cases it is better to add a `findXxx()` method to the code you want to call.
    * 
-   * @param <T> the type of the result
-   * @param supplier the supplier that might throw an exception
-   * @return the value wrapped in an exception, empty if the method returns null or an exception is thrown
+   * @param <T>  the type of the result in the optional
+   * @param supplier  the supplier that might throw an exception
+   * @return the value wrapped in an optional, empty if the method returns null or an exception is thrown
    */
   public static <T> Optional<T> tryCatchToOptional(Supplier<T> supplier) {
     try {

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -121,6 +122,14 @@ public class GuavateTest {
         map2,
         (a, b) -> Double.sum(a.doubleValue(), b.doubleValue()));
     assertThat(test).isEqualTo(ImmutableMap.of("a", 6d, "b", 2, "c", 3d));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_tryCatchToOptional() {
+    assertThat(Guavate.tryCatchToOptional(() -> LocalDate.parse("2020-06-01"))).hasValue(LocalDate.of(2020, 6, 1));
+    assertThat(Guavate.tryCatchToOptional(() -> null)).isEmpty();
+    assertThat(Guavate.tryCatchToOptional(() -> LocalDate.parse("XXX"))).isEmpty();
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Convert an exception throwing `getFoo()` method to an `Optional` returning `findFoo()` method