### PR TITLE
Ensure that different kinds of index serialize

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/FloatingRateIndex.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/FloatingRateIndex.java
@@ -7,6 +7,9 @@ package com.opengamma.strata.basics.index;
 
 import java.util.Optional;
 
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.Tenor;
@@ -120,7 +123,33 @@ public interface FloatingRateIndex
         });
   }
 
+  /**
+   * Obtains an instance from the specified unique name.
+   * <p>
+   * This parses names from {@link IborIndex}, {@link OvernightIndex} and {@link PriceIndex}.
+   * 
+   * @param uniqueName  the unique name
+   * @return the index
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static FloatingRateIndex of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return Indices.FLOATING_RATE_INDEX_LOOKUP.lookup(uniqueName);
+  }
+
   //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this index.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public abstract String getName();
+
   /**
    * Gets the currency of the index.
    * 

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/Index.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/Index.java
@@ -35,7 +35,7 @@ public interface Index
   @FromString
   public static Index of(String uniqueName) {
     ArgChecker.notNull(uniqueName, "uniqueName");
-    return Indices.ENUM_LOOKUP.lookup(uniqueName);
+    return Indices.INDEX_LOOKUP.lookup(uniqueName);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/Indices.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/Indices.java
@@ -15,7 +15,16 @@ final class Indices {
   /**
    * The extended enum lookup from name to instance.
    */
-  static final CombinedExtendedEnum<Index> ENUM_LOOKUP = CombinedExtendedEnum.of(Index.class);
+  static final CombinedExtendedEnum<Index> INDEX_LOOKUP = CombinedExtendedEnum.of(Index.class);
+  /**
+   * The extended enum lookup from name to instance.
+   */
+  static final CombinedExtendedEnum<RateIndex> RATE_INDEX_LOOKUP = CombinedExtendedEnum.of(RateIndex.class);
+  /**
+   * The extended enum lookup from name to instance.
+   */
+  static final CombinedExtendedEnum<FloatingRateIndex> FLOATING_RATE_INDEX_LOOKUP =
+      CombinedExtendedEnum.of(FloatingRateIndex.class);
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/index/RateIndex.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/index/RateIndex.java
@@ -5,8 +5,12 @@
  */
 package com.opengamma.strata.basics.index;
 
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
 import com.opengamma.strata.basics.date.HolidayCalendarId;
 import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.collect.ArgChecker;
 
 /**
  * A index of interest rates, such as an Overnight or Inter-Bank rate.
@@ -19,6 +23,33 @@ import com.opengamma.strata.basics.date.Tenor;
  */
 public interface RateIndex
     extends FloatingRateIndex {
+
+  /**
+   * Obtains an instance from the specified unique name.
+   * <p>
+   * This parses names from {@link IborIndex} and {@link OvernightIndex}.
+   * 
+   * @param uniqueName  the unique name
+   * @return the index
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static RateIndex of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return Indices.RATE_INDEX_LOOKUP.lookup(uniqueName);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this index.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public abstract String getName();
 
   /**
    * Gets the calendar that determines which dates are fixing dates.

--- a/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/FloatingRateIndex.ini
+++ b/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/FloatingRateIndex.ini
@@ -1,0 +1,7 @@
+# CombinedExtendedEnum configuration
+
+# The enum types to combine
+[types]
+com.opengamma.strata.basics.index.IborIndex
+com.opengamma.strata.basics.index.OvernightIndex
+com.opengamma.strata.basics.index.PriceIndex

--- a/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/RateIndex.ini
+++ b/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/RateIndex.ini
@@ -1,0 +1,6 @@
+# CombinedExtendedEnum configuration
+
+# The enum types to combine
+[types]
+com.opengamma.strata.basics.index.IborIndex
+com.opengamma.strata.basics.index.OvernightIndex

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateIndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateIndexTest.java
@@ -10,7 +10,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 import java.util.Optional;
 
+import org.joda.convert.StringConvert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.opengamma.strata.basics.date.Tenor;
 
@@ -61,6 +64,62 @@ public class FloatingRateIndexTest {
     assertThat(FloatingRateIndex.tryParse("GB-RPI", Tenor.TENOR_6M)).isEqualTo(Optional.of(PriceIndices.GB_RPI));
     assertThat(FloatingRateIndex.tryParse(null, Tenor.TENOR_6M)).isEqualTo(Optional.empty());
     assertThat(FloatingRateIndex.tryParse("NotAnIndex", Tenor.TENOR_6M)).isEqualTo(Optional.empty());
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_name() {
+    return new Object[][] {
+        {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
+        {IborIndices.CHF_LIBOR_6M, "CHF-LIBOR-6M"},
+        {IborIndices.EUR_LIBOR_6M, "EUR-LIBOR-6M"},
+        {IborIndices.JPY_LIBOR_6M, "JPY-LIBOR-6M"},
+        {IborIndices.USD_LIBOR_6M, "USD-LIBOR-6M"},
+
+        {OvernightIndices.GBP_SONIA, "GBP-SONIA"},
+        {OvernightIndices.CHF_SARON, "CHF-SARON"},
+        {OvernightIndices.EUR_EONIA, "EUR-EONIA"},
+        {OvernightIndices.JPY_TONAR, "JPY-TONAR"},
+        {OvernightIndices.USD_FED_FUND, "USD-FED-FUND"},
+
+        {PriceIndices.GB_HICP, "GB-HICP"},
+        {PriceIndices.CH_CPI, "CH-CPI"},
+        {PriceIndices.EU_AI_CPI, "EU-AI-CPI"},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_name(FloatingRateIndex convention, String name) {
+    assertThat(convention.getName()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_toString(FloatingRateIndex convention, String name) {
+    assertThat(convention.toString()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_of_lookup(FloatingRateIndex convention, String name) {
+    assertThat(FloatingRateIndex.of(name)).isEqualTo(convention);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_of_convert(FloatingRateIndex convention, String name) {
+    assertThat(StringConvert.INSTANCE.convertToString(convention)).isEqualTo(name);
+    assertThat(StringConvert.INSTANCE.convertFromString(FloatingRateIndex.class, name)).isEqualTo(convention);
+  }
+
+  @Test
+  public void test_of_lookup_notFound() {
+    assertThatIllegalArgumentException().isThrownBy(() -> FloatingRateIndex.of(FxIndices.EUR_USD_ECB.getName()));
+  }
+
+  @Test
+  public void test_of_lookup_null() {
+    assertThatIllegalArgumentException().isThrownBy(() -> FloatingRateIndex.of((String) null));
   }
 
 }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/RateIndexTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/RateIndexTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics.index;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.joda.convert.StringConvert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test {@link RateIndex}.
+ */
+public class RateIndexTest {
+
+  public static Object[][] data_name() {
+    return new Object[][] {
+        {IborIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
+        {IborIndices.CHF_LIBOR_6M, "CHF-LIBOR-6M"},
+        {IborIndices.EUR_LIBOR_6M, "EUR-LIBOR-6M"},
+        {IborIndices.JPY_LIBOR_6M, "JPY-LIBOR-6M"},
+        {IborIndices.USD_LIBOR_6M, "USD-LIBOR-6M"},
+
+        {OvernightIndices.GBP_SONIA, "GBP-SONIA"},
+        {OvernightIndices.CHF_SARON, "CHF-SARON"},
+        {OvernightIndices.EUR_EONIA, "EUR-EONIA"},
+        {OvernightIndices.JPY_TONAR, "JPY-TONAR"},
+        {OvernightIndices.USD_FED_FUND, "USD-FED-FUND"},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_name(RateIndex convention, String name) {
+    assertThat(convention.getName()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_toString(RateIndex convention, String name) {
+    assertThat(convention.toString()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_of_lookup(RateIndex convention, String name) {
+    assertThat(RateIndex.of(name)).isEqualTo(convention);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_of_convert(FloatingRateIndex convention, String name) {
+    assertThat(StringConvert.INSTANCE.convertToString(convention)).isEqualTo(name);
+    assertThat(StringConvert.INSTANCE.convertFromString(RateIndex.class, name)).isEqualTo(convention);
+  }
+
+  @Test
+  public void test_of_lookup_notFound() {
+    assertThatIllegalArgumentException().isThrownBy(() -> RateIndex.of(PriceIndices.GB_RPI.getName()));
+  }
+
+  @Test
+  public void test_of_lookup_null() {
+    assertThatIllegalArgumentException().isThrownBy(() -> RateIndex.of((String) null));
+  }
+
+}


### PR DESCRIPTION
Allow `RateIndex` and `FloatingRateIndex` to work with Joda-Convert