### PR TITLE
Fix the trade type name in TradeCsvWriter exception message

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvWriter.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvWriter.java
@@ -286,7 +286,7 @@ public final class TradeCsvWriter {
       TradeTypeCsvWriter detailsWriter = WRITERS.get(entry.getKey());
       if (detailsWriter == null) {
         throw new IllegalArgumentException(
-            "Unable to write trade to CSV: " + entry.getKey().getClass().getSimpleName());
+            "Unable to write trade type to CSV: " + entry.getKey().getSimpleName());
       }
       headers.addAll(detailsWriter.headers((List) entry.getValue()));
     }


### PR DESCRIPTION
On exception, the trade type was always 'Class' when a CSV converter could not be found. 