### PR TITLE
Fix lastBusinessDayOfMonth() @return javadoc

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/HolidayCalendar.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/HolidayCalendar.java
@@ -212,7 +212,7 @@ public interface HolidayCalendar
    * Given a date, this method returns the date of the last business day of the month.
    * 
    * @param date  the date to check
-   * @return true if the specified date is the last business day of the month
+   * @return the date of the last business day of the month
    * @throws IllegalArgumentException if the date is outside the supported range
    */
   public default LocalDate lastBusinessDayOfMonth(LocalDate date) {


### PR DESCRIPTION
The javadoc of `lastBusinessDayOfMonth()` was probably copy/pasted from `isLastBusinessDayOfMonth()` but the description of the returned value was not modified.