### PR TITLE
Make ESTR the default EUR overnight index.

### DIFF
--- a/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/FloatingRateNameData.ini
+++ b/modules/basics/src/main/resources/META-INF/com/opengamma/strata/config/base/FloatingRateNameData.ini
@@ -549,7 +549,7 @@ ZAR = ZAR-JIBAR
 # The default Overnight name for each currency
 [currencyDefaultOvernight]
 CHF = CHF-SARON
-EUR = EUR-EONIA
+EUR = EUR-ESTR
 GBP = GBP-SONIA
 JPY = JPY-TONAR
 USD = USD-FED-FUND

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNamesTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/index/FloatingRateNamesTest.java
@@ -192,7 +192,7 @@ public class FloatingRateNamesTest {
   @Test
   public void test_defaultOvernightIndex() {
     assertThat(FloatingRateName.defaultOvernightIndex(Currency.GBP)).isEqualTo(FloatingRateName.of("GBP-SONIA"));
-    assertThat(FloatingRateName.defaultOvernightIndex(Currency.EUR)).isEqualTo(FloatingRateName.of("EUR-EONIA"));
+    assertThat(FloatingRateName.defaultOvernightIndex(Currency.EUR)).isEqualTo(FloatingRateName.of("EUR-ESTR"));
     assertThat(FloatingRateName.defaultOvernightIndex(Currency.USD)).isEqualTo(FloatingRateName.of("USD-FED-FUND"));
   }
 


### PR DESCRIPTION
As indicated by
https://www.ecb.europa.eu/paym/interest_rate_benchmarks/WG_euro_risk-free_rates/shared/pdf/20191016/2019-10-16_WG_on_euro_RFR_meeting_Checklist.pdf
EONIA publication stopped on the 3rd of January and ESTR should be the preferred alternative.
