### PR TITLE
Update CDS Fpml parser to use the indexId element

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/CdsFpmlParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/CdsFpmlParserPlugin.java
@@ -202,8 +202,10 @@ final class CdsFpmlParserPlugin
     if (idOpt.isPresent()) {
       XmlElement idElement = idOpt.get();
       String id = idElement.getContent();
-      String indexIdScheme = idElement.findAttribute("indexIdScheme").orElse(StandardSchemes.RED9_SCHEME);
-      return Optional.of(StandardId.of(indexIdScheme, id));
+      if(id.length() == 9) {
+        return Optional.of(StandardId.of(StandardSchemes.RED9_SCHEME, id));
+      }
+      return idElement.findAttribute("indexIdScheme").map(scheme -> StandardId.of(scheme, id));
     }
     return Optional.empty();
   }

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/CdsFpmlParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/CdsFpmlParserPlugin.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.basics.currency.AdjustablePayment;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.date.AdjustableDate;
@@ -173,10 +174,12 @@ final class CdsFpmlParserPlugin
     // CDS index
     Optional<XmlElement> indexOptEl = generalTermsEl.findChild("indexReferenceInformation");
     if (indexOptEl.isPresent()) {
-      String indexName = indexOptEl.get().getChild("indexName").getContent();
+      XmlElement indexInformation = indexOptEl.get();
+      StandardId standardId = tryParseIndexId(indexInformation)
+          .orElseGet(() -> StandardId.of("CDX-Name", indexInformation.getChild("indexName").getContent()));
       CdsIndex cdsIndex = CdsIndex.builder()
           .buySell(buySell)
-          .cdsIndexId(StandardId.of("CDX-Name", indexName))
+          .cdsIndexId(standardId)
           .currency(notional.getCurrency())
           .notional(notional.getAmount())
           .paymentSchedule(scheduleBuilder.build())
@@ -192,6 +195,17 @@ final class CdsFpmlParserPlugin
 
     // unknown type
     throw new FpmlParseException("FpML CDS must be single name or index");
+  }
+
+  private Optional<StandardId> tryParseIndexId(XmlElement indexInformation) {
+    Optional<XmlElement> idOpt = indexInformation.findChild("indexId");
+    if (idOpt.isPresent()) {
+      XmlElement idElement = idOpt.get();
+      String id = idElement.getContent();
+      String indexIdScheme = idElement.findAttribute("indexIdScheme").orElse(StandardSchemes.RED9_SCHEME);
+      return Optional.of(StandardId.of(indexIdScheme, id));
+    }
+    return Optional.empty();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/CdsFpmlParserPlugin.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/impl/fpml/CdsFpmlParserPlugin.java
@@ -202,7 +202,7 @@ final class CdsFpmlParserPlugin
     if (idOpt.isPresent()) {
       XmlElement idElement = idOpt.get();
       String id = idElement.getContent();
-      if(id.length() == 9) {
+      if (id.length() == 9) {
         return Optional.of(StandardId.of(StandardSchemes.RED9_SCHEME, id));
       }
       return idElement.findAttribute("indexIdScheme").map(scheme -> StandardId.of(scheme, id));

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlDocumentParserTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/fpml/FpmlDocumentParserTest.java
@@ -75,6 +75,7 @@ import com.google.common.io.CharSource;
 import com.opengamma.strata.basics.ImmutableReferenceData;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.basics.currency.AdjustablePayment;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.CurrencyPair;
@@ -1530,6 +1531,36 @@ public class FpmlDocumentParserTest {
         .build();
     assertEqualsBean(cdsTrade.getProduct(), expected);
     assertThat(cdsTrade.getUpfrontFee().get()).isEqualTo(AdjustablePayment.of(USD, 16000, AdjustableDate.of(date(2004, 3, 23))));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void cdsIndex02() {
+    String location = "classpath:com/opengamma/strata/loader/fpml/cdindex-ex02-indexId.xml";
+    ByteSource resource = ResourceLocator.of(location).getByteSource();
+    List<Trade> trades = FpmlDocumentParser.of(FpmlPartySelector.matching("Party2")).parseTrades(resource);
+    assertThat(trades).hasSize(1);
+    CdsIndexTrade cdsTrade = (CdsIndexTrade) trades.get(0);
+    assertThat(cdsTrade.getInfo().getTradeDate()).isEqualTo(Optional.of(date(2020, 1, 24)));
+
+    CdsIndex expected = CdsIndex.builder()
+        .buySell(BUY)
+        .cdsIndexId(StandardId.of(StandardSchemes.RED9_SCHEME, "2I65BYCM5"))
+        .currency(USD)
+        .notional(25000000d)
+        .paymentSchedule(PeriodicSchedule.builder()
+            .startDate(date(2020, 3, 23))
+            .endDate(date(2021, 6, 20))
+            .startDateBusinessDayAdjustment(BusinessDayAdjustment.NONE)
+            .endDateBusinessDayAdjustment(BusinessDayAdjustment.NONE)
+            .businessDayAdjustment(BusinessDayAdjustment.NONE)
+            .frequency(Frequency.P3M)
+            .build())
+        .fixedRate(0.0060)
+        .dayCount(ACT_360)
+        .build();
+    assertEqualsBean(cdsTrade.getProduct(), expected);
+    assertThat(cdsTrade.getUpfrontFee()).hasValue(AdjustablePayment.of(USD, 16000, AdjustableDate.of(date(2020, 3, 23))));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/cdindex-ex02-indexId.xml
+++ b/modules/loader/src/test/resources/com/opengamma/strata/loader/fpml/cdindex-ex02-indexId.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--View is confirmation-->
+<!--Version is 5-8-->
+<!--NS is http://www.fpml.org/FpML-5/confirmation-->
+<!--
+        == Copyright (c) 2014-2015 All rights reserved.
+        == Financial Products Markup Language is subject to the FpML public license.
+        == A copy of this license is available at http://www.fpml.org/license/license.html
+-->
+<!--5.0:Message type is a Root of the message-->
+<dataDocument xmlns="http://www.fpml.org/FpML-5/confirmation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" fpmlVersion="5-8" xsi:schemaLocation="http://www.fpml.org/FpML-5/confirmation ../../fpml-main-5-8.xsd http://www.w3.org/2000/09/xmldsig# ../../xmldsig-core-schema.xsd">
+  <trade>
+    <tradeHeader>
+      <partyTradeIdentifier>
+        <partyReference href="party1" />
+        <tradeId tradeIdScheme="http://www.newbank.com/trade-id">CDX1234</tradeId>
+      </partyTradeIdentifier>
+      <partyTradeIdentifier>
+        <partyReference href="party2" />
+        <tradeId tradeIdScheme="http://www.massivebank.com/trade-id">1234A6</tradeId>
+      </partyTradeIdentifier>
+      <tradeDate>2020-01-24</tradeDate>
+    </tradeHeader>
+    <creditDefaultSwap>
+      <generalTerms>
+        <effectiveDate>
+          <unadjustedDate>2020-03-23</unadjustedDate>
+        </effectiveDate>
+        <scheduledTerminationDate>
+          <unadjustedDate>2021-06-20</unadjustedDate>
+        </scheduledTerminationDate>
+        <buyerPartyReference href="party2" />
+        <sellerPartyReference href="party1" />
+        <indexReferenceInformation>
+          <indexName>CDX.NA.IG</indexName>
+          <indexId>2I65BYCM5</indexId>
+          <indexSeries>16</indexSeries>
+          <indexAnnexDate>2018-03-12</indexAnnexDate>
+          <indexAnnexSource>Publisher</indexAnnexSource>
+        </indexReferenceInformation>
+      </generalTerms>
+      <feeLeg>
+        <initialPayment>
+          <payerPartyReference href="party1" />
+          <receiverPartyReference href="party2" />
+          <paymentAmount>
+            <currency>USD</currency>
+            <amount>16000</amount>
+          </paymentAmount>
+        </initialPayment>
+        <periodicPayment>
+          <fixedAmountCalculation>
+            <fixedRate>0.0060</fixedRate>
+          </fixedAmountCalculation>
+        </periodicPayment>
+      </feeLeg>
+      <protectionTerms>
+        <calculationAmount>
+          <currency>USD</currency>
+          <amount>25000000</amount>
+        </calculationAmount>
+      </protectionTerms>
+    </creditDefaultSwap>
+    <documentation>
+      <masterConfirmation>
+        <masterConfirmationType>CDX.NA.IG</masterConfirmationType>
+        <masterConfirmationDate>2020-10-18</masterConfirmationDate>
+      </masterConfirmation>
+    </documentation>
+  </trade>
+  <party id="party1">
+    <partyId>Party1</partyId>
+  </party>
+  <party id="party2">
+    <partyId>Party2</partyId>
+  </party>
+</dataDocument>


### PR DESCRIPTION
indexId, if provided, is a better option to indentify the CDS Index than
the free form index name.
We re-use the index scheme if provided, but default to
StandardSchemes.RED9_SCHEME if not. (This is probably what the id is, as
it's the de facto standard for CDS indices.)