### PR TITLE
Ensure only one direction per FX pair is considered conventional

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyPair.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyPair.java
@@ -262,6 +262,12 @@ public final class CurrencyPair
     if (CONFIGURED.containsKey(this)) {
       return true;
     }
+
+    // If the inverse of the pair is in the configuration file then it is not a market convention pair
+    if (CONFIGURED.containsKey(inverse())) {
+      return false;
+    }
+
     // Get the priorities of the currencies to determine which should be the base
     Integer basePriority = CURRENCY_ORDERING.getOrDefault(base, Integer.MAX_VALUE);
     Integer counterPriority = CURRENCY_ORDERING.getOrDefault(counter, Integer.MAX_VALUE);

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyPairTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/currency/CurrencyPairTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Test {@link CurrencyPair}.
  */
@@ -79,7 +81,7 @@ public class CurrencyPairTest {
 
   //-------------------------------------------------------------------------
   public static Object[][] data_parseGood() {
-    return new Object[][] {
+    return new Object[][]{
         {"USD/EUR", USD, EUR},
         {"EUR/USD", EUR, USD},
         {"EUR/EUR", EUR, EUR},
@@ -94,7 +96,7 @@ public class CurrencyPairTest {
   }
 
   public static Object[][] data_parseBad() {
-    return new Object[][] {
+    return new Object[][]{
         {"AUD"},
         {"AUD/GB"},
         {"AUD GBP"},
@@ -234,6 +236,23 @@ public class CurrencyPairTest {
     assertThat(CurrencyPair.of(BHD, BRL).isConventional()).isEqualTo(true);
     assertThat(CurrencyPair.of(BRL, BHD).isConventional()).isEqualTo(false);
     assertThat(CurrencyPair.of(GBP, GBP).isConventional()).isEqualTo(true);
+  }
+
+  @Test
+  public void test_isConventional_Consistency() {
+
+    // Assert that all possible pairs of currencies have 1 'conventional' direction
+    ImmutableList<Currency> allCurrencies = ImmutableList.copyOf(Currency.getAvailableCurrencies());
+
+    for (int i = 0; i < allCurrencies.size(); i++) {
+      Currency currency1 = allCurrencies.get(i);
+      for (int j = i + 1; j < allCurrencies.size(); j++) {
+        Currency currency2 = allCurrencies.get(j);
+        CurrencyPair pair = CurrencyPair.of(currency1, currency2);
+        CurrencyPair inversePair = CurrencyPair.of(currency2, currency1);
+        assertThat(pair.isConventional()).isNotEqualTo(inversePair.isConventional());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Prior to this there could be a situation where both directions would return true for isConventional().

This was the case for all USD/metal pairs (e.g. USD/XAU) and occurred because one direction was listed in the static file (XAU/USD) but the first currency (XAU) had a lower priority order than the second (USD).

Thus isConventional() returned true for USD/XAU because USD is higher priority whilst XAU/USD also returned true because that pair is in the file