### PR TITLE
Fix LinearInterpolator and FastCreditCurveCalibrator

### DIFF
--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator.java
@@ -56,8 +56,6 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }
-      double bound = Math.max(Math.abs(ref) + Math.abs(yValuesSrt[i + 1]), 1.e-1);
-      ArgChecker.isTrue(Math.abs(ref - yValuesSrt[i + 1]) < ERROR * bound, "Input is too large/small or data are not distinct enough");
     }
 
     return new PiecewisePolynomialResult(DoubleArray.copyOf(xValuesSrt), coefMatrix, coefMatrix.columnCount(), 1);
@@ -101,8 +99,6 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
           ArgChecker.isFalse(Double.isNaN(coefMatrix[i].get(k, j)), "Too large input");
           ArgChecker.isFalse(Double.isInfinite(coefMatrix[i].get(k, j)), "Too large input");
         }
-        double bound = Math.max(Math.abs(ref) + Math.abs(yValuesSrt[k + 1]), 1.e-1);
-        ArgChecker.isTrue(Math.abs(ref - yValuesSrt[k + 1]) < ERROR * bound, "Input is too large/small or data points are too close");
       }
     }
 
@@ -154,9 +150,6 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }
-      double bound = Math.max(Math.abs(ref) + Math.abs(yValuesSrt[i + 1]), 1.e-1);
-      ArgChecker.isTrue(Math.abs(ref - yValuesSrt[i + 1]) < ERROR * bound,
-          "Input is too large/small or data are not distinct enough");
     }
 
     return new PiecewisePolynomialResultsWithSensitivity(

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolator.java
@@ -18,8 +18,6 @@ import com.opengamma.strata.collect.array.DoubleMatrix;
  */
 public class LinearInterpolator extends PiecewisePolynomialInterpolator {
 
-  private static final double ERROR = 1.e-13;
-
   @Override
   public PiecewisePolynomialResult interpolate(double[] xValues, double[] yValues) {
     ArgChecker.notEmpty(xValues, "xValues");
@@ -32,9 +30,6 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
       ArgChecker.isFalse(Double.isInfinite(xValues[i]), "xData containing Infinity");
       ArgChecker.isFalse(Double.isNaN(yValues[i]), "yData containing NaN");
       ArgChecker.isFalse(Double.isInfinite(yValues[i]), "yData containing Infinity");
-    }
-    if (nDataPts == 1) {
-      return new PiecewisePolynomialResult(DoubleArray.copyOf(xValues), DoubleMatrix.filled(1, 1, yValues[0]), 1, 1);
     }
 
     double[] xValuesSrt = Arrays.copyOf(xValues, nDataPts);
@@ -49,10 +44,7 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }
-      double ref = 0.;
-      double interval = xValuesSrt[i + 1] - xValuesSrt[i];
       for (int j = 0; j < 2; ++j) {
-        ref += coefMatrix.get(i, j) * Math.pow(interval, 1 - j);
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }
@@ -74,9 +66,9 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
     for (int i = 0; i < nDataPts; ++i) {
       ArgChecker.isFalse(Double.isNaN(xValues[i]), "xData containing NaN");
       ArgChecker.isFalse(Double.isInfinite(xValues[i]), "xData containing Infinity");
-      for (int j = 0; j < dim; ++j) {
-        ArgChecker.isFalse(Double.isNaN(yValuesMatrix[j][i]), "yValuesMatrix containing NaN");
-        ArgChecker.isFalse(Double.isInfinite(yValuesMatrix[j][i]), "yValuesMatrix containing Infinity");
+      for (double[] valuesMatrix : yValuesMatrix) {
+        ArgChecker.isFalse(Double.isNaN(valuesMatrix[i]), "yValuesMatrix containing NaN");
+        ArgChecker.isFalse(Double.isInfinite(valuesMatrix[i]), "yValuesMatrix containing Infinity");
       }
     }
 
@@ -92,10 +84,7 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
       coefMatrix[i] = solve(xValuesSrt, yValuesSrt);
 
       for (int k = 0; k < xValuesSrt.length - 1; ++k) {
-        double ref = 0.;
-        double interval = xValuesSrt[k + 1] - xValuesSrt[k];
         for (int j = 0; j < 2; ++j) {
-          ref += coefMatrix[i].get(k, j) * Math.pow(interval, 1 - j);
           ArgChecker.isFalse(Double.isNaN(coefMatrix[i].get(k, j)), "Too large input");
           ArgChecker.isFalse(Double.isInfinite(coefMatrix[i].get(k, j)), "Too large input");
         }
@@ -143,10 +132,7 @@ public class LinearInterpolator extends PiecewisePolynomialInterpolator {
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }
-      double ref = 0.;
-      double interval = xValuesSrt[i + 1] - xValuesSrt[i];
       for (int j = 0; j < 2; ++j) {
-        ref += coefMatrix.get(i, j) * Math.pow(interval, 1 - j);
         ArgChecker.isFalse(Double.isNaN(coefMatrix.get(i, j)), "Too large input");
         ArgChecker.isFalse(Double.isInfinite(coefMatrix.get(i, j)), "Too large input");
       }

--- a/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolatorTest.java
+++ b/modules/math/src/test/java/com/opengamma/strata/math/impl/interpolation/LinearInterpolatorTest.java
@@ -27,7 +27,7 @@ public class LinearInterpolatorTest {
   private static final LinearInterpolator INTERP = new LinearInterpolator();
 
   /**
-   * 
+   *
    */
   @Test
   public void recov2ptsTest() {
@@ -60,7 +60,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void recov4ptsTest() {
@@ -94,7 +94,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullXvaluesTest() {
@@ -105,7 +105,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullYvaluesTest() {
@@ -116,7 +116,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void wrongDatalengthTest() {
@@ -127,7 +127,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void shortDataLengthTest() {
@@ -138,7 +138,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void naNxValuesTest() {
@@ -149,7 +149,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void naNyValuesTest() {
@@ -160,7 +160,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void infxValuesTest() {
@@ -171,7 +171,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void infyValuesTest() {
@@ -182,7 +182,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void coincideXvaluesTest() {
@@ -193,7 +193,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void recov2ptsMultiTest() {
@@ -222,7 +222,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void recov4ptsMultiTest() {
@@ -252,7 +252,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullXvaluesMultiTest() {
@@ -263,7 +263,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullYvaluesMultiTest() {
@@ -274,7 +274,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void wrongDatalengthMultiTest() {
@@ -285,7 +285,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void shortDataLengthMultiTest() {
@@ -296,7 +296,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void naNxValuesMultiTest() {
@@ -307,7 +307,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void naNyValuesMultiTest() {
@@ -318,7 +318,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void infxValuesMultiTest() {
@@ -329,7 +329,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void infyValuesMultiTest() {
@@ -340,7 +340,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void coincideXvaluesMultiTest() {
@@ -415,7 +415,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void largeOutputTest() {
@@ -426,7 +426,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void largeOutputMultiTest() {
@@ -437,7 +437,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void largeInterpolantsTest() {
@@ -448,7 +448,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullKeyTest() {
@@ -460,7 +460,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullKeyMultiTest() {
@@ -472,7 +472,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullKeyMatrixTest() {
@@ -484,7 +484,7 @@ public class LinearInterpolatorTest {
   }
 
   /**
-   * 
+   *
    */
   @Test
   public void nullKeyMatrixMultiTest() {
@@ -493,32 +493,6 @@ public class LinearInterpolatorTest {
     double[][] xKey = null;
     assertThatIllegalArgumentException()
         .isThrownBy(() -> INTERP.interpolate(xValues, yValues, xKey));
-  }
-
-  /**
-   * 
-   */
-  @Test
-  public void notReconnectedTest() {
-    double[] xValues = new double[] {1., 2.000000000001, 2.000000000002, 4.};
-    double[] yValues = new double[] {2., 4.e10, 3.e-5, 5.e11};
-
-    PiecewisePolynomialInterpolator interpPos = new LinearInterpolator();
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> interpPos.interpolate(xValues, yValues));
-  }
-
-  /**
-   * 
-   */
-  @Test
-  public void notReconnectedMultiTest() {
-    double[] xValues = new double[] {1., 2.000000000001, 2.000000000002, 4.};
-    double[][] yValues = new double[][] {{2., 4.e10, 3.e-5, 5.e11}};
-
-    PiecewisePolynomialInterpolator interpPos = new LinearInterpolator();
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> interpPos.interpolate(xValues, yValues));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/credit/FastCreditCurveCalibrator.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/credit/FastCreditCurveCalibrator.java
@@ -55,6 +55,11 @@ public final class FastCreditCurveCalibrator extends IsdaCompliantCreditCurveCal
    * The root finder.
    */
   private static final RealSingleRootFinder ROOTFINDER = new BrentSingleRootFinder();
+  /**
+   * The maximum value of rate times year fraction
+   * for which the survival probability is numerically zero within the tolerance of {@code RealSingleRootFinder}.
+   */
+  private static final double MAX_RT = 37d;
 
   //-------------------------------------------------------------------------
   /**
@@ -162,6 +167,8 @@ public final class FastCreditCurveCalibrator extends IsdaCompliantCreditCurveCal
           } catch (final MathException e) { //handling bracketing failure due to small survival probability
             if (Math.abs(func.apply(creditCurve.getYValues().get(i - 1))) < 1.e-12) {
               creditCurve = creditCurve.withParameter(i, creditCurve.getYValues().get(i - 1));
+            } else if (func.apply(MAX_RT / times.get(i)) <  -1.e-12) { // root does not exist for positive survival probability
+              creditCurve = creditCurve.withParameter(i, MAX_RT / times.get(i));
             } else {
               throw new MathException(e);
             }


### PR DESCRIPTION
LinearInterpolator #interpolate() was fixed by removing the numerical accuracy check which is wrong with survival probabilities close to zero.

FastCreditCurveCalibrator handles positive survival probability.