### PR TITLE
Allow any curve to be used in PriceIndexValues

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/PriceIndexValues.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/PriceIndexValues.java
@@ -10,13 +10,11 @@ import java.time.LocalDate;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.index.PriceIndex;
 import com.opengamma.strata.basics.index.PriceIndexObservation;
-import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.MarketDataView;
 import com.opengamma.strata.market.ValueType;
 import com.opengamma.strata.market.curve.Curve;
-import com.opengamma.strata.market.curve.NodalCurve;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivity;
 import com.opengamma.strata.market.param.ParameterPerturbation;
@@ -52,12 +50,7 @@ public interface PriceIndexValues
       Curve forwardCurve,
       LocalDateDoubleTimeSeries fixings) {
 
-    if (forwardCurve instanceof NodalCurve) {
-      return SimplePriceIndexValues.of(index, valuationDate, (NodalCurve) forwardCurve, fixings);
-    }
-    throw new IllegalArgumentException(Messages.format(
-        "Unknown curve type for PriceIndexValues, must be 'NodalCurve' but was '{}'",
-        forwardCurve.getClass().getName()));
+    return SimplePriceIndexValues.of(index, valuationDate, forwardCurve, fixings);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/SimplePriceIndexValues.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/rate/SimplePriceIndexValues.java
@@ -38,8 +38,8 @@ import com.opengamma.strata.collect.array.DoubleArray;
 import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.data.MarketDataName;
 import com.opengamma.strata.market.ValueType;
+import com.opengamma.strata.market.curve.Curve;
 import com.opengamma.strata.market.curve.InflationNodalCurve;
-import com.opengamma.strata.market.curve.NodalCurve;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.param.ParameterMetadata;
 import com.opengamma.strata.market.param.ParameterPerturbation;
@@ -74,7 +74,7 @@ public final class SimplePriceIndexValues
    * For example, zero represents the valuation month, one the next month and so on.
    */
   @PropertyDefinition(validate = "notNull")
-  private final NodalCurve curve;
+  private final Curve curve;
   /**
    * The monthly time-series of fixings.
    * This includes the known historical fixings and must not be empty.
@@ -107,7 +107,7 @@ public final class SimplePriceIndexValues
   public static SimplePriceIndexValues of(
       PriceIndex index,
       LocalDate valuationDate,
-      NodalCurve curve,
+      Curve curve,
       LocalDateDoubleTimeSeries fixings) {
 
     return new SimplePriceIndexValues(index, valuationDate, curve, fixings);
@@ -117,7 +117,7 @@ public final class SimplePriceIndexValues
   private SimplePriceIndexValues(
       PriceIndex index,
       LocalDate valuationDate,
-      NodalCurve curve,
+      Curve curve,
       LocalDateDoubleTimeSeries fixings) {
 
     ArgChecker.isFalse(fixings.isEmpty(), "Fixings must not be empty");
@@ -227,7 +227,7 @@ public final class SimplePriceIndexValues
    * @param curve  the new curve
    * @return the new instance
    */
-  public SimplePriceIndexValues withCurve(NodalCurve curve) {
+  public SimplePriceIndexValues withCurve(Curve curve) {
     return new SimplePriceIndexValues(index, valuationDate, curve, fixings);
   }
 
@@ -285,7 +285,7 @@ public final class SimplePriceIndexValues
    * For example, zero represents the valuation month, one the next month and so on.
    * @return the value of the property, not null
    */
-  public NodalCurve getCurve() {
+  public Curve getCurve() {
     return curve;
   }
 
@@ -364,8 +364,8 @@ public final class SimplePriceIndexValues
     /**
      * The meta-property for the {@code curve} property.
      */
-    private final MetaProperty<NodalCurve> curve = DirectMetaProperty.ofImmutable(
-        this, "curve", SimplePriceIndexValues.class, NodalCurve.class);
+    private final MetaProperty<Curve> curve = DirectMetaProperty.ofImmutable(
+        this, "curve", SimplePriceIndexValues.class, Curve.class);
     /**
      * The meta-property for the {@code fixings} property.
      */
@@ -438,7 +438,7 @@ public final class SimplePriceIndexValues
      * The meta-property for the {@code curve} property.
      * @return the meta-property, not null
      */
-    public MetaProperty<NodalCurve> curve() {
+    public MetaProperty<Curve> curve() {
       return curve;
     }
 
@@ -485,7 +485,7 @@ public final class SimplePriceIndexValues
 
     private PriceIndex index;
     private LocalDate valuationDate;
-    private NodalCurve curve;
+    private Curve curve;
     private LocalDateDoubleTimeSeries fixings;
 
     /**
@@ -521,7 +521,7 @@ public final class SimplePriceIndexValues
           this.valuationDate = (LocalDate) newValue;
           break;
         case 95027439:  // curve
-          this.curve = (NodalCurve) newValue;
+          this.curve = (Curve) newValue;
           break;
         case -843784602:  // fixings
           this.fixings = (LocalDateDoubleTimeSeries) newValue;


### PR DESCRIPTION
Originally it was restricted to just NodalCurve
That blocked parallel shifts

This change does introduce a source and binary incompatibility, but most users will be using the interface, not the concrete class.