### PR TITLE
Fix ArrayByteSource.contentEquals

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/ArrayByteSource.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/ArrayByteSource.java
@@ -35,7 +35,6 @@ import org.joda.beans.impl.BasicImmutableBeanBuilder;
 import org.joda.beans.impl.BasicMetaBean;
 import org.joda.beans.impl.BasicMetaProperty;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -529,7 +528,7 @@ public final class ArrayByteSource extends BeanByteSource implements ImmutableBe
   @Override
   public boolean contentEquals(ByteSource other) throws IOException {
     if (other instanceof ArrayByteSource) {
-      return equals(other);
+      return JodaBeanUtils.equal(array, ((ArrayByteSource) other).array);
     }
     return super.contentEquals(other);
   }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
@@ -331,6 +331,7 @@ public class ArrayByteSourceTest {
     assertThat(test.contentEquals(test)).isTrue();
     assertThat(test.toString()).isEqualTo("ArrayByteSource[3 bytes]");
     assertThat(test.withFileName("name.txt").toString()).isEqualTo("ArrayByteSource[3 bytes, name.txt]");
+    assertThat(test.withFileName("name.txt").contentEquals(test)).isTrue();
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Since equals() changed, this now needs to be implemented from scratch