### PR TITLE
Accept paths that are not normalized in ZipUtils.unzip

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/ZipUtils.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/ZipUtils.java
@@ -321,8 +321,9 @@ public final class ZipUtils {
 
   // prevent ZIP slip attack
   private static Path validateZipPathName(Path rootPath, ZipEntry entry) throws ZipException {
-    Path resolved = rootPath.normalize().resolve(entry.getName()).normalize();
-    if (!resolved.startsWith(rootPath)) {
+    Path normalizedRootPath = rootPath.normalize();
+    Path resolved = normalizedRootPath.resolve(entry.getName()).normalize();
+    if (!resolved.startsWith(normalizedRootPath)) {
       throw new ZipException("ZIP file contains illegal file name: " + entry.getName());
     }
     return resolved;

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ZipUtilsTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ZipUtilsTest.java
@@ -119,6 +119,18 @@ public class ZipUtilsTest {
   }
 
   @Test
+  public void test_unzip_toPath_notNormalized() {
+    ArrayByteSource source1 = ArrayByteSource.ofUtf8("Hello World").withFileName("TestFile3.txt");
+    ArrayByteSource source2 = ArrayByteSource.ofUtf8("Hello Planet").withFileName("TestFile4.txt");
+    ArrayByteSource zipFile = ZipUtils.zipInMemory(ImmutableList.of(source1, source2)).withFileName("Test.foo");
+
+    ZipUtils.unzip(zipFile, tmpDir.resolve("abc").resolve(".."));
+
+    assertThat(tmpDir.resolve("TestFile3.txt")).hasContent("Hello World");
+    assertThat(tmpDir.resolve("TestFile4.txt")).hasContent("Hello Planet");
+  }
+
+  @Test
   public void test_unzip_toPath_withFolders() {
     ArrayByteSource zipFile = load("TestFolder.zip");
 


### PR DESCRIPTION
Normalize the root path before performing the ZIP slip attack check.

This allows users to submit destination paths that are not normalized.