### PR TITLE
Comparable MarketDataId

### DIFF
--- a/modules/data/src/main/java/com/opengamma/strata/data/MarketDataId.java
+++ b/modules/data/src/main/java/com/opengamma/strata/data/MarketDataId.java
@@ -15,7 +15,7 @@ package com.opengamma.strata.data;
  *
  * @param <T>  the type of the market data this identifier refers to
  */
-public interface MarketDataId<T> {
+public interface MarketDataId<T> extends Comparable<MarketDataId<?>> {
 
   /**
    * Gets the type of data this identifier refers to.
@@ -23,5 +23,21 @@ public interface MarketDataId<T> {
    * @return the type of the market data this identifier refers to
    */
   public abstract Class<T> getMarketDataType();
+
+  /**
+   * Compares two market data identifiers.
+   * <p>
+   * This compares the identifiers using their {@code toString} form.
+   * It is intended that the string fully represents the state of the identifier.
+   * It is recommended that the string starts with the short class name of the implementing class and a colon.
+   * For example, {@link FxRateId#toString()} returns 'FxRate:{currencyPair}'.
+   * 
+   * @param other  the other identifier
+   * @return the comparison
+   */
+  @Override
+  public default int compareTo(MarketDataId<?> other) {
+    return toString().compareTo(other.toString());
+  }
 
 }

--- a/modules/data/src/test/java/com/opengamma/strata/data/MarketDataIdTest.java
+++ b/modules/data/src/test/java/com/opengamma/strata/data/MarketDataIdTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.data;
+
+import static com.opengamma.strata.basics.currency.Currency.CHF;
+import static com.opengamma.strata.basics.currency.Currency.EUR;
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test {@link MarketDataId}.
+ */
+public class MarketDataIdTest {
+
+  @Test
+  public void test_compareSingleType() {
+    FxRateId test1 = FxRateId.of(EUR, CHF);
+    FxRateId test2 = FxRateId.of(EUR, GBP);
+    assertThat(test1).isLessThan(test2);
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void test_compareCrossType() {
+    MarketDataId test1 = FxMatrixId.standard();
+    MarketDataId test2 = FxRateId.of(EUR, GBP);
+    assertThat(test1).isLessThan(test2);
+  }
+
+}


### PR DESCRIPTION
`MarketDataId` should be comparable.
It is possible that this will be incompatible if someone has implemented `Comparable` themselves.