### PR TITLE
Expose forward rate and implied volatility in swaption pricers

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricer.java
@@ -190,7 +190,8 @@ public class BlackSwaptionTradePricer {
   }
 
   /**
-   * Provides the forward rate of the next fixing date
+   * Provides the forward rate.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricer.java
@@ -169,6 +169,43 @@ public class BlackSwaptionTradePricer {
   }
 
   /**
+   * Computes the implied volatility of the swaption.
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @param swaptionVolatilities  the volatilities
+   * @return the implied volatility
+   */
+  public double impliedVolatility(
+      ResolvedSwaptionTrade swaptionTrade,
+      RatesProvider ratesProvider,
+      SwaptionVolatilities swaptionVolatilities) {
+
+    ResolvedSwaption product = swaptionTrade.getProduct();
+    if (isCash(product)) {
+      return cashParYieldPricer.impliedVolatility(product, ratesProvider, swaptionVolatilities);
+    } else {
+      return physicalPricer.impliedVolatility(product, ratesProvider, swaptionVolatilities);
+    }
+  }
+
+  /**
+   * Provides the forward rate of the next fixing date
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @return the forward rate
+   */
+  public double forwardRate(ResolvedSwaptionTrade swaptionTrade, RatesProvider ratesProvider) {
+    ResolvedSwaption product = swaptionTrade.getProduct();
+    if (isCash(product)) {
+      return cashParYieldPricer.forwardRate(product, ratesProvider);
+    } else {
+      return physicalPricer.forwardRate(product, ratesProvider);
+    }
+  }
+
+  /**
    * Calculates the current cash of the swaption trade.
    * <p>
    * Only the premium is contributing to the current cash for non-cash settle swaptions.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricer.java
@@ -191,6 +191,7 @@ public class BlackSwaptionTradePricer {
 
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricer.java
@@ -77,7 +77,7 @@ public class NormalSwaptionCashParYieldProductPricer
     double expiry = dayCount.yearFraction(valuationDate, expiryDate);
     ResolvedSwap underlying = swaption.getUnderlying();
     ResolvedSwapLeg fixedLeg = fixedLeg(underlying);
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     double strike = calculateStrike(fixedLeg);
     PutCall putCall = PutCall.ofPut(fixedLeg.getPayReceive().isReceive());

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricer.java
@@ -77,7 +77,7 @@ public class NormalSwaptionPhysicalProductPricer
     double expiry = dayCount.yearFraction(valuationDate, expiryDate);
     ResolvedSwap underlying = swaption.getUnderlying();
     ResolvedSwapLeg fixedLeg = fixedLeg(underlying);
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double numeraire = Math.abs(pvbp);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricer.java
@@ -169,6 +169,43 @@ public class NormalSwaptionTradePricer {
   }
 
   /**
+   * Computes the implied volatility of the swaption.
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @param swaptionVolatilities  the volatilities
+   * @return the implied volatility
+   */
+  public double impliedVolatility(
+      ResolvedSwaptionTrade swaptionTrade,
+      RatesProvider ratesProvider,
+      SwaptionVolatilities swaptionVolatilities) {
+
+    ResolvedSwaption product = swaptionTrade.getProduct();
+    if (isCash(product)) {
+      return cashParYieldPricer.impliedVolatility(product, ratesProvider, swaptionVolatilities);
+    } else {
+      return physicalPricer.impliedVolatility(product, ratesProvider, swaptionVolatilities);
+    }
+  }
+
+  /**
+   * Provides the forward rate of the next fixing date
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @return the forward rate
+   */
+  public double forwardRate(ResolvedSwaptionTrade swaptionTrade, RatesProvider ratesProvider) {
+    ResolvedSwaption product = swaptionTrade.getProduct();
+    if (isCash(product)) {
+      return cashParYieldPricer.forwardRate(product, ratesProvider);
+    } else {
+      return physicalPricer.forwardRate(product, ratesProvider);
+    }
+  }
+
+  /**
    * Calculates the current cash of the swaption trade.
    * <p>
    * Only the premium is contributing to the current cash for non-cash settle swaptions.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricer.java
@@ -191,6 +191,7 @@ public class NormalSwaptionTradePricer {
 
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricer.java
@@ -190,7 +190,8 @@ public class NormalSwaptionTradePricer {
   }
 
   /**
-   * Provides the forward rate of the next fixing date
+   * Provides the forward rate.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricer.java
@@ -82,7 +82,7 @@ public class SabrSwaptionCashParYieldProductPricer
     if (expiry < 0d) { // Option has expired already
       return PointSensitivityBuilder.none();
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     ValueDerivatives annuityDerivative = getSwapPricer().getLegPricer().annuityCashDerivative(fixedLeg, forward);
     double annuityCash = annuityDerivative.getValue();
     double annuityCashDr = annuityDerivative.getDerivative(0);
@@ -133,7 +133,7 @@ public class SabrSwaptionCashParYieldProductPricer
     if (expiry < 0d) { // Option has expired already
       return PointSensitivityBuilder.none();
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double volatility = swaptionVolatilities.volatility(expiry, tenor, strike, forward);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     DoubleArray derivative = swaptionVolatilities.volatilityAdjoint(expiry, tenor, strike, forward).getDerivatives();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricer.java
@@ -80,7 +80,7 @@ public class SabrSwaptionPhysicalProductPricer
     if (expiry < 0d) { // Option has expired already
       return PointSensitivityBuilder.none();
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -128,7 +128,7 @@ public class SabrSwaptionPhysicalProductPricer
     if (expiry < 0d) { // Option has expired already
       return PointSensitivityBuilder.none();
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double volatility = swaptionVolatilities.volatility(expiry, tenor, strike, forward);
     DoubleArray derivative =
         swaptionVolatilities.volatilityAdjoint(expiry, tenor, strike, forward).getDerivatives();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionTradePricer.java
@@ -241,7 +241,8 @@ public class SabrSwaptionTradePricer {
   }
 
   /**
-   * Provides the forward rate of the next fixing date
+   * Provides the forward rate.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionTradePricer.java
@@ -220,6 +220,43 @@ public class SabrSwaptionTradePricer {
   }
 
   /**
+   * Computes the implied volatility of the swaption.
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @param swaptionVolatilities  the volatilities
+   * @return the implied volatility
+   */
+  public double impliedVolatility(
+      ResolvedSwaptionTrade swaptionTrade,
+      RatesProvider ratesProvider,
+      SwaptionVolatilities swaptionVolatilities) {
+
+    ResolvedSwaption product = swaptionTrade.getProduct();
+    if (isCash(product)) {
+      return cashParYieldPricer.impliedVolatility(product, ratesProvider, swaptionVolatilities);
+    } else {
+      return physicalPricer.impliedVolatility(product, ratesProvider, swaptionVolatilities);
+    }
+  }
+
+  /**
+   * Provides the forward rate of the next fixing date
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @return the forward rate
+   */
+  public double forwardRate(ResolvedSwaptionTrade swaptionTrade, RatesProvider ratesProvider) {
+    ResolvedSwaption product = swaptionTrade.getProduct();
+    if (isCash(product)) {
+      return cashParYieldPricer.forwardRate(product, ratesProvider);
+    } else {
+      return physicalPricer.forwardRate(product, ratesProvider);
+    }
+  }
+
+  /**
    * Calculates the current cash of the swaption trade.
    * <p>
    * Only the premium is contributing to the current cash for non-cash settle swaptions.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/SabrSwaptionTradePricer.java
@@ -242,6 +242,7 @@ public class SabrSwaptionTradePricer {
 
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -161,7 +161,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
    * @return the forward rate
    */
   public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
-    return VolatilitySwaptionProductPricer.forwardRate(swaption, ratesProvider);
+    return swapPricer.parRate(swaption.getUnderlying(), ratesProvider);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -154,6 +154,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption  the swaption

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -154,7 +154,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Provides the forward rate.
-   * This is par rate for the forward starting swap that is the underlying of the swaption.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -39,7 +39,7 @@ import com.opengamma.strata.product.swaption.ResolvedSwaption;
  * The volatility parameters are not adjusted for the underlying swap convention.
  * <p>
  * The value of the swaption after expiry is 0.
- * For a swaption which already expired, negative number is returned by 
+ * For a swaption which already expired, negative number is returned by
  * {@link SwaptionVolatilities#relativeTime(ZonedDateTime)}.
  */
 public class VolatilitySwaptionCashParYieldProductPricer {
@@ -51,13 +51,13 @@ public class VolatilitySwaptionCashParYieldProductPricer {
       new VolatilitySwaptionCashParYieldProductPricer(DiscountingSwapProductPricer.DEFAULT);
 
   /**
-   * Pricer for {@link SwapProduct}. 
+   * Pricer for {@link ResolvedSwap}.
    */
   private final DiscountingSwapProductPricer swapPricer;
 
   /**
    * Creates an instance.
-   * 
+   *
    * @param swapPricer  the pricer for {@link Swap}
    */
   public VolatilitySwaptionCashParYieldProductPricer(DiscountingSwapProductPricer swapPricer) {
@@ -67,7 +67,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Gets the swap pricer.
-   * 
+   *
    * @return the swap pricer
    */
   protected DiscountingSwapProductPricer getSwapPricer() {
@@ -79,7 +79,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
    * Calculates the present value of the swaption.
    * <p>
    * The result is expressed using the currency of the swaption.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -112,7 +112,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
    * Computes the currency exposure of the swaption.
    * <p>
    * This is equivalent to the present value of the swaption.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -129,7 +129,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Computes the implied volatility of the swaption.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -153,13 +153,25 @@ public class VolatilitySwaptionCashParYieldProductPricer {
 
   //-------------------------------------------------------------------------
   /**
+   * Provides the forward rate of the next fixing date
+   *
+   * @param swaption  the swaption
+   * @param ratesProvider  the rates provider
+   * @return the forward rate
+   */
+  public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
+    return VolatilitySwaptionProductPricer.DEFAULT.forwardRate(swaption, ratesProvider);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Calculates the present value delta of the swaption.
    * <p>
    * The present value delta is given by {@code pvbp * priceDelta} where {@code priceDelta}
    * is the first derivative of the price with respect to forward.
    * <p>
    * The result is expressed using the currency of the swaption.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -195,7 +207,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
    * is the second derivative of the price with respect to forward.
    * <p>
    * The result is expressed using the currency of the swaption.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -231,7 +243,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
    * is the minus of the price sensitivity to {@code timeToExpiry}.
    * <p>
    * The result is expressed using the currency of the swaption.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -263,10 +275,10 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   /**
    * Calculates the present value sensitivity of the swaption to the rate curves.
    * <p>
-   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the 
-   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential 
+   * The present value sensitivity is computed in a "sticky strike" style, i.e. the sensitivity to the
+   * curve nodes with the volatility at the swaption strike unchanged. This sensitivity does not include a potential
    * change of volatility due to the implicit change of forward rate or moneyness.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -310,7 +322,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
    * Calculates the present value sensitivity to the implied volatility of the swaption.
    * <p>
    * The sensitivity to the implied volatility is also called vega.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -349,7 +361,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Calculates the numeraire, used to multiply the results.
-   * 
+   *
    * @param swaption  the swap
    * @param fixedLeg  the fixed leg
    * @param forward  the forward rate
@@ -370,7 +382,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
 
   /**
    * Calculates the strike.
-   * 
+   *
    * @param fixedLeg  the fixed leg
    * @return the strike
    */
@@ -386,7 +398,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
 
   /**
    * Checks that there is exactly one fixed leg and returns it.
-   * 
+   *
    * @param swap  the swap
    * @return the fixed leg
    */
@@ -403,7 +415,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
   /**
    * Validates that the rates and volatilities providers are coherent
    * and that the swaption is single currency cash par-yield.
-   * 
+   *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @param swaptionVolatilities  the volatilities
@@ -420,7 +432,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
 
   /**
    * Validates that the swaption is single currency cash par-yield.
-   * 
+   *
    * @param swaption  the swaption
    */
   protected void validateSwaption(ResolvedSwaption swaption) {

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionCashParYieldProductPricer.java
@@ -97,7 +97,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = swapPricer.parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     double strike = calculateStrike(fixedLeg);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -145,7 +145,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     ResolvedSwap underlying = swaption.getUnderlying();
     ResolvedSwapLeg fixedLeg = fixedLeg(underlying);
     ArgChecker.isTrue(expiry >= 0d, "Option must be before expiry to compute an implied volatility");
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double strike = calculateStrike(fixedLeg);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
     return swaptionVolatilities.volatility(expiry, tenor, strike, forward);
@@ -153,14 +153,15 @@ public class VolatilitySwaptionCashParYieldProductPricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Provides the forward rate of the next fixing date
+   * Provides the forward rate.
+   * This is par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @return the forward rate
    */
   public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
-    return VolatilitySwaptionProductPricer.DEFAULT.forwardRate(swaption, ratesProvider);
+    return VolatilitySwaptionProductPricer.forwardRate(swaption, ratesProvider);
   }
 
   //-------------------------------------------------------------------------
@@ -189,7 +190,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     double strike = calculateStrike(fixedLeg);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -225,7 +226,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     double strike = calculateStrike(fixedLeg);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -261,7 +262,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     double strike = calculateStrike(fixedLeg);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -296,7 +297,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
     if (expiry < 0d) { // Option has expired already
       return PointSensitivityBuilder.none();
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     ValueDerivatives annuityDerivative = getSwapPricer().getLegPricer().annuityCashDerivative(fixedLeg, forward);
     double annuityCash = annuityDerivative.getValue();
     double annuityCashDr = annuityDerivative.getDerivative(0);
@@ -343,7 +344,7 @@ public class VolatilitySwaptionCashParYieldProductPricer {
       return SwaptionSensitivity.of(
           swaptionVolatilities.getName(), expiry, tenor, strike, 0d, fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = calculateNumeraire(swaption, fixedLeg, forward, ratesProvider);
     double volatility = swaptionVolatilities.volatility(expiry, tenor, strike, forward);
     PutCall putCall = PutCall.ofPut(fixedLeg.getPayReceive().isReceive());

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -89,7 +89,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = swapPricer.parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = swapPricer.getLegPricer().pvbp(fixedLeg, ratesProvider);
     double strike = swapPricer.getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -137,7 +137,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     ResolvedSwap underlying = swaption.getUnderlying();
     ResolvedSwapLeg fixedLeg = fixedLeg(underlying);
     ArgChecker.isTrue(expiry >= 0d, "Option must be before expiry to compute an implied volatility");
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -146,14 +146,15 @@ public class VolatilitySwaptionPhysicalProductPricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Provides the forward rate of the next fixing date
+   * Provides the forward rate.
+   * This is par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider
    * @return the forward rate
    */
   public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
-    return VolatilitySwaptionProductPricer.DEFAULT.forwardRate(swaption, ratesProvider);
+    return VolatilitySwaptionProductPricer.forwardRate(swaption, ratesProvider);
   }
 
   //-------------------------------------------------------------------------
@@ -188,7 +189,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double numeraire = Math.abs(pvbp);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
@@ -225,7 +226,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double numeraire = Math.abs(pvbp);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
@@ -262,7 +263,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     if (expiry < 0d) { // Option has expired already
       return CurrencyAmount.of(fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double numeraire = Math.abs(pvbp);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
@@ -298,7 +299,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
     if (expiry < 0d) { // Option has expired already
       return PointSensitivityBuilder.none();
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double pvbp = getSwapPricer().getLegPricer().pvbp(fixedLeg, ratesProvider);
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
@@ -341,7 +342,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
       return SwaptionSensitivity.of(
           swaptionVolatilities.getName(), expiry, tenor, strike, 0d, fixedLeg.getCurrency(), 0d);
     }
-    double forward = getSwapPricer().parRate(underlying, ratesProvider);
+    double forward = forwardRate(swaption, ratesProvider);
     double numeraire = Math.abs(pvbp);
     double volatility = swaptionVolatilities.volatility(expiry, tenor, strike, forward);
     PutCall putCall = PutCall.ofPut(fixedLeg.getPayReceive().isReceive());

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -147,6 +147,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption  the swaption

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -154,7 +154,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
    * @return the forward rate
    */
   public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
-    return VolatilitySwaptionProductPricer.forwardRate(swaption, ratesProvider);
+    return swapPricer.parRate(swaption.getUnderlying(), ratesProvider);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -43,7 +43,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
       new VolatilitySwaptionPhysicalProductPricer(DiscountingSwapProductPricer.DEFAULT);
 
   /**
-   * Pricer for {@link SwapProduct}. 
+   * Pricer for {@link ResolvedSwap}.
    */
   private final DiscountingSwapProductPricer swapPricer;
 
@@ -142,6 +142,18 @@ public class VolatilitySwaptionPhysicalProductPricer {
     double strike = getSwapPricer().getLegPricer().couponEquivalent(fixedLeg, ratesProvider, pvbp);
     double tenor = swaptionVolatilities.tenor(fixedLeg.getStartDate(), fixedLeg.getEndDate());
     return swaptionVolatilities.volatility(expiry, tenor, strike, forward);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Provides the forward rate of the next fixing date
+   *
+   * @param swaption  the swaption
+   * @param ratesProvider  the rates provider
+   * @return the forward rate
+   */
+  public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
+    return VolatilitySwaptionProductPricer.DEFAULT.forwardRate(swaption, ratesProvider);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionPhysicalProductPricer.java
@@ -147,7 +147,7 @@ public class VolatilitySwaptionPhysicalProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Provides the forward rate.
-   * This is par rate for the forward starting swap that is the underlying of the swaption.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption  the swaption
    * @param ratesProvider  the rates provider

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
@@ -5,23 +5,16 @@
  */
 package com.opengamma.strata.pricer.swaption;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
-import com.opengamma.strata.basics.date.HolidayCalendar;
-import com.opengamma.strata.basics.index.IborIndex;
-import com.opengamma.strata.basics.index.IborIndexObservation;
-import com.opengamma.strata.basics.index.OvernightIndex;
-import com.opengamma.strata.basics.index.OvernightIndexObservation;
-import com.opengamma.strata.basics.index.RateIndex;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.product.common.SettlementType;
+import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swaption.ResolvedSwaption;
 
 /**
@@ -53,6 +46,10 @@ public class VolatilitySwaptionProductPricer {
    * Pricer for physical.
    */
   private final VolatilitySwaptionPhysicalProductPricer physicalPricer;
+  /**
+   * Pricer for {@link ResolvedSwap}.
+   */
+  private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;
 
   /**
    * Creates an instance.
@@ -137,31 +134,15 @@ public class VolatilitySwaptionProductPricer {
 
   //-------------------------------------------------------------------------
   /**
-   * Provides the forward rate of the next fixing date
+   * Provides the forward rate.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption the swaption
    * @param ratesProvider the rates provider
    * @return the forward rate
    */
-  public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
-    RateIndex index = swaption.getIndex();
-    HolidayCalendar holidayCalendar = ReferenceData.standard().getValue(index.getFixingCalendar());
-    if (index instanceof IborIndex) {
-      IborIndex iborIndex = (IborIndex) index;
-      return ratesProvider.iborIndexRates(iborIndex).rate(IborIndexObservation.of(
-          iborIndex,
-          holidayCalendar.next(LocalDate.now(ZoneId.systemDefault())),
-          ReferenceData.standard()));
-    }
-    if (index instanceof OvernightIndex) {
-      OvernightIndex overnightIndex = (OvernightIndex) index;
-      return ratesProvider.overnightIndexRates(overnightIndex).rate(OvernightIndexObservation.of(
-          overnightIndex,
-          holidayCalendar.next(LocalDate.now(ZoneId.systemDefault())),
-          ReferenceData.standard()));
-    }
-    throw new IllegalArgumentException("OvernightIndex and IborIndex are the only expected extensions of RateIndex. " +
-        "But found: " + index.getClass().getSimpleName());
+  public static double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
+    return SWAP_PRICER.parRate(swaption.getUnderlying(), ratesProvider);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
@@ -12,9 +12,7 @@ import com.opengamma.strata.basics.currency.MultiCurrencyAmount;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
 import com.opengamma.strata.pricer.rate.RatesProvider;
-import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.product.common.SettlementType;
-import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swaption.ResolvedSwaption;
 
 /**
@@ -46,10 +44,6 @@ public class VolatilitySwaptionProductPricer {
    * Pricer for physical.
    */
   private final VolatilitySwaptionPhysicalProductPricer physicalPricer;
-  /**
-   * Pricer for {@link ResolvedSwap}.
-   */
-  private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;
 
   /**
    * Creates an instance.
@@ -141,8 +135,12 @@ public class VolatilitySwaptionProductPricer {
    * @param ratesProvider the rates provider
    * @return the forward rate
    */
-  public static double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
-    return SWAP_PRICER.parRate(swaption.getUnderlying(), ratesProvider);
+  public double forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider) {
+    if (isCash(swaption)) {
+      return cashParYieldPricer.forwardRate(swaption, ratesProvider);
+    } else {
+      return physicalPricer.forwardRate(swaption, ratesProvider);
+    }
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
@@ -161,7 +161,7 @@ public class VolatilitySwaptionProductPricer {
           ReferenceData.standard()));
     }
     throw new IllegalArgumentException("OvernightIndex and IborIndex are the only expected extensions of RateIndex. " +
-        "Found: " + index.getClass().getSimpleName());
+        "But found: " + index.getClass().getSimpleName());
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionProductPricer.java
@@ -129,6 +129,7 @@ public class VolatilitySwaptionProductPricer {
   //-------------------------------------------------------------------------
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaption the swaption

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
@@ -178,7 +178,7 @@ public class VolatilitySwaptionTradePricer {
    * @return the forward rate
    */
   public double forwardRate(ResolvedSwaptionTrade swaptionTrade, RatesProvider ratesProvider) {
-    return productPricer.forwardRate(swaptionTrade.getProduct(), ratesProvider);
+    return VolatilitySwaptionProductPricer.forwardRate(swaptionTrade.getProduct(), ratesProvider);
   }
 
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
@@ -155,6 +155,33 @@ public class VolatilitySwaptionTradePricer {
   }
 
   /**
+   * Computes the implied volatility of the swaption.
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @param swaptionVolatilities  the volatilities
+   * @return the implied volatility
+   */
+  public double impliedVolatility(
+      ResolvedSwaptionTrade swaptionTrade,
+      RatesProvider ratesProvider,
+      SwaptionVolatilities swaptionVolatilities) {
+
+    return productPricer.impliedVolatility(swaptionTrade.getProduct(), ratesProvider, swaptionVolatilities);
+  }
+
+  /**
+   * Provides the forward rate for the next fixing date
+   *
+   * @param swaptionTrade  the swaption trade
+   * @param ratesProvider  the rates provider
+   * @return the forward rate
+   */
+  public double forwardRate(ResolvedSwaptionTrade swaptionTrade, RatesProvider ratesProvider) {
+    return productPricer.forwardRate(swaptionTrade.getProduct(), ratesProvider);
+  }
+
+  /**
    * Calculates the current cash of the swaption trade.
    * <p>
    * Only the premium is contributing to the current cash for non-cash settle swaptions.

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
@@ -171,14 +171,15 @@ public class VolatilitySwaptionTradePricer {
   }
 
   /**
-   * Provides the forward rate for the next fixing date
+   * Provides the forward rate.
+   * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade
    * @param ratesProvider  the rates provider
    * @return the forward rate
    */
   public double forwardRate(ResolvedSwaptionTrade swaptionTrade, RatesProvider ratesProvider) {
-    return VolatilitySwaptionProductPricer.forwardRate(swaptionTrade.getProduct(), ratesProvider);
+    return productPricer.forwardRate(swaptionTrade.getProduct(), ratesProvider);
   }
 
   /**

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/swaption/VolatilitySwaptionTradePricer.java
@@ -172,6 +172,7 @@ public class VolatilitySwaptionTradePricer {
 
   /**
    * Provides the forward rate.
+   * <p>
    * This is the par rate for the forward starting swap that is the underlying of the swaption.
    *
    * @param swaptionTrade  the swaption trade

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
@@ -739,11 +739,4 @@ public class BlackSwaptionCashParYieldProductPricerTest {
     assertThat(computed.equalWithTolerance(expected, NOTIONAL * TOL)).isTrue();
   }
 
-  @Test
-  void forward_rate_is_swaption_independent() {
-    double forwardRate1 = PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
-    double forwardRate2 = PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
-    assertThat(forwardRate1).isEqualTo(forwardRate2);
-  }
-
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
@@ -740,7 +740,7 @@ public class BlackSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  void forward_rate_is_swaption_independent(){
+  void forward_rate_is_swaption_independent() {
     double forwardRate1 = PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
     double forwardRate2 = PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
     assertThat(forwardRate1).isEqualTo(forwardRate2);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionCashParYieldProductPricerTest.java
@@ -739,4 +739,11 @@ public class BlackSwaptionCashParYieldProductPricerTest {
     assertThat(computed.equalWithTolerance(expected, NOTIONAL * TOL)).isTrue();
   }
 
+  @Test
+  void forward_rate_is_swaption_independent(){
+    double forwardRate1 = PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
+    double forwardRate2 = PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
+    assertThat(forwardRate1).isEqualTo(forwardRate2);
+  }
+
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
@@ -164,14 +164,14 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void validate_physical_settlement() {
+  void validate_physical_settlement() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC_CASH, MULTI_USD, BLACK_VOLS_USD_STD));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_implied_volatility() {
+  void test_implied_volatility() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double volExpected = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
@@ -181,14 +181,14 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_implied_volatility_after_expiry() {
+  void test_implied_volatility_after_expiry() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER_SWAPTION_BLACK.impliedVolatility(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_formula() {
+  void present_value_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -202,7 +202,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_long_short_parity() {
+  void present_value_long_short_parity() {
     CurrencyAmount pvLong =
         PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvShort =
@@ -211,7 +211,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_payer_receiver_parity() {
+  void present_value_payer_receiver_parity() {
     CurrencyAmount pvLongPay =
         PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvShortRec =
@@ -222,7 +222,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_at_expiry() {
+  void present_value_at_expiry() {
     CurrencyAmount pvRec =
         PRICER_SWAPTION_BLACK.presentValue(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvRec.getAmount()).isCloseTo(0.0d, offset(TOLERANCE_PV));
@@ -232,14 +232,14 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_after_expiry() {
+  void present_value_after_expiry() {
     CurrencyAmount pv = PRICER_SWAPTION_BLACK.presentValue(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pv.getAmount()).isCloseTo(0.0d, offset(TOLERANCE_PV));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_delta_formula() {
+  void present_value_delta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -253,7 +253,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_long_short_parity() {
+  void present_value_delta_long_short_parity() {
     CurrencyAmount pvDeltaLong =
         PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvDeltaShort =
@@ -262,7 +262,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_payer_receiver_parity() {
+  void present_value_delta_payer_receiver_parity() {
     CurrencyAmount pvDeltaLongPay =
         PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvDeltaShortRec =
@@ -272,7 +272,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_at_expiry() {
+  void present_value_delta_at_expiry() {
     CurrencyAmount pvDeltaRec =
         PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvDeltaRec.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -283,7 +283,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_after_expiry() {
+  void present_value_delta_after_expiry() {
     CurrencyAmount pvDelta =
         PRICER_SWAPTION_BLACK.presentValueDelta(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvDelta.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -291,7 +291,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_gamma_formula() {
+  void present_value_gamma_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -305,7 +305,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_long_short_parity() {
+  void present_value_gamma_long_short_parity() {
     CurrencyAmount pvGammaLong =
         PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvGammaShort =
@@ -314,7 +314,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_payer_receiver_parity() {
+  void present_value_gamma_payer_receiver_parity() {
     CurrencyAmount pvGammaLongPay =
         PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvGammaShortRec =
@@ -323,7 +323,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_at_expiry() {
+  void present_value_gamma_at_expiry() {
     CurrencyAmount pvGammaRec =
         PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvGammaRec.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -333,7 +333,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_after_expiry() {
+  void present_value_gamma_after_expiry() {
     CurrencyAmount pvGamma =
         PRICER_SWAPTION_BLACK.presentValueGamma(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvGamma.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -341,7 +341,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_theta_formula() {
+  void present_value_theta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = BLACK_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -355,7 +355,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_long_short_parity() {
+  void present_value_theta_long_short_parity() {
     CurrencyAmount pvThetaLong =
         PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvThetaShort =
@@ -364,7 +364,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_payer_receiver_parity() {
+  void present_value_theta_payer_receiver_parity() {
     CurrencyAmount pvThetaLongPay =
         PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     CurrencyAmount pvThetaShortRec =
@@ -373,7 +373,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_at_expiry() {
+  void present_value_theta_at_expiry() {
     CurrencyAmount pvThetaRec =
         PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvThetaRec.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -383,7 +383,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_after_expiry() {
+  void present_value_theta_after_expiry() {
     CurrencyAmount pvTheta =
         PRICER_SWAPTION_BLACK.presentValueTheta(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvTheta.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -391,7 +391,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------  
   @Test
-  public void currency_exposure() {
+  void currency_exposure() {
     CurrencyAmount pv =
         PRICER_SWAPTION_BLACK.presentValue(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     MultiCurrencyAmount ce =
@@ -401,7 +401,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_FD() {
+  void present_value_sensitivity_FD() {
     PointSensitivities pvpt = PRICER_SWAPTION_BLACK
         .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, BLACK_VOLS_CST_USD)
         .build();
@@ -412,7 +412,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_long_short_parity() {
+  void present_value_sensitivity_long_short_parity() {
     PointSensitivities pvptLong = PRICER_SWAPTION_BLACK
         .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD).build();
     PointSensitivities pvptShort = PRICER_SWAPTION_BLACK
@@ -424,7 +424,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_payer_receiver_parity() {
+  void present_value_sensitivity_payer_receiver_parity() {
     PointSensitivities pvptLongPay = PRICER_SWAPTION_BLACK
         .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD).build();
     PointSensitivities pvptShortRec = PRICER_SWAPTION_BLACK
@@ -438,7 +438,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_at_expiry() {
+  void present_value_sensitivity_at_expiry() {
     PointSensitivities sensiRec = PRICER_SWAPTION_BLACK.presentValueSensitivityRatesStickyStrike(
         SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD).build();
     for (PointSensitivity sensi : sensiRec.getSensitivities()) {
@@ -452,7 +452,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_after_expiry() {
+  void present_value_sensitivity_after_expiry() {
     PointSensitivityBuilder pvpts = PRICER_SWAPTION_BLACK
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(pvpts).isEqualTo(PointSensitivityBuilder.none());
@@ -460,7 +460,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivityBlackVolatility_FD() {
+  void present_value_sensitivityBlackVolatility_FD() {
     double shiftVol = 1.0E-4;
     Surface surfaceUp = ConstantSurface.of(
         SwaptionBlackVolatilityDataSets.META_DATA, SwaptionBlackVolatilityDataSets.VOLATILITY + shiftVol);
@@ -486,7 +486,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityBlackVolatility_long_short_parity() {
+  void present_value_sensitivityBlackVolatility_long_short_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_BLACK
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_BLACK
@@ -495,7 +495,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityBlackVolatility_payer_receiver_parity() {
+  void present_value_sensitivityBlackVolatility_payer_receiver_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_BLACK
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, BLACK_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_BLACK
@@ -504,7 +504,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityBlackVolatility_at_expiry() {
+  void present_value_sensitivityBlackVolatility_at_expiry() {
     SwaptionSensitivity sensiRec = PRICER_SWAPTION_BLACK.presentValueSensitivityModelParamsVolatility(
         SWAPTION_REC_AT_EXPIRY, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(sensiRec.getSensitivity()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -514,10 +514,17 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityBlackVolatility_after_expiry() {
+  void present_value_sensitivityBlackVolatility_after_expiry() {
     SwaptionSensitivity v = PRICER_SWAPTION_BLACK
         .presentValueSensitivityModelParamsVolatility(SWAPTION_PAST, MULTI_USD, BLACK_VOLS_USD_STD);
     assertThat(v.getSensitivity()).isCloseTo(0.0d, offset(TOLERANCE_PV_VEGA));
+  }
+
+  @Test
+  void forward_rate_is_swaption_independent(){
+    double forwardRate1 = PRICER_SWAPTION_BLACK.forwardRate(SWAPTION_PAST, MULTI_USD);
+    double forwardRate2 = PRICER_SWAPTION_BLACK.forwardRate(SWAPTION_LONG_PAY, MULTI_USD);
+    assertThat(forwardRate1).isEqualTo(forwardRate2);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
@@ -521,7 +521,7 @@ public class BlackSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  void forward_rate_is_swaption_independent(){
+  void forward_rate_is_swaption_independent() {
     double forwardRate1 = PRICER_SWAPTION_BLACK.forwardRate(SWAPTION_PAST, MULTI_USD);
     double forwardRate2 = PRICER_SWAPTION_BLACK.forwardRate(SWAPTION_LONG_PAY, MULTI_USD);
     assertThat(forwardRate1).isEqualTo(forwardRate2);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionPhysicalProductPricerTest.java
@@ -520,11 +520,4 @@ public class BlackSwaptionPhysicalProductPricerTest {
     assertThat(v.getSensitivity()).isCloseTo(0.0d, offset(TOLERANCE_PV_VEGA));
   }
 
-  @Test
-  void forward_rate_is_swaption_independent() {
-    double forwardRate1 = PRICER_SWAPTION_BLACK.forwardRate(SWAPTION_PAST, MULTI_USD);
-    double forwardRate2 = PRICER_SWAPTION_BLACK.forwardRate(SWAPTION_LONG_PAY, MULTI_USD);
-    assertThat(forwardRate1).isEqualTo(forwardRate2);
-  }
-
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerCashParYieldTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerCashParYieldTest.java
@@ -100,7 +100,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_premium_forward() {
+  void present_value_premium_forward() {
     CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, RATE_PROVIDER);
@@ -111,7 +111,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_premium_valuedate() {
+  void present_value_premium_valuedate() {
     CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, RATE_PROVIDER);
@@ -119,7 +119,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_premium_past() {
+  void present_value_premium_past() {
     CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(pvTrade.getAmount()).isCloseTo(pvProduct.getAmount(), offset(NOTIONAL * TOL));
@@ -127,7 +127,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void currency_exposure_premium_forward() {
+  void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount ce = PRICER_TRADE.currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(pv.getAmount()).isCloseTo(ce.getAmount(USD).getAmount(), offset(NOTIONAL * TOL));
@@ -135,26 +135,26 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void current_cash_forward() {
+  void current_cash_forward() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREFWD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0d, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_vd() {
+  void current_cash_vd() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PRETOD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(-PREMIUM_AMOUNT, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_past() {
+  void current_cash_past() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREPAST_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0d, offset(NOTIONAL * TOL));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_premium_forward() {
+  void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade =
         PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
@@ -167,7 +167,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_valuedate() {
+  void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -178,7 +178,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_past() {
+  void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade =
         PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
@@ -190,7 +190,7 @@ public class BlackSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_black_vol_sensitivity_premium_forward() {
+  void present_value_black_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
         .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaProduct = PRICER_PRODUCT
@@ -198,4 +198,18 @@ public class BlackSwaptionTradePricerCashParYieldTest {
     assertThat(vegaTrade.getSensitivities().get(0).getSensitivity()).isCloseTo(vegaProduct.getSensitivity(), offset(NOTIONAL * TOL));
   }
 
+  @Test
+  void implied_volatiltity(){
+    double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
+    assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
+  }
+
+  @Test
+  void forward_rate(){
+    double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
+    double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
+    assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
+  }
+  
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerCashParYieldTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerCashParYieldTest.java
@@ -199,14 +199,14 @@ public class BlackSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  void implied_volatiltity(){
+  void implied_volatiltity() {
     double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
   }
 
   @Test
-  void forward_rate(){
+  void forward_rate() {
     double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
     double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
     assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerPhysicalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerPhysicalTest.java
@@ -212,14 +212,14 @@ public class BlackSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  void implied_volatiltity(){
+  void implied_volatiltity() {
     double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
   }
 
   @Test
-  void forward_rate(){
+  void forward_rate() {
     double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, MULTI_USD);
     double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, MULTI_USD);
     assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerPhysicalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/BlackSwaptionTradePricerPhysicalTest.java
@@ -103,7 +103,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_premium_forward() {
+  void present_value_premium_forward() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     CurrencyAmount pvProduct =
@@ -116,7 +116,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_premium_valuedate() {
+  void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
         PRICER_TRADE
             .presentValue(SWAPTION_PRETOD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
@@ -127,7 +127,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_premium_past() {
+  void present_value_premium_past() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, MULTI_USD,
             BLACK_VOLS_USD);
@@ -138,7 +138,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void currency_exposure_premium_forward() {
+  void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
         .presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     MultiCurrencyAmount ce = PRICER_TRADE
@@ -148,26 +148,26 @@ public class BlackSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void current_cash_forward() {
+  void current_cash_forward() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREFWD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(TOLERANCE_PV));
   }
 
   @Test
-  public void current_cash_vd() {
+  void current_cash_vd() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PRETOD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(-PREMIUM_AMOUNT, offset(TOLERANCE_PV));
   }
 
   @Test
-  public void current_cash_past() {
+  void current_cash_past() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREPAST_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(TOLERANCE_PV));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_premium_forward() {
+  void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -180,7 +180,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_valuedate() {
+  void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -191,7 +191,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_past() {
+  void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -203,7 +203,7 @@ public class BlackSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_black_vol_sensitivity_premium_forward() {
+  void present_value_black_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
         .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
     SwaptionSensitivity vegaProduct = PRICER_PRODUCT
@@ -211,4 +211,18 @@ public class BlackSwaptionTradePricerPhysicalTest {
     assertThat(vegaTrade.getSensitivities().get(0).getSensitivity()).isCloseTo(vegaProduct.getSensitivity(), offset(TOLERANCE_PV_VEGA));
   }
 
+  @Test
+  void implied_volatiltity(){
+    double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
+    double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, BLACK_VOLS_USD);
+    assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
+  }
+
+  @Test
+  void forward_rate(){
+    double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, MULTI_USD);
+    double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, MULTI_USD);
+    assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
+  }
+  
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
@@ -665,11 +665,4 @@ public class NormalSwaptionCashParYieldProductPricerTest {
     assertThat(pvSensiPayShort.getSensitivity()).isCloseTo(pvSensiPayShort.getSensitivity(), offset(NOTIONAL * TOL));
   }
 
-  @Test
-  void forward_rate_is_swaption_independent() {
-    double forwardRate1 = PRICER_SWAPTION.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
-    double forwardRate2 = PRICER_SWAPTION.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
-    assertThat(forwardRate1).isEqualTo(forwardRate2);
-  }
-
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
@@ -172,7 +172,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValue() {
+  void test_presentValue() {
     CurrencyAmount pvRecComputed = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPayComputed = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -192,7 +192,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_at_expiry() {
+  void test_presentValue_at_expiry() {
     CurrencyAmount pvRec = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_AT_EXPIRY, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -203,7 +203,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_after_expiry() {
+  void test_presentValue_after_expiry() {
     CurrencyAmount pvRec = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPay = PRICER_SWAPTION.presentValue(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertThat(pvRec.getAmount()).isCloseTo(0d, offset(NOTIONAL * TOL));
@@ -211,7 +211,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_parity() {
+  void test_presentValue_parity() {
     CurrencyAmount pvRecLong = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvRecShort = PRICER_SWAPTION.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPayLong = PRICER_SWAPTION.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
@@ -227,7 +227,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_physicalSettlement() {
+  void test_physicalSettlement() {
     Swaption swaption = Swaption.builder()
         .swaptionSettlement(PhysicalSwaptionSettlement.DEFAULT)
         .expiryDate(AdjustableDate.of(SWAPTION_EXERCISE_DATE))
@@ -242,7 +242,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueDelta() {
+  void test_presentValueDelta() {
     CurrencyAmount pvDeltaRecComputed =
         PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaPayComputed =
@@ -264,7 +264,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_at_expiry() {
+  void test_presentValueDelta_at_expiry() {
     CurrencyAmount pvDeltaRec =
         PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaPay =
@@ -277,7 +277,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_after_expiry() {
+  void test_presentValueDelta_after_expiry() {
     CurrencyAmount pvDeltaRec = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaPay = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertThat(pvDeltaRec.getAmount()).isCloseTo(0d, offset(NOTIONAL * TOL));
@@ -285,7 +285,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_parity() {
+  void test_presentValueDelta_parity() {
     CurrencyAmount pvDeltaRecLong = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaRecShort = PRICER_SWAPTION.presentValueDelta(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvDeltaPayLong = PRICER_SWAPTION.presentValueDelta(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
@@ -302,7 +302,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueGamma() {
+  void test_presentValueGamma() {
     CurrencyAmount pvGammaRecComputed =
         PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaPayComputed =
@@ -324,7 +324,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueGamma_at_expiry() {
+  void test_presentValueGamma_at_expiry() {
     CurrencyAmount pvGammaRec =
         PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaPay =
@@ -334,7 +334,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueGamma_after_expiry() {
+  void test_presentValueGamma_after_expiry() {
     CurrencyAmount pvGammaRec = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaPay = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertThat(pvGammaRec.getAmount()).isCloseTo(0d, offset(NOTIONAL * TOL));
@@ -342,7 +342,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueGamma_parity() {
+  void test_presentValueGamma_parity() {
     CurrencyAmount pvGammaRecLong = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaRecShort = PRICER_SWAPTION.presentValueGamma(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvGammaPayLong = PRICER_SWAPTION.presentValueGamma(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
@@ -355,7 +355,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueTheta() {
+  void test_presentValueTheta() {
     CurrencyAmount pvThetaRecComputed =
         PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaPayComputed =
@@ -378,7 +378,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueTheta_at_expiry() {
+  void test_presentValueTheta_at_expiry() {
     CurrencyAmount pvThetaRec =
         PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaPay =
@@ -388,7 +388,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueTheta_after_expiry() {
+  void test_presentValueTheta_after_expiry() {
     CurrencyAmount pvThetaRec = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaPay = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_SHORT_PAST, RATE_PROVIDER, VOLS);
     assertThat(pvThetaRec.getAmount()).isCloseTo(0d, offset(NOTIONAL * TOL));
@@ -396,7 +396,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueTheta_parity() {
+  void test_presentValueTheta_parity() {
     CurrencyAmount pvThetaRecLong = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaRecShort = PRICER_SWAPTION.presentValueTheta(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvThetaPayLong = PRICER_SWAPTION.presentValueTheta(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
@@ -409,7 +409,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------  
   @Test
-  public void test_currencyExposure() {
+  void test_currencyExposure() {
     MultiCurrencyAmount computedRec = PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay = PRICER_SWAPTION.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointRec =
@@ -427,7 +427,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_currencyExposure_at_expiry() {
+  void test_currencyExposure_at_expiry() {
     MultiCurrencyAmount computedRec =
         PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay =
@@ -447,7 +447,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_currencyExposure_after_expiry() {
+  void test_currencyExposure_after_expiry() {
     MultiCurrencyAmount computedRec =
         PRICER_SWAPTION.currencyExposure(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay =
@@ -460,7 +460,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_impliedVolatility() {
+  void test_impliedVolatility() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double expected = VOLS.volatility(SWAPTION_REC_LONG.getExpiry(), SWAP_TENOR_YEAR, STRIKE, forward);
     double computedRec = PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
@@ -470,7 +470,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_impliedVolatility_at_expiry() {
+  void test_impliedVolatility_at_expiry() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     double expected = VOLS.volatility(
         VAL_DATE.atTime(SWAPTION_EXPIRY_TIME).atZone(SWAPTION_EXPIRY_ZONE), SWAP_TENOR_YEAR, STRIKE, forward);
@@ -481,7 +481,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_impliedVolatility_after_expiry() {
+  void test_impliedVolatility_after_expiry() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER_SWAPTION.impliedVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS));
     assertThatIllegalArgumentException()
@@ -490,7 +490,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
+  void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     double impliedLongRecComputed = PRICER_SWAPTION.impliedVolatilityFromPresentValue(
@@ -517,7 +517,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void implied_volatility_wrong_sign() {
+  void implied_volatility_wrong_sign() {
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     assertThatIllegalArgumentException()
@@ -527,7 +527,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueSensitivityRatesStickyStrike() {
+  void test_presentValueSensitivityRatesStickyStrike() {
     PointSensitivities pointRec = PRICER_SWAPTION
         .presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS_FLAT).build();
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec);
@@ -543,7 +543,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyStrike_at_expiry() {
+  void test_presentValueSensitivityRatesStickyStrike_at_expiry() {
     PointSensitivities pointRec = PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(
         SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
@@ -558,7 +558,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyStrike_after_expiry() {
+  void test_presentValueSensitivityRatesStickyStrike_after_expiry() {
     PointSensitivityBuilder pointRec = PRICER_SWAPTION
         .presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointPay = PRICER_SWAPTION
@@ -568,7 +568,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyStrike_parity() {
+  void test_presentValueSensitivityRatesStickyStrike_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
         PRICER_SWAPTION.presentValueSensitivityRatesStickyStrike(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
@@ -598,7 +598,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueSensitivityNormalVolatility() {
+  void test_presentValueSensitivityNormalVolatility() {
     SwaptionSensitivity computedRec = PRICER_SWAPTION
         .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvRecUp = PRICER_SWAPTION.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER,
@@ -630,7 +630,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityNormalVolatility_at_expiry() {
+  void test_presentValueSensitivityNormalVolatility_at_expiry() {
     SwaptionSensitivity sensiRec =
         PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG_AT_EXPIRY, RATE_PROVIDER, VOLS);
     assertThat(sensiRec.getSensitivity()).isCloseTo(0d, offset(NOTIONAL * TOL));
@@ -640,7 +640,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityNormalVolatility_after_expiry() {
+  void test_presentValueSensitivityNormalVolatility_after_expiry() {
     SwaptionSensitivity sensiRec =
         PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG_PAST, RATE_PROVIDER, VOLS);
     SwaptionSensitivity sensiPay =
@@ -650,7 +650,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityNormalVolatility_parity() {
+  void test_presentValueSensitivityNormalVolatility_parity() {
     SwaptionSensitivity pvSensiRecLong =
         PRICER_SWAPTION.presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     SwaptionSensitivity pvSensiRecShort =
@@ -663,6 +663,13 @@ public class NormalSwaptionCashParYieldProductPricerTest {
     assertThat(pvSensiPayLong.getSensitivity()).isCloseTo(-pvSensiPayShort.getSensitivity(), offset(NOTIONAL * TOL));
     assertThat(pvSensiRecLong.getSensitivity()).isCloseTo(pvSensiPayLong.getSensitivity(), offset(NOTIONAL * TOL));
     assertThat(pvSensiPayShort.getSensitivity()).isCloseTo(pvSensiPayShort.getSensitivity(), offset(NOTIONAL * TOL));
+  }
+
+  @Test
+  void forward_rate_is_swaption_independent(){
+    double forwardRate1 = PRICER_SWAPTION.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
+    double forwardRate2 = PRICER_SWAPTION.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
+    assertThat(forwardRate1).isEqualTo(forwardRate2);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionCashParYieldProductPricerTest.java
@@ -666,7 +666,7 @@ public class NormalSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  void forward_rate_is_swaption_independent(){
+  void forward_rate_is_swaption_independent() {
     double forwardRate1 = PRICER_SWAPTION.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
     double forwardRate2 = PRICER_SWAPTION.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
     assertThat(forwardRate1).isEqualTo(forwardRate2);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
@@ -560,7 +560,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  void forward_rate_is_swaption_independent(){
+  void forward_rate_is_swaption_independent() {
     double forwardRate1 = PRICER_SWAPTION_NORMAL.forwardRate(SWAPTION_LONG_PAY, MULTI_USD);
     double forwardRate2 = PRICER_SWAPTION_NORMAL.forwardRate(SWAPTION_PAST, MULTI_USD);
     assertThat(forwardRate1).isEqualTo(forwardRate2);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
@@ -559,11 +559,4 @@ public class NormalSwaptionPhysicalProductPricerTest {
     assertThat(v.getSensitivity()).isCloseTo(0.0d, offset(TOLERANCE_PV_VEGA));
   }
 
-  @Test
-  void forward_rate_is_swaption_independent() {
-    double forwardRate1 = PRICER_SWAPTION_NORMAL.forwardRate(SWAPTION_LONG_PAY, MULTI_USD);
-    double forwardRate2 = PRICER_SWAPTION_NORMAL.forwardRate(SWAPTION_PAST, MULTI_USD);
-    assertThat(forwardRate1).isEqualTo(forwardRate2);
-  }
-
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionPhysicalProductPricerTest.java
@@ -165,7 +165,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void validate_physical_settlement() {
+  void validate_physical_settlement() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC_CASH, MULTI_USD,
         NORMAL_VOLS_USD_STD));
@@ -173,7 +173,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_implied_volatility() {
+  void test_implied_volatility() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double volExpected = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
         SWAP_TENOR_YEAR, STRIKE, forward);
@@ -183,7 +183,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_implied_volatility_after_expiry() {
+  void test_implied_volatility_after_expiry() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER_SWAPTION_NORMAL.impliedVolatility(SWAPTION_PAST, MULTI_USD,
         NORMAL_VOLS_USD_STD));
@@ -191,7 +191,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
+  void implied_volatility_round_trip() { // Compute pv and then implied vol from PV and compare with direct implied vol
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     double impliedLongRecComputed = PRICER_SWAPTION_NORMAL.impliedVolatilityFromPresentValue(
@@ -218,7 +218,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void implied_volatility_wrong_sign() {
+  void implied_volatility_wrong_sign() {
     CurrencyAmount pvLongRec =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThatIllegalArgumentException()
@@ -228,7 +228,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_formula() {
+  void present_value_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -244,7 +244,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_long_short_parity() {
+  void present_value_long_short_parity() {
     CurrencyAmount pvLong =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvShort =
@@ -253,7 +253,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_payer_receiver_parity() {
+  void present_value_payer_receiver_parity() {
     CurrencyAmount pvLongPay =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvShortRec =
@@ -264,7 +264,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_at_expiry() {
+  void present_value_at_expiry() {
     CurrencyAmount pvRec =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvRec.getAmount()).isCloseTo(0.0d, offset(TOLERANCE_PV));
@@ -274,14 +274,14 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_after_expiry() {
+  void present_value_after_expiry() {
     CurrencyAmount pv = PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pv.getAmount()).isCloseTo(0.0d, offset(TOLERANCE_PV));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_delta_formula() {
+  void present_value_delta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -297,7 +297,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_long_short_parity() {
+  void present_value_delta_long_short_parity() {
     CurrencyAmount pvDeltaLong =
         PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvDeltaShort =
@@ -306,7 +306,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_payer_receiver_parity() {
+  void present_value_delta_payer_receiver_parity() {
     CurrencyAmount pvDeltaLongPay =
         PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvDeltaShortRec =
@@ -316,7 +316,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_at_expiry() {
+  void present_value_delta_at_expiry() {
     CurrencyAmount pvDeltaRec =
         PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvDeltaRec.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -327,7 +327,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_delta_after_expiry() {
+  void present_value_delta_after_expiry() {
     CurrencyAmount pvDelta =
         PRICER_SWAPTION_NORMAL.presentValueDelta(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvDelta.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -335,7 +335,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_gamma_formula() {
+  void present_value_gamma_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -351,7 +351,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_long_short_parity() {
+  void present_value_gamma_long_short_parity() {
     CurrencyAmount pvGammaLong =
         PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvGammaShort =
@@ -360,7 +360,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_payer_receiver_parity() {
+  void present_value_gamma_payer_receiver_parity() {
     CurrencyAmount pvGammaLongPay =
         PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvGammaShortRec =
@@ -369,7 +369,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_at_expiry() {
+  void present_value_gamma_at_expiry() {
     CurrencyAmount pvGammaRec =
         PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvGammaRec.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -379,7 +379,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_gamma_after_expiry() {
+  void present_value_gamma_after_expiry() {
     CurrencyAmount pvGamma =
         PRICER_SWAPTION_NORMAL.presentValueGamma(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvGamma.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -387,7 +387,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_theta_formula() {
+  void present_value_theta_formula() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, MULTI_USD);
     double pvbp = PRICER_SWAP.getLegPricer().pvbp(RSWAP_REC.getLegs(SwapLegType.FIXED).get(0), MULTI_USD);
     double volatility = NORMAL_VOLS_USD_STD.volatility(SWAPTION_LONG_REC.getExpiry(),
@@ -403,7 +403,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_long_short_parity() {
+  void present_value_theta_long_short_parity() {
     CurrencyAmount pvThetaLong =
         PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvThetaShort =
@@ -412,7 +412,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_payer_receiver_parity() {
+  void present_value_theta_payer_receiver_parity() {
     CurrencyAmount pvThetaLongPay =
         PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     CurrencyAmount pvThetaShortRec =
@@ -421,7 +421,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_at_expiry() {
+  void present_value_theta_at_expiry() {
     CurrencyAmount pvThetaRec =
         PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvThetaRec.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -431,7 +431,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_theta_after_expiry() {
+  void present_value_theta_after_expiry() {
     CurrencyAmount pvTheta =
         PRICER_SWAPTION_NORMAL.presentValueTheta(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvTheta.getAmount()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -439,7 +439,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------  
   @Test
-  public void currency_exposure() {
+  void currency_exposure() {
     CurrencyAmount pv =
         PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     MultiCurrencyAmount ce =
@@ -449,7 +449,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_FD() {
+  void present_value_sensitivity_FD() {
     PointSensitivities pvpt = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityRatesStickyStrike(SWAPTION_SHORT_REC, MULTI_USD, NORMAL_VOLS_USD_FLAT).build();
     CurrencyParameterSensitivities pvpsAd = MULTI_USD.parameterSensitivity(pvpt);
@@ -459,7 +459,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_long_short_parity() {
+  void present_value_sensitivity_long_short_parity() {
     PointSensitivities pvptLong = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     PointSensitivities pvptShort = PRICER_SWAPTION_NORMAL
@@ -470,7 +470,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_payer_receiver_parity() {
+  void present_value_sensitivity_payer_receiver_parity() {
     PointSensitivities pvptLongPay = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityRatesStickyStrike(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     PointSensitivities pvptShortRec = PRICER_SWAPTION_NORMAL
@@ -483,7 +483,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_at_expiry() {
+  void present_value_sensitivity_at_expiry() {
     PointSensitivities sensiRec = PRICER_SWAPTION_NORMAL.presentValueSensitivityRatesStickyStrike(
         SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD).build();
     for (PointSensitivity sensi : sensiRec.getSensitivities()) {
@@ -497,7 +497,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_after_expiry() {
+  void present_value_sensitivity_after_expiry() {
     PointSensitivityBuilder pvpts = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(pvpts).isEqualTo(PointSensitivityBuilder.none());
@@ -505,7 +505,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivityNormalVolatility_FD() {
+  void present_value_sensitivityNormalVolatility_FD() {
     double shiftVol = 1.0E-4;
     CurrencyAmount pvP = PRICER_SWAPTION_NORMAL.presentValue(SWAPTION_LONG_PAY, MULTI_USD,
         SwaptionNormalVolatilityDataSets.normalVolSwaptionProviderUsdStsShifted(shiftVol));
@@ -525,7 +525,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityNormalVolatility_long_short_parity() {
+  void present_value_sensitivityNormalVolatility_long_short_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_NORMAL
@@ -534,7 +534,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityNormalVolatility_payer_receiver_parity() {
+  void present_value_sensitivityNormalVolatility_payer_receiver_parity() {
     SwaptionSensitivity pvptLongPay = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_PAY, MULTI_USD, NORMAL_VOLS_USD_STD);
     SwaptionSensitivity pvptShortRec = PRICER_SWAPTION_NORMAL
@@ -543,7 +543,7 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityBlackVolatility_at_expiry() {
+  void present_value_sensitivityBlackVolatility_at_expiry() {
     SwaptionSensitivity sensiRec = PRICER_SWAPTION_NORMAL.presentValueSensitivityModelParamsVolatility(
         SWAPTION_REC_AT_EXPIRY, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(sensiRec.getSensitivity()).isCloseTo(0d, offset(TOLERANCE_PV));
@@ -553,10 +553,17 @@ public class NormalSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void present_value_sensitivityNormalVolatility_after_expiry() {
+  void present_value_sensitivityNormalVolatility_after_expiry() {
     SwaptionSensitivity v = PRICER_SWAPTION_NORMAL
         .presentValueSensitivityModelParamsVolatility(SWAPTION_PAST, MULTI_USD, NORMAL_VOLS_USD_STD);
     assertThat(v.getSensitivity()).isCloseTo(0.0d, offset(TOLERANCE_PV_VEGA));
+  }
+
+  @Test
+  void forward_rate_is_swaption_independent(){
+    double forwardRate1 = PRICER_SWAPTION_NORMAL.forwardRate(SWAPTION_LONG_PAY, MULTI_USD);
+    double forwardRate2 = PRICER_SWAPTION_NORMAL.forwardRate(SWAPTION_PAST, MULTI_USD);
+    assertThat(forwardRate1).isEqualTo(forwardRate2);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerCashParYieldTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerCashParYieldTest.java
@@ -198,14 +198,14 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  void implied_volatiltity(){
+  void implied_volatiltity() {
     double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
   }
 
   @Test
-  void forward_rate(){
+  void forward_rate() {
     double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
     double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
     assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerCashParYieldTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerCashParYieldTest.java
@@ -99,7 +99,7 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_premium_forward() {
+  void present_value_premium_forward() {
     CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_FWD_PAY, RATE_PROVIDER);
@@ -110,7 +110,7 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_premium_valuedate() {
+  void present_value_premium_valuedate() {
     CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPremium = PRICER_PAYMENT.presentValue(PREMIUM_TRA_PAY, RATE_PROVIDER);
@@ -118,7 +118,7 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_premium_past() {
+  void present_value_premium_past() {
     CurrencyAmount pvTrade = PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct = PRICER_PRODUCT.presentValue(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(pvTrade.getAmount()).isCloseTo(pvProduct.getAmount(), offset(NOTIONAL * TOL));
@@ -126,7 +126,7 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void currency_exposure_premium_forward() {
+  void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount ce = PRICER_TRADE.currencyExposure(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(pv.getAmount()).isCloseTo(ce.getAmount(USD).getAmount(), offset(NOTIONAL * TOL));
@@ -134,26 +134,26 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void current_cash_forward() {
+  void current_cash_forward() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREFWD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_vd() {
+  void current_cash_vd() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PRETOD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(-PREMIUM_AMOUNT, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_past() {
+  void current_cash_past() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREPAST_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(NOTIONAL * TOL));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_premium_forward() {
+  void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade =
         PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
@@ -166,7 +166,7 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_valuedate() {
+  void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade =
         PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
@@ -177,7 +177,7 @@ public class NormalSwaptionTradePricerCashParYieldTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_past() {
+  void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade =
         PRICER_TRADE.presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct =
@@ -189,12 +189,26 @@ public class NormalSwaptionTradePricerCashParYieldTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_normal_vol_sensitivity_premium_forward() {
+  void present_value_normal_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade =
         PRICER_TRADE.presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaProduct =
         PRICER_PRODUCT.presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(vegaTrade.getSensitivities().get(0).getSensitivity()).isCloseTo(vegaProduct.getSensitivity(), offset(NOTIONAL * TOL));
+  }
+
+  @Test
+  void implied_volatiltity(){
+    double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
+    assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
+  }
+
+  @Test
+  void forward_rate(){
+    double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
+    double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
+    assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerPhysicalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerPhysicalTest.java
@@ -208,18 +208,17 @@ public class NormalSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  void implied_volatiltity(){
+  void implied_volatiltity() {
     double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
   }
 
   @Test
-  void forward_rate(){
+  void forward_rate() {
     double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, MULTI_USD);
     double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, MULTI_USD);
     assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
   }
-
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerPhysicalTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/NormalSwaptionTradePricerPhysicalTest.java
@@ -101,7 +101,7 @@ public class NormalSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_premium_forward() {
+  void present_value_premium_forward() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvProduct =
@@ -114,7 +114,7 @@ public class NormalSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_premium_valuedate() {
+  void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvProduct =
@@ -124,7 +124,7 @@ public class NormalSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_premium_past() {
+  void present_value_premium_past() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     CurrencyAmount pvProduct =
@@ -134,7 +134,7 @@ public class NormalSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void currency_exposure_premium_forward() {
+  void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
         .presentValue(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     MultiCurrencyAmount ce = PRICER_TRADE
@@ -144,26 +144,26 @@ public class NormalSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void current_cash_forward() {
+  void current_cash_forward() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREFWD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(TOLERANCE_PV));
   }
 
   @Test
-  public void current_cash_vd() {
+  void current_cash_vd() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PRETOD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(-PREMIUM_AMOUNT, offset(TOLERANCE_PV));
   }
 
   @Test
-  public void current_cash_past() {
+  void current_cash_past() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREPAST_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(TOLERANCE_PV));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_premium_forward() {
+  void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -176,7 +176,7 @@ public class NormalSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_valuedate() {
+  void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PRETOD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -187,7 +187,7 @@ public class NormalSwaptionTradePricerPhysicalTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_past() {
+  void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyStrike(SWAPTION_PREPAST_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -199,12 +199,27 @@ public class NormalSwaptionTradePricerPhysicalTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_normal_vol_sensitivity_premium_forward() {
+  void present_value_normal_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
         .presentValueSensitivityModelParamsVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     SwaptionSensitivity vegaProduct = PRICER_PRODUCT
         .presentValueSensitivityModelParamsVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
     assertThat(vegaTrade.getSensitivities().get(0).getSensitivity()).isCloseTo(vegaProduct.getSensitivity(), offset(TOLERANCE_PV_VEGA));
   }
+
+  @Test
+  void implied_volatiltity(){
+    double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
+    double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, MULTI_USD, NORMAL_VOLS_USD);
+    assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
+  }
+
+  @Test
+  void forward_rate(){
+    double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, MULTI_USD);
+    double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, MULTI_USD);
+    assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
+  }
+
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -235,14 +235,14 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void validate_cash_settlement() {
+  void validate_cash_settlement() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER.presentValue(SWAPTION_PHYS, RATE_PROVIDER, VOLS));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValue() {
+  void test_presentValue() {
     CurrencyAmount computedRec = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount computedPay = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -261,7 +261,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_atMaturity() {
+  void test_presentValue_atMaturity() {
     CurrencyAmount computedRec =
         PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount computedPay =
@@ -274,7 +274,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_afterExpiry() {
+  void test_presentValue_afterExpiry() {
     CurrencyAmount computedRec =
         PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     CurrencyAmount computedPay =
@@ -284,7 +284,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_parity() {
+  void test_presentValue_parity() {
     CurrencyAmount pvRecLong = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvRecShort = PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPayLong = PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
@@ -300,7 +300,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_parity_atMaturity() {
+  void test_presentValue_parity_atMaturity() {
     CurrencyAmount pvRecLong =
         PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount pvRecShort =
@@ -321,7 +321,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_currencyExposure() {
+  void test_currencyExposure() {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointRec =
@@ -339,7 +339,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_currencyExposure_atMaturity() {
+  void test_currencyExposure_atMaturity() {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(
         SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(
@@ -359,7 +359,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_currencyExposure_afterMaturity() {
+  void test_currencyExposure_afterMaturity() {
     MultiCurrencyAmount computedRec = PRICER.currencyExposure(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     MultiCurrencyAmount computedPay = PRICER.currencyExposure(
@@ -372,7 +372,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_impliedVolatility() {
+  void test_impliedVolatility() {
     double computedRec = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     double computedPay = PRICER.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -382,7 +382,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_impliedVolatility_atMaturity() {
+  void test_impliedVolatility_atMaturity() {
     double computedRec =
         PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     double computedPay =
@@ -394,7 +394,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_impliedVolatility_afterMaturity() {
+  void test_impliedVolatility_afterMaturity() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> PRICER.impliedVolatility(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY));
@@ -405,7 +405,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueDelta_parity() {
+  void test_presentValueDelta_parity() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER);
     ResolvedSwapLeg fixedLeg = SWAPTION_REC_LONG.getUnderlying().getLegs(SwapLegType.FIXED).get(0);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(fixedLeg, forward);
@@ -418,7 +418,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_afterMaturity() {
+  void test_presentValueDelta_afterMaturity() {
     CurrencyAmount deltaRec =
         PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertThat(deltaRec.getAmount()).isCloseTo(0, offset(TOLERANCE_DELTA));
@@ -428,7 +428,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_atMaturity() {
+  void test_presentValueDelta_atMaturity() {
     double forward = PRICER_SWAP.parRate(RSWAP_REC, RATE_PROVIDER_AT_MATURITY);
     ResolvedSwapLeg fixedLeg = SWAPTION_REC_LONG.getUnderlying().getLegs(SwapLegType.FIXED).get(0);
     double annuityCash = PRICER_SWAP.getLegPricer().annuityCash(fixedLeg, forward);
@@ -445,7 +445,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueSensitivityRatesStickyModel() {
+  void test_presentValueSensitivityRatesStickyModel() {
     PointSensitivityBuilder pointRec =
         PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
@@ -461,7 +461,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyStrike() {
+  void test_presentValueSensitivityRatesStickyStrike() {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesEur(VAL_DATE_TIME.toLocalDate(), false);
     double impliedVol = PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
@@ -485,7 +485,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyModel_atMaturity() {
+  void test_presentValueSensitivityRatesStickyModel_atMaturity() {
     PointSensitivityBuilder pointRec =
         PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
@@ -501,7 +501,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyModel_afterMaturity() {
+  void test_presentValueSensitivityRatesStickyModel_afterMaturity() {
     PointSensitivities pointRec = PRICER.presentValueSensitivityRatesStickyModel(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
@@ -515,7 +515,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyModel_parity() {
+  void test_presentValueSensitivityRatesStickyModel_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
         PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
@@ -545,7 +545,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueVega_parity() {
+  void test_presentValueVega_parity() {
     SwaptionSensitivity vegaRec = PRICER
         .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaPay = PRICER
@@ -554,7 +554,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueVega_atMaturity() {
+  void test_presentValueVega_atMaturity() {
     SwaptionSensitivity vegaRec = PRICER.presentValueSensitivityModelParamsVolatility(
         SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertThat(vegaRec.getSensitivity()).isCloseTo(0, offset(TOLERANCE_DELTA));
@@ -564,7 +564,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueVega_afterMaturity() {
+  void test_presentValueVega_afterMaturity() {
     SwaptionSensitivity vegaRec = PRICER.presentValueSensitivityModelParamsVolatility(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertThat(vegaRec.getSensitivity()).isCloseTo(0, offset(TOLERANCE_DELTA));
@@ -574,7 +574,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueVega_SwaptionSensitivity() {
+  void test_presentValueVega_SwaptionSensitivity() {
     SwaptionSensitivity vegaRec = PRICER
         .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     assertThat(VOLS.parameterSensitivity(vegaRec)).isEqualTo(CurrencyParameterSensitivities.empty());
@@ -582,7 +582,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueSensitivityModelParamsSabr() {
+  void test_presentValueSensitivityModelParamsSabr() {
     PointSensitivities sensiRec =
         PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities sensiPay =
@@ -622,7 +622,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityModelParamsSabr_atMaturity() {
+  void test_presentValueSensitivityModelParamsSabr_atMaturity() {
     PointSensitivities sensiRec = PRICER.presentValueSensitivityModelParamsSabr(
         SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY).build();
     assertSensitivity(sensiRec, SabrParameterType.ALPHA, 0);
@@ -638,7 +638,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityModelParamsSabr_afterMaturity() {
+  void test_presentValueSensitivityModelParamsSabr_afterMaturity() {
     PointSensitivities sensiRec = PRICER.presentValueSensitivityModelParamsSabr(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     assertThat(sensiRec.getSensitivities()).hasSize(0);
@@ -648,7 +648,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityModelParamsSabr_parity() {
+  void test_presentValueSensitivityModelParamsSabr_parity() {
     PointSensitivities pvSensiRecLong =
         PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities pvSensiRecShort =
@@ -691,7 +691,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void regressionPresentValue() {
+  void regressionPresentValue() {
     CurrencyAmount pvLongPay = PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REG);
     CurrencyAmount pvShortPay = PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS_REG);
     CurrencyAmount pvLongRec = PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS_REG);
@@ -703,7 +703,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void regressionCurveSensitivity() {
+  void regressionCurveSensitivity() {
     double[] sensiDscExp = new double[] {0.0, 0.0, 0.0, 0.0, -1.1942174487944763E7, -1565567.6976298545};
     double[] sensiFwdExp = new double[] {0.0, 0.0, 0.0, 0.0, -2.3978768078237808E8, 4.8392987803482056E8};
     PointSensitivityBuilder point = PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REG);
@@ -717,7 +717,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  public void regressionSurfaceSensitivity() {
+  void regressionSurfaceSensitivity() {
     PointSensitivities pointComputed =
         PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REG).build();
     assertSensitivity(pointComputed, SabrParameterType.ALPHA, 4.862767907309804E7);
@@ -802,6 +802,13 @@ public class SabrSwaptionCashParYieldProductPricerTest {
       }
       listComputed.remove(index);
     }
+  }
+
+  @Test
+  void forward_rate_is_swaption_independent(){
+    double forwardRate1 = PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
+    double forwardRate2 = PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
+    assertThat(forwardRate1).isEqualTo(forwardRate2);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -804,11 +804,4 @@ public class SabrSwaptionCashParYieldProductPricerTest {
     }
   }
 
-  @Test
-  void forward_rate_is_swaption_independent() {
-    double forwardRate1 = PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
-    double forwardRate2 = PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
-    assertThat(forwardRate1).isEqualTo(forwardRate2);
-  }
-
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldProductPricerTest.java
@@ -805,7 +805,7 @@ public class SabrSwaptionCashParYieldProductPricerTest {
   }
 
   @Test
-  void forward_rate_is_swaption_independent(){
+  void forward_rate_is_swaption_independent() {
     double forwardRate1 = PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
     double forwardRate2 = PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
     assertThat(forwardRate1).isEqualTo(forwardRate2);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
@@ -96,7 +96,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_premium_forward() {
+  void present_value_premium_forward() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
@@ -109,7 +109,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   }
 
   @Test
-  public void present_value_premium_valuedate() {
+  void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
@@ -119,7 +119,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   }
 
   @Test
-  public void present_value_premium_past() {
+  void present_value_premium_past() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
@@ -129,7 +129,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void currency_exposure_premium_forward() {
+  void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
         .presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount ce = PRICER_TRADE
@@ -139,26 +139,26 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void current_cash_forward() {
+  void current_cash_forward() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREFWD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_vd() {
+  void current_cash_vd() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PRETOD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(-PREMIUM_AMOUNT, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_past() {
+  void current_cash_past() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREPAST_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(NOTIONAL * TOL));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_premium_forward() {
+  void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -172,7 +172,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_valuedate() {
+  void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -183,7 +183,7 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_past() {
+  void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -195,12 +195,26 @@ public class SabrSwaptionCashParYieldTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_vol_sensitivity_premium_forward() {
+  void present_value_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
         .presentValueSensitivityModelParamsSabr(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivities vegaProduct = PRICER_PRODUCT
         .presentValueSensitivityModelParamsSabr(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS).build();
     assertThat(vegaTrade).isEqualTo(vegaProduct);
+  }
+
+  @Test
+  void implied_volatiltity(){
+    double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
+    assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
+  }
+
+  @Test
+  void forward_rate(){
+    double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
+    double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
+    assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionCashParYieldTradePricerTest.java
@@ -204,14 +204,14 @@ public class SabrSwaptionCashParYieldTradePricerTest {
   }
 
   @Test
-  void implied_volatiltity(){
+  void implied_volatiltity() {
     double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
   }
 
   @Test
-  void forward_rate(){
+  void forward_rate() {
     double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
     double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
     assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -687,7 +687,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  void forward_rate_is_swaption_independent(){
+  void forward_rate_is_swaption_independent() {
     double forwardRate1 = SWAPTION_PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
     double forwardRate2 = SWAPTION_PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
     assertThat(forwardRate1).isEqualTo(forwardRate2);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -142,6 +142,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   private static final double TOL = 1.0e-13;
   private static final double TOLERANCE_DELTA = 1.0E-2;
   private static final double FD_EPS = 1.0e-6;
+  private static final double TOLERANCE_RATE = 1.0E-8;
   private static final double REGRESSION_TOL = 1.0e-4; // due to tenor computation difference
   private static final SabrSwaptionPhysicalProductPricer SWAPTION_PRICER = SabrSwaptionPhysicalProductPricer.DEFAULT;
   private static final DiscountingSwapProductPricer SWAP_PRICER = DiscountingSwapProductPricer.DEFAULT;
@@ -150,14 +151,14 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void validate_physical_settlement() {
+  void validate_physical_settlement() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> SWAPTION_PRICER.presentValue(SWAPTION_CASH, RATE_PROVIDER, VOLS));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValue() {
+  void test_presentValue() {
     CurrencyAmount computedRec = SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount computedPay = SWAPTION_PRICER.presentValue(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = SWAP_PRICER.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -176,7 +177,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_atMaturity() {
+  void test_presentValue_atMaturity() {
     CurrencyAmount computedRec =
         SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount computedPay =
@@ -187,7 +188,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_afterExpiry() {
+  void test_presentValue_afterExpiry() {
     CurrencyAmount computedRec =
         SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     CurrencyAmount computedPay =
@@ -197,7 +198,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_parity() {
+  void test_presentValue_parity() {
     CurrencyAmount pvRecLong = SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyAmount pvRecShort = SWAPTION_PRICER.presentValue(SWAPTION_REC_SHORT, RATE_PROVIDER, VOLS);
     CurrencyAmount pvPayLong = SWAPTION_PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS);
@@ -210,7 +211,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValue_parity_atMaturity() {
+  void test_presentValue_parity_atMaturity() {
     CurrencyAmount pvRecLong =
         SWAPTION_PRICER.presentValue(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyAmount pvRecShort =
@@ -228,7 +229,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_currencyExposure() {
+  void test_currencyExposure() {
     MultiCurrencyAmount computedRec = SWAPTION_PRICER.currencyExposure(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pointRec =
@@ -246,7 +247,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_currencyExposure_atMaturity() {
+  void test_currencyExposure_atMaturity() {
     MultiCurrencyAmount computedRec = SWAPTION_PRICER.currencyExposure(
         SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(
@@ -266,7 +267,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_currencyExposure_afterMaturity() {
+  void test_currencyExposure_afterMaturity() {
     MultiCurrencyAmount computedRec = SWAPTION_PRICER.currencyExposure(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     MultiCurrencyAmount computedPay = SWAPTION_PRICER.currencyExposure(
@@ -279,7 +280,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_impliedVolatility() {
+  void test_impliedVolatility() {
     double computedRec = SWAPTION_PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     double computedPay = SWAPTION_PRICER.impliedVolatility(SWAPTION_PAY_SHORT, RATE_PROVIDER, VOLS);
     double forward = SWAP_PRICER.parRate(RSWAP_REC, RATE_PROVIDER);
@@ -289,7 +290,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_impliedVolatility_atMaturity() {
+  void test_impliedVolatility_atMaturity() {
     double computedRec =
         SWAPTION_PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     double computedPay =
@@ -301,7 +302,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_impliedVolatility_afterMaturity() {
+  void test_impliedVolatility_afterMaturity() {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> SWAPTION_PRICER.impliedVolatility(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY));
@@ -312,7 +313,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueDelta_parity() {
+  void test_presentValueDelta_parity() {
     double pvbp = SWAP_PRICER.getLegPricer()
         .pvbp(SWAPTION_REC_LONG.getUnderlying().getLegs(SwapLegType.FIXED).get(0), RATE_PROVIDER);
     CurrencyAmount deltaRec = SWAPTION_PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
@@ -321,7 +322,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_afterMaturity() {
+  void test_presentValueDelta_afterMaturity() {
     CurrencyAmount deltaRec =
         SWAPTION_PRICER.presentValueDelta(SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertThat(deltaRec.getAmount()).isCloseTo(0, offset(TOLERANCE_DELTA));
@@ -331,7 +332,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueDelta_atMaturity() {
+  void test_presentValueDelta_atMaturity() {
     double forward = SWAP_PRICER.parRate(RSWAP_REC, RATE_PROVIDER_AT_MATURITY);
     double pvbp = SWAP_PRICER.getLegPricer()
         .pvbp(SWAPTION_REC_LONG.getUnderlying().getLegs(SwapLegType.FIXED).get(0), RATE_PROVIDER_AT_MATURITY);
@@ -345,7 +346,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueSensitivityRatesStickyModel() {
+  void test_presentValueSensitivityRatesStickyModel() {
     PointSensitivityBuilder pointRec =
         SWAPTION_PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     CurrencyParameterSensitivities computedRec = RATE_PROVIDER.parameterSensitivity(pointRec.build());
@@ -361,7 +362,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyModel_stickyStrike() {
+  void test_presentValueSensitivityRatesStickyModel_stickyStrike() {
     SwaptionVolatilities volSabr = SwaptionSabrRateVolatilityDataSet.getVolatilitiesUsd(VAL_DATE, false);
     double impliedVol = SWAPTION_PRICER.impliedVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, volSabr);
     SurfaceMetadata blackMeta =
@@ -385,7 +386,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyModel_atMaturity() {
+  void test_presentValueSensitivityRatesStickyModel_atMaturity() {
     PointSensitivityBuilder pointRec =
         SWAPTION_PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     CurrencyParameterSensitivities computedRec =
@@ -401,7 +402,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityRatesStickyModel_afterMaturity() {
+  void test_presentValueSensitivityRatesStickyModel_afterMaturity() {
     PointSensitivities pointRec = SWAPTION_PRICER.presentValueSensitivityRatesStickyModel(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     for (PointSensitivity sensi : pointRec.getSensitivities()) {
@@ -415,7 +416,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivity_parity() {
+  void test_presentValueSensitivity_parity() {
     CurrencyParameterSensitivities pvSensiRecLong = RATE_PROVIDER.parameterSensitivity(
         SWAPTION_PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build());
     CurrencyParameterSensitivities pvSensiRecShort = RATE_PROVIDER.parameterSensitivity(
@@ -437,7 +438,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueVega_parity() {
+  void test_presentValueVega_parity() {
     SwaptionSensitivity vegaRec = SWAPTION_PRICER
         .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     SwaptionSensitivity vegaPay = SWAPTION_PRICER
@@ -446,7 +447,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueVega_atMaturity() {
+  void test_presentValueVega_atMaturity() {
     SwaptionSensitivity vegaRec = SWAPTION_PRICER.presentValueSensitivityModelParamsVolatility(
         SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY);
     assertThat(vegaRec.getSensitivity()).isCloseTo(0, offset(TOLERANCE_DELTA));
@@ -456,7 +457,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueVega_afterMaturity() {
+  void test_presentValueVega_afterMaturity() {
     SwaptionSensitivity vegaRec = SWAPTION_PRICER.presentValueSensitivityModelParamsVolatility(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY);
     assertThat(vegaRec.getSensitivity()).isCloseTo(0, offset(TOLERANCE_DELTA));
@@ -466,7 +467,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueVega_SwaptionSensitivity() {
+  void test_presentValueVega_SwaptionSensitivity() {
     SwaptionSensitivity vegaRec = SWAPTION_PRICER
         .presentValueSensitivityModelParamsVolatility(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS);
     assertThat(VOLS.parameterSensitivity(vegaRec)).isEqualTo(CurrencyParameterSensitivities.empty());
@@ -474,7 +475,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void test_presentValueSensitivityModelParamsSabr() {
+  void test_presentValueSensitivityModelParamsSabr() {
     PointSensitivities sensiRec =
         SWAPTION_PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities sensiPay =
@@ -505,7 +506,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
       SwaptionSabrSensitivity sens = (SwaptionSabrSensitivity) point;
       assertThat(sens.getCurrency()).isEqualTo(USD);
       assertThat(sens.getVolatilitiesName()).isEqualTo(VOLS.getName());
-      assertThat(sens.getTenor()).isEqualTo((double) TENOR_YEAR);
+      assertThat(sens.getTenor()).isEqualTo(TENOR_YEAR);
       if (sens.getSensitivityType() == type) {
         assertThat(sens.getSensitivity()).isCloseTo(expected, offset(NOTIONAL * tol));
         return;
@@ -515,7 +516,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityModelParamsSabr_atMaturity() {
+  void test_presentValueSensitivityModelParamsSabr_atMaturity() {
     PointSensitivities sensiRec = SWAPTION_PRICER.presentValueSensitivityModelParamsSabr(
         SWAPTION_REC_LONG, RATE_PROVIDER_AT_MATURITY, VOLS_AT_MATURITY).build();
     assertSensitivity(sensiRec, SabrParameterType.ALPHA, 0, TOL);
@@ -531,7 +532,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityModelParamsSabr_afterMaturity() {
+  void test_presentValueSensitivityModelParamsSabr_afterMaturity() {
     PointSensitivities sensiRec = SWAPTION_PRICER.presentValueSensitivityModelParamsSabr(
         SWAPTION_REC_LONG, RATE_PROVIDER_AFTER_MATURITY, VOLS_AFTER_MATURITY).build();
     assertThat(sensiRec.getSensitivities()).hasSize(0);
@@ -541,7 +542,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void test_presentValueSensitivityModelParamsSabr_parity() {
+  void test_presentValueSensitivityModelParamsSabr_parity() {
     PointSensitivities pvSensiRecLong =
         SWAPTION_PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_REC_LONG, RATE_PROVIDER, VOLS).build();
     PointSensitivities pvSensiRecShort =
@@ -584,13 +585,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void regressionPv() {
+  void regressionPv() {
     CurrencyAmount pvComputed = SWAPTION_PRICER.presentValue(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REGRESSION);
     assertThat(pvComputed.getAmount()).isCloseTo(3156216.489577751, offset(REGRESSION_TOL * NOTIONAL));
   }
 
   @Test
-  public void regressionPvCurveSensi() {
+  void regressionPvCurveSensi() {
     PointSensitivityBuilder point =
         SWAPTION_PRICER.presentValueSensitivityRatesStickyModel(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REGRESSION);
     CurrencyParameterSensitivities sensiComputed = RATE_PROVIDER.parameterSensitivity(point.build());
@@ -606,7 +607,7 @@ public class SabrSwaptionPhysicalProductPricerTest {
   }
 
   @Test
-  public void regressionPvSurfaceSensi() {
+  void regressionPvSurfaceSensi() {
     PointSensitivities pointComputed =
         SWAPTION_PRICER.presentValueSensitivityModelParamsSabr(SWAPTION_PAY_LONG, RATE_PROVIDER, VOLS_REGRESSION).build();
     assertSensitivity(pointComputed, SabrParameterType.ALPHA, 6.5786313367554754E7, REGRESSION_TOL);
@@ -683,6 +684,13 @@ public class SabrSwaptionPhysicalProductPricerTest {
       }
       listComputed.remove(index);
     }
+  }
+
+  @Test
+  void forward_rate_is_swaption_independent(){
+    double forwardRate1 = SWAPTION_PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
+    double forwardRate2 = SWAPTION_PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
+    assertThat(forwardRate1).isEqualTo(forwardRate2);
   }
 
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalProductPricerTest.java
@@ -686,11 +686,4 @@ public class SabrSwaptionPhysicalProductPricerTest {
     }
   }
 
-  @Test
-  void forward_rate_is_swaption_independent() {
-    double forwardRate1 = SWAPTION_PRICER.forwardRate(SWAPTION_PAY_LONG, RATE_PROVIDER);
-    double forwardRate2 = SWAPTION_PRICER.forwardRate(SWAPTION_REC_SHORT, RATE_PROVIDER);
-    assertThat(forwardRate1).isEqualTo(forwardRate2);
-  }
-
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
@@ -92,7 +92,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_premium_forward() {
+  void present_value_premium_forward() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
@@ -105,7 +105,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
   }
 
   @Test
-  public void present_value_premium_valuedate() {
+  void present_value_premium_valuedate() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
@@ -115,7 +115,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
   }
 
   @Test
-  public void present_value_premium_past() {
+  void present_value_premium_past() {
     CurrencyAmount pvTrade =
         PRICER_TRADE.presentValue(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     CurrencyAmount pvProduct =
@@ -125,7 +125,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void currency_exposure_premium_forward() {
+  void currency_exposure_premium_forward() {
     CurrencyAmount pv = PRICER_TRADE
         .presentValue(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     MultiCurrencyAmount ce = PRICER_TRADE
@@ -135,26 +135,26 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void current_cash_forward() {
+  void current_cash_forward() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREFWD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_vd() {
+  void current_cash_vd() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PRETOD_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(-PREMIUM_AMOUNT, offset(NOTIONAL * TOL));
   }
 
   @Test
-  public void current_cash_past() {
+  void current_cash_past() {
     CurrencyAmount ccTrade = PRICER_TRADE.currentCash(SWAPTION_PREPAST_LONG_REC, VAL_DATE);
     assertThat(ccTrade.getAmount()).isCloseTo(0, offset(NOTIONAL * TOL));
   }
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_sensitivity_premium_forward() {
+  void present_value_sensitivity_premium_forward() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyModel(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -167,7 +167,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_valuedate() {
+  void present_value_sensitivity_premium_valuedate() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyModel(SWAPTION_PRETOD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -178,7 +178,7 @@ public class SabrSwaptionPhysicalTradePricerTest {
   }
 
   @Test
-  public void present_value_sensitivity_premium_past() {
+  void present_value_sensitivity_premium_past() {
     PointSensitivities pvcsTrade = PRICER_TRADE
         .presentValueSensitivityRatesStickyModel(SWAPTION_PREPAST_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivityBuilder pvcsProduct = PRICER_PRODUCT
@@ -190,11 +190,25 @@ public class SabrSwaptionPhysicalTradePricerTest {
 
   //-------------------------------------------------------------------------
   @Test
-  public void present_value_vol_sensitivity_premium_forward() {
+  void present_value_vol_sensitivity_premium_forward() {
     PointSensitivities vegaTrade = PRICER_TRADE
         .presentValueSensitivityModelParamsSabr(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     PointSensitivities vegaProduct = PRICER_PRODUCT
         .presentValueSensitivityModelParamsSabr(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS).build();
     assertThat(vegaTrade).isEqualTo(vegaProduct);
+  }
+
+  @Test
+  void implied_volatiltity(){
+    double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
+    double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
+    assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
+  }
+
+  @Test
+  void forward_rate(){
+    double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
+    double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
+    assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);
   }
 }

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/swaption/SabrSwaptionPhysicalTradePricerTest.java
@@ -199,14 +199,14 @@ public class SabrSwaptionPhysicalTradePricerTest {
   }
 
   @Test
-  void implied_volatiltity(){
+  void implied_volatiltity() {
     double impliedVolTrade = PRICER_TRADE.impliedVolatility(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER, VOLS);
     double impliedVolProduct = PRICER_PRODUCT.impliedVolatility(SWAPTION_LONG_REC, RATE_PROVIDER, VOLS);
     assertThat(impliedVolProduct).isEqualTo(impliedVolTrade);
   }
 
   @Test
-  void forward_rate(){
+  void forward_rate() {
     double forwardRateTrade = PRICER_TRADE.forwardRate(SWAPTION_PREFWD_LONG_REC, RATE_PROVIDER);
     double forwardRateProduct = PRICER_PRODUCT.forwardRate(SWAPTION_LONG_REC, RATE_PROVIDER);
     assertThat(forwardRateTrade).isEqualTo(forwardRateProduct);


### PR DESCRIPTION
Most of this merge request is refactoring / plumbery. What requires more attention is 
```java
VolatilitySwaptionProductPricer::forwardRate(ResolvedSwaption swaption, RatesProvider ratesProvider)
```