### PR TITLE
Fix Hungarian working Saturdays for 2020.

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
@@ -1028,6 +1028,7 @@ final class GlobalHolidayCalendars {
   // http://www.ucmsgroup.hu/newsletter/public-holiday-and-related-work-schedule-changes-in-2015/
   // http://www.ucmsgroup.hu/newsletter/public-holiday-and-related-work-schedule-changes-in-2014/
   // https://www.bse.hu/Products-and-Services/Trading-information/tranding-calendar-2019
+  // https://www.bse.hu/Products-and-Services/Trading-information/trading-calendar-2020
   static ImmutableHolidayCalendar generateBudapest() {
     List<LocalDate> holidays = new ArrayList<>(2000);
     Set<LocalDate> workDays = new HashSet<>(500);
@@ -1047,7 +1048,10 @@ final class GlobalHolidayCalendars {
       // pentecost monday
       holidays.add(easter(year).plusDays(50));
       // state foundation day
-      addDateWithHungarianBridging(date(year, 8, 20), 0, -2, holidays, workDays);
+      // in 2015 the working saturday was 2 weeks before, in 2020 it was 1 week after
+      // unclear what the logic behind this is,
+      int foundationDayThuRelativeWeeks = year == 2020 ? 1 : -2 ;
+      addDateWithHungarianBridging(date(year, 8, 20), 0 , foundationDayThuRelativeWeeks, holidays, workDays);
       // national day
       addDateWithHungarianBridging(date(year, 10, 23), 0, -1, holidays, workDays);
       // all saints day

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
@@ -1050,7 +1050,7 @@ final class GlobalHolidayCalendars {
       // state foundation day
       // in 2015 the working saturday was 2 weeks before, in 2020 it was 1 week after
       // unclear what the logic behind this is,
-      int foundationDayThuRelativeWeeks = year == 2020 ? 1 : -2 ;
+      int foundationDayThuRelativeWeeks = year == 2020 ? 1 : -2;
       addDateWithHungarianBridging(date(year, 8, 20), 0 , foundationDayThuRelativeWeeks, holidays, workDays);
       // national day
       addDateWithHungarianBridging(date(year, 10, 23), 0, -1, holidays, workDays);

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
@@ -899,6 +899,9 @@ public class GlobalHolidayCalendarsTest {
         {2016, mds(2016, md(1, 1), md(3, 14), md(3, 15), md(3, 28), md(5, 1), md(5, 16),
             md(10, 31), md(11, 1), md(12, 24), md(12, 25), md(12, 26)),
             ImmutableList.of(date(2016, 3, 5), date(2016, 10, 15))},
+        {2020, mds(2020, md(1, 1), md(3, 15), md(4, 10), md(4, 13), md(5, 1), md(6, 1),
+            md(8, 20), md(8, 21), md(10, 23), md(12, 24), md(12, 25), md(12, 26)),
+            ImmutableList.of(date(2020, 8, 29), date(2020, 12, 12))},
     };
   }
 


### PR DESCRIPTION
Per below sources, the August working Saturday for 2020 is 1 week after the long weekend.
https://helpers.hu/other/bank-holidays-in-hungary-in-2020/
https://www.timeanddate.com/holidays/hungary/2020

The last time that National Day fell on a Thursday was 2015. On this occasion the working Saturday was two weeks prior to the long weekend. Assumedly that's where we derived our logic from.
https://www.timeanddate.com/holidays/hungary/2015

So unclear what the logic is for deciding where the working Saturday falls, it may not even be algorithmic.

This change ensures we at least get the right date for 2020. Probably need to revisit in 2026!