### PR TITLE
Cash flow equivalent calculator improvements

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/CashFlowEquivalentCalculator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/rate/swap/CashFlowEquivalentCalculator.java
@@ -7,29 +7,35 @@ package com.opengamma.strata.pricer.impl.rate.swap;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.Payment;
 import com.opengamma.strata.basics.index.IborIndex;
 import com.opengamma.strata.basics.index.IborIndexObservation;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.market.sensitivity.PointSensitivityBuilder;
+import com.opengamma.strata.pricer.DiscountFactors;
+import com.opengamma.strata.pricer.ZeroRateSensitivity;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.product.common.PayReceive;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 import com.opengamma.strata.product.rate.IborRateComputation;
+import com.opengamma.strata.product.rate.OvernightCompoundedRateComputation;
+import com.opengamma.strata.product.rate.RateComputation;
 import com.opengamma.strata.product.swap.NotionalExchange;
 import com.opengamma.strata.product.swap.RateAccrualPeriod;
 import com.opengamma.strata.product.swap.RatePaymentPeriod;
 import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.ResolvedSwapLeg;
 import com.opengamma.strata.product.swap.SwapLegType;
+import com.opengamma.strata.product.swap.SwapPaymentEvent;
 import com.opengamma.strata.product.swap.SwapPaymentPeriod;
 
 /**
@@ -53,12 +59,20 @@ public final class CashFlowEquivalentCalculator {
    * @return the cash flow equivalent
    */
   public static ResolvedSwapLeg cashFlowEquivalentSwap(ResolvedSwap swap, RatesProvider ratesProvider) {
-    validateSwap(swap);
-    ResolvedSwapLeg cfFixed = cashFlowEquivalentFixedLeg(swap.getLegs(SwapLegType.FIXED).get(0), ratesProvider);
-    ResolvedSwapLeg cfIbor = cashFlowEquivalentIborLeg(swap.getLegs(SwapLegType.IBOR).get(0), ratesProvider);
+    List<SwapPaymentEvent> cfEquivalent = new ArrayList<>();
+    for (ResolvedSwapLeg leg : swap.getLegs()) {
+      if (leg.getType().equals(SwapLegType.FIXED)) {
+        cfEquivalent.addAll(cashFlowEquivalentFixedLeg(leg, ratesProvider).getPaymentEvents());
+      } else if (leg.getType().equals(SwapLegType.IBOR)) {
+        cfEquivalent.addAll(cashFlowEquivalentIborLeg(leg, ratesProvider).getPaymentEvents());
+      } else if (leg.getType().equals(SwapLegType.OVERNIGHT)) {
+        cfEquivalent.addAll(cashFlowEquivalentOnLeg(leg, ratesProvider).getPaymentEvents());
+      } else {
+        throw new IllegalArgumentException("leg type must be FIXED, IBOR or OVERNIGHT");
+      }
+    }
     ResolvedSwapLeg leg = ResolvedSwapLeg.builder()
-        .paymentEvents(
-            Stream.concat(cfFixed.getPaymentEvents().stream(), cfIbor.getPaymentEvents().stream()).collect(Collectors.toList()))
+        .paymentEvents(cfEquivalent)
         .payReceive(PayReceive.RECEIVE)
         .type(SwapLegType.OTHER)
         .build();
@@ -141,6 +155,65 @@ public final class CashFlowEquivalentCalculator {
     return leg;
   }
 
+  /**
+   * Computes cash flow equivalent of overnight leg.
+   * <p>
+   * Each payment period should contain one accrual period of type {@link OvernightCompoundedRateComputation}.
+   * When the payment date is not equal to the end composition date, the start and end cashflow equivalent are
+   * adjusted by the ratio of discount factors between the payment date and the end date.
+   * <p>
+   * The return type is {@code ResolvedSwapLeg} in which individual payments are
+   * represented in terms of {@code NotionalExchange}.
+   * 
+   * @param onLeg  the overnight leg
+   * @param multicurve  the multi-curve rates provider
+   * @return the cash flow equivalent
+   */
+  public static ResolvedSwapLeg cashFlowEquivalentOnLeg(
+      ResolvedSwapLeg onLeg,
+      RatesProvider multicurve) {
+
+    Currency ccy = onLeg.getCurrency();
+    ArgChecker.isTrue(onLeg.getType().equals(SwapLegType.OVERNIGHT), "Leg type should be OVERNIGHT");
+    ArgChecker.isTrue(onLeg.getPaymentEvents().isEmpty(), "PaymentEvent should be empty");
+    List<NotionalExchange> paymentEvents = new ArrayList<NotionalExchange>();
+    for (SwapPaymentPeriod paymentPeriod : onLeg.getPaymentPeriods()) {
+      ArgChecker.isTrue(paymentPeriod instanceof RatePaymentPeriod,
+          "rate payment should be RatePaymentPeriod");
+      RatePaymentPeriod ratePaymentPeriod = (RatePaymentPeriod) paymentPeriod;
+      ArgChecker.isTrue(ratePaymentPeriod.getAccrualPeriods().size() == 1,
+          "rate payment should not be compounding");
+      RateAccrualPeriod rateAccrualPeriod = ratePaymentPeriod.getAccrualPeriods().get(0);
+      CurrencyAmount notional = ratePaymentPeriod.getNotionalAmount();
+      RateComputation rateComputation = rateAccrualPeriod.getRateComputation();
+      ArgChecker.isTrue(rateComputation instanceof OvernightCompoundedRateComputation,
+          "RateComputation should be of type OvernightCompoundedRateComputation");
+      OvernightCompoundedRateComputation onComputation = (OvernightCompoundedRateComputation) rateComputation;
+      LocalDate startDate = rateAccrualPeriod.getStartDate();
+      LocalDate endDate = rateAccrualPeriod.getEndDate();
+      double computationAccrual = onComputation.getIndex().getDayCount().yearFraction(startDate, endDate);
+      LocalDate paymentDate = ratePaymentPeriod.getPaymentDate();
+      double paymentAccural = rateAccrualPeriod.getYearFraction();
+      double payDateRatio =
+          multicurve.discountFactor(ccy, paymentDate) / multicurve.discountFactor(ccy, endDate);
+      NotionalExchange payStart = NotionalExchange.of(
+          notional.multipliedBy(payDateRatio * paymentAccural / computationAccrual),
+          startDate);
+      double spread = rateAccrualPeriod.getSpread();
+      NotionalExchange payEnd = NotionalExchange.of(
+          notional.multipliedBy(-paymentAccural / computationAccrual + spread * paymentAccural),
+          paymentDate);
+      paymentEvents.add(payStart);
+      paymentEvents.add(payEnd);
+    }
+    ResolvedSwapLeg leg = ResolvedSwapLeg.builder()
+        .paymentEvents(paymentEvents)
+        .payReceive(PayReceive.RECEIVE)
+        .type(SwapLegType.OTHER)
+        .build();
+    return leg;
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Computes cash flow equivalent and sensitivity of swap.
@@ -157,12 +230,20 @@ public final class CashFlowEquivalentCalculator {
       ResolvedSwap swap,
       RatesProvider ratesProvider) {
 
-    validateSwap(swap);
-    ImmutableMap<Payment, PointSensitivityBuilder> mapFixed =
-        cashFlowEquivalentAndSensitivityFixedLeg(swap.getLegs(SwapLegType.FIXED).get(0), ratesProvider);
-    ImmutableMap<Payment, PointSensitivityBuilder> mapIbor =
-        cashFlowEquivalentAndSensitivityIborLeg(swap.getLegs(SwapLegType.IBOR).get(0), ratesProvider);
-    return ImmutableMap.<Payment, PointSensitivityBuilder>builder().putAll(mapFixed).putAll(mapIbor).build();
+    Builder<Payment, PointSensitivityBuilder> cfEquivalentSensitivity =
+        ImmutableMap.<Payment, PointSensitivityBuilder>builder();
+    for (ResolvedSwapLeg leg : swap.getLegs()) {
+      if (leg.getType().equals(SwapLegType.FIXED)) {
+        cfEquivalentSensitivity.putAll(cashFlowEquivalentAndSensitivityFixedLeg(leg, ratesProvider));
+      } else if (leg.getType().equals(SwapLegType.IBOR)) {
+        cfEquivalentSensitivity.putAll(cashFlowEquivalentAndSensitivityIborLeg(leg, ratesProvider));
+      } else if (leg.getType().equals(SwapLegType.OVERNIGHT)) {
+        cfEquivalentSensitivity.putAll(cashFlowEquivalentAndSensitivityOnLeg(leg, ratesProvider));
+      } else {
+        throw new IllegalArgumentException("leg type must be FIXED, IBOR or OVERNIGHT");
+      }
+    }
+    return cfEquivalentSensitivity.build();
   }
 
   /**
@@ -245,11 +326,93 @@ public final class CashFlowEquivalentCalculator {
     return ImmutableMap.copyOf(res);
   }
 
-  //-------------------------------------------------------------------------
-  private static void validateSwap(ResolvedSwap swap) {
-    ArgChecker.isTrue(swap.getLegs().size() == 2, "swap should have 2 legs");
-    ArgChecker.isTrue(swap.getLegs(SwapLegType.FIXED).size() == 1, "swap should have unique fixed leg");
-    ArgChecker.isTrue(swap.getLegs(SwapLegType.IBOR).size() == 1, "swap should have unique Ibor leg");
+  /**
+   * Computes cash flow equivalent of and sensitivity overnight leg.
+   * <p>
+   * Each payment period should contain one accrual period of type {@link OvernightCompoundedRateComputation}.
+   * When the payment date is not equal to the end composition date, the start and end cashflow equivalent are
+   * adjusted by the ratio of discount factors between the payment date and the end date.
+   * <p>
+   * The return type is a map of {@code NotionalExchange} and {@code PointSensitivityBuilder}.
+   * 
+   * @param onLeg  the overnight leg
+   * @param multicurve  the multi-curve rates provider
+   * @return the cash flow equivalent
+   */
+  public static ImmutableMap<Payment, PointSensitivityBuilder> cashFlowEquivalentAndSensitivityOnLeg(
+      ResolvedSwapLeg onLeg,
+      RatesProvider multicurve) {
+
+    Currency ccy = onLeg.getCurrency();
+    DiscountFactors df = multicurve.discountFactors(ccy);
+    ArgChecker.isTrue(onLeg.getType().equals(SwapLegType.OVERNIGHT), "Leg type should be OVERNIGHT");
+    ArgChecker.isTrue(onLeg.getPaymentEvents().isEmpty(), "PaymentEvent should be empty");
+    Map<Payment, PointSensitivityBuilder> res = new HashMap<Payment, PointSensitivityBuilder>();
+    for (SwapPaymentPeriod paymentPeriod : onLeg.getPaymentPeriods()) {
+      ArgChecker.isTrue(paymentPeriod instanceof RatePaymentPeriod,
+          "rate payment should be RatePaymentPeriod");
+      RatePaymentPeriod ratePaymentPeriod = (RatePaymentPeriod) paymentPeriod;
+      ArgChecker.isTrue(ratePaymentPeriod.getAccrualPeriods().size() == 1,
+          "rate payment should not be compounding");
+      RateAccrualPeriod rateAccrualPeriod = ratePaymentPeriod.getAccrualPeriods().get(0);
+      CurrencyAmount notional = ratePaymentPeriod.getNotionalAmount();
+      RateComputation rateComputation = rateAccrualPeriod.getRateComputation();
+      ArgChecker.isTrue(rateComputation instanceof OvernightCompoundedRateComputation,
+          "RateComputation should be of type OvernightCompoundedRateComputation");
+      OvernightCompoundedRateComputation onComputation = (OvernightCompoundedRateComputation) rateComputation;
+      LocalDate startDate = rateAccrualPeriod.getStartDate();
+      LocalDate endDate = rateAccrualPeriod.getEndDate();
+      double computationAccrual = onComputation.getIndex().getDayCount().yearFraction(startDate, endDate);
+      LocalDate paymentDate = ratePaymentPeriod.getPaymentDate();
+      double paymentAccural = rateAccrualPeriod.getYearFraction();
+      double dfPay = df.discountFactor(paymentDate);
+      double dfEnd = df.discountFactor(endDate);
+      ZeroRateSensitivity dfPayDr = df.zeroRatePointSensitivity(paymentDate);
+      ZeroRateSensitivity dfEndDr = df.zeroRatePointSensitivity(endDate);
+      double payDateRatio = dfPay / dfEnd;
+      PointSensitivityBuilder payDateRatioDr = dfPayDr.multipliedBy(1.0d / dfEnd)
+          .combinedWith(dfEndDr.multipliedBy(-dfPay / (dfEnd * dfEnd)));
+      Payment payStart = Payment.of(
+          notional.multipliedBy(payDateRatio * paymentAccural / computationAccrual),
+          startDate);
+      double spread = rateAccrualPeriod.getSpread();
+      Payment payEnd = Payment.of(
+          notional.multipliedBy(-paymentAccural / computationAccrual + spread * paymentAccural),
+          paymentDate);
+      res.put(payStart, payDateRatioDr
+          .multipliedBy(notional.getAmount() * paymentAccural / computationAccrual));
+      res.put(payEnd, PointSensitivityBuilder.none());
+    }
+    return ImmutableMap.copyOf(res);
+  }
+
+  /**
+   * Generate a new list with the dates sorted and the amounts of elements with same payment date compressed.
+   * <p>
+   * The original list is unchanged.
+   * 
+   * @param input  the starting list
+   * @return the normalized list
+   */
+  public static List<NotionalExchange> normalize(List<NotionalExchange> input) {
+    List<NotionalExchange> sorted = new ArrayList<>(input); // copy for sorting
+    Collections.sort(sorted, (a, b) -> (int) (a.getPaymentDate().toEpochDay() - b.getPaymentDate().toEpochDay()));
+    NotionalExchange previous = sorted.get(0);
+    for (int i = 1; i < sorted.size(); i++) {
+      NotionalExchange current = sorted.get(i);
+      if (current.getPaymentDate().equals(previous.getPaymentDate()) &&
+          current.getCurrency().equals(previous.getCurrency())) {
+        current = NotionalExchange.of(
+            CurrencyAmount.of(current.getCurrency(),
+                current.getPaymentAmount().getAmount() + previous.getPaymentAmount().getAmount()),
+            current.getPaymentDate());
+        sorted.set(i - 1, current);
+        sorted.remove(i);
+        i--;
+      }
+      previous = current;
+    }
+    return sorted;
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/CashFlowEquivalentCalculatorTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/rate/swap/CashFlowEquivalentCalculatorTest.java
@@ -8,17 +8,21 @@ package com.opengamma.strata.pricer.impl.rate.swap;
 import static com.opengamma.strata.basics.currency.Currency.GBP;
 import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
 import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.product.common.PayReceive.PAY;
 import static com.opengamma.strata.product.common.PayReceive.RECEIVE;
 import static com.opengamma.strata.product.swap.SwapLegType.FIXED;
 import static com.opengamma.strata.product.swap.SwapLegType.IBOR;
 import static com.opengamma.strata.product.swap.SwapLegType.OTHER;
+import static com.opengamma.strata.product.swap.SwapLegType.OVERNIGHT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.data.Offset.offset;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +42,9 @@ import com.opengamma.strata.pricer.swap.DiscountingSwapLegPricer;
 import com.opengamma.strata.pricer.swap.DiscountingSwapProductPricer;
 import com.opengamma.strata.product.rate.FixedRateComputation;
 import com.opengamma.strata.product.rate.IborRateComputation;
+import com.opengamma.strata.product.rate.OvernightRateComputation;
 import com.opengamma.strata.product.swap.NotionalExchange;
+import com.opengamma.strata.product.swap.OvernightAccrualMethod;
 import com.opengamma.strata.product.swap.RateAccrualPeriod;
 import com.opengamma.strata.product.swap.RatePaymentPeriod;
 import com.opengamma.strata.product.swap.ResolvedSwap;
@@ -67,21 +73,25 @@ public class CashFlowEquivalentCalculatorTest {
   private static final double NOTIONAL = 100_000_000;
   private static final IborRateComputation GBP_LIBOR_3M_COMP1 = IborRateComputation.of(GBP_LIBOR_3M, FIXING1, REF_DATA);
   private static final IborRateComputation GBP_LIBOR_3M_COMP2 = IborRateComputation.of(GBP_LIBOR_3M, FIXING2, REF_DATA);
+  private static final OvernightRateComputation GBP_SONIA_COMP1 =
+      OvernightRateComputation.of(GBP_SONIA, START1, END1, 0, OvernightAccrualMethod.COMPOUNDED, REF_DATA);
+  private static final OvernightRateComputation GBP_SONIA_COMP2 =
+      OvernightRateComputation.of(GBP_SONIA, START2, END2, 0, OvernightAccrualMethod.COMPOUNDED, REF_DATA);
 
   // accrual periods
-  private static final  RateAccrualPeriod IBOR1 = RateAccrualPeriod.builder()
+  private static final RateAccrualPeriod IBOR1 = RateAccrualPeriod.builder()
       .startDate(START1)
       .endDate(END1)
       .rateComputation(GBP_LIBOR_3M_COMP1)
       .yearFraction(PAY_YC1)
       .build();
-  private static final  RateAccrualPeriod IBOR2 = RateAccrualPeriod.builder()
+  private static final RateAccrualPeriod IBOR2 = RateAccrualPeriod.builder()
       .startDate(START2)
       .endDate(END2)
       .rateComputation(GBP_LIBOR_3M_COMP2)
       .yearFraction(PAY_YC2)
       .build();
-  private static final  RateAccrualPeriod FIXED1 = RateAccrualPeriod.builder()
+  private static final RateAccrualPeriod FIXED1 = RateAccrualPeriod.builder()
       .startDate(START1)
       .endDate(END1)
       .rateComputation(FixedRateComputation.of(RATE))
@@ -92,6 +102,19 @@ public class CashFlowEquivalentCalculatorTest {
       .endDate(END2)
       .rateComputation(FixedRateComputation.of(RATE))
       .yearFraction(PAY_YC2)
+      .build();
+  private static final RateAccrualPeriod ON1 = RateAccrualPeriod.builder()
+      .startDate(START1)
+      .endDate(END1)
+      .rateComputation(GBP_SONIA_COMP1)
+      .yearFraction(PAY_YC1)
+      .build();
+  private static final RateAccrualPeriod ON2 = RateAccrualPeriod.builder()
+      .startDate(START2)
+      .endDate(END2)
+      .rateComputation(GBP_SONIA_COMP2)
+      .yearFraction(PAY_YC2)
+      .spread(RATE)
       .build();
   //Ibor leg
   private static final RatePaymentPeriod IBOR_RATE_PAYMENT1 = RatePaymentPeriod.builder()
@@ -133,9 +156,69 @@ public class CashFlowEquivalentCalculatorTest {
       .payReceive(RECEIVE)
       .paymentPeriods(FIXED_RATE_PAYMENT1, FIXED_RATE_PAYMENT2)
       .build();
-  
+  //Overnight leg
+  private static final RatePaymentPeriod ON_RATE_PAYMENT1 = RatePaymentPeriod.builder()
+      .paymentDate(PAYMENT1)
+      .accrualPeriods(ON1)
+      .dayCount(ACT_365F)
+      .currency(GBP)
+      .notional(NOTIONAL)
+      .build();
+  private static final RatePaymentPeriod ON_RATE_PAYMENT2 = RatePaymentPeriod.builder()
+      .paymentDate(PAYMENT2)
+      .accrualPeriods(ON2)
+      .dayCount(ACT_365F)
+      .currency(GBP)
+      .notional(NOTIONAL)
+      .build();
+  private static final ResolvedSwapLeg ON_LEG = ResolvedSwapLeg.builder()
+      .type(OVERNIGHT)
+      .payReceive(RECEIVE)
+      .paymentPeriods(ON_RATE_PAYMENT1, ON_RATE_PAYMENT2)
+      .build();
+
   private static final ImmutableRatesProvider PROVIDER = RatesProviderDataSets.MULTI_GBP;
   private static final double TOLERANCE_PV = 1.0E-2;
+
+  @Test
+  public void test_cashFlowEquivalent_onleg() {
+    ResolvedSwapLeg computedOnLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentOnLeg(ON_LEG, PROVIDER);
+    int nbEquiv = 4; // 2 coupons x 2 dates
+    assertThat(computedOnLeg.getPaymentEvents()).hasSize(nbEquiv);
+    List<NotionalExchange> onEquivalent = new ArrayList<>();
+    double ratio1 = PROVIDER.discountFactor(GBP, PAYMENT1) / PROVIDER.discountFactor(GBP, END1);
+    double computationAccrual1 = ACT_365F.yearFraction(START1, END1);
+    double ratioAccrual1 = PAY_YC1 / computationAccrual1;
+    onEquivalent.add(NotionalExchange.of(CurrencyAmount.of(GBP, NOTIONAL * ratio1 * ratioAccrual1), START1));
+    onEquivalent.add(NotionalExchange.of(CurrencyAmount.of(GBP, -NOTIONAL * ratioAccrual1), PAYMENT1));
+    double ratio2 = PROVIDER.discountFactor(GBP, PAYMENT2) / PROVIDER.discountFactor(GBP, END2);
+    double computationAccrual2 = ACT_365F.yearFraction(START2, END2);
+    double ratioAccrual2 = PAY_YC2 / computationAccrual2;
+    onEquivalent.add(NotionalExchange.of(CurrencyAmount.of(GBP, NOTIONAL * ratio2 * ratioAccrual2), START2));
+    onEquivalent.add(NotionalExchange.of(
+        CurrencyAmount.of(GBP, -NOTIONAL * (ratioAccrual2 - RATE * PAY_YC2)), PAYMENT2));
+    for (int i = 0; i < nbEquiv; ++i) {
+      NotionalExchange payCmp = (NotionalExchange) computedOnLeg.getPaymentEvents().get(i);
+      assertThat(payCmp.getCurrency()).isEqualTo(GBP);
+      assertThat(payCmp.getPaymentDate()).isEqualTo(onEquivalent.get(i).getPaymentDate());
+      assertThat(DoubleMath.fuzzyEquals(payCmp.getPaymentAmount().getAmount(),
+          onEquivalent.get(i).getPaymentAmount().getAmount(), TOLERANCE_PV)).isTrue();
+      assertThat(payCmp).isEqualTo(onEquivalent.get(i));
+    }
+  }
+
+  @Test
+  public void test_cashFlowEquivalent_swap_on() {
+    ResolvedSwap swap = ResolvedSwap.of(ON_LEG, FIXED_LEG);
+    ResolvedSwapLeg computed = CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap, PROVIDER);
+    ResolvedSwapLeg computedOnLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentOnLeg(ON_LEG, PROVIDER);
+    ResolvedSwapLeg computedFixedLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentFixedLeg(FIXED_LEG, PROVIDER);
+    assertThat(computedOnLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(0, 4));
+    assertThat(computedFixedLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(4, 6));
+  }
 
   @Test
   public void test_cashFlowEquivalent() {
@@ -145,8 +228,8 @@ public class CashFlowEquivalentCalculatorTest {
         CashFlowEquivalentCalculator.cashFlowEquivalentIborLeg(IBOR_LEG, PROVIDER);
     ResolvedSwapLeg computedFixedLeg =
         CashFlowEquivalentCalculator.cashFlowEquivalentFixedLeg(FIXED_LEG, PROVIDER);
-    assertThat(computedFixedLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(0, 2));
-    assertThat(computedIborLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(2, 6));
+    assertThat(computedIborLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(0, 4));
+    assertThat(computedFixedLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(4, 6));
 
     // expected payments from fixed leg
     NotionalExchange fixedPayment1 = NotionalExchange.of(CurrencyAmount.of(GBP, NOTIONAL * RATE * PAY_YC1), PAYMENT1);
@@ -155,8 +238,9 @@ public class CashFlowEquivalentCalculatorTest {
     LocalDate fixingSTART1 = GBP_LIBOR_3M.calculateEffectiveFromFixing(FIXING1, REF_DATA);
     double fixedYearFraction1 = GBP_LIBOR_3M.getDayCount().relativeYearFraction(fixingSTART1,
         GBP_LIBOR_3M.calculateMaturityFromEffective(fixingSTART1, REF_DATA));
-    double beta1 = (1d + fixedYearFraction1 * PROVIDER.iborIndexRates(GBP_LIBOR_3M).rate(GBP_LIBOR_3M_COMP1.getObservation()))
-        * PROVIDER.discountFactor(GBP, PAYMENT1) / PROVIDER.discountFactor(GBP, fixingSTART1);
+    double beta1 =
+        (1d + fixedYearFraction1 * PROVIDER.iborIndexRates(GBP_LIBOR_3M).rate(GBP_LIBOR_3M_COMP1.getObservation())) *
+            PROVIDER.discountFactor(GBP, PAYMENT1) / PROVIDER.discountFactor(GBP, fixingSTART1);
     NotionalExchange iborPayment11 =
         NotionalExchange.of(CurrencyAmount.of(GBP, -NOTIONAL * beta1 * PAY_YC1 / fixedYearFraction1), fixingSTART1);
     NotionalExchange iborPayment12 =
@@ -164,8 +248,9 @@ public class CashFlowEquivalentCalculatorTest {
     LocalDate fixingSTART2 = GBP_LIBOR_3M.calculateEffectiveFromFixing(FIXING2, REF_DATA);
     double fixedYearFraction2 = GBP_LIBOR_3M.getDayCount().relativeYearFraction(fixingSTART2,
         GBP_LIBOR_3M.calculateMaturityFromEffective(fixingSTART2, REF_DATA));
-    double beta2 = (1d + fixedYearFraction2 * PROVIDER.iborIndexRates(GBP_LIBOR_3M).rate(GBP_LIBOR_3M_COMP2.getObservation()))
-        * PROVIDER.discountFactor(GBP, PAYMENT2) / PROVIDER.discountFactor(GBP, fixingSTART2);
+    double beta2 =
+        (1d + fixedYearFraction2 * PROVIDER.iborIndexRates(GBP_LIBOR_3M).rate(GBP_LIBOR_3M_COMP2.getObservation())) *
+            PROVIDER.discountFactor(GBP, PAYMENT2) / PROVIDER.discountFactor(GBP, fixingSTART2);
     NotionalExchange iborPayment21 =
         NotionalExchange.of(CurrencyAmount.of(GBP, -NOTIONAL * beta2 * PAY_YC2 / fixedYearFraction2), fixingSTART2);
     NotionalExchange iborPayment22 =
@@ -175,7 +260,7 @@ public class CashFlowEquivalentCalculatorTest {
         .builder()
         .type(OTHER)
         .payReceive(RECEIVE)
-        .paymentEvents(fixedPayment1, fixedPayment2, iborPayment11, iborPayment12, iborPayment21, iborPayment22)
+        .paymentEvents(iborPayment11, iborPayment12, iborPayment21, iborPayment22, fixedPayment1, fixedPayment2)
         .build();
 
     double eps = 1.0e-12;
@@ -189,7 +274,22 @@ public class CashFlowEquivalentCalculatorTest {
           payExp.getPaymentAmount().getAmount(), NOTIONAL * eps)).isTrue();
     }
   }
-  
+
+  @Test
+  public void test_cashFlowEquivalent_swap_3legs() {
+    ResolvedSwap swap = ResolvedSwap.of(ON_LEG, FIXED_LEG, IBOR_LEG);
+    ResolvedSwapLeg computed = CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap, PROVIDER);
+    ResolvedSwapLeg computedOnLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentOnLeg(ON_LEG, PROVIDER);
+    ResolvedSwapLeg computedFixedLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentFixedLeg(FIXED_LEG, PROVIDER);
+    ResolvedSwapLeg computedIborLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentIborLeg(IBOR_LEG, PROVIDER);
+    assertThat(computedOnLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(0, 4));
+    assertThat(computedFixedLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(4, 6));
+    assertThat(computedIborLeg.getPaymentEvents()).isEqualTo(computed.getPaymentEvents().subList(6, 10));
+  }
+
   @Test
   public void test_cashFlowEquivalent_pv() {
     ResolvedSwap swap = ResolvedSwap.of(IBOR_LEG, FIXED_LEG);
@@ -237,12 +337,6 @@ public class CashFlowEquivalentCalculatorTest {
 
   @Test
   public void test_cashFlowEquivalent_wrongSwap() {
-    ResolvedSwap swap1 = ResolvedSwap.of(IBOR_LEG, FIXED_LEG, IBOR_LEG);
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap1, PROVIDER));
-    ResolvedSwap swap2 = ResolvedSwap.of(FIXED_LEG, FIXED_LEG);
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap2, PROVIDER));
     ResolvedSwap swap3 = ResolvedSwap.of(
         FIXED_LEG,
         CashFlowEquivalentCalculator.cashFlowEquivalentIborLeg(IBOR_LEG, PROVIDER));
@@ -252,8 +346,62 @@ public class CashFlowEquivalentCalculatorTest {
 
   //-------------------------------------------------------------------------
   @Test
+  public void test_cashFlowEquivalentAndSensitivity_onleg() {
+    ResolvedSwapLeg computedCfe =
+        CashFlowEquivalentCalculator.cashFlowEquivalentOnLeg(ON_LEG, PROVIDER);
+    ImmutableMap<Payment, PointSensitivityBuilder> computedCfeSensi =
+        CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivityOnLeg(ON_LEG, PROVIDER);
+    int nbEquiv = 4; // 2 coupons x 2 dates
+    assertThat(computedCfe.getPaymentEvents()).hasSize(nbEquiv);
+    assertThat(computedCfeSensi).hasSize(nbEquiv);
+    // expected payments from fixed leg
+    for (int i = 0; i < nbEquiv; ++i) {
+      Payment payment = Payment.of(computedCfe.getPaymentEvents().get(i).getCurrency(),
+          ((NotionalExchange) computedCfe.getPaymentEvents().get(i)).getPaymentAmount().getAmount(),
+          computedCfe.getPaymentEvents().get(i).getPaymentDate());
+      assertThat(computedCfeSensi.containsKey(payment)).isTrue();
+    }
+    ImmutableList<Payment> keyComputedFull = computedCfeSensi.keySet().asList();
+    double eps = 1.0e-7;
+    RatesFiniteDifferenceSensitivityCalculator calc = new RatesFiniteDifferenceSensitivityCalculator(eps);
+    int size = keyComputedFull.size();
+    for (int i = 0; i < size; ++i) {
+      final int index = i;
+      CurrencyParameterSensitivities expected = calc.sensitivity(PROVIDER,
+          p -> ((NotionalExchange) CashFlowEquivalentCalculator.cashFlowEquivalentOnLeg(ON_LEG, p)
+              .getPaymentEvents().get(index)).getPaymentAmount());
+      SwapPaymentEvent event = CashFlowEquivalentCalculator.cashFlowEquivalentOnLeg(ON_LEG, PROVIDER)
+          .getPaymentEvents().get(index);
+      PointSensitivityBuilder point = computedCfeSensi.get(((NotionalExchange) event).getPayment());
+      CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point.build());
+      assertThat(computed.equalWithTolerance(expected, eps * NOTIONAL)).isTrue();
+    }
+  }
+
+  @Test
+  public void test_cashFlowEquivalentAndSensitivity_3legs() {
+    ResolvedSwap swap = ResolvedSwap.of(ON_LEG, FIXED_LEG, IBOR_LEG);
+    ImmutableMap<Payment, PointSensitivityBuilder> computed =
+        CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivitySwap(swap, PROVIDER);
+    ImmutableList<Payment> keyComputedFull = computed.keySet().asList();
+    ImmutableList<PointSensitivityBuilder> valueComputedFull = computed.values().asList();
+    ImmutableMap<Payment, PointSensitivityBuilder> computedOnLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivityOnLeg(ON_LEG, PROVIDER);
+    ImmutableMap<Payment, PointSensitivityBuilder> computedFixedLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivityFixedLeg(FIXED_LEG, PROVIDER);
+    ImmutableMap<Payment, PointSensitivityBuilder> computedIborLeg =
+        CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivityIborLeg(IBOR_LEG, PROVIDER);
+    assertThat(computedOnLeg.keySet().asList()).isEqualTo(keyComputedFull.subList(0, 4));
+    assertThat(computedFixedLeg.keySet().asList()).isEqualTo(keyComputedFull.subList(4, 6));
+    assertThat(computedIborLeg.keySet().asList()).isEqualTo(keyComputedFull.subList(6, 10));
+    assertThat(computedOnLeg.values().asList()).isEqualTo(valueComputedFull.subList(0, 4));
+    assertThat(computedFixedLeg.values().asList()).isEqualTo(valueComputedFull.subList(4, 6));
+    assertThat(computedIborLeg.values().asList()).isEqualTo(valueComputedFull.subList(6, 10));
+  }
+
+  @Test
   public void test_cashFlowEquivalentAndSensitivity() {
-    ResolvedSwap swap = ResolvedSwap.of(IBOR_LEG, FIXED_LEG);
+    ResolvedSwap swap = ResolvedSwap.of(FIXED_LEG, IBOR_LEG);
     ImmutableMap<Payment, PointSensitivityBuilder> computedFull =
         CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivitySwap(swap, PROVIDER);
     ImmutableList<Payment> keyComputedFull = computedFull.keySet().asList();
@@ -275,7 +423,8 @@ public class CashFlowEquivalentCalculatorTest {
       CurrencyParameterSensitivities expected = calc.sensitivity(PROVIDER,
           p -> ((NotionalExchange) CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap, p)
               .getPaymentEvents().get(index)).getPaymentAmount());
-      SwapPaymentEvent event = CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap, PROVIDER).getPaymentEvents().get(index);
+      SwapPaymentEvent event =
+          CashFlowEquivalentCalculator.cashFlowEquivalentSwap(swap, PROVIDER).getPaymentEvents().get(index);
       PointSensitivityBuilder point = computedFull.get(((NotionalExchange) event).getPayment());
       CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point.build());
       assertThat(computed.equalWithTolerance(expected, eps * NOTIONAL)).isTrue();
@@ -317,14 +466,28 @@ public class CashFlowEquivalentCalculatorTest {
   }
 
   @Test
+  public void test_cashFlowEquivalent_normalize() {
+    List<NotionalExchange> cfeInput = new ArrayList<>();
+    cfeInput.add(NotionalExchange.of(CurrencyAmount.of(GBP, 1.0), LocalDate.of(2020, 1, 3)));
+    cfeInput.add(NotionalExchange.of(CurrencyAmount.of(GBP, 2.0), LocalDate.of(2020, 1, 5)));
+    cfeInput.add(NotionalExchange.of(CurrencyAmount.of(GBP, 3.0), LocalDate.of(2020, 1, 2)));
+    cfeInput.add(NotionalExchange.of(CurrencyAmount.of(GBP, 4.0), LocalDate.of(2020, 1, 1)));
+    cfeInput.add(NotionalExchange.of(CurrencyAmount.of(GBP, 5.0), LocalDate.of(2020, 1, 5)));
+    cfeInput.add(NotionalExchange.of(CurrencyAmount.of(GBP, -6.0), LocalDate.of(2020, 1, 2)));
+    List<NotionalExchange> cfeComputed = CashFlowEquivalentCalculator.normalize(cfeInput);
+    assertThat(cfeComputed.size()).isEqualTo(4);
+    List<NotionalExchange> cfeExpected = new ArrayList<>();
+    cfeExpected.add(NotionalExchange.of(CurrencyAmount.of(GBP, 4.0), LocalDate.of(2020, 1, 1)));
+    cfeExpected.add(NotionalExchange.of(CurrencyAmount.of(GBP, -3.0), LocalDate.of(2020, 1, 2)));
+    cfeExpected.add(NotionalExchange.of(CurrencyAmount.of(GBP, 1.0), LocalDate.of(2020, 1, 3)));
+    cfeExpected.add(NotionalExchange.of(CurrencyAmount.of(GBP, 7.0), LocalDate.of(2020, 1, 5)));
+    assertThat(cfeExpected).isEqualTo(cfeComputed);
+  }
+
+  @Test
   public void test_cashFlowEquivalentAndSensitivity_wrongSwap() {
-    ResolvedSwap swap1 = ResolvedSwap.of(IBOR_LEG, FIXED_LEG, IBOR_LEG);
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivitySwap(swap1, PROVIDER));
-    ResolvedSwap swap2 = ResolvedSwap.of(FIXED_LEG, FIXED_LEG);
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivitySwap(swap2, PROVIDER));
-    ResolvedSwap swap3 = ResolvedSwap.of(FIXED_LEG, CashFlowEquivalentCalculator.cashFlowEquivalentIborLeg(IBOR_LEG, PROVIDER));
+    ResolvedSwap swap3 =
+        ResolvedSwap.of(FIXED_LEG, CashFlowEquivalentCalculator.cashFlowEquivalentIborLeg(IBOR_LEG, PROVIDER));
     assertThatIllegalArgumentException()
         .isThrownBy(() -> CashFlowEquivalentCalculator.cashFlowEquivalentAndSensitivitySwap(swap3, PROVIDER));
   }


### PR DESCRIPTION
* Adding the overnight compounding leg case
* Allows swap with multiple legs
* Method to normalize/compress cash flow equivalent on the same date.