### PR TITLE
Add getFileNameOrThrow utility method to BeanByteSource

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/io/BeanByteSource.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/io/BeanByteSource.java
@@ -49,6 +49,19 @@ public abstract class BeanByteSource extends ByteSource implements ImmutableBean
     return Optional.empty();
   }
 
+  /**
+   * Gets the file name of the source.
+   * <p>
+   * Most sources originate from a file-based location.
+   * This is captured and returned here where available.
+   *
+   * @return the file name
+   * @throws IllegalArgumentException if the file name is not known
+   */
+  public String getFileNameOrThrow() {
+    return getFileName().orElseThrow(() -> new IllegalArgumentException("No file name present on byte source"));
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Checks if the byte source is empty, throwing an unchecked exception.

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/ArrayByteSourceTest.java
@@ -249,7 +249,9 @@ public class ArrayByteSourceTest {
     assertThat(test.getFileName()).isEmpty();
     assertThat(test.withFileName("name.txt").getFileName()).hasValue("name.txt");
     assertThat(test.withFileName("foo/name.txt").getFileName()).hasValue("name.txt");
+    assertThat(test.withFileName("foo/name.txt").getFileNameOrThrow()).isEqualTo("name.txt");
     assertThat(test.withFileName("").getFileName()).isEmpty();
+    assertThatIllegalArgumentException().isThrownBy(() -> test.withFileName("").getFileNameOrThrow());
     assertThatIllegalArgumentException().isThrownBy(() -> test.withFileName(null).getFileName());
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/FileByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/FileByteSourceTest.java
@@ -26,6 +26,7 @@ public class FileByteSourceTest {
     File file = new File("pom.xml");
     FileByteSource test = FileByteSource.of(file);
     assertThat(test.getFileName()).hasValue("pom.xml");
+    assertThat(test.getFileNameOrThrow()).isEqualTo("pom.xml");
     assertThat(test.getFile()).isSameAs(file);
     assertThat(test.isEmpty()).isFalse();
     assertThat(test.size()).isGreaterThan(100);
@@ -36,6 +37,7 @@ public class FileByteSourceTest {
     assertThat(test.asCharSourceUtf8().read()).startsWith("<");
     assertThat(test.asCharSourceUtf8UsingBom().read()).startsWith("<");
     assertThat(test.load().getFileName()).hasValue("pom.xml");
+    assertThat(test.load().getFileNameOrThrow()).isEqualTo("pom.xml");
     assertThat(test.load().readUtf8()).startsWith("<");
   }
 

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/io/UriByteSourceTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/io/UriByteSourceTest.java
@@ -26,6 +26,7 @@ public class UriByteSourceTest {
     URI uri = new File("pom.xml").toURI();
     UriByteSource test = UriByteSource.of(uri);
     assertThat(test.getFileName()).hasValue("pom.xml");
+    assertThat(test.getFileNameOrThrow()).isEqualTo("pom.xml");
     assertThat(test.getUri()).isSameAs(uri);
     assertThat(test.isEmpty()).isFalse();
     assertThat(test.size()).isGreaterThan(100);
@@ -36,6 +37,7 @@ public class UriByteSourceTest {
     assertThat(test.asCharSourceUtf8().read()).startsWith("<");
     assertThat(test.asCharSourceUtf8UsingBom().read()).startsWith("<");
     assertThat(test.load().getFileName()).hasValue("pom.xml");
+    assertThat(test.load().getFileNameOrThrow()).isEqualTo("pom.xml");
     assertThat(test.load().readUtf8()).startsWith("<");
   }
 


### PR DESCRIPTION
Working with lots of files and having to use `.getFileName().orElseThrow(() -> )` gets repetitive, and despite knowing that the Optional is always present doesn't mean I want to use `.get()` on the end and have to suppress a warning.