### PR TITLE
Overriden daysBetween implementation for ImmutableHolidayCalendar performance

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendar.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendar.java
@@ -626,7 +626,7 @@ public final class ImmutableHolidayCalendar
       // e.g 4th day of month - want holidays from index 3 inclusive
       int start = Integer.bitCount(lookup[startIndex] & (BIT_MASK_ALL_ONES << (startInclusive.getDayOfMonth() - 1)));
       // count of last month = ones before day of month exclusive == total for month - ones after end inclusive
-      int missingEnd = Integer.bitCount(lookup[endIndex] & (BIT_MASK_ALL_ONES << endExclusive.getDayOfMonth() - 1));
+      int missingEnd = Integer.bitCount(lookup[endIndex] & (BIT_MASK_ALL_ONES << (endExclusive.getDayOfMonth() - 1)));
       if (startIndex == endIndex) {
         // same month - return holidays up to end exclusive 
         return start - missingEnd;
@@ -634,11 +634,11 @@ public final class ImmutableHolidayCalendar
       
       int end = Integer.bitCount(lookup[endIndex]) - missingEnd;
       // otherwise add start and end month counts, and sum months between
-      long count = start + end;
+      int count = start + end;
       for (int i = startIndex + 1; i < endIndex; i++) {
         count += Integer.bitCount(lookup[i]);
       }
-      return Math.toIntExact(count);
+      return count;
 
     } catch (ArrayIndexOutOfBoundsException ex) {
       return daysBetweenOutOfRange(startInclusive, endExclusive);

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendar.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/ImmutableHolidayCalendar.java
@@ -645,7 +645,6 @@ public final class ImmutableHolidayCalendar
     }
   }
 
-
   // pulled out to aid hotspot inlining
   private int daysBetweenOutOfRange(LocalDate startInclusive, LocalDate endExclusive) {
     if (startInclusive.getYear() >= 0 && startInclusive.getYear() < 10000 &&


### PR DESCRIPTION
Noticed when calculating lots of PVs that there was a major hot spot calculating year fractions using Business252DayCount.
Other day counts calls have a relatively fixed cost - they don't need to check individual holidays.
Whereas this uses the holiday calendar `daysBetween` which streams over every date and checks whether it is a holiday, creating lots of intermediary objects and lookups.
We can use the bit-packed lookup in ImmutableHolidayCalendar and the JDK method `Integer.bitCount()` to count business days per month in a single call.

Using some very unscientific benchmarking of the `test_yearFraction` method on `Business252DayCountTest` for 300K year fraction calls between 1 and 1000 days in the future the total time went from 51.49 seconds locally to 256ms, or just over 200 times faster.

Limiting to just the next day (as in requesting the yearFraction between today and tomorrow) 100 million times the speed up was from 27 seconds to 8s, or roughly 3 times faster