### PR TITLE
Enhance failure exceptions

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Messages.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Messages.java
@@ -277,7 +277,7 @@ public final class Messages {
   /**
    * Merges two template locations.
    * <p>
-   * This takes two template locations and the legth of the first message and returns the combined template.
+   * This takes two template locations and the length of the first message and returns the combined template.
    * 
    * @param location1  the first location, null tolerant
    * @param location2  the second location, null tolerant

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/Messages.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/Messages.java
@@ -138,7 +138,7 @@ public final class Messages {
    * </pre>
    * This will return a {@link Pair} with a String and a Map.
    * The String will be the formatted message: {@code "Foo=abc, Bar=123"}.
-   * The Map will look like: <code>{"foo": "123"}</code>.
+   * The Map will look like: <code>{"foo": "abc"}</code>.
    * <p>
    * This method combines a template message with a list of specific arguments.
    * It can be useful to delay string concatenation, which is sometimes a performance issue.

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Failure.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Failure.java
@@ -193,7 +193,7 @@ public final class Failure
   /**
    * Creates a failure from the throwable.
    * <p>
-   * This recognizes {@link FailureException}, {@link FailureItemException} and {@link ParseFailureException}.
+   * This recognizes {@link FailureException} and {@link FailureItemProvider}.
    *
    * @param th  the throwable to be processed
    * @return the failure
@@ -203,11 +203,10 @@ public final class Failure
       throw th;
     } catch (FailureException ex) {
       return ex.getFailure();
-    } catch (FailureItemException ex) {
-      return of(ex.getFailureItem());
-    } catch (ParseFailureException ex) {
-      return of(ex.getFailureItem());
     } catch (Throwable ex) {
+      if (ex instanceof FailureItemProvider) {
+        return of(((FailureItemProvider) ex).getFailureItem());
+      }
       return of(FailureReason.ERROR, ex);
     }
   }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItemException.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItemException.java
@@ -11,7 +11,7 @@ import com.opengamma.strata.collect.Messages;
 /**
  * An exception thrown when an exception can be represented by a {@code FailureItem}.
  */
-public class FailureItemException extends RuntimeException {
+public class FailureItemException extends RuntimeException implements FailureItemProvider {
 
   /** Serialization version. */
   private static final long serialVersionUID = 1L;
@@ -72,6 +72,7 @@ public class FailureItemException extends RuntimeException {
    *
    * @return the failure item
    */
+  @Override
   public FailureItem getFailureItem() {
     return item;
   }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItemProvider.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/FailureItemProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.collect.result;
+
+/**
+ * Provides access to a {@code FailureItem}.
+ * <p>
+ * This is intended to be implemented by exception classes
+ */
+public interface FailureItemProvider {
+
+  /**
+   * Gets the failure item.
+   *
+   * @return the failure item
+   */
+  public abstract FailureItem getFailureItem();
+
+}

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/ParseFailureException.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/ParseFailureException.java
@@ -11,7 +11,7 @@ import com.opengamma.strata.collect.Messages;
 /**
  * Exception thrown when parsing.
  */
-public class ParseFailureException extends IllegalArgumentException {
+public class ParseFailureException extends IllegalArgumentException implements FailureItemProvider {
 
   /** Serialization version. */
   private static final long serialVersionUID = 1L;
@@ -72,6 +72,7 @@ public class ParseFailureException extends IllegalArgumentException {
    *
    * @return the failure item
    */
+  @Override
   public FailureItem getFailureItem() {
     return item;
   }

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/Result.java
@@ -123,7 +123,7 @@ public final class Result<T>
    * <p>
    * Note that if the supplier throws an exception, this will be caught
    * and converted to a failure {@code Result}.
-   * The exception types {@link FailureException}, {@link FailureItemException} and {@link ParseFailureException} are recognized.
+   * This recognizes and handles {@link FailureException} and {@link FailureItemProvider} exceptions.
    *
    * @param <T> the type of the value
    * @param supplier  supplier of the result value
@@ -142,7 +142,7 @@ public final class Result<T>
    * <p>
    * Note that if the supplier throws an exception, this will be caught
    * and converted to a failure {@code Result}.
-   * The exception types {@link FailureException}, {@link FailureItemException} and {@link ParseFailureException} are recognized.
+   * This recognizes and handles {@link FailureException} and {@link FailureItemProvider} exceptions.
    *
    * @param <T> the type of the result value
    * @param supplier  supplier of the result
@@ -159,7 +159,7 @@ public final class Result<T>
   /**
    * Creates a failed result caused by a throwable.
    * <p>
-   * The exception types {@link FailureException}, {@link FailureItemException} and {@link ParseFailureException} are recognized.
+   * This recognizes and handles {@link FailureException} and {@link FailureItemProvider} exceptions.
    * If the exception type is not recognized, the failure will have a reason of {@code ERROR}.
    *
    * @param <R> the expected type of the result
@@ -173,7 +173,7 @@ public final class Result<T>
   /**
    * Creates a failed result caused by an exception.
    * <p>
-   * The exception types {@link FailureException}, {@link FailureItemException} and {@link ParseFailureException} are recognized.
+   * This recognizes and handles {@link FailureException} and {@link FailureItemProvider} exceptions.
    * If the exception type is not recognized, the failure will have a reason of {@code ERROR}.
    *
    * @param <R> the expected type of the result

--- a/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
+++ b/modules/collect/src/main/java/com/opengamma/strata/collect/result/ValueWithFailures.java
@@ -116,7 +116,7 @@ public final class ValueWithFailures<T>
    * If the supplier succeeds normally, the supplied value will be returned.
    * If the supplier fails, the empty value will be returned along with a failure.
    * <p>
-   * The exception types {@link FailureItemException} and {@link ParseFailureException} are recognized.
+   * This recognizes and handles {@link FailureItemProvider} exceptions.
    * If the exception type is not recognized, the failure item will have a reason of {@code ERROR}.
    *
    * @param <T> the type of the value

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/MessagesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/MessagesTest.java
@@ -224,9 +224,34 @@ public class MessagesTest {
     }
   }
 
+  @Test
   public void test_recreateTemplateBadLocation() {
     String message = "A B";
-    assertThat(Messages.recreateTemplate(message, "a:0|b:4")).isEqualTo("A B");
+    assertThat(Messages.recreateTemplate(message, "a:0:1|b:4:1")).isEqualTo("A B");
+  }
+
+  public static Object[][] data_mergeTemplateLocations() {
+    return new Object[][] {
+        {"x:2:3", "a:0:1", 5, "x:2:3|a:5:1"},
+        {"x:2:3", "a:0:1|b:4:1", 5, "x:2:3|a:5:1|b:9:1"},
+        {"x:2:3|y:5:1", "a:0:1|b:4:1", 7, "x:2:3|y:5:1|a:7:1|b:11:1"},
+        {"x:2:3|y:5:1", "a:0:1|b:4:1|+:8", 7, "x:2:3|y:5:1|a:7:1|b:11:1|+:15"},
+        {"x:2:3|y:5:1|+:6", "a:0:1|b:4:1|+:8", 7, "x:2:3|y:5:1|a:7:1|b:11:1|+:15"},
+        {"a:0:1|b:4:1", "", 5, "a:0:1|b:4:1"},
+        {"+:2", "a:2:1", 6, "a:8:1"},
+        {"", "a:0:1|b:4:1", 5, "a:5:1|b:9:1"},
+        {null, "a:0:1|b:4:1", 5, "a:5:1|b:9:1"},
+        {"x:2:3", "a:0:1", -1, ""},
+        {"x:2:3", "a", 6, ""},
+        {"x:2:3", "a:1", 6, ""},
+        {"x:2:3", "a:1:1:1", 6, ""},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_mergeTemplateLocations")
+  public void test_mergeTemplateLocations(String loc1, String loc2, int loc1MsgLength, String expected) {
+    assertThat(Messages.mergeTemplateLocations(loc1, loc2, loc1MsgLength)).isEqualTo(expected);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
@@ -112,7 +112,7 @@ public class FailureItemTest {
   }
 
   @Test
-  public void test_of_reasonMessageWithAttributes() {
+  public void test_of_reasonMessageExceptionWithAttributes() {
     IllegalArgumentException innerEx = new IllegalArgumentException("inner");
     IllegalArgumentException ex = new IllegalArgumentException("exmsg", innerEx);
     FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "failure: {exceptionMessage}", "error");
@@ -122,8 +122,34 @@ public class FailureItemTest {
     assertThat(test.getMessage()).isEqualTo("failure: error");
     assertThat(test.getCauseType()).isPresent();
     assertThat(test.getCauseType()).hasValue(IllegalArgumentException.class);
-    assertThat(test.getStackTrace()).contains(".test_of_reasonMessageWithAttributes(");
+    assertThat(test.getStackTrace()).contains(".test_of_reasonMessageExceptionWithAttributes(");
     assertThat(test.toString()).isEqualTo("INVALID: failure: error: java.lang.IllegalArgumentException: exmsg");
+  }
+
+  @Test
+  public void test_of_reasonMessageExceptionWithFailureItemException() {
+    ParseFailureException ex = new ParseFailureException("Bad value '{value}'", "foo");
+    FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "Error on line {lineNumber}: {exceptionMessage}", 23, "NPE");
+    assertThat(test.getReason()).isEqualTo(FailureReason.PARSING);
+    assertThat(test.getMessage()).isEqualTo("Error on line 23: Bad value 'foo'");
+    assertThat(test.getAttributes())
+        .containsEntry(FailureAttributeKeys.LINE_NUMBER, "23")
+        .containsEntry(FailureAttributeKeys.VALUE, "foo");
+    assertThat(test.getCauseType()).isEmpty();
+    assertThat(test.getStackTrace()).contains(".test_of_reasonMessageExceptionWithFailureItemException(");
+  }
+
+  @Test
+  public void test_of_reasonMessageExceptionWithFailureItemExceptionNoExMessageParam() {
+    ParseFailureException ex = new ParseFailureException("Bad value '{value}'", "foo");
+    FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "Error on line {lineNumber}", 23);
+    assertThat(test.getReason()).isEqualTo(FailureReason.PARSING);
+    assertThat(test.getMessage()).isEqualTo("Error on line 23: Bad value 'foo'");
+    assertThat(test.getAttributes())
+        .containsEntry(FailureAttributeKeys.LINE_NUMBER, "23")
+        .containsEntry(FailureAttributeKeys.VALUE, "foo");
+    assertThat(test.getCauseType()).isEmpty();
+    assertThat(test.getStackTrace()).contains(".test_of_reasonMessageExceptionWithFailureItemExceptionNoExMessageParam(");
   }
 
   @Test

--- a/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
+++ b/modules/collect/src/test/java/com/opengamma/strata/collect/result/FailureItemTest.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.collect.result;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import org.junit.jupiter.api.Test;
 
@@ -132,9 +133,10 @@ public class FailureItemTest {
     FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "Error on line {lineNumber}: {exceptionMessage}", 23, "NPE");
     assertThat(test.getReason()).isEqualTo(FailureReason.PARSING);
     assertThat(test.getMessage()).isEqualTo("Error on line 23: Bad value 'foo'");
-    assertThat(test.getAttributes())
-        .containsEntry(FailureAttributeKeys.LINE_NUMBER, "23")
-        .containsEntry(FailureAttributeKeys.VALUE, "foo");
+    assertThat(test.getAttributes()).containsOnly(
+        entry(FailureAttributeKeys.TEMPLATE_LOCATION, "lineNumber:14:2|value:29:3"),
+        entry(FailureAttributeKeys.LINE_NUMBER, "23"),
+        entry(FailureAttributeKeys.VALUE, "foo"));
     assertThat(test.getCauseType()).isEmpty();
     assertThat(test.getStackTrace()).contains(".test_of_reasonMessageExceptionWithFailureItemException(");
   }
@@ -142,14 +144,26 @@ public class FailureItemTest {
   @Test
   public void test_of_reasonMessageExceptionWithFailureItemExceptionNoExMessageParam() {
     ParseFailureException ex = new ParseFailureException("Bad value '{value}'", "foo");
-    FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "Error on line {lineNumber}", 23);
+    FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "Error on line {lineNumber}: \n {exceptionMessage}", 23, "NPE");
     assertThat(test.getReason()).isEqualTo(FailureReason.PARSING);
     assertThat(test.getMessage()).isEqualTo("Error on line 23: Bad value 'foo'");
-    assertThat(test.getAttributes())
-        .containsEntry(FailureAttributeKeys.LINE_NUMBER, "23")
-        .containsEntry(FailureAttributeKeys.VALUE, "foo");
-    assertThat(test.getCauseType()).isEmpty();
-    assertThat(test.getStackTrace()).contains(".test_of_reasonMessageExceptionWithFailureItemExceptionNoExMessageParam(");
+    assertThat(test.getAttributes()).containsOnly(
+        entry(FailureAttributeKeys.TEMPLATE_LOCATION, "lineNumber:14:2|value:29:3"),
+        entry(FailureAttributeKeys.LINE_NUMBER, "23"),
+        entry(FailureAttributeKeys.VALUE, "foo"));
+  }
+
+  @Test
+  public void test_of_reasonMessageExceptionWithFailureItemExceptionDuplicateName() {
+    ParseFailureException ex = new ParseFailureException("Bad value {value}", 3);
+    FailureItem test = FailureItem.of(FailureReason.INVALID, ex, "Error {value} {value1}", 1, 2);
+    assertThat(test.getReason()).isEqualTo(FailureReason.PARSING);
+    assertThat(test.getMessage()).isEqualTo("Error 1 2: Bad value 3");
+    assertThat(test.getAttributes()).containsOnly(
+        entry(FailureAttributeKeys.TEMPLATE_LOCATION, "value:6:1|value1:8:1|value2:21:1"),
+        entry("value", "1"),
+        entry("value1", "2"),
+        entry("value2", "3"));
   }
 
   @Test

--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvParseException.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvParseException.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (C) 2015 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2022 - present by OpenGamma Inc. and the OpenGamma group of companies
  *
  * Please see distribution for license.
  */
-package com.opengamma.strata.loader.fpml;
+package com.opengamma.strata.loader.csv;
 
 import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.collect.result.ParseFailureException;
 
 /**
- * Exception thrown when parsing FpML.
+ * Exception thrown when parsing CSV.
  */
-public final class FpmlParseException extends ParseFailureException {
+public final class CsvParseException extends ParseFailureException {
 
   /** Serialization version. */
   private static final long serialVersionUID = 1L;
@@ -21,7 +21,7 @@ public final class FpmlParseException extends ParseFailureException {
    * 
    * @param message  the message, null tolerant
    */
-  public FpmlParseException(String message) {
+  public CsvParseException(String message) {
     super(message);
   }
 
@@ -34,7 +34,7 @@ public final class FpmlParseException extends ParseFailureException {
    * @param messageTemplate  the message template, null tolerant
    * @param messageArgs  the message arguments, null tolerant
    */
-  public FpmlParseException(String messageTemplate, Object... messageArgs) {
+  public CsvParseException(String messageTemplate, Object... messageArgs) {
     super(messageTemplate, messageArgs);
   }
 


### PR DESCRIPTION
* Ensure that `FailureItem` captures underlying failures
* This avoids losing failure information within wrapped exceptions