### PR TITLE
Fix time-series merge to correctly handle weekends

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilder.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilder.java
@@ -155,6 +155,7 @@ public final class LocalDateDoubleTimeSeriesBuilder {
    * @return this builder
    */
   public LocalDateDoubleTimeSeriesBuilder merge(LocalDateDoublePoint point, DoubleBinaryOperator operator) {
+    ArgChecker.notNull(point, "point");
     return merge(point.getDate(), point.getValue(), operator);
   }
 

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilder.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/timeseries/LocalDateDoubleTimeSeriesBuilder.java
@@ -110,9 +110,7 @@ public final class LocalDateDoubleTimeSeriesBuilder {
     ArgChecker.notNull(date, "date");
     ArgChecker.isFalse(Double.isNaN(value), "NaN is not allowed as a value");
     entries.put(date, value);
-    if (!containsWeekends && date.get(ChronoField.DAY_OF_WEEK) > 5) {
-      containsWeekends = true;
-    }
+    updateWeekendFlag(date);
     return this;
   }
 
@@ -143,6 +141,7 @@ public final class LocalDateDoubleTimeSeriesBuilder {
     ArgChecker.notNull(date, "date");
     ArgChecker.notNull(operator, "operator");
     entries.merge(date, value, (a, b) -> operator.applyAsDouble(a, b));
+    updateWeekendFlag(date);
     return this;
   }
 
@@ -156,9 +155,14 @@ public final class LocalDateDoubleTimeSeriesBuilder {
    * @return this builder
    */
   public LocalDateDoubleTimeSeriesBuilder merge(LocalDateDoublePoint point, DoubleBinaryOperator operator) {
-    ArgChecker.notNull(point, "point");
-    entries.merge(point.getDate(), point.getValue(), (a, b) -> operator.applyAsDouble(a, b));
-    return this;
+    return merge(point.getDate(), point.getValue(), operator);
+  }
+
+  // updates the weekend flag, if not updated exceptions will occur during build()
+  private void updateWeekendFlag(LocalDate date) {
+    if (!containsWeekends && date.get(ChronoField.DAY_OF_WEEK) > 5) {
+      containsWeekends = true;
+    }
   }
 
   //-------------------------------------------------------------------------
@@ -277,7 +281,6 @@ public final class LocalDateDoubleTimeSeriesBuilder {
    * @return a time-series containing the entries from the builder
    */
   public LocalDateDoubleTimeSeries build() {
-
     if (entries.isEmpty()) {
       return LocalDateDoubleTimeSeries.empty();
     }

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -61,17 +61,16 @@ public class DenseLocalDateDoubleTimeSeriesTest {
   private static final LocalDate DATE_2012_01_01 = date(2012, 1, 1);
   private static final LocalDate DATE_2013_01_01 = date(2013, 1, 1);
 
-  private static final LocalDate DATE_2014_01_01 = date(2014, 1, 1);
-
-  private static final LocalDate DATE_2015_01_02 = date(2015, 1, 2);
-  private static final LocalDate DATE_2015_01_03 = date(2015, 1, 3);
-  private static final LocalDate DATE_2015_01_04 = date(2015, 1, 4);
-  private static final LocalDate DATE_2015_01_05 = date(2015, 1, 5);
-  private static final LocalDate DATE_2015_01_06 = date(2015, 1, 6);
-  private static final LocalDate DATE_2015_01_07 = date(2015, 1, 7);
-  private static final LocalDate DATE_2015_01_08 = date(2015, 1, 8);
-  private static final LocalDate DATE_2015_01_09 = date(2015, 1, 9);
-  private static final LocalDate DATE_2015_01_11 = date(2015, 1, 11);
+  private static final LocalDate DATE_2014_01_01 = date(2014, 1, 1);  // Thu
+  private static final LocalDate DATE_2015_01_02 = date(2015, 1, 2);  // Fri
+  private static final LocalDate DATE_2015_01_03 = date(2015, 1, 3);  // Sat
+  private static final LocalDate DATE_2015_01_04 = date(2015, 1, 4);  // Sun
+  private static final LocalDate DATE_2015_01_05 = date(2015, 1, 5);  // Mon
+  private static final LocalDate DATE_2015_01_06 = date(2015, 1, 6);  // Tue
+  private static final LocalDate DATE_2015_01_07 = date(2015, 1, 7);  // Wed
+  private static final LocalDate DATE_2015_01_08 = date(2015, 1, 8);  // Thu
+  private static final LocalDate DATE_2015_01_09 = date(2015, 1, 9);  // Fri
+  private static final LocalDate DATE_2015_01_11 = date(2015, 1, 11);  // Sun
 
   private static final LocalDate DATE_2015_01_12 = date(2015, 1, 12);
 
@@ -673,7 +672,6 @@ public class DenseLocalDateDoubleTimeSeriesTest {
   //-------------------------------------------------------------------------
   @Test
   public void test_union_withMatchingElements() {
-
     List<LocalDate> dates1 = dates(DATE_2015_01_03, DATE_2015_01_05, DATE_2015_01_06);
     List<LocalDate> dates2 = dates(DATE_2015_01_02, DATE_2015_01_03, DATE_2015_01_05, DATE_2015_01_08);
     LocalDateDoubleTimeSeries series1 =
@@ -694,7 +692,6 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
   @Test
   public void test_union_withNoMatchingElements() {
-
     List<LocalDate> dates1 = dates(DATE_2015_01_03, DATE_2015_01_05, DATE_2015_01_06);
     List<LocalDate> dates2 = dates(DATE_2015_01_02, DATE_2015_01_04, DATE_2015_01_08);
     LocalDateDoubleTimeSeries series1 =
@@ -712,6 +709,21 @@ public class DenseLocalDateDoubleTimeSeriesTest {
     assertThat(test.get(DATE_2015_01_05)).isEqualTo(OptionalDouble.of(11d));
     assertThat(test.get(DATE_2015_01_06)).isEqualTo(OptionalDouble.of(12d));
     assertThat(test.get(DATE_2015_01_08)).isEqualTo(OptionalDouble.of(3d));
+  }
+
+  @Test
+  public void test_union_weekends() {
+    List<LocalDate> dates1 = dates(DATE_2015_01_03, DATE_2015_01_05, DATE_2015_01_11);  // start/end on weekend
+    List<LocalDate> dates2 = dates(DATE_2015_01_02, DATE_2015_01_05, DATE_2015_01_12);  // no weekend
+    LocalDateDoubleTimeSeries series1 =
+        LocalDateDoubleTimeSeries.builder().putAll(dates1, VALUES_10_12).build();
+    LocalDateDoubleTimeSeries series2 =
+        LocalDateDoubleTimeSeries.builder().putAll(dates2, VALUES_1_3).build();
+
+    LocalDateDoubleTimeSeries test = series1.union(series2, Double::sum);
+    LocalDateDoubleTimeSeries test2 = series2.union(series1, Double::sum);
+    assertThat(test.size()).isEqualTo(5);
+    assertThat(test).isEqualTo(test2);
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
The merge method did not set the `containsWeekends` flag
This caused an exception on building