### PR TITLE
Provide ability to box OptionalInt and friends

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Guavate.java
@@ -17,6 +17,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.TreeMap;
@@ -292,6 +295,46 @@ public final class Guavate {
       builder.add(element);
     }
     return builder.build();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Boxes an {@code OptionalInt}.
+   * <p>
+   * {@code OptionalInt} has almost no useful methods and no easy way to convert it to an {@code Optional}.
+   * This method provides the conversion to {@code Optional<Integer>}.
+   * 
+   * @param optional the {@code OptionalInt}
+   * @return an equivalent optional
+   */
+  public static Optional<Integer> boxed(OptionalInt optional) {
+    return optional.isPresent() ? Optional.of(optional.getAsInt()) : Optional.empty();
+  }
+
+  /**
+   * Boxes an {@code OptionalLong}.
+   * <p>
+   * {@code OptionalLong} has almost no useful methods and no easy way to convert it to an {@code Optional}.
+   * This method provides the conversion to {@code Optional<Long>}.
+   * 
+   * @param optional the {@code OptionalLong}
+   * @return an equivalent optional
+   */
+  public static Optional<Long> boxed(OptionalLong optional) {
+    return optional.isPresent() ? Optional.of(optional.getAsLong()) : Optional.empty();
+  }
+
+  /**
+   * Boxes an {@code OptionalDouble}.
+   * <p>
+   * {@code OptionalDouble} has almost no useful methods and no easy way to convert it to an {@code Optional}.
+   * This method provides the conversion to {@code Optional<Double>}.
+   * 
+   * @param optional the {@code OptionalDouble}
+   * @return an equivalent optional
+   */
+  public static Optional<Double> boxed(OptionalDouble optional) {
+    return optional.isPresent() ? Optional.of(optional.getAsDouble()) : Optional.empty();
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/GuavateTest.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -205,6 +208,17 @@ public class GuavateTest {
     assertThat(Guavate.set("a")).isEqualTo(ImmutableSet.of("a"));
     assertThat(Guavate.set("a", "b", "c")).isEqualTo(ImmutableSet.of("a", "b", "c"));
     assertThat(Guavate.set("a", "b", "b")).isEqualTo(ImmutableSet.of("a", "b"));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_boxed() {
+    assertThat(Guavate.boxed(OptionalInt.of(1))).isEqualTo(Optional.of(1));
+    assertThat(Guavate.boxed(OptionalInt.empty())).isEqualTo(Optional.empty());
+    assertThat(Guavate.boxed(OptionalLong.of(1L))).isEqualTo(Optional.of(1L));
+    assertThat(Guavate.boxed(OptionalLong.empty())).isEqualTo(Optional.empty());
+    assertThat(Guavate.boxed(OptionalDouble.of(1d))).isEqualTo(Optional.of(1d));
+    assertThat(Guavate.boxed(OptionalDouble.empty())).isEqualTo(Optional.empty());
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
`OptionalInt` has no `map()`, `flatMap()`, `or()` or `boxed()` making it painful to work with.