### PR TITLE
Add a plugin for Trade CSV parsing

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/BulletPaymentTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/BulletPaymentTradeCsvPlugin.java
@@ -14,12 +14,16 @@ import static com.opengamma.strata.loader.csv.TradeCsvLoader.PAYMENT_DATE_CNV_FI
 import static com.opengamma.strata.loader.csv.TradeCsvLoader.PAYMENT_DATE_FIELD;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.PayReceive;
 import com.opengamma.strata.product.payment.BulletPayment;
@@ -28,7 +32,7 @@ import com.opengamma.strata.product.payment.BulletPaymentTrade;
 /**
  * Handles the CSV file format for Bullet Payment trades.
  */
-final class BulletPaymentTradeCsvPlugin implements TradeTypeCsvWriter<BulletPaymentTrade> {
+final class BulletPaymentTradeCsvPlugin implements TradeCsvParserPlugin, TradeTypeCsvWriter<BulletPaymentTrade> {
 
   /**
    * The singleton instance of the plugin.
@@ -44,6 +48,31 @@ final class BulletPaymentTradeCsvPlugin implements TradeTypeCsvWriter<BulletPaym
       .add(PAYMENT_DATE_CNV_FIELD)
       .add(PAYMENT_DATE_CAL_FIELD)
       .build();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("BULLET", "BULLETPAYMENT", "BULLET PAYMENT");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(BulletPaymentTrade.class)) {
+      return Optional.of(resolver.parseBulletPaymentTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "BulletPayment";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CdsIndexTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CdsIndexTradeCsvPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2021 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.opengamma.strata.collect.io.CsvRow;
+import com.opengamma.strata.product.Trade;
+import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.credit.CdsIndexTrade;
+
+/**
+ * Handles the CSV file format for CDS index trades.
+ */
+final class CdsIndexTradeCsvPlugin implements TradeCsvParserPlugin {
+
+  /**
+   * The singleton instance of the plugin.
+   */
+  public static final CdsIndexTradeCsvPlugin INSTANCE = new CdsIndexTradeCsvPlugin();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("CDSINDEX", "CDS INDEX");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(CdsIndexTrade.class)) {
+      return Optional.of(resolver.parseCdsIndexTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "CdsIndex";
+  }
+
+}

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CdsTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CdsTradeCsvPlugin.java
@@ -44,6 +44,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
@@ -52,6 +53,7 @@ import org.joda.beans.MetaProperty;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.currency.AdjustablePayment;
@@ -69,6 +71,7 @@ import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.common.PayReceive;
@@ -83,8 +86,12 @@ import com.opengamma.strata.product.credit.type.CdsConvention;
 /**
  * Handles the CSV file format for CDS and CDS index trades.
  */
-final class CdsTradeCsvPlugin {
+final class CdsTradeCsvPlugin implements TradeCsvParserPlugin {
 
+  /**
+   * The singleton instance of the plugin.
+   */
+  public static final CdsTradeCsvPlugin INSTANCE = new CdsTradeCsvPlugin();
   /**
    * The singleton instance of the plugin.
    */
@@ -110,6 +117,31 @@ final class CdsTradeCsvPlugin {
   private static final String SETTLEMENT_DATE_OFFSET_CAL_FIELD = "Settlement Date Offset Calendar";
   private static final String SETTLEMENT_DATE_OFFSET_ADJ_CNV_FIELD = "Settlement Date Offset Adjustment Convention";
   private static final String SETTLEMENT_DATE_OFFSET_ADJ_CAL_FIELD = "Settlement Date Offset Adjustment Calendar";
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("CDS");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(CdsTrade.class)) {
+      return Optional.of(resolver.parseCdsTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "Cds";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FraTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FraTradeCsvPlugin.java
@@ -30,8 +30,10 @@ import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
@@ -42,6 +44,7 @@ import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.fra.Fra;
@@ -52,12 +55,37 @@ import com.opengamma.strata.product.fra.type.FraConvention;
 /**
  * Handles the CSV file format for FRA trades.
  */
-final class FraTradeCsvPlugin implements TradeTypeCsvWriter<FraTrade> {
+final class FraTradeCsvPlugin implements TradeCsvParserPlugin, TradeTypeCsvWriter<FraTrade> {
 
   /**
    * The singleton instance of the plugin.
    */
   public static final FraTradeCsvPlugin INSTANCE = new FraTradeCsvPlugin();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("FRA");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(FraTrade.class)) {
+      return Optional.of(resolver.parseFraTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "Fra";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FxSingleTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FxSingleTradeCsvPlugin.java
@@ -18,8 +18,10 @@ import static com.opengamma.strata.loader.csv.TradeCsvLoader.PAYMENT_DATE_FIELD;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -29,6 +31,7 @@ import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.common.PayReceive;
@@ -38,7 +41,7 @@ import com.opengamma.strata.product.fx.FxSingleTrade;
 /**
  * Handles the CSV file format for FX Single trades.
  */
-class FxSingleTradeCsvPlugin implements TradeTypeCsvWriter<FxSingleTrade> {
+class FxSingleTradeCsvPlugin implements TradeCsvParserPlugin, TradeTypeCsvWriter<FxSingleTrade> {
 
   /**
    * The singleton instance of the plugin.
@@ -68,6 +71,31 @@ class FxSingleTradeCsvPlugin implements TradeTypeCsvWriter<FxSingleTrade> {
       .add(PAYMENT_DATE_CNV_FIELD)
       .add(PAYMENT_DATE_CAL_FIELD)
       .build();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("FX", "FXSINGLE", "FX SINGLE");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(FxSingleTrade.class)) {
+      return Optional.of(resolver.parseFxSingleTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "FxSingle";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FxSwapTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FxSwapTradeCsvPlugin.java
@@ -25,8 +25,10 @@ import static com.opengamma.strata.loader.csv.TradeCsvLoader.PAYMENT_DATE_FIELD;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.CurrencyPair;
 import com.opengamma.strata.basics.currency.FxRate;
@@ -34,6 +36,7 @@ import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.fx.FxSingle;
@@ -43,7 +46,7 @@ import com.opengamma.strata.product.fx.FxSwapTrade;
 /**
  * Handles the CSV file format for FX Swap trades.
  */
-class FxSwapTradeCsvPlugin implements TradeTypeCsvWriter<FxSwapTrade> {
+class FxSwapTradeCsvPlugin implements TradeCsvParserPlugin, TradeTypeCsvWriter<FxSwapTrade> {
 
   /**
    * The singleton instance of the plugin.
@@ -77,6 +80,31 @@ class FxSwapTradeCsvPlugin implements TradeTypeCsvWriter<FxSwapTrade> {
       .add(FAR + PAYMENT_DATE_CNV_FIELD)
       .add(FAR + PAYMENT_DATE_CAL_FIELD)
       .build();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("FXSWAP", "FX SWAP");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(FxSwapTrade.class)) {
+      return Optional.of(resolver.parseFxSwapTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "FxSwap";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FxVanillaOptionTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/FxVanillaOptionTradeCsvPlugin.java
@@ -30,14 +30,18 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.AdjustablePayment;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.AdjustableDate;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.LongShort;
 import com.opengamma.strata.product.common.PayReceive;
@@ -49,7 +53,7 @@ import com.opengamma.strata.product.fxopt.FxVanillaOptionTrade;
 /**
  * Handles the CSV file format for FX vanilla option trades.
  */
-class FxVanillaOptionTradeCsvPlugin implements TradeTypeCsvWriter<FxVanillaOptionTrade> {
+class FxVanillaOptionTradeCsvPlugin implements TradeCsvParserPlugin, TradeTypeCsvWriter<FxVanillaOptionTrade> {
 
   /**
    * The singleton instance of the plugin.
@@ -79,6 +83,31 @@ class FxVanillaOptionTradeCsvPlugin implements TradeTypeCsvWriter<FxVanillaOptio
       .add(PAYMENT_DATE_CNV_FIELD)
       .add(PAYMENT_DATE_CAL_FIELD)
       .build();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("FXVANILLAOPTION", "FX VANILLA OPTION");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(FxVanillaOptionTrade.class)) {
+      return Optional.of(resolver.parseFxVanillaOptionTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "FxVanillaOption";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/RatesCalibrationCsvLoader.java
@@ -7,7 +7,6 @@ package com.opengamma.strata.loader.csv;
 
 import static com.opengamma.strata.collect.Guavate.toImmutableList;
 import static com.opengamma.strata.collect.Guavate.toImmutableMap;
-import static com.opengamma.strata.collect.Guavate.toImmutableSet;
 import static java.util.stream.Collectors.toList;
 
 import java.time.Period;

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/SwapTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/SwapTradeCsvPlugin.java
@@ -18,15 +18,19 @@ import static com.opengamma.strata.loader.csv.TradeCsvLoader.PERIOD_TO_START_FIE
 import static com.opengamma.strata.loader.csv.TradeCsvLoader.START_DATE_FIELD;
 import static com.opengamma.strata.loader.csv.TradeCsvLoader.TENOR_FIELD;
 import static com.opengamma.strata.loader.csv.TradeCsvLoader.TRADE_DATE_FIELD;
+import static com.opengamma.strata.loader.csv.TradeCsvLoader.TYPE_FIELD;
 
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
@@ -42,6 +46,7 @@ import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.basics.value.ValueStep;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.swap.FixedRateCalculation;
@@ -56,7 +61,12 @@ import com.opengamma.strata.product.swap.type.XCcyIborIborSwapConvention;
 /**
  * Loads Swap trades from CSV files.
  */
-final class SwapTradeCsvPlugin {
+final class SwapTradeCsvPlugin implements TradeCsvParserPlugin {
+
+  /**
+   * The singleton instance of the plugin.
+   */
+  public static final SwapTradeCsvPlugin INSTANCE = new SwapTradeCsvPlugin();
 
   // CSV column headers
   private static final String ROLL_CONVENTION_FIELD = "Roll Convention";
@@ -65,6 +75,37 @@ final class SwapTradeCsvPlugin {
   private static final String LAST_REGULAR_END_DATE_FIELD = "Last Regular End Date";
   static final String KNOWN_AMOUNT_FIELD = "Known Amount";
 
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("SWAP");
+  }
+
+  @Override
+  public boolean isAdditionalRow(CsvRow baseRow, CsvRow additionalRow) {
+    return additionalRow.getField(TYPE_FIELD).toUpperCase(Locale.ENGLISH).equals("VARIABLE");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(SwapTrade.class)) {
+      return Optional.of(resolver.parseSwapTrade(baseRow, additionalRows, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "Swap";
+  }
+
+  //-------------------------------------------------------------------------
   /**
    * Parses from the CSV row.
    * 

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TermDepositTradeCsvPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TermDepositTradeCsvPlugin.java
@@ -23,8 +23,10 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.BusinessDayConvention;
@@ -34,6 +36,7 @@ import com.opengamma.strata.basics.date.HolidayCalendarId;
 import com.opengamma.strata.collect.io.CsvOutput.CsvRowOutputWithHeaders;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.loader.LoaderUtils;
+import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.common.BuySell;
 import com.opengamma.strata.product.deposit.TermDeposit;
@@ -43,7 +46,7 @@ import com.opengamma.strata.product.deposit.type.TermDepositConvention;
 /**
  * Handles the CSV file format for Term Deposit trades.
  */
-final class TermDepositTradeCsvPlugin implements TradeTypeCsvWriter<TermDepositTrade> {
+final class TermDepositTradeCsvPlugin implements TradeCsvParserPlugin, TradeTypeCsvWriter<TermDepositTrade> {
 
   /**
    * The singleton instance of the plugin.
@@ -62,6 +65,31 @@ final class TermDepositTradeCsvPlugin implements TradeTypeCsvWriter<TermDepositT
       .add(DATE_ADJ_CNV_FIELD)
       .add(DATE_ADJ_CAL_FIELD)
       .build();
+
+  //-------------------------------------------------------------------------
+  @Override
+  public Set<String> tradeTypeNames() {
+    return ImmutableSet.of("TERMDEPOSIT", "TERM DEPOSIT");
+  }
+
+  @Override
+  public Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver) {
+
+    if (requiredJavaType.isAssignableFrom(TermDepositTrade.class)) {
+      return Optional.of(resolver.parseTermDepositTrade(baseRow, info));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public String getName() {
+    return "TermDeposit";
+  }
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvInfoResolver.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvInfoResolver.java
@@ -320,7 +320,7 @@ public interface TradeCsvInfoResolver {
    * @throws RuntimeException if the row contains invalid data
    */
   public default SecurityQuantityTrade parseSecurityTrade(CsvRow row, TradeInfo info) {
-    return SecurityCsvPlugin.parseTrade(row, info, this);
+    return SecurityCsvPlugin.parseTradeWithPriceInfo(row, info, this);
   }
 
   /**

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvLoader.java
@@ -17,41 +17,29 @@ import java.util.Locale;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharSource;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Guavate;
+import com.opengamma.strata.collect.MapStream;
 import com.opengamma.strata.collect.io.CsvIterator;
 import com.opengamma.strata.collect.io.CsvRow;
 import com.opengamma.strata.collect.io.ResourceLocator;
 import com.opengamma.strata.collect.io.UnicodeBom;
+import com.opengamma.strata.collect.named.ExtendedEnum;
 import com.opengamma.strata.collect.result.FailureItem;
 import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.ValueWithFailures;
 import com.opengamma.strata.loader.LoaderUtils;
-import com.opengamma.strata.product.GenericSecurityTrade;
-import com.opengamma.strata.product.ResolvableSecurityTrade;
-import com.opengamma.strata.product.SecurityQuantityTrade;
-import com.opengamma.strata.product.SecurityTrade;
 import com.opengamma.strata.product.Trade;
 import com.opengamma.strata.product.TradeInfo;
 import com.opengamma.strata.product.TradeInfoBuilder;
-import com.opengamma.strata.product.credit.CdsIndexTrade;
-import com.opengamma.strata.product.credit.CdsTrade;
-import com.opengamma.strata.product.deposit.TermDepositTrade;
 import com.opengamma.strata.product.deposit.type.TermDepositConventions;
-import com.opengamma.strata.product.fra.FraTrade;
 import com.opengamma.strata.product.fra.type.FraConventions;
-import com.opengamma.strata.product.fx.FxSingleTrade;
-import com.opengamma.strata.product.fx.FxSwapTrade;
-import com.opengamma.strata.product.fx.FxTrade;
-import com.opengamma.strata.product.fxopt.FxVanillaOptionTrade;
-import com.opengamma.strata.product.payment.BulletPaymentTrade;
-import com.opengamma.strata.product.swap.SwapTrade;
 import com.opengamma.strata.product.swap.type.SingleCurrencySwapConvention;
-import com.opengamma.strata.product.swaption.SwaptionTrade;
 
 /**
  * Loads trades from CSV files.
@@ -270,6 +258,21 @@ public final class TradeCsvLoader {
   static final String SETTLEMENT_DATE_FIELD = "Settlement Date";
 
   /**
+   * The lookup of trade parsers.
+   */
+  static final ExtendedEnum<TradeCsvParserPlugin> ENUM_LOOKUP = ExtendedEnum.of(TradeCsvParserPlugin.class);
+  /**
+   * The lookup of trade parsers.
+   */
+  private static final ImmutableMap<String, TradeCsvParserPlugin> PLUGINS =
+      MapStream.of(TradeCsvParserPlugin.extendedEnum().lookupAllNormalized().values())
+          .flatMapKeys(plugin -> plugin.tradeTypeNames().stream())
+          .toMap((a, b) -> {
+            System.err.println("Two plugins declare the same product type: " + a.tradeTypeNames());
+            return a;
+          });
+
+  /**
    * The resolver, providing additional information.
    */
   private final TradeCsvInfoResolver resolver;
@@ -452,126 +455,65 @@ public final class TradeCsvLoader {
   }
 
   // loads a single CSV file
+  @SuppressWarnings("unchecked")
   private <T extends Trade> ValueWithFailures<List<T>> parseFile(CsvIterator csv, Class<T> tradeType) {
     List<T> trades = new ArrayList<>();
     List<FailureItem> failures = new ArrayList<>();
+    rows:
     for (CsvRow row : csv.asIterable()) {
+      String typeRaw = row.findField(TYPE_FIELD).orElse("");
+      String typeUpper = typeRaw.toUpperCase(Locale.ENGLISH);
       try {
-        String typeRaw = row.getField(TYPE_FIELD);
         TradeInfo info = parseTradeInfo(row);
-        String typeUpper = typeRaw.toUpperCase(Locale.ENGLISH);
         // allow type matching to be overridden
         Optional<Trade> overrideOpt = resolver.overrideParseTrade(typeUpper, row, info);
         if (overrideOpt.isPresent()) {
           if (tradeType.isInstance(overrideOpt.get())) {
             trades.add(tradeType.cast(overrideOpt.get()));
           }
-          continue;
+          continue rows;
         }
         // standard type matching
-        switch (typeUpper) {
-          case "FRA":
-            if (tradeType == FraTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseFraTrade(row, info)));
-            }
-            break;
-          case "SECURITY":
-            if (tradeType == SecurityTrade.class || tradeType == GenericSecurityTrade.class ||
-                tradeType == ResolvableSecurityTrade.class || tradeType == Trade.class) {
-              SecurityQuantityTrade parsed = resolver.parseSecurityTrade(row, info);
-              if (tradeType.isInstance(parsed)) {
-                trades.add(tradeType.cast(parsed));
-              }
-            }
-            break;
-          case "SWAP":
-            if (tradeType == SwapTrade.class || tradeType == Trade.class) {
-              List<CsvRow> variableRows = new ArrayList<>();
-              while (csv.hasNext() && csv.peek().getField(TYPE_FIELD).toUpperCase(Locale.ENGLISH).equals("VARIABLE")) {
-                variableRows.add(csv.next());
-              }
-              trades.add(tradeType.cast(resolver.parseSwapTrade(row, variableRows, info)));
-            }
-            break;
-          case "SWAPTION":
-            if (tradeType == SwaptionTrade.class || tradeType == Trade.class) {
-              List<CsvRow> variableRows = new ArrayList<>();
-              while (csv.hasNext() && csv.peek().getField(TYPE_FIELD).toUpperCase(Locale.ENGLISH).equals("VARIABLE")) {
-                variableRows.add(csv.next());
-              }
-              trades.add(tradeType.cast(resolver.parseSwaptionTrade(row, variableRows, info)));
-            }
-            break;
-          case "BULLET":
-          case "BULLETPAYMENT":
-          case "BULLET PAYMENT":
-            if (tradeType == BulletPaymentTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseBulletPaymentTrade(row, info)));
-            }
-            break;
-          case "TERMDEPOSIT":
-          case "TERM DEPOSIT":
-            if (tradeType == TermDepositTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseTermDepositTrade(row, info)));
-            }
-            break;
-          case "VARIABLE":
-            failures.add(FailureItem.of(
-                FailureReason.PARSING,
-                "CSV file contained a 'Variable' type at line {lineNumber} that was not preceeded by a 'Swap' or 'Swaption'",
-                row.lineNumber()));
-            break;
-          case "FX":
-          case "FXSINGLE":
-          case "FX SINGLE":
-            if (tradeType == FxSingleTrade.class || tradeType == FxTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseFxSingleTrade(row, info)));
-            }
-            break;
-          case "FXSWAP":
-          case "FX SWAP":
-            if (tradeType == FxSwapTrade.class || tradeType == FxTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseFxSwapTrade(row, info)));
-            }
-            break;
-          case "FXVANILLAOPTION":
-          case "FX VANILLA OPTION":
-            if (tradeType == FxVanillaOptionTrade.class || tradeType == FxTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseFxVanillaOptionTrade(row, info)));
-            }
-            break;
-          case "CDS":
-            if (tradeType == CdsTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseCdsTrade(row, info)));
-            }
-            break;
-          case "CDSINDEX":
-          case "CDS INDEX":
-            if (tradeType == CdsIndexTrade.class || tradeType == Trade.class) {
-              trades.add(tradeType.cast(resolver.parseCdsIndexTrade(row, info)));
-            }
-            break;
-          default:
-            // type is not a standard one
-            Optional<Trade> parsedOpt = resolver.parseOtherTrade(typeUpper, row, info);
-            if (parsedOpt.isPresent()) {
-              if (tradeType.isInstance(parsedOpt.get())) {
-                trades.add(tradeType.cast(parsedOpt.get()));
-              }
-            } else {
-              failures.add(FailureItem.of(
-                  FailureReason.PARSING,
-                  "CSV file trade type '{tradeType}' is not known at line {lineNumber}",
-                  typeRaw,
-                  row.lineNumber()));
-            }
-            break;
+        TradeCsvParserPlugin plugin = PLUGINS.get(typeUpper);
+        if (plugin != null) {
+          List<CsvRow> additionalRows = new ArrayList<>();
+          while (csv.hasNext() && plugin.isAdditionalRow(row, csv.peek())) {
+            additionalRows.add(csv.next());
+          }
+          plugin.parseTrade(tradeType, row, additionalRows, info, resolver)
+              .filter(parsed -> tradeType.isInstance(parsed))
+              .ifPresent(parsed -> trades.add((T) parsed));
+          continue rows;
         }
+        // match type using the resolver
+        Optional<Trade> parsedOpt = resolver.parseOtherTrade(typeUpper, row, info);
+        if (parsedOpt.isPresent()) {
+          if (tradeType.isInstance(parsedOpt.get())) {
+            trades.add(tradeType.cast(parsedOpt.get()));
+          }
+          continue rows;
+        }
+        // better error for VARIABLE
+        if (typeUpper.equals("VARIABLE")) {
+          failures.add(FailureItem.of(
+              FailureReason.PARSING,
+              "CSV file contained a 'Variable' type at line {lineNumber} that was not preceeded by a 'Swap' or 'Swaption'",
+              row.lineNumber()));
+        } else {
+          // failed to find the type
+          failures.add(FailureItem.of(
+              FailureReason.PARSING,
+              "CSV trade file type '{tradeType}' is not known at line {lineNumber}",
+              typeRaw,
+              row.lineNumber()));
+        }
+
       } catch (RuntimeException ex) {
         failures.add(FailureItem.of(
             FailureReason.PARSING,
             ex,
-            "CSV file trade could not be parsed at line {lineNumber}: {exceptionMessage}",
+            "CSV trade file type '{tradeType}' could not be parsed at line {lineNumber}: {exceptionMessage}",
+            typeRaw,
             row.lineNumber(),
             ex.getMessage()));
       }

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvParserPlugin.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2021 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.loader.csv;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.io.CsvRow;
+import com.opengamma.strata.collect.named.ExtendedEnum;
+import com.opengamma.strata.collect.named.Named;
+import com.opengamma.strata.product.Product;
+import com.opengamma.strata.product.Trade;
+import com.opengamma.strata.product.TradeInfo;
+
+/**
+ * Pluggable CSV trade parser.
+ * <p>
+ * Implementations of this interface parse a CSV file.
+ * <p>
+ * See {@link TradeCsvLoader} for the main entry point to parsing.
+ */
+public interface TradeCsvParserPlugin
+    extends Named {
+
+  /**
+   * Obtains an instance from the specified unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the parser
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static TradeCsvParserPlugin of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return extendedEnum().lookup(uniqueName);
+  }
+
+  /**
+   * Gets the extended enum helper.
+   * <p>
+   * This helper allows instances of the parser to be looked up.
+   * It also provides the complete set of available instances.
+   * 
+   * @return the extended enum helper
+   */
+  public static ExtendedEnum<TradeCsvParserPlugin> extendedEnum() {
+    return TradeCsvLoader.ENUM_LOOKUP;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns the upper-case product type names that this plugin supports.
+   * <p>
+   * These are matched against the CSV file type column.
+   * 
+   * @return the types that this plugin supports
+   */
+  public abstract Set<String> tradeTypeNames();
+
+  /**
+   * Checks if there is an additional row that must be parsed alongside the base row.
+   * <p>
+   * An example use for this is parsing variable notional swaps.
+   * 
+   * @param baseRow  the base row
+   * @param additionalRow  the additional row
+   * @return true if the base row and additional row must be parsed together
+   */
+  public default boolean isAdditionalRow(CsvRow baseRow, CsvRow additionalRow) {
+    return false;
+  }
+
+  /**
+   * Parses a single CSV format trade from the input.
+   * <p>
+   * This parses a single trade from the CSV rows provided.
+   * The trade may exist on multiple rows
+   * 
+   * @param requiredJavaType  the Java type to return
+   * @param baseRow  the base row to parse
+   * @param additionalRows  the additional rows to parse, may be empty
+   * @param info  the trade info
+   * @param resolver  the resolver
+   * @return the trade object, empty if choosing not to parse because the Java type does not match
+   * @throws RuntimeException if unable to parse
+   */
+  public abstract Optional<Trade> parseTrade(
+      Class<?> requiredJavaType,
+      CsvRow baseRow,
+      List<CsvRow> additionalRows,
+      TradeInfo info,
+      TradeCsvInfoResolver resolver);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this parser.
+   * <p>
+   * The name should typically be the name of the {@link Product} that can be parsed.
+   * For example, 'Fra', 'Swap' or 'FxSingle'.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public abstract String getName();
+
+}

--- a/modules/loader/src/main/resources/META-INF/com/opengamma/strata/config/base/TradeCsvParserPlugin.ini
+++ b/modules/loader/src/main/resources/META-INF/com/opengamma/strata/config/base/TradeCsvParserPlugin.ini
@@ -1,0 +1,25 @@
+# TradeCsvParserPlugin configuration
+
+# The providers are the classes that define the enum
+# The key is of the form 'provider.full.class.name'
+# The value is either
+#  'constants', the public static final constants from the class
+#  'lookup', the class implements NamedLookup with a no-args constructor
+#  'instance', the class has a static field named INSTANCE that is of type NamedLookup
+[providers]
+com.opengamma.strata.loader.csv.BulletPaymentTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.CdsTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.CdsIndexTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.FraTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.FxSingleTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.FxSwapTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.FxVanillaOptionTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.SecurityCsvPlugin = constants
+com.opengamma.strata.loader.csv.SwapTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.SwaptionTradeCsvPlugin = constants
+com.opengamma.strata.loader.csv.TermDepositTradeCsvPlugin = constants
+
+# The set of alternate names
+# The key is the alternate name
+# The value is the standard name (loaded by a provider)
+[alternates]


### PR DESCRIPTION
Allow application code to plugin their own products.
Approach is more standard than the resolver used up to now.
This change should be fully backwards compatible, the same parsing will occur.