### PR TITLE
Correct bug for negative forward price in NormalFormulaRepository

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
@@ -279,15 +279,15 @@ public final class NormalFormulaRepository {
     if (Double.doubleToLongBits(optionPrice) == Double.doubleToLongBits(intrinsicPrice)) {
       return 0d;
     }
-    double sigma = (Math.abs(initialNormalVol) < 1e-10 ? 0.3 * forward : initialNormalVol);
-    double maxChange = 0.5 * forward;
+    double sigma = (Math.abs(initialNormalVol) < 1e-10 ? 1e-10 : initialNormalVol); // to start with a non zero vol
+    double maxChange = 0.5 * sigma; // to avoid jumping around too fast
     ValueDerivatives price = priceAdjoint(forward, strike, timeToExpiry, sigma, numeraire, putCall);
     double vega = price.getDerivative(1);
     double change = (price.getValue() - optionPrice) / vega;
     double sign = Math.signum(change);
     change = sign * Math.min(maxChange, Math.abs(change));
     if (change > 0 && change > sigma) {
-      change = sigma;
+      change = 0.9d * sigma; // to avoid jumping through 0
     }
     int count = 0;
     while (Math.abs(change) > EPS) {
@@ -298,7 +298,7 @@ public final class NormalFormulaRepository {
       sign = Math.signum(change);
       change = sign * Math.min(maxChange, Math.abs(change));
       if (change > 0 && change > sigma) {
-        change = sigma;
+        change = 0.9d * sigma;
       }
       if (count++ > MAX_ITERATIONS) {
         BracketRoot bracketer = new BracketRoot();

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepository.java
@@ -279,7 +279,7 @@ public final class NormalFormulaRepository {
     if (Double.doubleToLongBits(optionPrice) == Double.doubleToLongBits(intrinsicPrice)) {
       return 0d;
     }
-    double sigma = (Math.abs(initialNormalVol) < 1e-10 ? 1e-10 : initialNormalVol); // to start with a non zero vol
+    double sigma = Math.min(Math.abs(initialNormalVol), 1e-10); // to start with a positive non zero vol
     double maxChange = 0.5 * sigma; // to avoid jumping around too fast
     ValueDerivatives price = priceAdjoint(forward, strike, timeToExpiry, sigma, numeraire, putCall);
     double vega = price.getDerivative(1);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepositoryImpliedVolatilityTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/NormalFormulaRepositoryImpliedVolatilityTest.java
@@ -31,7 +31,6 @@ public class NormalFormulaRepositoryImpliedVolatilityTest {
   private static final double[] SIGMA;
   private static final double[] SIGMA_BLACK = new double[N];
   private static final NormalPriceFunction FUNCTION = new NormalPriceFunction();
-
   static {
     PRICES = new double[N];
     SIGMA = new double[N];
@@ -55,6 +54,24 @@ public class NormalFormulaRepositoryImpliedVolatilityTest {
     for (int i = 0; i < N; i++) {
       impliedVolatility[i] = impliedVolatility(DATA[i], OPTIONS[i], PRICES[i]);
       assertThat(impliedVolatility[i]).isCloseTo(SIGMA[i], offset(1e-6));
+    }
+  }
+  
+  @Test
+  public void implied_volatility_negative() {
+    double forward = -0.0050; // 50 bps
+    double[] strikes = {0.0150, -0.0100, -0.0050, -0.00};
+    int nbTests = strikes.length;
+    double[] volatilities = {0.0075, 0.0100, 0.0050, 0.0200};
+    double[] volatilitiesStart = {0.0100, 0.0010, 0.0049, 0.0400};
+    double[] timesToExpiry = {1.0, 5.0, 0.25, 1.0};
+    PutCall[] putCall = {PutCall.PUT, PutCall.CALL, PutCall.CALL, PutCall.PUT};
+    for (int i = 0; i < nbTests; i++) {
+      double price = NormalFormulaRepository
+          .price(forward, strikes[i], timesToExpiry[i], volatilities[i], putCall[i]);
+      double ivComputed = NormalFormulaRepository
+          .impliedVolatility(price, forward, strikes[i], timesToExpiry[i], volatilitiesStart[i], 1.0d, putCall[i]);
+      assertThat(ivComputed).isCloseTo(volatilities[i], offset(1e-8));   
     }
   }
 


### PR DESCRIPTION
Change starting point and maxChange in implied volatility computation to deal with negative forwards.