### PR TITLE
More efficient collector of Result -> ValueWithFailures

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -782,7 +782,7 @@ public final class Result<T>
   /**
    * Returns the failure instance indicating the reason why the calculation failed.
    * <p>
-   * If this result is a success then an an IllegalStateException will be thrown.
+   * If this result is a success then an IllegalStateException will be thrown.
    * To avoid this, call {@link #isSuccess()} or {@link #isFailure()} first.
    *
    * @return the details of the failure, only available if calculation failed

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
@@ -295,8 +295,11 @@ public final class ValueWithFailures<T>
     }
 
     private void addResult(Result<? extends T> item) {
-      item.ifSuccess(values::add);
-      item.ifFailure(failure -> failures.addAll(failure.getItems()));
+      if (item.isSuccess()) {
+        values.add(item.getValue());
+      } else {
+        failures.addAll(item.getFailure().getItems());
+      }
     }
 
     private StreamBuilder<T, B> combine(StreamBuilder<T, B> builder) {

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
@@ -295,11 +295,8 @@ public final class ValueWithFailures<T>
     }
 
     private void addResult(Result<? extends T> item) {
-      if (item.isSuccess()) {
-        values.add(item.getValue());
-      } else {
-        failures.addAll(item.getFailure().getItems());
-      }
+      item.ifSuccess(value -> values.add(value));
+      item.ifFailure(failure -> failures.addAll(failure.getItems()));
     }
 
     private StreamBuilder<T, B> combine(StreamBuilder<T, B> builder) {

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
@@ -39,7 +39,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.opengamma.strata.collect.ArgChecker;
-import com.opengamma.strata.collect.Guavate;
 
 /**
  * A value with associated failures.
@@ -223,12 +222,11 @@ public final class ValueWithFailures<T>
    * @return a {@link Collector}
    */
   public static <T> Collector<Result<T>, ?, ValueWithFailures<List<T>>> toCombinedResultsAsList() {
-    return Collectors.reducing(
-        ValueWithFailures.of(ImmutableList.of()),
-        (Result<T> t) -> ValueWithFailures.of(
-            t.map(ImmutableList::of).getValueOrElse(ImmutableList.of()),
-            t.isSuccess() ? ImmutableList.of() : t.getFailure().getItems()),
-        (t, t2) -> t.combinedWith(t2, Guavate::concatToList));
+    return Collector.of(
+        () -> new StreamBuilder<>(ImmutableList.<T>builder()),
+        StreamBuilder::addResult,
+        StreamBuilder::combine,
+        StreamBuilder::build);
   }
 
   /**
@@ -294,6 +292,11 @@ public final class ValueWithFailures<T>
     private void add(ValueWithFailures<? extends T> item) {
       values.add(item.getValue());
       failures.addAll(item.getFailures());
+    }
+
+    private void addResult(Result<? extends T> item) {
+      item.ifSuccess(values::add);
+      item.ifFailure(failure -> failures.addAll(failure.getItems()));
     }
 
     private StreamBuilder<T, B> combine(StreamBuilder<T, B> builder) {

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
@@ -221,7 +221,7 @@ public final class ValueWithFailures<T>
    * @param <T>  the type of the success value in the {@link ValueWithFailures}
    * @return a {@link Collector}
    */
-  public static <T> Collector<Result<T>, ?, ValueWithFailures<List<T>>> toCombinedResultsAsList() {
+  public static <T> Collector<Result<? extends T>, ?, ValueWithFailures<List<T>>> toCombinedResultsAsList() {
     return Collector.of(
         () -> new StreamBuilder<>(ImmutableList.<T>builder()),
         StreamBuilder::addResult,

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/FixedAccrualMethod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/FixedAccrualMethod.java
@@ -25,7 +25,7 @@ public enum FixedAccrualMethod implements NamedEnum {
    */
   DEFAULT,
   /**
-   * Defines overnight compounding using an an annual rate.
+   * Defines overnight compounding using an annual rate.
    * <p>
    * The notional accrues interest on an overnight basis using an annual fixed rate.
    * <p>

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/OvernightAccrualMethod.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/OvernightAccrualMethod.java
@@ -29,7 +29,7 @@ public enum OvernightAccrualMethod implements NamedEnum {
    */
   COMPOUNDED,
   /**
-   * Defines overnight compounding using an an annual rate.
+   * Defines overnight compounding using an annual rate.
    * <p>
    * Interest is accrued by overnight compounding of each rate during the accrual period using an annual rate.
    * <p>


### PR DESCRIPTION
Stops using `Collectors.reducing` to avoid creating many intermediate arrays