### PR TITLE
Correcting bug in MutablePointSensitivities.normalize()

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/MutablePointSensitivities.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/sensitivity/MutablePointSensitivities.java
@@ -194,7 +194,8 @@ public final class MutablePointSensitivities
     for (int i = 1; i < sensitivities.size(); i++) {
       PointSensitivity current = sensitivities.get(i);
       if (current.compareKey(previous) == 0) {
-        sensitivities.set(i - 1, previous.withSensitivity(previous.getSensitivity() + current.getSensitivity()));
+        current = previous.withSensitivity(previous.getSensitivity() + current.getSensitivity());
+        sensitivities.set(i - 1, current);
         sensitivities.remove(i);
         i--;
       }

--- a/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/MutablePointSensitivitiesTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/sensitivity/MutablePointSensitivitiesTest.java
@@ -26,6 +26,8 @@ public class MutablePointSensitivitiesTest {
   private static final PointSensitivity CS2 = DummyPointSensitivity.of(GBP, date(2015, 7, 30), 22d);
   private static final PointSensitivity CS3 = DummyPointSensitivity.of(GBP, date(2015, 8, 30), 32d);
   private static final PointSensitivity CS3B = DummyPointSensitivity.of(GBP, date(2015, 8, 30), 3d);
+  private static final PointSensitivity CS3C = DummyPointSensitivity.of(GBP, date(2015, 8, 30), 10d);
+  private static final PointSensitivity CS3D = DummyPointSensitivity.of(GBP, date(2015, 8, 30), -2d);
   private static final Object ANOTHER_TYPE = "";
 
   //-------------------------------------------------------------------------
@@ -167,6 +169,14 @@ public class MutablePointSensitivitiesTest {
     test.addAll(Lists.newArrayList(CS3, CS2, CS1, CS3B));
     test.normalize();
     assertThat(test.getSensitivities()).containsExactly(CS1, CS2, CS3.withSensitivity(35d));
+  }
+
+  @Test
+  public void test_normalize_4() {
+    MutablePointSensitivities test = new MutablePointSensitivities();
+    test.addAll(Lists.newArrayList(CS3, CS2, CS3D, CS1, CS3B, CS3C));
+    test.normalize();
+    assertThat(test.getSensitivities()).containsExactly(CS1, CS2, CS3.withSensitivity(43d));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
The method MutablePointSensitivities.normalize() lose some some sensitivities when more than 2 sensitivities have the same key. Corrected the method.