### PR TITLE
Increase schedule flexibility

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -230,7 +230,7 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
    * This is used to identify the boundary date between the initial stub and the first regular schedule period.
    * <p>
    * This is an unadjusted date, and as such it might not be a valid business day.
-   * This date must be on or after 'startDate'.
+   * This date must be on or after 'startDate' and on or before 'endDate'.
    * <p>
    * During schedule generation, if this is present it will be used to determine the schedule.
    * If not present, then the overall schedule start date will be used instead, resulting in no initial stub.
@@ -243,8 +243,7 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
    * This is used to identify the boundary date between the last regular schedule period and the final stub.
    * <p>
    * This is an unadjusted date, and as such it might not be a valid business day.
-   * This date must be after 'startDate' and on or after 'firstRegularStartDate'.
-   * This date must be on or before 'endDate'.
+   * This date must be one or after 'startDate', on or after 'firstRegularStartDate' and on or before 'endDate'.
    * <p>
    * During schedule generation, if this is present it will be used to determine the schedule.
    * If not present, then the overall schedule end date will be used instead, resulting in no final stub.
@@ -263,7 +262,8 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
    * then the override will be used when generating regular periods.
    * <p>
    * If set, it should be different to the start date, although this is not validated.
-   * Validation does check that it is before the 'firstRegularStartDate'.
+   * Validation does check that it is on or before 'firstRegularStartDate' and 'lastRegularEndDate',
+   * and before 'endDate'.
    * <p>
    * During schedule generation, if this is present it will be used to override the start date
    * of the first generated schedule period.
@@ -354,25 +354,37 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
   //-------------------------------------------------------------------------
   @ImmutableValidator
   private void validate() {
-    ArgChecker.inOrderNotEqual(
-        startDate, endDate, "startDate", "endDate");
+    // startDate < endDate
+    ArgChecker.inOrderNotEqual(startDate, endDate, "startDate", "endDate");
+    if (overrideStartDate != null) {
+      ArgChecker.inOrderNotEqual(overrideStartDate.getUnadjusted(), endDate, "overrideStartDate", "endDate");
+    }
     if (firstRegularStartDate != null) {
+      // firstRegularStartDate <= endDate
+      ArgChecker.inOrderOrEqual(firstRegularStartDate, endDate, "firstRegularStartDate", "endDate");
+      // firstRegularStartDate <= lastRegularEndDate
       if (lastRegularEndDate != null) {
         ArgChecker.inOrderOrEqual(
             firstRegularStartDate, lastRegularEndDate, "firstRegularStartDate", "lastRegularEndDate");
       }
-      // Check override start date if present, otherwise use regular start date
+      // startDate (or overrideStartDate) <= firstRegularStartDate
       if (overrideStartDate != null) {
-        ArgChecker.inOrderNotEqual(
+        ArgChecker.inOrderOrEqual(
             overrideStartDate.getUnadjusted(), firstRegularStartDate, "overrideStartDate", "firstRegularStartDate");
       } else {
-        ArgChecker.inOrderOrEqual(
-            startDate, firstRegularStartDate, "unadjusted", "firstRegularStartDate");
+        ArgChecker.inOrderOrEqual(startDate, firstRegularStartDate, "unadjusted", "firstRegularStartDate");
       }
     }
     if (lastRegularEndDate != null) {
-      ArgChecker.inOrderOrEqual(
-          lastRegularEndDate, endDate, "lastRegularEndDate", "endDate");
+      // startDate (or overrideStartDate) < lastRegularEndDate
+      if (overrideStartDate != null) {
+        ArgChecker.inOrderOrEqual(
+            overrideStartDate.getUnadjusted(), lastRegularEndDate, "overrideStartDate", "lastRegularEndDate");
+      } else {
+        ArgChecker.inOrderOrEqual(startDate, lastRegularEndDate, "unadjusted", "lastRegularEndDate");
+      }
+      // lastRegularEndDate <= endDate
+      ArgChecker.inOrderOrEqual(lastRegularEndDate, endDate, "lastRegularEndDate", "endDate");
     }
   }
 
@@ -629,10 +641,8 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
       LocalDate end) {
 
     if (stubCnv.isCalculateBackwards()) {
-      // called only when stub is initial, validate that explicit stub flags have been resolved to stub convention NONE
-      ArgChecker.isFalse(explicitInitStub, "Value explicitInitStub must be false");
-      ArgChecker.isFalse(explicitFinalStub, "Value explicitFinalStub must be false");
-      return generateBackwards(this, regStart, regEnd, frequency, rollCnv, stubCnv, overrideStart);
+      return generateBackwards(
+          this, regStart, regEnd, frequency, rollCnv, stubCnv, overrideStart, explicitFinalStub, end);
     } else {
       return generateForwards(
           this, regStart, regEnd, frequency, rollCnv, stubCnv, explicitInitStub, overrideStart, explicitFinalStub, end);
@@ -647,7 +657,9 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
       Frequency frequency,
       RollConvention rollConv,
       StubConvention stubConv,
-      LocalDate explicitStartDate) {
+      LocalDate explicitStartDate,
+      boolean explicitFinalStub,
+      LocalDate explicitEndDate) {
 
     // validate
     if (rollConv.matches(end) == false) {
@@ -656,6 +668,9 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
     }
     // generate
     BackwardsList dates = new BackwardsList(estimateNumberPeriods(start, end, frequency));
+    if (explicitFinalStub) {
+      dates.addFirst(explicitEndDate);
+    }
     dates.addFirst(end);
     LocalDate temp = rollConv.previous(end, frequency);
     while (temp.isAfter(start)) {
@@ -1256,7 +1271,7 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
    * This is used to identify the boundary date between the initial stub and the first regular schedule period.
    * <p>
    * This is an unadjusted date, and as such it might not be a valid business day.
-   * This date must be on or after 'startDate'.
+   * This date must be on or after 'startDate' and on or before 'endDate'.
    * <p>
    * During schedule generation, if this is present it will be used to determine the schedule.
    * If not present, then the overall schedule start date will be used instead, resulting in no initial stub.
@@ -1273,8 +1288,7 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
    * This is used to identify the boundary date between the last regular schedule period and the final stub.
    * <p>
    * This is an unadjusted date, and as such it might not be a valid business day.
-   * This date must be after 'startDate' and on or after 'firstRegularStartDate'.
-   * This date must be on or before 'endDate'.
+   * This date must be one or after 'startDate', on or after 'firstRegularStartDate' and on or before 'endDate'.
    * <p>
    * During schedule generation, if this is present it will be used to determine the schedule.
    * If not present, then the overall schedule end date will be used instead, resulting in no final stub.
@@ -1297,7 +1311,8 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
    * then the override will be used when generating regular periods.
    * <p>
    * If set, it should be different to the start date, although this is not validated.
-   * Validation does check that it is before the 'firstRegularStartDate'.
+   * Validation does check that it is on or before 'firstRegularStartDate' and 'lastRegularEndDate',
+   * and before 'endDate'.
    * <p>
    * During schedule generation, if this is present it will be used to override the start date
    * of the first generated schedule period.
@@ -1936,7 +1951,7 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
      * This is used to identify the boundary date between the initial stub and the first regular schedule period.
      * <p>
      * This is an unadjusted date, and as such it might not be a valid business day.
-     * This date must be on or after 'startDate'.
+     * This date must be on or after 'startDate' and on or before 'endDate'.
      * <p>
      * During schedule generation, if this is present it will be used to determine the schedule.
      * If not present, then the overall schedule start date will be used instead, resulting in no initial stub.
@@ -1954,8 +1969,7 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
      * This is used to identify the boundary date between the last regular schedule period and the final stub.
      * <p>
      * This is an unadjusted date, and as such it might not be a valid business day.
-     * This date must be after 'startDate' and on or after 'firstRegularStartDate'.
-     * This date must be on or before 'endDate'.
+     * This date must be one or after 'startDate', on or after 'firstRegularStartDate' and on or before 'endDate'.
      * <p>
      * During schedule generation, if this is present it will be used to determine the schedule.
      * If not present, then the overall schedule end date will be used instead, resulting in no final stub.
@@ -1979,7 +1993,8 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
      * then the override will be used when generating regular periods.
      * <p>
      * If set, it should be different to the start date, although this is not validated.
-     * Validation does check that it is before the 'firstRegularStartDate'.
+     * Validation does check that it is on or before 'firstRegularStartDate' and 'lastRegularEndDate',
+     * and before 'endDate'.
      * <p>
      * During schedule generation, if this is present it will be used to override the start date
      * of the first generated schedule period.

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/StubConvention.java
@@ -139,7 +139,6 @@ public enum StubConvention implements NamedEnum {
    * If there is no remaining period when calculating, then there is no stub.
    * For example, a 6 month trade can be exactly divided by a 3 month frequency.
    * <p>
-   * When creating a schedule, there must be no explicit final stub.
    * If there is an explicit initial stub, then this convention is considered to be matched
    * and the remaining period is calculated using the stub convention 'None'.
    */
@@ -147,8 +146,7 @@ public enum StubConvention implements NamedEnum {
     @Override
     StubConvention toImplicit(PeriodicSchedule definition, boolean explicitInitialStub, boolean explicitFinalStub) {
       if (explicitFinalStub) {
-        throw new ScheduleException(
-            definition, "Dates specify an explicit final stub, but stub convention is 'SmartInitial'");
+        return (explicitInitialStub ? BOTH : SMART_INITIAL);
       }
       return (explicitInitialStub ? NONE : SMART_INITIAL);
     }
@@ -230,7 +228,6 @@ public enum StubConvention implements NamedEnum {
    * If there is no remaining period when calculating, then there is no stub.
    * For example, a 6 month trade can be exactly divided by a 3 month frequency.
    * <p>
-   * When creating a schedule, there must be no explicit initial stub.
    * If there is an explicit final stub, then this convention is considered to be matched
    * and the remaining period is calculated using the stub convention 'None'.
    */
@@ -238,8 +235,7 @@ public enum StubConvention implements NamedEnum {
     @Override
     StubConvention toImplicit(PeriodicSchedule definition, boolean explicitInitialStub, boolean explicitFinalStub) {
       if (explicitInitialStub) {
-        throw new ScheduleException(
-            definition, "Dates specify an explicit initial stub, but stub convention is 'SmartFinal'");
+        return (explicitFinalStub ? BOTH : SMART_FINAL);
       }
       return (explicitFinalStub ? NONE : SMART_FINAL);
     }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -408,6 +408,9 @@ public class PeriodicScheduleTest {
         {JUN_17, SEP_17, P1M, null, null, BDA, JUN_17, null, null,
             list(JUN_17, JUL_17, AUG_17, SEP_17),
             list(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
+        {JUN_04, SEP_04, P1M, SMART_FINAL, null, BDA, JUN_17, null, null,
+            list(JUN_04, JUN_17, JUL_17, AUG_17, SEP_04),
+            list(JUN_04, JUN_17, JUL_17, AUG_18, SEP_04), DAY_17},
 
         // explicit final stub
         {JUN_04, SEP_17, P1M, null, null, BDA, null, AUG_04, null,
@@ -419,6 +422,9 @@ public class PeriodicScheduleTest {
         {JUN_17, SEP_17, P1M, null, null, BDA, null, AUG_17, null,
             list(JUN_17, JUL_17, AUG_17, SEP_17),
             list(JUN_17, JUL_17, AUG_18, SEP_17), DAY_17},
+        {JUN_04, SEP_04, P1M, SMART_INITIAL, null, BDA, null, AUG_17, null,
+            list(JUN_04, JUN_17, JUL_17, AUG_17, SEP_04),
+            list(JUN_04, JUN_17, JUL_17, AUG_18, SEP_04), DAY_17},
 
         // explicit double stub
         {JUN_04, SEP_17, P1M, null, null, BDA, JUL_11, AUG_11, null,

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/StubConventionTest.java
@@ -183,8 +183,8 @@ public class StubConventionTest {
 
         {SMART_INITIAL, false, false, SMART_INITIAL},
         {SMART_INITIAL, true, false, NONE},
-        {SMART_INITIAL, false, true, null},
-        {SMART_INITIAL, true, true, null},
+        {SMART_INITIAL, false, true, SMART_INITIAL},
+        {SMART_INITIAL, true, true, BOTH},
 
         {SHORT_FINAL, false, false, SHORT_FINAL},
         {SHORT_FINAL, true, false, null},
@@ -197,9 +197,9 @@ public class StubConventionTest {
         {LONG_FINAL, true, true, null},
 
         {SMART_FINAL, false, false, SMART_FINAL},
-        {SMART_FINAL, true, false, null},
+        {SMART_FINAL, true, false, SMART_FINAL},
         {SMART_FINAL, false, true, NONE},
-        {SMART_FINAL, true, true, null},
+        {SMART_FINAL, true, true, BOTH},
 
         {BOTH, false, false, null},
         {BOTH, true, false, null},


### PR DESCRIPTION
Allow "SmartInitial" to work with an explicit final stub
Allow "SmartFinal" to work with an explicit initial stub
Adjust validation of dates in `PeriodicSchedule`