### PR TITLE
Create sample trades from curve nodes

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/CurveNode.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.MarketDataId;
 import com.opengamma.strata.market.ValueType;
@@ -112,6 +113,34 @@ public interface CurveNode {
    * @throws RuntimeException if unable to resolve due to an invalid definition
    */
   public abstract ResolvedTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData);
+
+  /**
+   * Creates a resolved trade representing the instrument at the node.
+   * <p>
+   * This uses an arbitrary quantity, typically 1, and an arbitrary market data quote, typically 0, to create a trade.
+   * This is useful when the trade is to be used to calculate the current par value.
+   * The FX provider is typically only used for cross-currency trades.
+   * In many cases, {@link FxRateProvider#minimal()} can be passed in.
+   * <p>
+   * Resolved objects may be bound to data that changes over time, such as holiday calendars.
+   * If the data changes, such as the addition of a new holiday, the resolved form will not be updated.
+   * Care must be taken when placing the resolved form in a cache or persistence layer.
+   *
+   * @param valuationDate  the valuation date
+   * @param fxProvider  the FX rate provider
+   * @param refData  the reference data, used to resolve the trade
+   * @return a trade representing the instrument at the node
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   * @throws RuntimeException if unable to resolve due to an invalid definition
+   */
+  public default ResolvedTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    // deprecated - this will be made abstract with next set of breaking changes
+    throw new UnsupportedOperationException("CurveNode.sampleResolvedTrade() is not supported");
+  }
 
   /**
    * Gets the initial guess used for calibrating the node.

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNode.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.market.ValueType;
@@ -212,6 +213,16 @@ public final class FixedIborSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedInflationSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedInflationSwapCurveNode.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.MarketData;
@@ -236,6 +237,16 @@ public final class FixedInflationSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNode.java
@@ -27,6 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.market.ValueType;
@@ -200,6 +201,16 @@ public final class FixedOvernightSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FraCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FraCurveNode.java
@@ -27,6 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
@@ -194,6 +195,16 @@ public final class FraCurveNode
   @Override
   public ResolvedFraTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedFraTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    FraTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FxSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/FxSwapCurveNode.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.FxRate;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.data.FxRateId;
@@ -197,6 +198,17 @@ public final class FxSwapCurveNode
   @Override
   public ResolvedFxSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedFxSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    double rate = fxProvider.fxRate(template.getCurrencyPair());
+    FxSwapTrade trade = template.createTrade(valuationDate, BuySell.BUY, 1d, rate, 0d, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFixingDepositCurveNode.java
@@ -27,6 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
@@ -202,6 +203,16 @@ public final class IborFixingDepositCurveNode
   @Override
   public ResolvedIborFixingDepositTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedIborFixingDepositTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    IborFixingDepositTrade trade = template.createTrade(valuationDate, BuySell.BUY, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFutureCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborFutureCurveNode.java
@@ -27,6 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
@@ -188,6 +189,17 @@ public final class IborFutureCurveNode
   @Override
   public ResolvedIborFutureTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedIborFutureTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SecurityId secId = SecurityId.of(rateId.getStandardId());  // quote must also be security
+    IborFutureTrade trade = template.createTrade(valuationDate, secId, 1d, 1d, 1d, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/IborIborSwapCurveNode.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.market.ValueType;
@@ -216,6 +217,16 @@ public final class IborIborSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/OvernightIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/OvernightIborSwapCurveNode.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.market.ValueType;
@@ -215,6 +216,16 @@ public final class OvernightIborSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/TermDepositCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/TermDepositCurveNode.java
@@ -27,6 +27,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
@@ -196,6 +197,16 @@ public final class TermDepositCurveNode
   @Override
   public ResolvedTermDepositTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedTermDepositTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    TermDepositTrade trade = template.createTrade(valuationDate, BuySell.BUY, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/ThreeLegBasisSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/ThreeLegBasisSwapCurveNode.java
@@ -28,6 +28,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.data.MarketData;
 import com.opengamma.strata.data.ObservableId;
 import com.opengamma.strata.market.ValueType;
@@ -216,6 +217,16 @@ public final class ThreeLegBasisSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/node/XCcyIborIborSwapCurveNode.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/node/XCcyIborIborSwapCurveNode.java
@@ -29,6 +29,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.FxRate;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.data.FxRateId;
 import com.opengamma.strata.data.MarketData;
@@ -249,6 +250,17 @@ public final class XCcyIborIborSwapCurveNode
   @Override
   public ResolvedSwapTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData).resolve(refData);
+  }
+
+  @Override
+  public ResolvedSwapTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    double rate = fxProvider.fxRate(template.getCurrencyPair());
+    SwapTrade trade = template.createTrade(valuationDate, BuySell.SELL, 1d, rate, additionalSpread, refData);
+    return trade.resolve(refData);
   }
 
   @Override

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/DummyFraCurveNode.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/DummyFraCurveNode.java
@@ -21,6 +21,7 @@ import org.joda.beans.impl.light.LightMetaBean;
 
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.HolidayCalendars;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.data.MarketData;
@@ -107,6 +108,15 @@ public final class DummyFraCurveNode
   @Override
   public DummyFraTrade resolvedTrade(double quantity, MarketData marketData, ReferenceData refData) {
     return trade(quantity, marketData, refData);
+  }
+
+  @Override
+  public DummyFraTrade sampleResolvedTrade(
+      LocalDate valuationDate,
+      FxRateProvider fxProvider,
+      ReferenceData refData) {
+
+    return DummyFraTrade.of(valuationDate, spread);
   }
 
   @Override

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedIborSwapCurveNodeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;
@@ -35,6 +36,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.FixedIborSwapConventions;
 import com.opengamma.strata.product.swap.type.FixedIborSwapTemplate;
@@ -124,6 +127,15 @@ public class FixedIborSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(VAL_DATE);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    FixedIborSwapCurveNode node = FixedIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedInflationSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedInflationSwapCurveNodeTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.index.PriceIndices;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
@@ -39,6 +40,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.FixedInflationSwapConventions;
 import com.opengamma.strata.product.swap.type.FixedInflationSwapTemplate;
@@ -130,6 +133,15 @@ public class FixedInflationSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(valuationDate);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    FixedInflationSwapCurveNode node = FixedInflationSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FixedOvernightSwapCurveNodeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;
@@ -35,6 +36,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.FixedOvernightSwapConventions;
 import com.opengamma.strata.product.swap.type.FixedOvernightSwapTemplate;
@@ -121,6 +124,15 @@ public class FixedOvernightSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(VAL_DATE);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    FixedOvernightSwapCurveNode node = FixedOvernightSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FraCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FraCurveNodeTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
@@ -46,6 +47,7 @@ import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.fra.Fra;
 import com.opengamma.strata.product.fra.FraTrade;
 import com.opengamma.strata.product.fra.ResolvedFra;
+import com.opengamma.strata.product.fra.ResolvedFraTrade;
 import com.opengamma.strata.product.fra.type.FraTemplate;
 import com.opengamma.strata.product.rate.IborRateComputation;
 
@@ -169,6 +171,15 @@ public class FraCurveNodeTest {
     MarketData marketData = MarketData.empty(valuationDate);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    FraCurveNode node = FraCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedFraTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedFraTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FxSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/FxSwapCurveNodeTest.java
@@ -44,6 +44,7 @@ import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.fx.FxSwapTrade;
+import com.opengamma.strata.product.fx.ResolvedFxSwapTrade;
 import com.opengamma.strata.product.fx.type.FxSwapTemplate;
 import com.opengamma.strata.product.fx.type.ImmutableFxSwapConvention;
 
@@ -154,6 +155,15 @@ public class FxSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(VAL_DATE);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    FxSwapCurveNode node = FxSwapCurveNode.of(TEMPLATE, QUOTE_ID_PTS);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedFxSwapTrade trade = node.sampleResolvedTrade(valuationDate, FX_RATE_NEAR, REF_DATA);
+    ResolvedFxSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.BUY, 1d, 1.3d, 0d, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/IborIborSwapCurveNodeTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;
@@ -34,6 +35,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.IborIborSwapConventions;
 import com.opengamma.strata.product.swap.type.IborIborSwapTemplate;
@@ -125,6 +128,15 @@ public class IborIborSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(valuationDate);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    IborIborSwapCurveNode node = IborIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/OvernightIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/OvernightIborSwapCurveNodeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;
@@ -35,6 +36,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.OvernightIborSwapConventions;
 import com.opengamma.strata.product.swap.type.OvernightIborSwapTemplate;
@@ -126,6 +129,15 @@ public class OvernightIborSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(valuationDate);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    OvernightIborSwapCurveNode node = OvernightIborSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
@@ -172,7 +172,7 @@ public class TermDepositCurveNodeTest {
     TermDepositCurveNode node = TermDepositCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
     LocalDate valuationDate = LocalDate.of(2015, 1, 22);
     ResolvedTermDepositTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
-    ResolvedTermDepositTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    ResolvedTermDepositTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.BUY, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
     assertThat(trade).isEqualTo(expected);
   }
 

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/TermDepositCurveNodeTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.Tenor;
@@ -41,6 +42,7 @@ import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.deposit.ResolvedTermDepositTrade;
 import com.opengamma.strata.product.deposit.TermDeposit;
 import com.opengamma.strata.product.deposit.TermDepositTrade;
 import com.opengamma.strata.product.deposit.type.TermDepositConvention;
@@ -163,6 +165,15 @@ public class TermDepositCurveNodeTest {
     MarketData marketData = MarketData.empty(valuationDate);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    TermDepositCurveNode node = TermDepositCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedTermDepositTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedTermDepositTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/ThreeLegBasisSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/ThreeLegBasisSwapCurveNodeTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.FxRateProvider;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.data.ImmutableMarketData;
 import com.opengamma.strata.data.MarketData;
@@ -34,6 +35,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.ThreeLegBasisSwapConventions;
 import com.opengamma.strata.product.swap.type.ThreeLegBasisSwapTemplate;
@@ -123,6 +126,15 @@ public class ThreeLegBasisSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(VAL_DATE);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    ThreeLegBasisSwapCurveNode node = ThreeLegBasisSwapCurveNode.of(TEMPLATE, QUOTE_ID, SPREAD);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FxRateProvider.minimal(), REF_DATA);
+    ResolvedSwapTrade expected = TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, SPREAD, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/node/XCcyIborIborSwapCurveNodeTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/node/XCcyIborIborSwapCurveNodeTest.java
@@ -39,6 +39,8 @@ import com.opengamma.strata.market.observable.QuoteId;
 import com.opengamma.strata.market.param.DatedParameterMetadata;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.TenorDateParameterMetadata;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.ResolvedSwapTrade;
 import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.XCcyIborIborSwapConventions;
 import com.opengamma.strata.product.swap.type.XCcyIborIborSwapTemplate;
@@ -159,6 +161,16 @@ public class XCcyIborIborSwapCurveNodeTest {
     MarketData marketData = MarketData.empty(VAL_DATE);
     assertThatExceptionOfType(MarketDataNotFoundException.class)
         .isThrownBy(() -> node.trade(1d, marketData, REF_DATA));
+  }
+
+  @Test
+  public void test_sampleResolvedTrade() {
+    XCcyIborIborSwapCurveNode node = XCcyIborIborSwapCurveNode.of(TEMPLATE, SPREAD_ID, SPREAD_ADJ);
+    LocalDate valuationDate = LocalDate.of(2015, 1, 22);
+    ResolvedSwapTrade trade = node.sampleResolvedTrade(valuationDate, FX_EUR_USD, REF_DATA);
+    ResolvedSwapTrade expected =
+        TEMPLATE.createTrade(valuationDate, BuySell.SELL, 1d, 1.25d, SPREAD_ADJ, REF_DATA).resolve(REF_DATA);
+    assertThat(trade).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
A curve node is often used to create a sample trade, one without a real notional or market quote 