### PR TITLE
Fix DaysAdjustment.ofBusinessDays

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/DaysAdjustment.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/DaysAdjustment.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.basics.date;
 
+import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
+
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Map;
@@ -149,12 +151,18 @@ public final class DaysAdjustment
    * This is equivalent to repeatedly finding the next business day.
    * <p>
    * No business day adjustment is applied to the result of the addition.
+   * <p>
+   * If the input is a holiday, the first business day counted will be the next business day.
+   * If the input is a holiday and the number of days to add is zero, the result will be the next business day.
    * 
    * @param numberOfDays  the number of days
    * @param holidayCalendar  the calendar that defines holidays and business days
    * @return the days adjustment
    */
   public static DaysAdjustment ofBusinessDays(int numberOfDays, HolidayCalendarId holidayCalendar) {
+    if (numberOfDays == 0) {
+      return new DaysAdjustment(0, HolidayCalendarIds.NO_HOLIDAYS, BusinessDayAdjustment.of(FOLLOWING, holidayCalendar));
+    }
     return new DaysAdjustment(numberOfDays, holidayCalendar, BusinessDayAdjustment.NONE);
   }
 

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/DaysAdjustmentTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/DaysAdjustmentTest.java
@@ -101,6 +101,14 @@ public class DaysAdjustmentTest {
   }
 
   @Test
+  public void test_ofCalendarDays2_adjustHoliday() {
+    DaysAdjustment test = DaysAdjustment.ofCalendarDays(2, BDA_FOLLOW_SAT_SUN);
+    LocalDate base = date(2014, 8, 16);  // Sat
+    assertThat(test.adjust(base, REF_DATA)).isEqualTo(date(2014, 8, 18));  // Mon
+    assertThat(test.resolve(REF_DATA).adjust(base)).isEqualTo(date(2014, 8, 18));  // Mon
+  }
+
+  @Test
   public void test_ofCalendarDays2_null() {
     assertThatIllegalArgumentException().isThrownBy(() -> DaysAdjustment.ofCalendarDays(2, null));
   }
@@ -173,6 +181,20 @@ public class DaysAdjustmentTest {
     assertThatIllegalArgumentException().isThrownBy(() -> DaysAdjustment.ofBusinessDays(3, null, BDA_FOLLOW_SAT_SUN));
     assertThatIllegalArgumentException().isThrownBy(() -> DaysAdjustment.ofBusinessDays(3, SAT_SUN, null));
     assertThatIllegalArgumentException().isThrownBy(() -> DaysAdjustment.ofBusinessDays(3, null, null));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_ofBusinessDays0() {
+    DaysAdjustment test = DaysAdjustment.ofBusinessDays(0, SAT_SUN);
+    assertThat(test.getDays()).isEqualTo(0);
+    assertThat(test.getCalendar()).isEqualTo(NO_HOLIDAYS);
+    assertThat(test.getAdjustment()).isEqualTo(BDA_FOLLOW_SAT_SUN);
+    assertThat(test.toString()).isEqualTo("0 calendar days then apply Following using calendar Sat/Sun");
+    assertThat(test.adjust(date(2014, 8, 15), REF_DATA)).isEqualTo(date(2014, 8, 15));  // Fri
+    assertThat(test.adjust(date(2014, 8, 16), REF_DATA)).isEqualTo(date(2014, 8, 18));  // Sat -> Mon
+    assertThat(test.adjust(date(2014, 8, 17), REF_DATA)).isEqualTo(date(2014, 8, 18));  // Sun -> Mon
+    assertThat(test.adjust(date(2014, 8, 18), REF_DATA)).isEqualTo(date(2014, 8, 18));  // Mon
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedOvernightSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedOvernightSwapConventionsTest.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.product.swap.type;
 
 import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
+import static com.opengamma.strata.collect.TestHelper.date;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
@@ -173,6 +174,13 @@ public class FixedOvernightSwapConventionsTest {
     LocalDate endDate = swapResolved.getLeg(PayReceive.PAY).get().getEndDate();
     assertThat(endDate.isAfter(tradeDate.plus(tenor).minusMonths(1))).isTrue();
     assertThat(endDate.isBefore(tradeDate.plus(tenor).plusMonths(1))).isTrue();
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_spotFromHoliday() {
+    FixedOvernightSwapConvention convention = FixedOvernightSwapConventions.GBP_FIXED_TERM_SONIA_OIS;
+    assertThat(convention.getSpotDateOffset().adjust(date(2020, 6, 14), REF_DATA)).isEqualTo(date(2020, 6, 15));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Ensure that `ofBusinessDays()` always returns a business day.
Fixes case where input is a holiday and days to add is zero.

https://forums.opengamma.com/t/1d-ois-periodic-schedule-adjusted-start-end-issue/1003/4