### PR TITLE
Fix RatesCurveGroupDefinitionBuilder

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/RatesCurveGroupDefinitionBuilder.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/RatesCurveGroupDefinitionBuilder.java
@@ -63,9 +63,9 @@ public final class RatesCurveGroupDefinitionBuilder {
       boolean computeJacobian,
       boolean computePvSensitivityToMarketQuote) {
     this.name = name;
-    this.entries = entries;
-    this.curveDefinitions = curveDefinitions;
-    this.seasonalityDefinitions = seasonalityDefinitions;
+    this.entries = new LinkedHashMap<>(entries);
+    this.curveDefinitions = new LinkedHashMap<>(curveDefinitions);
+    this.seasonalityDefinitions = new LinkedHashMap<>(seasonalityDefinitions);
     this.computeJacobian = computeJacobian;
     this.computePvSensitivityToMarketQuote = computePvSensitivityToMarketQuote;
   }


### PR DESCRIPTION
Calling `defn.toBuilder().add(xxx)` threw an exception because the `ImmutableMap` was assigned into the builder, thus `map.put()` failed