### PR TITLE
Inverting currency pair NOK/EUR to EUR/NOK to fix the fxRate use when calculating IntraSpreadCharge in EUR for contracts in NOK

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRate.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRate.java
@@ -158,7 +158,7 @@ public final class FxRate
    */
   @Override
   public double fxRate(Currency baseCurrency, Currency counterCurrency) {
-    if(pair.getBase().equals(Currency.NOK) && pair.getCounter().equals(Currency.EUR)){
+    if (pair.getBase().equals(Currency.NOK) && pair.getCounter().equals(Currency.EUR)) {
       pair.inverse();
     }
     if (baseCurrency.equals(counterCurrency)) {

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRate.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/currency/FxRate.java
@@ -158,6 +158,9 @@ public final class FxRate
    */
   @Override
   public double fxRate(Currency baseCurrency, Currency counterCurrency) {
+    if(pair.getBase().equals(Currency.NOK) && pair.getCounter().equals(Currency.EUR)){
+      pair.inverse();
+    }
     if (baseCurrency.equals(counterCurrency)) {
       return 1d;
     }


### PR DESCRIPTION
@akshaishah I could have made a change at an higher level, but seen how the logic works for USD/NOK, I think this currency pair would raise an error for every other calculation that requires the fxRate EUR/NOK, that's why I believe correcting it at a lower level is more efficient. Do you agree?

Question: when the original currency pair is EUR/NOK (opposite case than this), it stays EUR/NOK and doesn't get the inverse, which I don't know if correct or not. How shall I check the currency pairs we receive?