### PR TITLE
Change FixedInflationSwap from HCIP to HICP

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventions.java
@@ -19,11 +19,11 @@ public final class FixedInflationSwapConventions {
 
   //-------------------------------------------------------------------------
   /**
-   * GBP vanilla fixed vs UK HCIP swap.
+   * GBP vanilla fixed vs UK HICP swap.
    * Both legs are zero-coupon; the fixed rate is compounded.
    */
-  public static final FixedInflationSwapConvention GBP_FIXED_ZC_GB_HCIP =
-      FixedInflationSwapConvention.of(StandardFixedInflationSwapConventions.GBP_FIXED_ZC_GB_HCIP.getName());
+  public static final FixedInflationSwapConvention GBP_FIXED_ZC_GB_HICP =
+      FixedInflationSwapConvention.of(StandardFixedInflationSwapConventions.GBP_FIXED_ZC_GB_HICP.getName());
 
   /**
    * GBP vanilla fixed vs UK RPI swap.

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardFixedInflationSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardFixedInflationSwapConventions.java
@@ -45,12 +45,12 @@ final class StandardFixedInflationSwapConventions {
   private static final Period LAG_2M = Period.ofMonths(2);
 
   /**
-   * GBP vanilla fixed vs UK HCIP swap.
+   * GBP vanilla fixed vs UK HICP swap.
    * Both legs are zero-coupon; the fixed rate is compounded.
    */
-  public static final FixedInflationSwapConvention GBP_FIXED_ZC_GB_HCIP =
+  public static final FixedInflationSwapConvention GBP_FIXED_ZC_GB_HICP =
       ImmutableFixedInflationSwapConvention.of(
-          "GBP-FIXED-ZC-GB-HCIP",
+          "GBP-FIXED-ZC-GB-HICP",
           fixedLegZcConvention(GBP, GBLO),
           InflationRateSwapLegConvention.of(
               PriceIndices.GB_HICP,

--- a/modules/product/src/main/resources/META-INF/com/opengamma/strata/config/base/FixedInflationSwapConvention.ini
+++ b/modules/product/src/main/resources/META-INF/com/opengamma/strata/config/base/FixedInflationSwapConvention.ini
@@ -13,3 +13,4 @@ com.opengamma.strata.product.swap.type.StandardFixedInflationSwapConventions = c
 # The key is the alternate name
 # The value is the standard name (loaded by a provider)
 [alternates]
+GBP-FIXED-ZC-GB-HCIP=GBP-FIXED-ZC-GB-HICP

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionTest.java
@@ -127,7 +127,7 @@ public class FixedInflationSwapConventionTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_name() {
     return new Object[][] {
-        {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_HCIP, "GBP-FIXED-ZC-GB-HCIP"},
+        {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_HICP, "GBP-FIXED-ZC-GB-HICP"},
         {FixedInflationSwapConventions.USD_FIXED_ZC_US_CPI, "USD-FIXED-ZC-US-CPI"},
     };
   }

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/FixedInflationSwapConventionsTest.java
@@ -27,7 +27,7 @@ public class FixedInflationSwapConventionsTest {
         {FixedInflationSwapConventions.EUR_FIXED_ZC_EU_AI_CPI, PriceIndices.EU_AI_CPI},
         {FixedInflationSwapConventions.EUR_FIXED_ZC_EU_EXT_CPI, PriceIndices.EU_EXT_CPI},
         {FixedInflationSwapConventions.EUR_FIXED_ZC_FR_CPI, PriceIndices.FR_EXT_CPI},
-        {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_HCIP, PriceIndices.GB_HICP},
+        {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_HICP, PriceIndices.GB_HICP},
         {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_RPI, PriceIndices.GB_RPI},
         {FixedInflationSwapConventions.GBP_FIXED_ZC_GB_RPIX, PriceIndices.GB_RPIX},
         {FixedInflationSwapConventions.JPY_FIXED_ZC_JP_CPI, PriceIndices.JP_CPI_EXF},


### PR DESCRIPTION
Rename Fixed Inflation swap convention GBP-FIXED-ZC-GB-HCIP to GBP-FIXED-ZC-GB-HICP.