### PR TITLE
Periodic Schedule - Handle generation when using explicit final stub

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -737,11 +737,10 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
       boolean stub = temp.equals(end) == false;
       if (stub && dates.size() > 1) {
         StubConvention applicableStubConv = stubConv;
-        if (stubConv == StubConvention.NONE) {
+        if (stubConv == StubConvention.NONE && !explicitFinalStub) {
           // handle edge case where the end date does not follow the EOM rule
           if (rollConv == RollConventions.EOM &&
               frequency.isMonthBased() &&
-              !explicitFinalStub &&
               start.getDayOfMonth() == start.lengthOfMonth() &&
               end.getDayOfMonth() == start.getDayOfMonth()) {
             // accept the date and move on using smart rules


### PR DESCRIPTION
Looking at the docs for `SHORT_FINAL`, `LONG_FINAL`, `SMART_FINAL` stubs...

```When creating a schedule, there must be no explicit initial stub. If there is an explicit final stub, then this convention is considered to be matched and the remaining period is calculated using the stub convention 'None'.```

These get resolved to `StubConvention.NONE` when an explicit final stub is set. Sounds like we should be ignoring the fact that we are resolving to no stub convention rather than throwing an exception.