### PR TITLE
Handle generics in multi-scenario results

### DIFF
--- a/examples/src/main/java/com/opengamma/strata/examples/finance/CurveScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/CurveScenarioExample.java
@@ -137,12 +137,12 @@ public class CurveScenarioExample {
     // TODO Replace the results processing below with a report once the reporting framework supports scenarios
 
     // The results are lists of currency amounts containing one value for each scenario
-    ScenarioArray<?> pvList = (ScenarioArray<?>) results.get(0, 0).getValue();
-    ScenarioArray<?> pv01List = (ScenarioArray<?>) results.get(0, 1).getValue();
+    ScenarioArray<CurrencyAmount> pvList = results.getScenarios(0, 0, CurrencyAmount.class).getValue();
+    ScenarioArray<CurrencyAmount> pv01List = results.getScenarios(0, 1, CurrencyAmount.class).getValue();
 
-    double pvBase = ((CurrencyAmount) pvList.get(0)).getAmount();
-    double pvShifted = ((CurrencyAmount) pvList.get(1)).getAmount();
-    double pv01Base = ((CurrencyAmount) pv01List.get(0)).getAmount();
+    double pvBase = pvList.get(0).getAmount();
+    double pvShifted = pvList.get(1).getAmount();
+    double pv01Base = pv01List.get(0).getAmount();
     NumberFormat numberFormat = new DecimalFormat("###,##0.00", new DecimalFormatSymbols(Locale.ENGLISH));
 
     System.out.println("                         PV (base) = " + numberFormat.format(pvBase));

--- a/examples/src/main/java/com/opengamma/strata/examples/finance/HistoricalScenarioExample.java
+++ b/examples/src/main/java/com/opengamma/strata/examples/finance/HistoricalScenarioExample.java
@@ -137,7 +137,7 @@ public class HistoricalScenarioExample {
     Results results = runner.calculateMultiScenario(rules, trades, columns, scenarioMarketData, refData);
 
     // the results contain the one measure requested (Present Value) for each scenario
-    ScenarioArray<?> scenarioValuations = (ScenarioArray<?>) results.get(0, 0).getValue();
+    ScenarioArray<CurrencyAmount> scenarioValuations = results.getScenarios(0, 0, CurrencyAmount.class).getValue();
     outputPnl(scenarioDates, scenarioValuations);
   }
 
@@ -202,14 +202,14 @@ public class HistoricalScenarioExample {
     return builder.build();
   }
 
-  private static void outputPnl(List<LocalDate> scenarioDates, ScenarioArray<?> scenarioValuations) {
+  private static void outputPnl(List<LocalDate> scenarioDates, ScenarioArray<CurrencyAmount> scenarioValuations) {
     NumberFormat numberFormat = new DecimalFormat("0.00", new DecimalFormatSymbols(Locale.ENGLISH));
-    double basePv = ((CurrencyAmount) scenarioValuations.get(0)).getAmount();
+    double basePv = scenarioValuations.get(0).getAmount();
     System.out.println("Base PV (USD): " + numberFormat.format(basePv));
     System.out.println();
     System.out.println("P&L series (USD):");
     for (int i = 1; i < scenarioValuations.getScenarioCount(); i++) {
-      double scenarioPv = ((CurrencyAmount) scenarioValuations.get(i)).getAmount();
+      double scenarioPv = scenarioValuations.get(i).getAmount();
       double pnl = scenarioPv - basePv;
       LocalDate scenarioDate = scenarioDates.get(i);
       System.out.println(Messages.format("{} = {}", scenarioDate, numberFormat.format(pnl)));

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -1255,6 +1255,29 @@ public final class Guavate {
 
   //-------------------------------------------------------------------------
   /**
+   * Returns a generified {@code Class} instance.
+   * <p>
+   * It is not possible in Java generics to get a {@code Class} object with the desired generic
+   * signature, such as {@code Class<List<String>>}. This method provides a way to get such a value.
+   * The method returns the input parameter, but the compiler sees the result as being a different type.
+   * <p>
+   * Note that the generic part of the resulting type is not checked and can be unsound.
+   * The safest choice is to explicitly specify the type you want, by assigning to a variable or constant:
+   * <pre>
+   *   Class&lt;List&lt;String&gt;&gt; cls = genericClass(List.class);
+   * </pre>
+   *
+   * @param <T> the partially specified generic type, such as {@code List} from a constant such as {@code List.class}
+   * @param <S> the fully specified generic type, such as {@code List<String>}
+   * @param cls  the class instance to base the result in, such as {@code List.class}
+   * @return the class instance from the input, with whatever generic parameter is desired
+   */
+  @SuppressWarnings("unchecked")
+  public static <T, S extends T> Class<S> genericClass(Class<T> cls) {
+    return (Class<S>) cls;
+  }
+
+  /**
    * Finds the caller class.
    * <p>
    * This takes an argument which is the number of stack levels to look back.

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -851,6 +851,15 @@ public class GuavateTest {
 
   //-------------------------------------------------------------------------
   @Test
+  public void test_genericClass() {
+    Class<List<String>> test1 = Guavate.genericClass(List.class);
+    assertThat(test1).isEqualTo(List.class);
+    Class<List<Number>> test2 = Guavate.genericClass(List.class);
+    assertThat(test2).isEqualTo(List.class);
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
   public void test_callerClass() {
     assertThat(Guavate.callerClass(0)).isEqualTo(Guavate.CallerClassSecurityManager.class);
     assertThat(Guavate.callerClass(1)).isEqualTo(Guavate.class);

--- a/modules/measure/src/test/java/com/opengamma/strata/measure/swap/SwapPricingTest.java
+++ b/modules/measure/src/test/java/com/opengamma/strata/measure/swap/SwapPricingTest.java
@@ -10,6 +10,7 @@ import static com.opengamma.strata.basics.date.DayCounts.THIRTY_U_360;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
 import static com.opengamma.strata.collect.CollectProjectAssertions.assertThat;
 import static com.opengamma.strata.product.common.PayReceive.RECEIVE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
 import java.time.LocalDate;
@@ -142,11 +143,9 @@ public class SwapPricingTest {
     CalculationRunner runner = CalculationRunner.of(MoreExecutors.newDirectExecutorService());
     Results results = runner.calculate(rules, trades, columns, suppliedData, REF_DATA);
 
-    Result<?> result = results.get(0, 0);
+    Result<CurrencyAmount> result = results.get(0, 0, CurrencyAmount.class);
     assertThat(result).isSuccess();
-
-    CurrencyAmount pv = (CurrencyAmount) result.getValue();
-    assertThat(pv.getAmount()).isCloseTo(-1003684.8402, offset(TOLERANCE_PV));
+    assertThat(result.getValue().getAmount()).isCloseTo(-1003684.8402, offset(TOLERANCE_PV));
   }
 
   private static SwapLeg fixedLeg(

--- a/modules/report/src/main/java/com/opengamma/strata/report/cashflow/CashFlowReportRunner.java
+++ b/modules/report/src/main/java/com/opengamma/strata/report/cashflow/CashFlowReportRunner.java
@@ -123,15 +123,13 @@ public final class CashFlowReportRunner
               Measures.EXPLAIN_PRESENT_VALUE));
     }
 
-    Result<?> result = calculationResults.getCalculationResults().get(0, columnIdx);
+    Result<ExplainMap> result = calculationResults.getCalculationResults().get(0, columnIdx, ExplainMap.class);
     if (result.isFailure()) {
       throw new IllegalArgumentException(
           Messages.format("Failure result found for required measure '{}': {}",
               Measures.EXPLAIN_PRESENT_VALUE, result.getFailure().getMessage()));
     }
-    ExplainMap explainMap = (ExplainMap) result.getValue();
-
-    return runReport(explainMap, calculationResults.getValuationDate());
+    return runReport(result.getValue(), calculationResults.getValuationDate());
   }
 
   private Report runReport(ExplainMap explainMap, LocalDate valuationDate) {


### PR DESCRIPTION
Provide a mechanism to support `ScenarioArray<Foo>` type results
without the need for a dedicated subclass of `ScenarioArray`