### PR TITLE
Add constants for StandardId schemes

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/SwapTradeExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/SwapTradeExample.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.examples.finance;
 
+import static com.opengamma.strata.basics.StandardSchemes.OG_TRADE_SCHEME;
 import static com.opengamma.strata.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
 
 import java.time.LocalDate;
@@ -217,7 +218,7 @@ public class SwapTradeExample {
     // a SwapTrade combines the two legs
     SwapTrade trade = SwapTrade.builder()
         .info(TradeInfo.builder()
-            .id(StandardId.of("OG-Trade", "1"))
+            .id(StandardId.of(OG_TRADE_SCHEME, "1"))
             .tradeDate(LocalDate.of(2014, 9, 10))
             .build())
         .product(Swap.of(payLeg, receiveLeg))

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/StandardSchemes.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/StandardSchemes.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics;
+
+/**
+ * A set of schemes that can be used with {@code StandardId}.
+ * <p>
+ * The scheme part of a {@link StandardId} is freeform, but it obviously works best where
+ * the scheme name is widely agreed. This class contains a set of useful constants.
+ */
+public final class StandardSchemes {
+
+  /**
+   * The OpenGamma scheme used to identify values in market data.
+   */
+  public static final String OG_TICKER_SCHEME = "OG-Ticker";
+  /**
+   * The OpenGamma scheme used to identify ETDs in market data.
+   */
+  public static final String OG_ETD_SCHEME = "OG-ETD";
+  /**
+   * The OpenGamma scheme used for trade identifiers.
+   */
+  public static final String OG_TRADE_SCHEME = "OG-Trade";
+  /**
+   * The OpenGamma scheme used for position identifiers.
+   */
+  public static final String OG_POSITION_SCHEME = "OG-Position";
+  /**
+   * The OpenGamma scheme used for portfolio sensitivity identifiers.
+   */
+  public static final String OG_SENSITIVITY_SCHEME = "OG-Sensitivity";
+  /**
+   * The OpenGamma scheme used for securities.
+   */
+  public static final String OG_SECURITY_SCHEME = "OG-Security";
+  /**
+   * The OpenGamma scheme used for counterparties.
+   */
+  public static final String OG_COUNTERPARTY = "OG-Counterparty";
+
+  /**
+   * The scheme for ISINs.
+   * <p>
+   * https://en.wikipedia.org/wiki/International_Securities_Identification_Number
+   */
+  public static final String ISIN_SCHEME = "ISIN";
+  /**
+   * The scheme for CUSIPs, the North American numbering system.
+   * <p>
+   * https://en.wikipedia.org/wiki/CUSIP
+   */
+  public static final String CUSIP_SCHEME = "CUSIP";
+  /**
+   * The scheme for SEDOLs, the United Kingdom numbering system.
+   * <p>
+   * https://en.wikipedia.org/wiki/SEDOL
+   */
+  public static final String SEDOL_SCHEME = "SEDOL";
+  /**
+   * The scheme for Wertpapierkennnummer, the German numbering system.
+   * <p>
+   * https://en.wikipedia.org/wiki/Wertpapierkennnummer
+   */
+  public static final String WKN_SCHEME = "WKN";
+  /**
+   * The scheme for VALOR numbers, the Swiss numbering system.
+   * <p>
+   * https://en.wikipedia.org/wiki/Valoren_number
+   */
+  public static final String VALOR_SCHEME = "VALOR";
+
+  /**
+   * The scheme for RICs, the Reuters Instrument Code.
+   * <p>
+   * https://en.wikipedia.org/wiki/Reuters_Instrument_Code
+   */
+  public static final String RIC_SCHEME = "RIC";
+  /**
+   * The scheme for Chain RICs, which identifies a set of linked RICs.
+   */
+  public static final String CHAIN_RIC_SCHEME = "CHAINRIC";
+  /**
+   * The scheme for Bloomberg Tickers.
+   */
+  public static final String BBG_SCHEME = "BBG";
+  /**
+   * The scheme for FIGIs, the Financial Instrument Global Identifier.
+   * <p>
+   * https://en.wikipedia.org/wiki/Financial_Instrument_Global_Identifier
+   */
+  public static final String FIGI_SCHEME = "FIGI";
+  /**
+   * The scheme for LEIs, the Legal Entity Identifier.
+   * <p>
+   * https://en.wikipedia.org/wiki/Legal_Entity_Identifier
+   */
+  public static final String LEI_SCHEME = "LEI";
+  /**
+   * The scheme for 6 character RED codes, the Reference Entity Data code.
+   * <p>
+   * https://ihsmarkit.com/products/red-cds.html
+   */
+  public static final String RED6_SCHEME = "RED6";
+  /**
+   * The scheme for 9 character RED codes, the Reference Entity Data code.
+   * <p>
+   * https://ihsmarkit.com/products/red-cds.html
+   */
+  public static final String RED9_SCHEME = "RED9";
+
+  // restricted constructor
+  private StandardSchemes() {
+  }
+
+}

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/StandardSchemesTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/StandardSchemesTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test {@link StandardId}.
+ */
+public class StandardSchemesTest {
+
+  @Test
+  public void test_schemes() {
+    assertThat(StandardSchemes.OG_TICKER_SCHEME).isEqualTo("OG-Ticker");
+    assertThat(StandardSchemes.OG_ETD_SCHEME).isEqualTo("OG-ETD");
+    assertThat(StandardSchemes.OG_TRADE_SCHEME).isEqualTo("OG-Trade");
+    assertThat(StandardSchemes.OG_POSITION_SCHEME).isEqualTo("OG-Position");
+    assertThat(StandardSchemes.OG_SENSITIVITY_SCHEME).isEqualTo("OG-Sensitivity");
+    assertThat(StandardSchemes.OG_SECURITY_SCHEME).isEqualTo("OG-Security");
+    assertThat(StandardSchemes.OG_COUNTERPARTY).isEqualTo("OG-Counterparty");
+
+    assertThat(StandardSchemes.ISIN_SCHEME).isEqualTo("ISIN");
+    assertThat(StandardSchemes.CUSIP_SCHEME).isEqualTo("CUSIP");
+    assertThat(StandardSchemes.SEDOL_SCHEME).isEqualTo("SEDOL");
+    assertThat(StandardSchemes.WKN_SCHEME).isEqualTo("WKN");
+    assertThat(StandardSchemes.VALOR_SCHEME).isEqualTo("VALOR");
+
+    assertThat(StandardSchemes.RIC_SCHEME).isEqualTo("RIC");
+    assertThat(StandardSchemes.CHAIN_RIC_SCHEME).isEqualTo("CHAINRIC");
+    assertThat(StandardSchemes.BBG_SCHEME).isEqualTo("BBG");
+    assertThat(StandardSchemes.FIGI_SCHEME).isEqualTo("FIGI");
+    assertThat(StandardSchemes.LEI_SCHEME).isEqualTo("LEI");
+    assertThat(StandardSchemes.RED6_SCHEME).isEqualTo("RED6");
+    assertThat(StandardSchemes.RED9_SCHEME).isEqualTo("RED9");
+  }
+
+}

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/LoaderUtils.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/LoaderUtils.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import com.google.common.base.CharMatcher;
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
 import com.opengamma.strata.basics.date.DayCount;
@@ -52,15 +53,15 @@ public final class LoaderUtils {
   /**
    * Default scheme for trades.
    */
-  public static final String DEFAULT_TRADE_SCHEME = "OG-Trade";
+  public static final String DEFAULT_TRADE_SCHEME = StandardSchemes.OG_TRADE_SCHEME;
   /**
    * Default scheme for positions.
    */
-  public static final String DEFAULT_POSITION_SCHEME = "OG-Position";
+  public static final String DEFAULT_POSITION_SCHEME = StandardSchemes.OG_POSITION_SCHEME;
   /**
    * Default scheme for securities.
    */
-  public static final String DEFAULT_SECURITY_SCHEME = "OG-Security";
+  public static final String DEFAULT_SECURITY_SCHEME = StandardSchemes.OG_SECURITY_SCHEME;
 
   // date formats
   private static final DateTimeFormatter D_M_YEAR_SLASH = new DateTimeFormatterBuilder()

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/PositionCsvLoader.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharSource;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.io.CsvIterator;
@@ -137,8 +138,8 @@ import com.opengamma.strata.product.etd.EtdSettlementType;
 public final class PositionCsvLoader {
 
   // default schemes
-  static final String DEFAULT_POSITION_SCHEME = "OG-Position";
-  static final String DEFAULT_SECURITY_SCHEME = "OG-Security";
+  static final String DEFAULT_POSITION_SCHEME = StandardSchemes.OG_POSITION_SCHEME;
+  static final String DEFAULT_SECURITY_SCHEME = StandardSchemes.OG_SECURITY_SCHEME;
 
   // CSV column headers
   private static final String TYPE_FIELD = "Strata Position Type";

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/SensitivityCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/SensitivityCsvLoader.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.io.CharSource;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.Tenor;
 import com.opengamma.strata.basics.index.FloatingRateName;
@@ -141,7 +142,7 @@ import com.opengamma.strata.product.PortfolioItemInfo;
 public final class SensitivityCsvLoader {
 
   // default schemes
-  static final String DEFAULT_SCHEME = "OG-Sensitivity";
+  static final String DEFAULT_SCHEME = StandardSchemes.OG_SENSITIVITY_SCHEME;
 
   // CSV column headers
   private static final String ID_SCHEME_HEADER = "Id Scheme";

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharSource;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Guavate;
 import com.opengamma.strata.collect.io.CsvIterator;
@@ -204,8 +205,8 @@ import com.opengamma.strata.product.swaption.SwaptionTrade;
 public final class TradeCsvLoader {
 
   // default schemes
-  private static final String DEFAULT_TRADE_SCHEME = "OG-Trade";
-  private static final String DEFAULT_CPTY_SCHEME = "OG-Counterparty";
+  private static final String DEFAULT_TRADE_SCHEME = StandardSchemes.OG_TRADE_SCHEME;
+  private static final String DEFAULT_CPTY_SCHEME = StandardSchemes.OG_COUNTERPARTY;
 
   // common CSV headers
   static final String CONVENTION_FIELD = "Convention";

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/PositionCsvLoaderTest.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.loader.csv;
 
+import static com.opengamma.strata.basics.StandardSchemes.OG_ETD_SCHEME;
+import static com.opengamma.strata.basics.StandardSchemes.OG_SECURITY_SCHEME;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.collect.Guavate.casting;
 import static com.opengamma.strata.collect.Guavate.filtering;
@@ -64,7 +66,7 @@ public class PositionCsvLoaderTest {
       .info(PositionInfo.builder()
           .id(StandardId.of("OG", "123431"))
           .build())
-      .securityId(SecurityId.of("OG-Security", "AAPL"))
+      .securityId(SecurityId.of(OG_SECURITY_SCHEME, "AAPL"))
       .longQuantity(12d)
       .shortQuantity(14.5d)
       .build();
@@ -80,7 +82,7 @@ public class PositionCsvLoaderTest {
       .info(PositionInfo.builder()
           .id(StandardId.of("OG", "123433"))
           .build())
-      .securityId(SecurityId.of("OG-Security", "AAPL"))
+      .securityId(SecurityId.of(OG_SECURITY_SCHEME, "AAPL"))
       .longQuantity(12d)
       .shortQuantity(14.5d)
       .build();
@@ -91,7 +93,7 @@ public class PositionCsvLoaderTest {
       .security(
           GenericSecurity.of(
               SecurityInfo.of(
-                  SecurityId.of("OG-Security", "AAPL"),
+                  SecurityId.of(OG_SECURITY_SCHEME, "AAPL"),
                   SecurityPriceInfo.of(5, CurrencyAmount.of(USD, 0.01), 10))))
       .longQuantity(12d)
       .shortQuantity(14.5d)
@@ -147,7 +149,7 @@ public class PositionCsvLoaderTest {
   //-------------------------------------------------------------------------
   @Test
   public void test_parse_future() {
-    EtdContractSpecId specId = EtdContractSpecId.of("OG-ETD", "F-ECAG-FGBL");
+    EtdContractSpecId specId = EtdContractSpecId.of(OG_ETD_SCHEME, "F-ECAG-FGBL");
     EtdContractSpec contract = EtdContractSpec.builder()
         .id(specId)
         .type(EtdType.FUTURE)
@@ -207,7 +209,7 @@ public class PositionCsvLoaderTest {
   //-------------------------------------------------------------------------
   @Test
   public void test_parse_option() {
-    EtdContractSpecId specId = EtdContractSpecId.of("OG-ETD", "O-ECAG-OGBL");
+    EtdContractSpecId specId = EtdContractSpecId.of(OG_ETD_SCHEME, "O-ECAG-OGBL");
     EtdContractSpec contract = EtdContractSpec.builder()
         .id(specId)
         .type(EtdType.OPTION)
@@ -405,7 +407,7 @@ public class PositionCsvLoaderTest {
 
   @Test
   public void test_load_invalidNoQuantity() {
-    EtdContractSpecId specId = EtdContractSpecId.of("OG-ETD", "F-ECAG-FGBL");
+    EtdContractSpecId specId = EtdContractSpecId.of(OG_ETD_SCHEME, "F-ECAG-FGBL");
     EtdContractSpec contract = EtdContractSpec.builder()
         .id(specId)
         .type(EtdType.FUTURE)

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/SensitivityCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/SensitivityCsvLoaderTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.loader.csv;
 
+import static com.opengamma.strata.basics.StandardSchemes.OG_SENSITIVITY_SCHEME;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.basics.date.Tenor.TENOR_1M;
@@ -318,7 +319,7 @@ public final class SensitivityCsvLoaderTest {
     List<CurveSensitivities> list1 = test.getValue().get("OG-Sensitivity~TR2");
     assertThat(list1).hasSize(1);
     CurveSensitivities csens1 = list1.get(0);
-    assertThat(csens1.getId()).isEqualTo(Optional.of(StandardId.of("OG-Sensitivity", "TR2")));
+    assertThat(csens1.getId()).isEqualTo(Optional.of(StandardId.of(OG_SENSITIVITY_SCHEME, "TR2")));
     assertThat(csens1.getInfo().getAttribute(CCP_ATTR)).isEqualTo("CME");
     assertThat(csens1.getTypedSensitivities()).hasSize(1);
     assertSens(csens1, ZERO_RATE_DELTA, "GBCURVE", GBP, "1M, 3M, 6M", 7, 8, 9);

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/TradeCsvLoaderTest.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.strata.loader.csv;
 
+import static com.opengamma.strata.basics.StandardSchemes.OG_COUNTERPARTY;
+import static com.opengamma.strata.basics.StandardSchemes.OG_SECURITY_SCHEME;
 import static com.opengamma.strata.basics.currency.Currency.CAD;
 import static com.opengamma.strata.basics.currency.Currency.CZK;
 import static com.opengamma.strata.basics.currency.Currency.EUR;
@@ -486,7 +488,7 @@ public class TradeCsvLoaderTest {
             .tradeDate(date(2017, 6, 1))
             .tradeTime(LocalTime.of(12, 35))
             .zone(ZoneId.of("Europe/London"))
-            .counterparty(StandardId.of("OG-Counterparty", "Bank B"))
+            .counterparty(StandardId.of(OG_COUNTERPARTY, "Bank B"))
             .build())
         .build();
     assertBeanEquals(expected2, filtered.get(1));
@@ -1891,7 +1893,7 @@ public class TradeCsvLoaderTest {
             .tradeDate(date(2017, 6, 1))
             .settlementDate(date(2017, 6, 3))
             .build())
-        .securityId(SecurityId.of("OG-Security", "AAPL"))
+        .securityId(SecurityId.of(OG_SECURITY_SCHEME, "AAPL"))
         .quantity(12)
         .price(14.5)
         .build();
@@ -1931,7 +1933,7 @@ public class TradeCsvLoaderTest {
         .security(
             GenericSecurity.of(
                 SecurityInfo.of(
-                    SecurityId.of("OG-Security", "AAPL"),
+                    SecurityId.of(OG_SECURITY_SCHEME, "AAPL"),
                     SecurityPriceInfo.of(5, CurrencyAmount.of(USD, 0.01), 10))))
         .quantity(12)
         .price(14.5)

--- a/modules/market/src/main/java/com/opengamma/strata/market/observable/IndexQuoteId.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/observable/IndexQuoteId.java
@@ -92,7 +92,7 @@ public final class IndexQuoteId
   /**
    * Gets the identifier of the data.
    * <p>
-   * This returns an artificial identifier with a scheme of 'OG-Future' and
+   * This returns an artificial identifier with a scheme of 'OG-Index' and
    * a value of the index name.
    * 
    * @return the standard identifier

--- a/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
 
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.product.SecurityId;
 import com.opengamma.strata.product.common.ExchangeId;
@@ -32,7 +33,7 @@ public final class EtdIdUtils {
   /**
    * Scheme used for ETDs.
    */
-  public static final String ETD_SCHEME = "OG-ETD";
+  public static final String ETD_SCHEME = StandardSchemes.OG_ETD_SCHEME;
   /**
    * The separator to use.
    */

--- a/modules/product/src/test/java/com/opengamma/strata/product/SimpleLegalEntityTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/SimpleLegalEntityTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product;
 
+import static com.opengamma.strata.basics.StandardSchemes.LEI_SCHEME;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -18,8 +19,8 @@ import com.opengamma.strata.basics.location.Country;
  */
 public class SimpleLegalEntityTest {
 
-  private static final LegalEntityId LEI = LegalEntityId.of("LEI", "A");
-  private static final LegalEntityId LEI2 = LegalEntityId.of("LEI", "B");
+  private static final LegalEntityId LEI = LegalEntityId.of(LEI_SCHEME, "A");
+  private static final LegalEntityId LEI2 = LegalEntityId.of(LEI_SCHEME, "B");
 
   //-------------------------------------------------------------------------
   @Test

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.product.etd;
 
+import static com.opengamma.strata.basics.StandardSchemes.OG_ETD_SCHEME;
 import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static com.opengamma.strata.product.etd.EtdVariant.MONTHLY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,67 +30,67 @@ public class EtdIdUtilsTest {
   @Test
   public void test_contractSpecId_future() {
     EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.FUTURE, ExchangeIds.ECAG, FGBS);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "F-ECAG-FGBS"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-ECAG-FGBS"));
   }
 
   @Test
   public void test_contractSpecId_option() {
     EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.OPTION, ExchangeIds.ECAG, OGBS);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-OGBS"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-OGBS"));
   }
 
   //-------------------------------------------------------------------------
   @Test
   public void test_futureId_monthly() {
     SecurityId test = EtdIdUtils.futureId(ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), MONTHLY);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "F-ECAG-FGBS-201706"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-ECAG-FGBS-201706"));
   }
 
   @Test
   public void test_futureId_weekly() {
     SecurityId test = EtdIdUtils.futureId(ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofWeekly(2));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "F-ECAG-FGBS-201706W2"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-ECAG-FGBS-201706W2"));
   }
 
   @Test
   public void test_futureId_daily() {
     SecurityId test = EtdIdUtils.futureId(ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofDaily(2));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "F-ECAG-FGBS-20170602"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-ECAG-FGBS-20170602"));
   }
 
   @Test
   public void test_futureId_flex() {
     SecurityId test = EtdIdUtils.futureId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofFlexFuture(26, EtdSettlementType.DERIVATIVE));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "F-ECAG-FGBS-20170626D"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-ECAG-FGBS-20170626D"));
   }
 
   //-------------------------------------------------------------------------
   @Test
   public void test_optionId_monthly() {
     SecurityId test = EtdIdUtils.optionId(ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), MONTHLY, 0, PutCall.PUT, 12.34);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-201706-P12.34"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-201706-P12.34"));
   }
 
   @Test
   public void test_optionId_weekly() {
     SecurityId test = EtdIdUtils.optionId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofWeekly(3), 0, PutCall.CALL, -1.45);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-201706W3-CM1.45"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-201706W3-CM1.45"));
   }
 
   @Test
   public void test_optionId_daily9_version() {
     SecurityId test =
         EtdIdUtils.optionId(ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofDaily(9), 3, PutCall.PUT, 12.34);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-20170609-V3-P12.34"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-20170609-V3-P12.34"));
   }
 
   @Test
   public void test_optionId_daily21_version() {
     SecurityId test =
         EtdIdUtils.optionId(ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofDaily(21), 11, PutCall.PUT, 12.34);
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-20170621-V11-P12.34"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-20170621-V11-P12.34"));
   }
 
   //-------------------------------------------------------------------------
@@ -97,35 +98,35 @@ public class EtdIdUtilsTest {
   public void test_optionIdUnderlying_monthly() {
     SecurityId test = EtdIdUtils.optionId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), MONTHLY, 0, PutCall.PUT, 12.34, YearMonth.of(2017, 9));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-201706-P12.34-U201709"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-201706-P12.34-U201709"));
   }
 
   @Test
   public void test_optionIdUnderlying_monthlySameMonth() {
     SecurityId test = EtdIdUtils.optionId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), MONTHLY, 0, PutCall.PUT, 12.34, YearMonth.of(2017, 6));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-201706-P12.34"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-201706-P12.34"));
   }
 
   @Test
   public void test_optionIdUnderlying_weekly() {
     SecurityId test = EtdIdUtils.optionId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofWeekly(3), 0, PutCall.CALL, -1.45, YearMonth.of(2017, 9));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-201706W3-CM1.45-U201709"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-201706W3-CM1.45-U201709"));
   }
 
   @Test
   public void test_optionIdUnderlying_daily9_version() {
     SecurityId test = EtdIdUtils.optionId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofDaily(9), 3, PutCall.PUT, 12.34, YearMonth.of(2017, 9));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-20170609-V3-P12.34-U201709"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-20170609-V3-P12.34-U201709"));
   }
 
   @Test
   public void test_optionIdUnderlying_daily21_version() {
     SecurityId test = EtdIdUtils.optionId(
         ExchangeIds.ECAG, FGBS, YearMonth.of(2017, 6), EtdVariant.ofDaily(21), 11, PutCall.PUT, 12.34, YearMonth.of(2017, 9));
-    assertThat(test.getStandardId()).isEqualTo(StandardId.of("OG-ETD", "O-ECAG-FGBS-20170621-V11-P12.34-U201709"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-FGBS-20170621-V11-P12.34-U201709"));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/PositionTokenEvaluatorTest.java
+++ b/modules/report/src/test/java/com/opengamma/strata/report/framework/expression/PositionTokenEvaluatorTest.java
@@ -5,6 +5,7 @@
  */
 package com.opengamma.strata.report.framework.expression;
 
+import static com.opengamma.strata.basics.StandardSchemes.OG_POSITION_SCHEME;
 import static com.opengamma.strata.basics.currency.Currency.USD;
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,7 +73,7 @@ public class PositionTokenEvaluatorTest {
   }
 
   private static Position trade() {
-    PositionInfo info = PositionInfo.of(StandardId.of("OG-Position", "1"));
+    PositionInfo info = PositionInfo.of(StandardId.of(OG_POSITION_SCHEME, "1"));
     return GenericSecurityPosition.ofNet(info, SECURITY, 6);
   }
 


### PR DESCRIPTION
Standard constants should help unify the namespace over time