### PR TITLE
NDF Pricing: correction to currency exposure

### DIFF
--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/DiscountingFxNdfProductPricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/fx/DiscountingFxNdfProductPricerTest.java
@@ -24,8 +24,10 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.index.FxIndex;
 import com.opengamma.strata.basics.index.FxIndexObservation;
 import com.opengamma.strata.basics.index.ImmutableFxIndex;
+import com.opengamma.strata.collect.timeseries.LocalDateDoubleTimeSeries;
 import com.opengamma.strata.market.param.CurrencyParameterSensitivities;
 import com.opengamma.strata.market.sensitivity.PointSensitivities;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
 import com.opengamma.strata.pricer.rate.RatesProvider;
 import com.opengamma.strata.pricer.sensitivity.RatesFiniteDifferenceSensitivityCalculator;
 import com.opengamma.strata.product.fx.ResolvedFxNdf;
@@ -75,6 +77,7 @@ public class DiscountingFxNdfProductPricerTest {
   private static final RatesFiniteDifferenceSensitivityCalculator CAL_FD =
       new RatesFiniteDifferenceSensitivityCalculator(EPS_FD);
 
+  /* Present value before fixing. */
   @Test
   public void test_presentValue() {
     CurrencyAmount computed = PRICER.presentValue(NDF, PROVIDER);
@@ -85,16 +88,91 @@ public class DiscountingFxNdfProductPricerTest {
     assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * TOL));
   }
 
+  /* Present value on fixing, fixing not available, strictly before payment date. */
   @Test
-  public void test_presentValue_inverse() {
-    CurrencyAmount computed = PRICER.presentValue(NDF_INVERSE, PROVIDER);
-    double dscUsd = PROVIDER.discountFactor(USD, NDF_INVERSE.getPaymentDate());
-    double dscKrw = PROVIDER.discountFactor(KRW, NDF_INVERSE.getPaymentDate());
-    double expected = NOMINAL_USD * FX_RATE * (dscKrw - dscUsd * 1 / FX_RATE / PROVIDER.fxRate(CurrencyPair.of(KRW, USD)));
-    assertThat(computed.getCurrency()).isEqualTo(KRW);
-    assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * FX_RATE * TOL));
+  public void test_presentValue_onfixingdate_nofixing_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate();
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    CurrencyAmount computed = PRICER.presentValue(ndfOnFixing, PROVIDER);
+    double dscUsd = PROVIDER.discountFactor(USD, paymentDate);
+    double dscKrw = PROVIDER.discountFactor(KRW, paymentDate);
+    double expected = NOMINAL_USD * (dscUsd - dscKrw * FX_RATE / PROVIDER.fxRate(CurrencyPair.of(USD, KRW)));
+    assertThat(computed.getCurrency()).isEqualTo(USD);
+    assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * TOL));
   }
 
+  /* Present value on fixing, fixing available, strictly before payment date. */
+  @Test
+  public void test_presentValue_onfixingdate_withfixing_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate();
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    CurrencyAmount computed = PRICER.presentValue(ndfOnFixing, providerWithFixing);
+    double dscUsd = providerWithFixing.discountFactor(USD, paymentDate);
+    double expected = NOMINAL_USD * dscUsd * (1.0d - FX_RATE / fxFixing);
+    assertThat(computed.getCurrency()).isEqualTo(USD);
+    assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * TOL));
+  }
+
+  /* Present value strictly after fixing, strictly before payment date. */
+  @Test
+  public void test_presentValue_afterfixingdate_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate().minusDays(1);
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    CurrencyAmount computed = PRICER.presentValue(ndfOnFixing, providerWithFixing);
+    double dscUsd = providerWithFixing.discountFactor(USD, paymentDate);
+    double expected = NOMINAL_USD * dscUsd * (1.0d - FX_RATE / fxFixing);
+    assertThat(computed.getCurrency()).isEqualTo(USD);
+    assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * TOL));
+  }
+
+  /* Present value strictly after fixing, on payment date. */
+  @Test
+  public void test_presentValue_afterfixingdate_onpayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate().minusDays(2);
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    CurrencyAmount computed = PRICER.presentValue(ndfOnFixing, providerWithFixing);
+    double expected = NOMINAL_USD * (1.0d - FX_RATE / fxFixing); // no discounting
+    assertThat(computed.getCurrency()).isEqualTo(USD);
+    assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * TOL));
+  }
+
+  /* Present value after fixing, on after payment date. */
   @Test
   public void test_presentValue_ended() {
     ResolvedFxNdf ndf = ResolvedFxNdf.builder()
@@ -105,6 +183,16 @@ public class DiscountingFxNdfProductPricerTest {
         .build();
     CurrencyAmount computed = PRICER.presentValue(ndf, PROVIDER);
     assertThat(computed.getAmount()).isEqualTo(0d);
+  }
+
+  @Test
+  public void test_presentValue_inverse() {
+    CurrencyAmount computed = PRICER.presentValue(NDF_INVERSE, PROVIDER);
+    double dscUsd = PROVIDER.discountFactor(USD, NDF_INVERSE.getPaymentDate());
+    double dscKrw = PROVIDER.discountFactor(KRW, NDF_INVERSE.getPaymentDate());
+    double expected = NOMINAL_USD * FX_RATE * (dscKrw - dscUsd * 1 / FX_RATE / PROVIDER.fxRate(CurrencyPair.of(KRW, USD)));
+    assertThat(computed.getCurrency()).isEqualTo(KRW);
+    assertThat(computed.getAmount()).isCloseTo(expected, offset(NOMINAL_USD * FX_RATE * TOL));
   }
 
   @Test
@@ -120,11 +208,96 @@ public class DiscountingFxNdfProductPricerTest {
     assertThat(computedFwd.getAmount()).isCloseTo(0d, offset(NOMINAL_USD * TOL));
   }
 
+  //-------------------------------------------------------------------------
+
   @Test
   public void test_presentValueSensitivity() {
     PointSensitivities point = PRICER.presentValueSensitivity(NDF, PROVIDER);
     CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point);
     CurrencyParameterSensitivities expected = CAL_FD.sensitivity(PROVIDER, (p) -> PRICER.presentValue(NDF, (p)));
+    assertThat(computed.equalWithTolerance(expected, NOMINAL_USD * EPS_FD)).isTrue();
+  }
+
+  /* Present value sensitivity to rates on fixing, fixing not available, strictly before payment date. */
+  @Test
+  public void test_presentValueSensitivity_onfixingdate_nofixing_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate();
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    PointSensitivities point = PRICER.presentValueSensitivity(ndfOnFixing, PROVIDER);
+    CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point);
+    CurrencyParameterSensitivities expected = CAL_FD.sensitivity(PROVIDER, (p) -> PRICER.presentValue(ndfOnFixing, (p)));
+    assertThat(computed.equalWithTolerance(expected, NOMINAL_USD * EPS_FD)).isTrue();
+  }
+
+  /* Present value sensitivity to rates on fixing, fixing available, strictly before payment date. */
+  @Test
+  public void test_presentValueSensitivity_onfixingdate_withfixing_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate();
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    PointSensitivities point = PRICER.presentValueSensitivity(ndfOnFixing, providerWithFixing);
+    CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point);
+    CurrencyParameterSensitivities expected =
+        CAL_FD.sensitivity(providerWithFixing, (p) -> PRICER.presentValue(ndfOnFixing, (p)));
+    assertThat(computed.equalWithTolerance(expected, NOMINAL_USD * EPS_FD)).isTrue();
+  }
+
+  /* Present value sensitivity to rates strictly after fixing, strictly before payment date. */
+  @Test
+  public void test_presentValueSensitivity_afterfixingdate_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate().minusDays(1);
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfAfterFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    PointSensitivities point = PRICER.presentValueSensitivity(ndfAfterFixing, providerWithFixing);
+    CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point);
+    CurrencyParameterSensitivities expected =
+        CAL_FD.sensitivity(providerWithFixing, (p) -> PRICER.presentValue(ndfAfterFixing, (p)));
+    assertThat(computed.equalWithTolerance(expected, NOMINAL_USD * EPS_FD)).isTrue();
+  }
+
+  /* Present value sensitivity to rates strictly after fixing, on payment date. */
+  @Test
+  public void test_presentValueSensitivity_afterfixingdate_onpayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate().minusDays(2);
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfAfterFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    PointSensitivities point = PRICER.presentValueSensitivity(ndfAfterFixing, providerWithFixing);
+    CurrencyParameterSensitivities computed = PROVIDER.parameterSensitivity(point);
+    CurrencyParameterSensitivities expected =
+        CAL_FD.sensitivity(providerWithFixing, (p) -> PRICER.presentValue(ndfAfterFixing, (p)));
     assertThat(computed.equalWithTolerance(expected, NOMINAL_USD * EPS_FD)).isTrue();
   }
 
@@ -150,6 +323,90 @@ public class DiscountingFxNdfProductPricerTest {
     assertThat(pv.getAmount()).isCloseTo(ceConverted.getAmount(), offset(NOMINAL_USD * TOL));
   }
 
+  /* Currency exposure on fixing, fixing not available, strictly before payment date. */
+  @Test
+  public void test_currencyExposure_onfixingdate_nofixing_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate();
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    MultiCurrencyAmount computed = PRICER.currencyExposure(ndfOnFixing, PROVIDER);
+    double dscUsd = PROVIDER.discountFactor(USD, paymentDate);
+    double dscKrw = PROVIDER.discountFactor(KRW, paymentDate);
+    double expectedUsd = dscUsd * NOMINAL_USD;
+    double expectedKrw = -dscKrw * NOMINAL_USD * FX_RATE;
+    assertThat(computed.size()).isEqualTo(2);
+    assertThat(computed.getAmount(USD).getAmount()).isEqualTo(expectedUsd, offset(NOMINAL_USD * TOL));
+    assertThat(computed.getAmount(KRW).getAmount()).isEqualTo(expectedKrw, offset(NOMINAL_USD * TOL));
+  }
+
+  /* Currency exposure on fixing, fixing available, strictly before payment date. */
+  @Test
+  public void test_currencyExposure_onfixingdate_withfixing_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate();
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    MultiCurrencyAmount computedCe = PRICER.currencyExposure(ndfOnFixing, providerWithFixing);
+    CurrencyAmount computedPv = PRICER.presentValue(ndfOnFixing, providerWithFixing);
+    assertThat(computedCe.size()).isEqualTo(1);
+    assertThat(computedCe.getAmount(USD).getAmount()).isEqualTo(computedPv.getAmount(), offset(NOMINAL_USD * TOL));
+  }
+
+  /* Currency exposure strictly after fixing, strictly before payment date. */
+  @Test
+  public void test_currencyExposure_afterfixingdate_beforepayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate().minusDays(1);
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    MultiCurrencyAmount computedCe = PRICER.currencyExposure(ndfOnFixing, providerWithFixing);
+    CurrencyAmount computedPv = PRICER.presentValue(ndfOnFixing, providerWithFixing);
+    assertThat(computedCe.size()).isEqualTo(1);
+    assertThat(computedCe.getAmount(USD).getAmount()).isEqualTo(computedPv.getAmount(), offset(NOMINAL_USD * TOL));
+  }
+
+  /* Currency exposure strictly after fixing, on payment date. */
+  @Test
+  public void test_currencyExposure_afterfixingdate_onpayment() {
+    LocalDate fixingDate = PROVIDER.getValuationDate().minusDays(2);
+    LocalDate paymentDate = fixingDate.plusDays(2);
+    ResolvedFxNdf ndfOnFixing = ResolvedFxNdf.builder()
+        .settlementCurrencyNotional(CURRENCY_NOTIONAL)
+        .agreedFxRate(FxRate.of(USD, KRW, FX_RATE))
+        .observation(FxIndexObservation.of(INDEX, fixingDate, REF_DATA))
+        .paymentDate(paymentDate)
+        .build();
+    double fxFixing = 999.9;
+    LocalDateDoubleTimeSeries timeSeriesFx = LocalDateDoubleTimeSeries.of(fixingDate, fxFixing);
+    ImmutableRatesProvider providerWithFixing = ((ImmutableRatesProvider) PROVIDER).toBuilder()
+        .timeSeries(INDEX, timeSeriesFx).build();
+    MultiCurrencyAmount computedCe = PRICER.currencyExposure(ndfOnFixing, providerWithFixing);
+    CurrencyAmount computedPv = PRICER.presentValue(ndfOnFixing, providerWithFixing);
+    assertThat(computedCe.size()).isEqualTo(1);
+    assertThat(computedCe.getAmount(USD).getAmount()).isEqualTo(computedPv.getAmount(), offset(NOMINAL_USD * TOL));
+  }
+
   @Test
   public void test_currencyExposure_ended() {
     ResolvedFxNdf ndf = ResolvedFxNdf.builder()
@@ -170,7 +427,8 @@ public class DiscountingFxNdfProductPricerTest {
     CurrencyAmount cePv = PRICER.presentValue(NDF, PROVIDER);
     MultiCurrencyAmount ceExpected = cePts.plus(cePv);
     assertThat(ceDirect.getAmount(USD).getAmount()).isCloseTo(ceExpected.getAmount(USD).getAmount(), offset(NOMINAL_USD * TOL));
-    assertThat(ceDirect.getAmount(KRW).getAmount()).isCloseTo(ceExpected.getAmount(KRW).getAmount(), offset(NOMINAL_USD * TOL * FX_MATRIX.fxRate(USD, KRW)));
+    assertThat(ceDirect.getAmount(KRW).getAmount()).isCloseTo(ceExpected.getAmount(KRW).getAmount(),
+        offset(NOMINAL_USD * TOL * FX_MATRIX.fxRate(USD, KRW)));
   }
 
   @Test
@@ -181,7 +439,8 @@ public class DiscountingFxNdfProductPricerTest {
     CurrencyAmount cePv = PRICER.presentValue(NDF_INVERSE, PROVIDER);
     MultiCurrencyAmount ceExpected = cePts.plus(cePv);
     assertThat(ceDirect.getAmount(USD).getAmount()).isCloseTo(ceExpected.getAmount(USD).getAmount(), offset(NOMINAL_USD * TOL));
-    assertThat(ceDirect.getAmount(KRW).getAmount()).isCloseTo(ceExpected.getAmount(KRW).getAmount(), offset(NOMINAL_USD * TOL * FX_MATRIX.fxRate(USD, KRW)));
+    assertThat(ceDirect.getAmount(KRW).getAmount()).isCloseTo(ceExpected.getAmount(KRW).getAmount(),
+        offset(NOMINAL_USD * TOL * FX_MATRIX.fxRate(USD, KRW)));
   }
 
   //-------------------------------------------------------------------------
@@ -194,7 +453,9 @@ public class DiscountingFxNdfProductPricerTest {
   public void test_presentValueVsForex() {
     CurrencyAmount pvNDF = PRICER.presentValue(NDF, PROVIDER);
     MultiCurrencyAmount pvFX = PRICER_FX.presentValue(FOREX, PROVIDER);
-    assertThat(pvNDF.getAmount()).isCloseTo(pvFX.getAmount(USD).getAmount() + pvFX.getAmount(KRW).getAmount() * FX_MATRIX.fxRate(KRW, USD), offset(NOMINAL_USD * TOL));
+    assertThat(pvNDF.getAmount()).isCloseTo(
+        pvFX.getAmount(USD).getAmount() + pvFX.getAmount(KRW).getAmount() * FX_MATRIX.fxRate(KRW, USD),
+        offset(NOMINAL_USD * TOL));
   }
 
   // Checks that the NDF currency exposure is coherent with the standard FX forward present value.
@@ -203,7 +464,8 @@ public class DiscountingFxNdfProductPricerTest {
     MultiCurrencyAmount pvNDF = PRICER.currencyExposure(NDF, PROVIDER);
     MultiCurrencyAmount pvFX = PRICER_FX.currencyExposure(FOREX, PROVIDER);
     assertThat(pvNDF.getAmount(USD).getAmount()).isCloseTo(pvFX.getAmount(USD).getAmount(), offset(NOMINAL_USD * TOL));
-    assertThat(pvNDF.getAmount(KRW).getAmount()).isCloseTo(pvFX.getAmount(KRW).getAmount(), offset(NOMINAL_USD * TOL * FX_MATRIX.fxRate(USD, KRW)));
+    assertThat(pvNDF.getAmount(KRW).getAmount()).isCloseTo(pvFX.getAmount(KRW).getAmount(),
+        offset(NOMINAL_USD * TOL * FX_MATRIX.fxRate(USD, KRW)));
   }
 
   // Checks that the NDF forward rate is coherent with the standard FX forward present value.


### PR DESCRIPTION
FX NDF pricer:
Existing currency exposure computation contained a bug between fixing and payment date. The currency exposure was still present even if the fixing had already taken place.