### PR TITLE
Make header order of trade csv deterministic

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvWriter.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvWriter.java
@@ -42,7 +42,6 @@ import static com.opengamma.strata.loader.csv.CsvLoaderColumns.TRADE_TIME_FIELD;
 import static com.opengamma.strata.loader.csv.CsvLoaderColumns.TRADE_TYPE_FIELD;
 import static com.opengamma.strata.loader.csv.CsvLoaderColumns.TRADE_ZONE_FIELD;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
 
 import java.io.UncheckedIOException;
 import java.util.Comparator;
@@ -52,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -285,8 +285,8 @@ public final class TradeCsvWriter {
     // types
     Map<Class<?>, List<Trade>> splitByType = trades.stream().collect(groupingBy(
         Object::getClass,
-        LinkedHashMap::new,
-        toList()));
+        LinkedHashMap<Class<?>, List<Trade>>::new,
+        Collectors.<Trade>toList()));
     for (Entry<Class<?>, List<Trade>> entry : splitByType.entrySet()) {
       TradeTypeCsvWriter detailsWriter = WRITERS.get(entry.getKey());
       if (detailsWriter == null) {

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvWriter.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/TradeCsvWriter.java
@@ -42,9 +42,11 @@ import static com.opengamma.strata.loader.csv.CsvLoaderColumns.TRADE_TIME_FIELD;
 import static com.opengamma.strata.loader.csv.CsvLoaderColumns.TRADE_TYPE_FIELD;
 import static com.opengamma.strata.loader.csv.CsvLoaderColumns.TRADE_ZONE_FIELD;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 
 import java.io.UncheckedIOException;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -281,7 +283,10 @@ public final class TradeCsvWriter {
         .collect(toImmutableList()));
 
     // types
-    Map<Class<?>, List<Trade>> splitByType = trades.stream().collect(groupingBy(t -> t.getClass()));
+    Map<Class<?>, List<Trade>> splitByType = trades.stream().collect(groupingBy(
+        Object::getClass,
+        LinkedHashMap::new,
+        toList()));
     for (Entry<Class<?>, List<Trade>> entry : splitByType.entrySet()) {
       TradeTypeCsvWriter detailsWriter = WRITERS.get(entry.getKey());
       if (detailsWriter == null) {


### PR DESCRIPTION
For any extra headers which aren't covered by the header comparator, the order of the headers currently changes from run to run. This fix uses a `LinkedHashMap` so that the order of the headers is consistent with the ordering of the trades. 