### PR TITLE
Cache size call for DenseLocalDateDoubleTimeSeries

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeries.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeries.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.collect.timeseries;
 
+import static com.opengamma.strata.collect.Guavate.in;
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
 import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -40,7 +41,6 @@ import org.joda.beans.impl.direct.DirectPrivateBeanBuilder;
 import com.google.common.collect.Ordering;
 import com.google.common.primitives.Doubles;
 import com.opengamma.strata.collect.ArgChecker;
-import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.function.ObjDoublePredicate;
 
@@ -223,7 +223,7 @@ final class DenseLocalDateDoubleTimeSeries
     double[] points = new double[dateCalculation.calculatePosition(startDate, endDate) + 1];
     Arrays.fill(points, Double.NaN);
     int size = 0;
-    for (LocalDateDoublePoint pt : Guavate.in(values)) {
+    for (LocalDateDoublePoint pt : in(values)) {
       points[dateCalculation.calculatePosition(startDate, pt.getDate())] = pt.getValue();
       size++;
     }
@@ -263,6 +263,7 @@ final class DenseLocalDateDoubleTimeSeries
 
   @Override
   public int size() {
+    // threadsafe via racy single-check idiom
     int s = size;
     if (s == -1) {
       s = (int) validIndices().count();


### PR DESCRIPTION
Current implementation has an O(N) lookup time.

Profiling revealed the `isEmpty()` check in `.get(LocalDate)` to be a hotspot as it could potentially traverse a reasonable amount of the array (density is required to be >0.7 to become dense, so potentially up to 0.3 of a large array could be traversed, but additionally this isn't preserved when doing head or tail of the timeseries)

Could use a `Suppliers.memoize()` call instead but decided against as in several cases we can preserve the size information. Could switch back though if that would be clearer.
Also could have cached the `isEmpty()` check instead of piggy-backing on size() and a full traversal but that feels like over optimization.