### PR TITLE
Allow any index in ImmutableRatesProvider

### DIFF
--- a/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
+++ b/modules/measure/src/main/java/com/opengamma/strata/measure/rate/DefaultLookupRatesProvider.java
@@ -122,6 +122,11 @@ final class DefaultLookupRatesProvider
   }
 
   @Override
+  public Stream<Index> indices() {
+    return lookup.getForwardIndices().stream();
+  }
+
+  @Override
   public ImmutableSet<IborIndex> getIborIndices() {
     return lookup.getForwardIndices().stream()
         .flatMap(filtering(IborIndex.class))

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProvider.java
@@ -160,6 +160,11 @@ public final class ImmutableRatesProvider
   }
 
   @Override
+  public Stream<Index> indices() {
+    return indexCurves.keySet().stream();
+  }
+
+  @Override
   public ImmutableSet<IborIndex> getIborIndices() {
     return indexCurves.keySet().stream()
         .flatMap(filtering(IborIndex.class))

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderBuilder.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderBuilder.java
@@ -243,8 +243,10 @@ public final class ImmutableRatesProviderBuilder {
    * Adds an index forward curve to the provider.
    * <p>
    * This adds the specified forward curve to the provider.
-   * This is used for Ibor, Overnight and Price indices.
    * This operates using {@link Map#put(Object, Object)} semantics using the index as the key.
+   * <p>
+   * Any index may be used, however {@link RatesProvider} only directly supports
+   * Ibor, Overnight and Price indices.
    * 
    * @param index  the index of the curve
    * @param forwardCurve  the Ibor index forward curve
@@ -253,11 +255,7 @@ public final class ImmutableRatesProviderBuilder {
   public ImmutableRatesProviderBuilder indexCurve(Index index, Curve forwardCurve) {
     ArgChecker.notNull(index, "index");
     ArgChecker.notNull(forwardCurve, "forwardCurve");
-    if (index instanceof IborIndex || index instanceof OvernightIndex || index instanceof PriceIndex) {
-      this.indexCurves.put(index, forwardCurve);
-    } else {
-      throw new IllegalArgumentException("Unsupported index: " + index);
-    }
+    this.indexCurves.put(index, forwardCurve);
     return this;
   }
 
@@ -265,8 +263,10 @@ public final class ImmutableRatesProviderBuilder {
    * Adds an index forward curve to the provider with associated time-series.
    * <p>
    * This adds the specified forward curve to the provider.
-   * This is used for Ibor, Overnight and Price indices.
    * This operates using {@link Map#put(Object, Object)} semantics using the index as the key.
+   * <p>
+   * Any index may be used, however {@link RatesProvider} only directly supports
+   * Ibor, Overnight and Price indices.
    * 
    * @param index  the index of the curve
    * @param forwardCurve  the Ibor index forward curve
@@ -276,12 +276,8 @@ public final class ImmutableRatesProviderBuilder {
   public ImmutableRatesProviderBuilder indexCurve(Index index, Curve forwardCurve, LocalDateDoubleTimeSeries timeSeries) {
     ArgChecker.notNull(index, "index");
     ArgChecker.notNull(forwardCurve, "forwardCurve");
-    if (index instanceof IborIndex || index instanceof OvernightIndex || index instanceof PriceIndex) {
-      this.indexCurves.put(index, forwardCurve);
-      this.timeSeries.put(index, timeSeries);
-    } else {
-      throw new IllegalArgumentException("Unsupported index: " + index);
-    }
+    this.indexCurves.put(index, forwardCurve);
+    this.timeSeries.put(index, timeSeries);
     return this;
   }
 
@@ -289,8 +285,10 @@ public final class ImmutableRatesProviderBuilder {
    * Adds index forward curves to the provider with associated time-series.
    * <p>
    * This adds the specified index forward curves to the provider.
-   * This is used for Ibor, Overnight and Price indices.
    * This operates using {@link Map#putAll(Map)} semantics using the index as the key.
+   * <p>
+   * Any index may be used, however {@link RatesProvider} only directly supports
+   * Ibor, Overnight and Price indices.
    * 
    * @param indexCurves  the index forward curves
    * @return this, for chaining
@@ -307,8 +305,10 @@ public final class ImmutableRatesProviderBuilder {
    * Adds index forward curves to the provider with associated time-series.
    * <p>
    * This adds the specified index forward curves to the provider.
-   * This is used for Ibor, Overnight and Price indices.
    * This operates using {@link Map#putAll(Map)} semantics using the index as the key.
+   * <p>
+   * Any index may be used, however {@link RatesProvider} only directly supports
+   * Ibor, Overnight and Price indices.
    * 
    * @param indexCurves  the index forward curves
    * @param timeSeries  the associated time-series
@@ -334,6 +334,9 @@ public final class ImmutableRatesProviderBuilder {
    * <p>
    * This adds the specified time-series to the provider.
    * This operates using {@link Map#put(Object, Object)} semantics using the index as the key.
+   * <p>
+   * Any index may be used, however {@link RatesProvider} only directly supports
+   * Ibor, Overnight and Price indices.
    * 
    * @param index  the FX index
    * @param timeSeries  the FX index time-series
@@ -351,6 +354,9 @@ public final class ImmutableRatesProviderBuilder {
    * <p>
    * This adds the specified time-series to the provider.
    * This operates using {@link Map#putAll(Map)} semantics using the index as the key.
+   * <p>
+   * Any index may be used, however {@link RatesProvider} only directly supports
+   * Ibor, Overnight and Price indices.
    * 
    * @param timeSeries  the FX index time-series
    * @return this, for chaining

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/RatesProvider.java
@@ -7,6 +7,7 @@ package com.opengamma.strata.pricer.rate;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
@@ -15,6 +16,7 @@ import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.Index;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.index.PriceIndex;
+import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.MarketDataName;
 import com.opengamma.strata.market.curve.Curve;
@@ -42,6 +44,18 @@ import com.opengamma.strata.pricer.fx.FxIndexSensitivity;
  */
 public interface RatesProvider
     extends BaseProvider {
+
+  /**
+   * Gets the forward indices that are available.
+   * <p>
+   * Normally this will only return Ibor, Overnight and Price indices,
+   * however it may return other types of index.
+   *
+   * @return the indices
+   */
+  public default Stream<Index> indices() {
+    return Guavate.<Index>concatToSet(getIborIndices(), getOvernightIndices(), getPriceIndices()).stream();
+  }
 
   /**
    * Gets the set of Ibor indices that are available.

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/MockRatesProvider.java
@@ -69,17 +69,17 @@ public class MockRatesProvider
 
   @Override
   public ImmutableSet<IborIndex> getIborIndices() {
-    throw new UnsupportedOperationException();
+    return ImmutableSet.of();
   }
 
   @Override
   public ImmutableSet<OvernightIndex> getOvernightIndices() {
-    throw new UnsupportedOperationException();
+    return ImmutableSet.of();
   }
 
   @Override
   public ImmutableSet<PriceIndex> getPriceIndices() {
-    throw new UnsupportedOperationException();
+    return ImmutableSet.of();
   }
 
   @Override

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/ImmutableRatesProviderTest.java
@@ -161,6 +161,7 @@ public class ImmutableRatesProviderTest {
         .build();
     assertThat(test.iborIndexRates(USD_LIBOR_3M).getIndex()).isEqualTo(USD_LIBOR_3M);
     assertThat(test.iborIndexRates(USD_LIBOR_3M).getFixings()).isEqualTo(ts);
+    assertThat(test.indices()).containsOnly(USD_LIBOR_3M);
     assertThat(test.getIborIndices()).containsOnly(USD_LIBOR_3M);
     assertThat(test.getTimeSeriesIndices()).containsOnly(USD_LIBOR_3M);
   }
@@ -181,6 +182,7 @@ public class ImmutableRatesProviderTest {
         .build();
     assertThat(test.iborIndexRates(inactiveIndex).getIndex()).isEqualTo(inactiveIndex);
     assertThat(test.iborIndexRates(inactiveIndex).getFixings()).isEqualTo(ts);
+    assertThat(test.indices()).isEmpty();
     assertThat(test.getIborIndices()).isEmpty();
     assertThat(test.getTimeSeriesIndices()).containsOnly(inactiveIndex);
     assertThat(test.iborIndexRates(inactiveIndex).getClass()).isEqualTo(HistoricIborIndexRates.class);
@@ -204,6 +206,7 @@ public class ImmutableRatesProviderTest {
         .build();
     assertThat(test.overnightIndexRates(USD_FED_FUND).getIndex()).isEqualTo(USD_FED_FUND);
     assertThat(test.overnightIndexRates(USD_FED_FUND).getFixings()).isEqualTo(ts);
+    assertThat(test.indices()).containsOnly(USD_FED_FUND);
     assertThat(test.getOvernightIndices()).containsOnly(USD_FED_FUND);
     assertThat(test.getTimeSeriesIndices()).containsOnly(USD_FED_FUND);
   }
@@ -224,7 +227,8 @@ public class ImmutableRatesProviderTest {
         .build();
     assertThat(test.overnightIndexRates(inactiveIndex).getIndex()).isEqualTo(inactiveIndex);
     assertThat(test.overnightIndexRates(inactiveIndex).getFixings()).isEqualTo(ts);
-    assertThat(test.getIborIndices()).isEmpty();
+    assertThat(test.indices()).isEmpty();
+    assertThat(test.getOvernightIndices()).isEmpty();
     assertThat(test.getTimeSeriesIndices()).containsOnly(inactiveIndex);
     assertThat(test.overnightIndexRates(inactiveIndex).getClass()).isEqualTo(HistoricOvernightIndexRates.class);
   }
@@ -247,6 +251,7 @@ public class ImmutableRatesProviderTest {
         .build();
     assertThat(test.priceIndexValues(GB_RPI).getIndex()).isEqualTo(GB_RPI);
     assertThat(test.priceIndexValues(GB_RPI).getFixings()).isEqualTo(ts);
+    assertThat(test.indices()).containsOnly(GB_RPI);
     assertThat(test.getPriceIndices()).containsOnly(GB_RPI);
     assertThat(test.getTimeSeriesIndices()).containsOnly(GB_RPI);
   }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/RatesProviderTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/rate/RatesProviderTest.java
@@ -26,4 +26,10 @@ public class RatesProviderTest {
     assertThat(mockProv.fxRate(CurrencyPair.of(GBP, USD))).isEqualTo(RATE);
   }
 
+  @Test
+  public void test_indices() {
+    RatesProvider mockProv = new MockRatesProvider();
+    assertThat(mockProv.indices()).isEmpty();
+  }
+
 }


### PR DESCRIPTION
This is more consistent with `DefaultLookupRatesProvider`
It paves the way for extending `RatesProvider` if desired