### PR TITLE
helper methods for USD instances for CurrencyAmount and Money

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/CurrencyAmount.java
@@ -63,6 +63,16 @@ public final class CurrencyAmount
 
   //-------------------------------------------------------------------------
   /**
+   * Obtains a USD amount instance of {@code CurrencyAmount} for the specified currency.
+   *
+   * @param amount the amount in USD
+   * @return the USD amount instance
+   */
+  public static CurrencyAmount ofUsd(double amount) {
+    return of(Currency.USD, 0d);
+  }
+
+  /**
    * Obtains a zero amount instance of {@code CurrencyAmount} for the specified currency.
    *
    * @param currency  the currency the amount is in

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/Money.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/Money.java
@@ -47,6 +47,26 @@ public class Money
 
   //-------------------------------------------------------------------------
   /**
+   * Obtains a USD amount instance of {@code Money} for the specified currency.
+   *
+   * @param amount the amount in USD
+   * @return the USD amount instance
+   */
+  public static Money ofUsd(BigDecimal amount) {
+    return of(Currency.USD, amount);
+  }
+
+  /**
+   * Obtains a USD amount instance of {@code Money} for the specified currency.
+   *
+   * @param amount the amount in USD
+   * @return the USD amount instance
+   */
+  public static Money ofUsd(double amount) {
+    return of(Currency.USD, amount);
+  }
+
+  /**
    * Obtains a zero amount instance of {@code Money} for the specified currency.
    *
    * @param currency  the currency the amount is in


### PR DESCRIPTION
Since USD is "the" reserve currency and its explicit instances are created so widely in tests and parsers, it might be useful to have these helper methods.