### PR TITLE
Fix final stub handling

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/Schedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/Schedule.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.opengamma.strata.basics.date.DateAdjuster;
 import com.opengamma.strata.basics.date.DayCount.ScheduleInfo;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.tuple.Pair;
 
 /**
  * A complete schedule of periods (date ranges), with both unadjusted and adjusted dates.
@@ -240,6 +241,26 @@ public final class Schedule
   // checks if there is a final stub
   private boolean isFinalStub() {
     return !isSinglePeriod() && !getLastPeriod().isRegular(frequency, rollConvention);
+  }
+
+  /**
+   * Gets the stubs if they exist.
+   * <p>
+   * This method returns the initial and final stub.
+   * A flag is used to handle the case where there are no regular periods and it is unclear whether
+   * the stub is initial or final.
+   * <p>
+   * A period will be allocated to one and only one of {@link #getStubs} and {@link #getRegularPeriods()}.
+   * 
+   * @param preferFinal true to prefer final if there is only one period
+   * @return the stubs, empty if no stub
+   */
+  public Pair<Optional<SchedulePeriod>, Optional<SchedulePeriod>> getStubs(boolean preferFinal) {
+    Optional<SchedulePeriod> initialStub = getInitialStub();
+    if (preferFinal && size() == 1 && initialStub.isPresent()) {
+      return Pair.of(Optional.empty(), initialStub);
+    }
+    return Pair.of(initialStub, getFinalStub());
   }
 
   /**

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/ScheduleTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
+import com.opengamma.strata.collect.tuple.Pair;
 
 /**
  * Test {@link Schedule}.
@@ -95,6 +96,8 @@ public class ScheduleTest {
     assertThat(test.getLastPeriod()).isEqualTo(P1_STUB);
     assertThat(test.getInitialStub()).isEqualTo(Optional.empty());
     assertThat(test.getFinalStub()).isEqualTo(Optional.empty());
+    assertThat(test.getStubs(true)).isEqualTo(Pair.of(Optional.empty(), Optional.empty()));
+    assertThat(test.getStubs(false)).isEqualTo(Pair.of(Optional.empty(), Optional.empty()));
     assertThat(test.getRegularPeriods()).isEqualTo(ImmutableList.of(P1_STUB));
     assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> test.getPeriod(1));
     assertThat(test.getUnadjustedDates()).containsExactly(JUL_04, JUL_17);
@@ -123,6 +126,8 @@ public class ScheduleTest {
     assertThat(test.getLastPeriod()).isEqualTo(P1_STUB);
     assertThat(test.getInitialStub()).isEqualTo(Optional.of(P1_STUB));
     assertThat(test.getFinalStub()).isEqualTo(Optional.empty());
+    assertThat(test.getStubs(true)).isEqualTo(Pair.of(Optional.empty(), Optional.of(P1_STUB)));
+    assertThat(test.getStubs(false)).isEqualTo(Pair.of(Optional.of(P1_STUB), Optional.empty()));
     assertThat(test.getRegularPeriods()).isEqualTo(ImmutableList.of());
     assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> test.getPeriod(1));
     assertThat(test.getUnadjustedDates()).containsExactly(JUL_04, JUL_17);
@@ -151,6 +156,8 @@ public class ScheduleTest {
     assertThat(test.getLastPeriod()).isEqualTo(P2_NORMAL);
     assertThat(test.getInitialStub()).isEqualTo(Optional.empty());
     assertThat(test.getFinalStub()).isEqualTo(Optional.empty());
+    assertThat(test.getStubs(true)).isEqualTo(Pair.of(Optional.empty(), Optional.empty()));
+    assertThat(test.getStubs(false)).isEqualTo(Pair.of(Optional.empty(), Optional.empty()));
     assertThat(test.getRegularPeriods()).isEqualTo(ImmutableList.of(P2_NORMAL));
     assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> test.getPeriod(1));
     assertThat(test.getUnadjustedDates()).containsExactly(JUL_17, AUG_17);
@@ -180,6 +187,8 @@ public class ScheduleTest {
     assertThat(test.getLastPeriod()).isEqualTo(P2_NORMAL);
     assertThat(test.getInitialStub()).isEqualTo(Optional.of(P1_STUB));
     assertThat(test.getFinalStub()).isEqualTo(Optional.empty());
+    assertThat(test.getStubs(true)).isEqualTo(Pair.of(Optional.of(P1_STUB), Optional.empty()));
+    assertThat(test.getStubs(false)).isEqualTo(Pair.of(Optional.of(P1_STUB), Optional.empty()));
     assertThat(test.getRegularPeriods()).isEqualTo(ImmutableList.of(P2_NORMAL));
     assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> test.getPeriod(2));
     assertThat(test.getUnadjustedDates()).containsExactly(JUL_04, JUL_17, AUG_17);
@@ -209,6 +218,8 @@ public class ScheduleTest {
     assertThat(test.getLastPeriod()).isEqualTo(P3_NORMAL);
     assertThat(test.getInitialStub()).isEqualTo(Optional.empty());
     assertThat(test.getFinalStub()).isEqualTo(Optional.empty());
+    assertThat(test.getStubs(true)).isEqualTo(Pair.of(Optional.empty(), Optional.empty()));
+    assertThat(test.getStubs(false)).isEqualTo(Pair.of(Optional.empty(), Optional.empty()));
     assertThat(test.getRegularPeriods()).containsExactly(P2_NORMAL, P3_NORMAL);
     assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> test.getPeriod(2));
     assertThat(test.getUnadjustedDates()).containsExactly(JUL_17, AUG_17, SEP_17);
@@ -238,6 +249,8 @@ public class ScheduleTest {
     assertThat(test.getLastPeriod()).isEqualTo(P4_STUB);
     assertThat(test.getInitialStub()).isEqualTo(Optional.empty());
     assertThat(test.getFinalStub()).isEqualTo(Optional.of(P4_STUB));
+    assertThat(test.getStubs(true)).isEqualTo(Pair.of(Optional.empty(), Optional.of(P4_STUB)));
+    assertThat(test.getStubs(false)).isEqualTo(Pair.of(Optional.empty(), Optional.of(P4_STUB)));
     assertThat(test.getRegularPeriods()).isEqualTo(ImmutableList.of(P3_NORMAL));
     assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> test.getPeriod(2));
     assertThat(test.getUnadjustedDates()).containsExactly(AUG_17, SEP_17, SEP_30);

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/FixedRateCalculation.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/FixedRateCalculation.java
@@ -34,6 +34,7 @@ import com.opengamma.strata.basics.schedule.Schedule;
 import com.opengamma.strata.basics.schedule.SchedulePeriod;
 import com.opengamma.strata.basics.value.ValueSchedule;
 import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.collect.tuple.Pair;
 import com.opengamma.strata.product.rate.FixedOvernightCompoundedAnnualRateComputation;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 import com.opengamma.strata.product.rate.RateComputation;
@@ -136,8 +137,7 @@ public final class FixedRateCalculation
     // avoid null stub definitions if there are stubs
     FixedRateStubCalculation initialStub = firstNonNull(this.initialStub, FixedRateStubCalculation.NONE);
     FixedRateStubCalculation finalStub = firstNonNull(this.finalStub, FixedRateStubCalculation.NONE);
-    Optional<SchedulePeriod> scheduleInitialStub = accrualSchedule.getInitialStub();
-    Optional<SchedulePeriod> scheduleFinalStub = accrualSchedule.getFinalStub();
+
     // resolve data by schedule
     DoubleArray resolvedRates = rate.resolveValues(accrualSchedule);
 
@@ -154,6 +154,12 @@ public final class FixedRateCalculation
       RateAccrualPeriod accrualPeriod = new RateAccrualPeriod(period, yearFraction, rateComputation);
       return ImmutableList.of(accrualPeriod);
     }
+
+    // need to use getStubs(boolean) and not getInitialStub()/getFinalStub() to ensure correct stub allocation
+    Pair<Optional<SchedulePeriod>, Optional<SchedulePeriod>> scheduleStubs =
+        accrualSchedule.getStubs(this.initialStub == null && this.finalStub != null);
+    Optional<SchedulePeriod> scheduleInitialStub = scheduleStubs.getFirst();
+    Optional<SchedulePeriod> scheduleFinalStub = scheduleStubs.getSecond();
 
     // normal case
     ImmutableList.Builder<RateAccrualPeriod> accrualPeriods = ImmutableList.builder();

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/FixedRateCalculationTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/FixedRateCalculationTest.java
@@ -142,6 +142,48 @@ public class FixedRateCalculationTest {
     assertThat(periods).containsExactly(rap1, rap2, rap3);
   }
 
+  @Test
+  public void test_expand_onlyInitialStub() {
+    FixedRateCalculation test = FixedRateCalculation.builder()
+        .dayCount(ACT_365F)
+        .rate(ValueSchedule.of(0.025d))
+        .initialStub(FixedRateStubCalculation.ofFixedRate(0.03d))
+        .build();
+    SchedulePeriod period1 = SchedulePeriod.of(date(2014, 1, 6), date(2014, 2, 9), date(2014, 1, 5), date(2014, 2, 9));
+    Schedule schedule = Schedule.builder()
+        .periods(period1)
+        .frequency(Frequency.P1M)
+        .rollConvention(RollConventions.DAY_5)
+        .build();
+    RateAccrualPeriod rap1 = RateAccrualPeriod.builder(period1)
+        .yearFraction(period1.yearFraction(ACT_365F, schedule))
+        .rateComputation(FixedRateComputation.of(0.03d))
+        .build();
+    ImmutableList<RateAccrualPeriod> periods = test.createAccrualPeriods(schedule, schedule, REF_DATA);
+    assertThat(periods).containsExactly(rap1);
+  }
+
+  @Test
+  public void test_expand_onlyFinalStub() {
+    FixedRateCalculation test = FixedRateCalculation.builder()
+        .dayCount(ACT_365F)
+        .rate(ValueSchedule.of(0.025d))
+        .finalStub(FixedRateStubCalculation.ofFixedRate(0.03d))
+        .build();
+    SchedulePeriod period1 = SchedulePeriod.of(date(2014, 1, 6), date(2014, 2, 9), date(2014, 1, 5), date(2014, 2, 9));
+    Schedule schedule = Schedule.builder()
+        .periods(period1)
+        .frequency(Frequency.P1M)
+        .rollConvention(RollConventions.DAY_5)
+        .build();
+    RateAccrualPeriod rap1 = RateAccrualPeriod.builder(period1)
+        .yearFraction(period1.yearFraction(ACT_365F, schedule))
+        .rateComputation(FixedRateComputation.of(0.03d))
+        .build();
+    ImmutableList<RateAccrualPeriod> periods = test.createAccrualPeriods(schedule, schedule, REF_DATA);
+    assertThat(periods).containsExactly(rap1);
+  }
+
   //-------------------------------------------------------------------------
   @Test
   public void test_expand_onePeriod_with_futureValueNotional() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateCalculationTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/IborRateCalculationTest.java
@@ -399,6 +399,23 @@ public class IborRateCalculationTest {
     assertThat(periods).containsExactly(rap1);
   }
 
+  @Test
+  public void test_expand_singlePeriod_stubCalcsFinalStub_interpolated() {
+    IborRateCalculation test = IborRateCalculation.builder()
+        .dayCount(ACT_365F)
+        .index(GBP_LIBOR_2M)
+        .fixingDateOffset(MINUS_TWO_DAYS)
+        .finalStub(IborRateStubCalculation.ofIborInterpolatedRate(GBP_LIBOR_1W, GBP_LIBOR_1M))
+        .build();
+    RateAccrualPeriod rap1 = RateAccrualPeriod.builder(ACCRUAL1STUB)
+        .yearFraction(ACCRUAL1STUB.yearFraction(ACT_365F, ACCRUAL_SCHEDULE_STUBS))
+        .rateComputation(IborInterpolatedRateComputation.of(GBP_LIBOR_1W, GBP_LIBOR_1M, DATE_01_06, REF_DATA))
+        .build();
+    ImmutableList<RateAccrualPeriod> periods =
+        test.createAccrualPeriods(SINGLE_ACCRUAL_SCHEDULE_STUB, SINGLE_ACCRUAL_SCHEDULE_STUB, REF_DATA);
+    assertThat(periods).containsExactly(rap1);
+  }
+
   //-------------------------------------------------------------------------
   @Test
   public void test_expand_firstFixingDateOffsetNoStub() {


### PR DESCRIPTION
A swap is allowed to have only one period and that period can be a stub.
When defined as an initial stub, the stub information was picked up.
When defined as a final stub, the stub information was ignored.
Change this to correctly pickup any final stub info such as an interpolated Ibor rate.