### PR TITLE
Extend standard future convention/spec coverage

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/IborFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/IborFutureContractSpecs.java
@@ -28,6 +28,14 @@ public final class IborFutureContractSpecs {
 
   //-------------------------------------------------------------------------
   /**
+   * The 'EUR-EURIBOR-3M-IMM-EUREX' contract.
+   * <p>
+   * The EUREX contract based on quarterly IMM dates, also known as "FEU3".
+   */
+  public static final IborFutureContractSpec EUR_EURIBOR_3M_IMM_EUREX =
+      IborFutureContractSpec.of(StandardIborFutureContractSpecs.EUR_EURIBOR_3M_IMM_EUREX.getName());
+
+  /**
    * The 'EUR-EURIBOR-3M-IMM-ICE' contract.
    * <p>
    * The ICE "I" contract based on quarterly IMM dates, also known as "FEI".
@@ -36,6 +44,14 @@ public final class IborFutureContractSpecs {
       IborFutureContractSpec.of(StandardIborFutureContractSpecs.EUR_EURIBOR_3M_IMM_ICE.getName());
 
   //-------------------------------------------------------------------------
+  /**
+   * The 'USD-LIBOR-3M-IMM-CME' contract.
+   * <p>
+   * The CME "GLB" contract based on monthly IMM dates.
+   */
+  public static final IborFutureContractSpec USD_LIBOR_1M_IMM_CME =
+      IborFutureContractSpec.of(StandardIborFutureContractSpecs.USD_LIBOR_1M_IMM_CME.getName());
+
   /**
    * The 'USD-LIBOR-3M-IMM-CME' contract.
    * <p>

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecs.java
@@ -18,7 +18,6 @@ public final class OvernightFutureContractSpecs {
   static final ExtendedEnum<OvernightFutureContractSpec> ENUM_LOOKUP = ExtendedEnum.of(OvernightFutureContractSpec.class);
 
   //-------------------------------------------------------------------------
-
   /**
    * The 'GBP-SONIA-3M-IMM-CME' contract.
    * <p>

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecs.java
@@ -18,6 +18,7 @@ public final class OvernightFutureContractSpecs {
   static final ExtendedEnum<OvernightFutureContractSpec> ENUM_LOOKUP = ExtendedEnum.of(OvernightFutureContractSpec.class);
 
   //-------------------------------------------------------------------------
+
   /**
    * The 'GBP-SONIA-3M-IMM-CME' contract.
    * <p>
@@ -25,6 +26,30 @@ public final class OvernightFutureContractSpecs {
    */
   public static final OvernightFutureContractSpec GBP_SONIA_3M_IMM_CME =
       OvernightFutureContractSpec.of(StandardOvernightFutureContractSpecs.GBP_SONIA_3M_IMM_CME.getName());
+
+  /**
+   * The 'CHF-SARON-3M-IMM-CME' contract.
+   * <p>
+   * The ICE "SA3" contract based on quarterly IMM dates.
+   */
+  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_ICE =
+      OvernightFutureContractSpec.of(StandardOvernightFutureContractSpecs.CHF_SARON_3M_IMM_ICE.getName());
+
+  /**
+   * The 'GBP-CHF-SARON-3M-IMM-EUREX' contract.
+   * <p>
+   * The EUREX "FSR3" contract based on quarterly IMM dates.
+   */
+  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_EUREX =
+      OvernightFutureContractSpec.of(StandardOvernightFutureContractSpecs.CHF_SARON_3M_IMM_EUREX.getName());
+
+  /**
+   * The 'EUR_ESTR_1M_IMM_ICE' contract.
+   * <p>
+   * The ICE "EON" contract based on quarterly IMM dates.
+   */
+  public static final OvernightFutureContractSpec EUR_ESTR_1M_IMM_ICE =
+      OvernightFutureContractSpec.of(StandardOvernightFutureContractSpecs.EUR_ESTR_1M_IMM_ICE.getName());
 
   /**
    * The 'GBP-SONIA-3M-IMM-ICE' contract.
@@ -61,6 +86,14 @@ public final class OvernightFutureContractSpecs {
       OvernightFutureContractSpec.of(StandardOvernightFutureContractSpecs.GBP_SONIA_1M_IMM_LCH.getName());
 
   //-------------------------------------------------------------------------
+  /**
+   * The 'USD-SOFR-1M-IMM-CME' convention.
+   * <p>
+   * The CME "SR1" contract based on monthly IMM dates.
+   */
+  public static final OvernightFutureContractSpec USD_SOFR_1M_IMM_CME =
+      OvernightFutureContractSpec.of(StandardOvernightFutureContractSpecs.USD_SOFR_1M_IMM_CME.getName());
+
   /**
    * The 'USD-SOFR-3M-IMM-CME' contract.
    * <p>

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardIborFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardIborFutureContractSpecs.java
@@ -5,12 +5,14 @@
  */
 package com.opengamma.strata.product.index.type;
 
+import static com.opengamma.strata.basics.date.DateSequences.MONTHLY_IMM;
 import static com.opengamma.strata.basics.date.DateSequences.QUARTERLY_IMM;
 import static com.opengamma.strata.basics.date.DateSequences.QUARTERLY_IMM_3_SERIAL;
 import static com.opengamma.strata.basics.date.DateSequences.QUARTERLY_IMM_6_SERIAL;
 import static com.opengamma.strata.basics.index.IborIndices.CHF_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.EUR_EURIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_1M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 
 /**
@@ -56,6 +58,34 @@ final class StandardIborFutureContractSpecs {
           .name("EUR-EURIBOR-3M-IMM-ICE")
           .index(EUR_EURIBOR_3M)
           .dateSequence(QUARTERLY_IMM_6_SERIAL)
+          .notional(1_000_000d)
+          .build();
+
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 'EUR-EURIBOR-3M-IMM-EUREX' contract.
+   * <p>
+   * The EUREX "FEU3" contract based on quarterly IMM dates, also known as "FEU3".
+   */
+  public static final IborFutureContractSpec EUR_EURIBOR_3M_IMM_EUREX =
+      ImmutableIborFutureContractSpec.builder()
+          .name("EUR-EURIBOR-3M-IMM-ICE")
+          .index(EUR_EURIBOR_3M)
+          .dateSequence(QUARTERLY_IMM_6_SERIAL) //TODO check
+          .notional(1_000_000d)
+          .build();
+  //-------------------------------------------------------------------------
+  /**
+   * The 'USD-LIBOR-1M-IMM-CME' contract.
+   * <p>
+   * The CME "GLB" contract based on monthly IMM dates.
+   */
+  public static final IborFutureContractSpec USD_LIBOR_1M_IMM_CME =
+      ImmutableIborFutureContractSpec.builder()
+          .name("USD-LIBOR-1M-IMM-CME")
+          .index(USD_LIBOR_1M)
+          .dateSequence(MONTHLY_IMM) //TODO check
           .notional(1_000_000d)
           .build();
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardIborFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardIborFutureContractSpecs.java
@@ -61,7 +61,6 @@ final class StandardIborFutureContractSpecs {
           .notional(1_000_000d)
           .build();
 
-
   //-------------------------------------------------------------------------
   /**
    * The 'EUR-EURIBOR-3M-IMM-EUREX' contract.

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardIborFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardIborFutureContractSpecs.java
@@ -66,12 +66,13 @@ final class StandardIborFutureContractSpecs {
    * The 'EUR-EURIBOR-3M-IMM-EUREX' contract.
    * <p>
    * The EUREX "FEU3" contract based on quarterly IMM dates, also known as "FEU3".
+   * https://www.eurex.com/ex-en/markets/int/mon/packs-bundles/euribor/Three-Month-EURIBOR-Futures-137458
    */
   public static final IborFutureContractSpec EUR_EURIBOR_3M_IMM_EUREX =
       ImmutableIborFutureContractSpec.builder()
           .name("EUR-EURIBOR-3M-IMM-ICE")
           .index(EUR_EURIBOR_3M)
-          .dateSequence(QUARTERLY_IMM_6_SERIAL) //TODO check
+          .dateSequence(QUARTERLY_IMM_6_SERIAL)
           .notional(1_000_000d)
           .build();
   //-------------------------------------------------------------------------
@@ -79,12 +80,14 @@ final class StandardIborFutureContractSpecs {
    * The 'USD-LIBOR-1M-IMM-CME' contract.
    * <p>
    * The CME "GLB" contract based on monthly IMM dates.
+   * https://www.cmegroup.com/markets/interest-rates/stirs/1-month-libor.contractSpecs.html
+   *
    */
   public static final IborFutureContractSpec USD_LIBOR_1M_IMM_CME =
       ImmutableIborFutureContractSpec.builder()
           .name("USD-LIBOR-1M-IMM-CME")
           .index(USD_LIBOR_1M)
-          .dateSequence(MONTHLY_IMM) //TODO check
+          .dateSequence(MONTHLY_IMM)
           .notional(1_000_000d)
           .build();
 
@@ -93,6 +96,7 @@ final class StandardIborFutureContractSpecs {
    * The 'USD-LIBOR-3M-IMM-CME' contract.
    * <p>
    * The CME "ED" contract based on quarterly IMM dates.
+   * https://www.cmegroup.com/markets/interest-rates/stirs/eurodollar.contractSpecs.html
    */
   public static final IborFutureContractSpec USD_LIBOR_3M_IMM_CME =
       ImmutableIborFutureContractSpec.builder()

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -33,10 +33,10 @@ final class StandardOvernightFutureContractSpecs {
   /**
    * The 'CHF_SARON_3M_IMM_ICE' convention.
    * <p>
-   *  https://www.theice.com/products/72270612/Three-Month-Saron-Index-Futures-Contract
-   *  <p>
-   *  Contract code "SA3"
-   *  16 delivery months are available for trading
+   * https://www.theice.com/products/72270612/Three-Month-Saron-Index-Futures-Contract
+   * <p>
+   * Contract code "SA3"
+   * 16 delivery months are available for trading
    */
   public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_ICE =
       ImmutableOvernightFutureContractSpec.builder()
@@ -100,7 +100,10 @@ final class StandardOvernightFutureContractSpecs {
 
   /**
    * The 'GBP-SONIA-3M-IMM-ICE' convention.
+   * <p>
    * https://www.theice.com/products/68361266/Three-Month-Sonia-Index-Futures
+   * <p>
+   * Contract code "SO3"
    */
   public static final OvernightFutureContractSpec GBP_SONIA_3M_IMM_ICE =
       ImmutableOvernightFutureContractSpec.builder()
@@ -127,16 +130,13 @@ final class StandardOvernightFutureContractSpecs {
 
   /**
    * The 'GBP-SONIA-1M-ICE' convention.
-   * <p>
    * https://www.theice.com/products/66380299/One-Month-SONIA-Index-Futures
-   * <p>
-   * Contract code "SO3"
    */
   public static final OvernightFutureContractSpec GBP_SONIA_1M_ICE =
       ImmutableOvernightFutureContractSpec.builder()
           .name("GBP-SONIA-1M-ICE")
           .index(GBP_SONIA)
-          .dateSequence(MONTHLY_IMM)
+          .dateSequence(MONTHLY_1ST)
           .accrualMethod(AVERAGED_DAILY)
           .notional(3_000_000d)
           .build();
@@ -232,8 +232,8 @@ final class StandardOvernightFutureContractSpecs {
   /**
    * The 'USD-FED-FUND-1M-CME' convention.
    * https://www.cmegroup.com/trading/interest-rates/stir/30-day-federal-fund_contract_specifications.html
-   *
-   * "ZQ"
+   * <p>
+   * Contract code "ZQ"
    */
   public static final OvernightFutureContractSpec USD_FED_FUND_1M_CME =
       ImmutableOvernightFutureContractSpec.builder()

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -6,6 +6,7 @@
 package com.opengamma.strata.product.index.type;
 
 import static com.opengamma.strata.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.strata.basics.date.BusinessDayConventions.PRECEDING;
 import static com.opengamma.strata.basics.date.DateSequences.MONTHLY_1ST;
 import static com.opengamma.strata.basics.date.DateSequences.MONTHLY_IMM;
 import static com.opengamma.strata.basics.date.DateSequences.QUARTERLY_IMM;
@@ -31,37 +32,49 @@ final class StandardOvernightFutureContractSpecs {
 
   /**
    * The 'CHF_SARON_3M_IMM_ICE' convention.
-   * "SA3"
+   * <p>
+   *  https://www.theice.com/products/72270612/Three-Month-Saron-Index-Futures-Contract
+   *  <p>
+   *  Contract code "SA3"
+   *  16 delivery months are available for trading
    */
-  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_ICE = //TODO check
+  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_ICE =
       ImmutableOvernightFutureContractSpec.builder()
           .name("CHF-SARON-3M-IMM-ICE")
           .index(CHF_SARON)
-          .dateSequence(QUARTERLY_IMM)
+          .dateSequence(QUARTERLY_IMM_6_SERIAL)
           .accrualMethod(COMPOUNDED)
-          .lastTradeDateAdjustment(DaysAdjustment.ofCalendarDays(0, BusinessDayAdjustment.of(FOLLOWING, CHZU)))
-          .notional(1_000_000d)
+          .lastTradeDateAdjustment(DaysAdjustment.ofBusinessDays(1, CHZU, BusinessDayAdjustment.of(PRECEDING, CHZU)))
+          .notional(2_500d)
           .build();
 
   /**
    * The 'CHF_SARON_3M_IMM_ICE' convention.
-   * "FSR3"
+   * <p>
+   * https://www.eurex.com/ex-en/markets/int/mon/saron-futures/saron/3M-SARON-Futures-1405958
+   * <p>
+   * Contract code "FSR3"
+   * 12 delivery months are available for trading
    */
-  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_EUREX = //TODO check
+  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_EUREX =
       ImmutableOvernightFutureContractSpec.builder()
           .name("CHF-SARON-3M-IMM-EUREX")
           .index(CHF_SARON)
           .dateSequence(QUARTERLY_IMM)
           .accrualMethod(COMPOUNDED)
-          .lastTradeDateAdjustment(DaysAdjustment.ofCalendarDays(0, BusinessDayAdjustment.of(FOLLOWING, CHZU)))
+          .lastTradeDateAdjustment(DaysAdjustment.ofBusinessDays(1, CHZU, BusinessDayAdjustment.of(PRECEDING, CHZU)))
           .notional(1_000_000d)
           .build();
 
   /**
    * The 'EUR_ESTR_1M_IMM_ICE' convention.
-   * "EON"
+   * <p>
+   * https://www.theice.com/products/37650328/One-Month-ESTR-Index-Futures
+   * <p>
+   * Contract code "EON"
+   * Maximum of 24 delivery months available for trading
    */
-  public static final OvernightFutureContractSpec EUR_ESTR_1M_IMM_ICE = //TODO check maybe add TARGET 2
+  public static final OvernightFutureContractSpec EUR_ESTR_1M_IMM_ICE =
       ImmutableOvernightFutureContractSpec.builder()
           .name("EUR-ESTR-1M-IMM-ICE")
           .index(EUR_ESTR)
@@ -114,16 +127,18 @@ final class StandardOvernightFutureContractSpecs {
 
   /**
    * The 'GBP-SONIA-1M-ICE' convention.
+   * <p>
    * https://www.theice.com/products/66380299/One-Month-SONIA-Index-Futures
-   * "SO3"
+   * <p>
+   * Contract code "SO3"
    */
   public static final OvernightFutureContractSpec GBP_SONIA_1M_ICE =
       ImmutableOvernightFutureContractSpec.builder()
           .name("GBP-SONIA-1M-ICE")
           .index(GBP_SONIA)
-          .dateSequence(MONTHLY_1ST)
+          .dateSequence(MONTHLY_IMM)
           .accrualMethod(AVERAGED_DAILY)
-          .notional(3_000_000d)
+          .notional(2_500d)
           .build();
 
   /**
@@ -144,8 +159,10 @@ final class StandardOvernightFutureContractSpecs {
 
   /**
    * The 'USD-SOFR-3M-IMM-CME' convention.
+   * <p>
    * https://www.cmegroup.com/trading/interest-rates/stir/three-month-sofr_contract_specifications.html
-   * "SR1"
+   * <p>
+   * Contract code "SR1"
    */
   public static final OvernightFutureContractSpec USD_SOFR_1M_IMM_CME =
       ImmutableOvernightFutureContractSpec.builder()
@@ -153,13 +170,15 @@ final class StandardOvernightFutureContractSpecs {
           .index(USD_SOFR)
           .dateSequence(MONTHLY_IMM)
           .accrualMethod(COMPOUNDED)
-          .notional(1_000_000d)
+          .notional(4_167d)
           .build();
 
   /**
    * The 'USD-SOFR-3M-IMM-CME' convention.
+   * <p>
    * https://www.cmegroup.com/trading/interest-rates/stir/three-month-sofr_contract_specifications.html
-   * "SR3"
+   * <p>
+   * Contract code "SR3"
    */
   public static final OvernightFutureContractSpec USD_SOFR_3M_IMM_CME =
       ImmutableOvernightFutureContractSpec.builder()
@@ -167,7 +186,7 @@ final class StandardOvernightFutureContractSpecs {
           .index(USD_SOFR)
           .dateSequence(QUARTERLY_IMM)
           .accrualMethod(COMPOUNDED)
-          .notional(1_000_000d)
+          .notional(2_500d)
           .build();
 
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -45,7 +45,7 @@ final class StandardOvernightFutureContractSpecs {
           .dateSequence(QUARTERLY_IMM_6_SERIAL)
           .accrualMethod(COMPOUNDED)
           .lastTradeDateAdjustment(DaysAdjustment.ofBusinessDays(1, CHZU, BusinessDayAdjustment.of(PRECEDING, CHZU)))
-          .notional(2_500d)
+          .notional(1_000_000d)
           .build();
 
   /**
@@ -138,7 +138,7 @@ final class StandardOvernightFutureContractSpecs {
           .index(GBP_SONIA)
           .dateSequence(MONTHLY_IMM)
           .accrualMethod(AVERAGED_DAILY)
-          .notional(2_500d)
+          .notional(1_000_000d)
           .build();
 
   /**
@@ -186,7 +186,7 @@ final class StandardOvernightFutureContractSpecs {
           .index(USD_SOFR)
           .dateSequence(QUARTERLY_IMM)
           .accrualMethod(COMPOUNDED)
-          .notional(2_500d)
+          .notional(1_000_000d)
           .build();
 
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -156,7 +156,6 @@ final class StandardOvernightFutureContractSpecs {
           .build();
 
   //-------------------------------------------------------------------------
-
   /**
    * The 'USD-SOFR-3M-IMM-CME' convention.
    * <p>

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -29,7 +29,6 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
  */
 final class StandardOvernightFutureContractSpecs {
 
-
   /**
    * The 'CHF_SARON_3M_IMM_ICE' convention.
    * "SA3"
@@ -57,7 +56,6 @@ final class StandardOvernightFutureContractSpecs {
           .lastTradeDateAdjustment(DaysAdjustment.ofCalendarDays(0, BusinessDayAdjustment.of(FOLLOWING, CHZU)))
           .notional(1_000_000d)
           .build();
-
 
   /**
    * The 'EUR_ESTR_1M_IMM_ICE' convention.

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -10,7 +10,11 @@ import static com.opengamma.strata.basics.date.DateSequences.MONTHLY_1ST;
 import static com.opengamma.strata.basics.date.DateSequences.MONTHLY_IMM;
 import static com.opengamma.strata.basics.date.DateSequences.QUARTERLY_IMM;
 import static com.opengamma.strata.basics.date.DateSequences.QUARTERLY_IMM_6_SERIAL;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.CHZU;
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.EUTA;
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
+import static com.opengamma.strata.basics.index.OvernightIndices.CHF_SARON;
+import static com.opengamma.strata.basics.index.OvernightIndices.EUR_ESTR;
 import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_SOFR;
@@ -24,6 +28,50 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
  * Commonly traded Overnight future contract specifications.
  */
 final class StandardOvernightFutureContractSpecs {
+
+
+  /**
+   * The 'CHF_SARON_3M_IMM_ICE' convention.
+   * "SA3"
+   */
+  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_ICE = //TODO check
+      ImmutableOvernightFutureContractSpec.builder()
+          .name("CHF-SARON-3M-IMM-ICE")
+          .index(CHF_SARON)
+          .dateSequence(QUARTERLY_IMM)
+          .accrualMethod(COMPOUNDED)
+          .lastTradeDateAdjustment(DaysAdjustment.ofCalendarDays(0, BusinessDayAdjustment.of(FOLLOWING, CHZU)))
+          .notional(1_000_000d)
+          .build();
+
+  /**
+   * The 'CHF_SARON_3M_IMM_ICE' convention.
+   * "FSR3"
+   */
+  public static final OvernightFutureContractSpec CHF_SARON_3M_IMM_EUREX = //TODO check
+      ImmutableOvernightFutureContractSpec.builder()
+          .name("CHF-SARON-3M-IMM-EUREX")
+          .index(CHF_SARON)
+          .dateSequence(QUARTERLY_IMM)
+          .accrualMethod(COMPOUNDED)
+          .lastTradeDateAdjustment(DaysAdjustment.ofCalendarDays(0, BusinessDayAdjustment.of(FOLLOWING, CHZU)))
+          .notional(1_000_000d)
+          .build();
+
+
+  /**
+   * The 'EUR_ESTR_1M_IMM_ICE' convention.
+   * "EON"
+   */
+  public static final OvernightFutureContractSpec EUR_ESTR_1M_IMM_ICE = //TODO check maybe add TARGET 2
+      ImmutableOvernightFutureContractSpec.builder()
+          .name("EUR-ESTR-1M-IMM-ICE")
+          .index(EUR_ESTR)
+          .dateSequence(MONTHLY_IMM)
+          .accrualMethod(COMPOUNDED)
+          .lastTradeDateAdjustment(DaysAdjustment.ofCalendarDays(0, BusinessDayAdjustment.of(FOLLOWING, EUTA)))
+          .notional(1_000_000d)
+          .build();
 
   /**
    * The 'GBP-SONIA-3M-IMM-CME' convention.
@@ -69,6 +117,7 @@ final class StandardOvernightFutureContractSpecs {
   /**
    * The 'GBP-SONIA-1M-ICE' convention.
    * https://www.theice.com/products/66380299/One-Month-SONIA-Index-Futures
+   * "SO3"
    */
   public static final OvernightFutureContractSpec GBP_SONIA_1M_ICE =
       ImmutableOvernightFutureContractSpec.builder()
@@ -94,9 +143,25 @@ final class StandardOvernightFutureContractSpecs {
           .build();
 
   //-------------------------------------------------------------------------
+
   /**
    * The 'USD-SOFR-3M-IMM-CME' convention.
    * https://www.cmegroup.com/trading/interest-rates/stir/three-month-sofr_contract_specifications.html
+   * "SR1"
+   */
+  public static final OvernightFutureContractSpec USD_SOFR_1M_IMM_CME =
+      ImmutableOvernightFutureContractSpec.builder()
+          .name("USD-SOFR-1M-IMM-CME")
+          .index(USD_SOFR)
+          .dateSequence(MONTHLY_IMM)
+          .accrualMethod(COMPOUNDED)
+          .notional(1_000_000d)
+          .build();
+
+  /**
+   * The 'USD-SOFR-3M-IMM-CME' convention.
+   * https://www.cmegroup.com/trading/interest-rates/stir/three-month-sofr_contract_specifications.html
+   * "SR3"
    */
   public static final OvernightFutureContractSpec USD_SOFR_3M_IMM_CME =
       ImmutableOvernightFutureContractSpec.builder()
@@ -150,6 +215,8 @@ final class StandardOvernightFutureContractSpecs {
   /**
    * The 'USD-FED-FUND-1M-CME' convention.
    * https://www.cmegroup.com/trading/interest-rates/stir/30-day-federal-fund_contract_specifications.html
+   *
+   * "ZQ"
    */
   public static final OvernightFutureContractSpec USD_FED_FUND_1M_CME =
       ImmutableOvernightFutureContractSpec.builder()

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -49,7 +49,7 @@ final class StandardOvernightFutureContractSpecs {
           .build();
 
   /**
-   * The 'CHF_SARON_3M_IMM_ICE' convention.
+   * The 'CHF_SARON_3M_IMM_EUREX' convention.
    * <p>
    * https://www.eurex.com/ex-en/markets/int/mon/saron-futures/saron/3M-SARON-Futures-1405958
    * <p>

--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -138,7 +138,7 @@ final class StandardOvernightFutureContractSpecs {
           .index(GBP_SONIA)
           .dateSequence(MONTHLY_IMM)
           .accrualMethod(AVERAGED_DAILY)
-          .notional(1_000_000d)
+          .notional(3_000_000d)
           .build();
 
   /**
@@ -170,7 +170,7 @@ final class StandardOvernightFutureContractSpecs {
           .index(USD_SOFR)
           .dateSequence(MONTHLY_IMM)
           .accrualMethod(COMPOUNDED)
-          .notional(4_167d)
+          .notional(5_000_000d)
           .build();
 
   /**

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecTest.java
@@ -381,7 +381,7 @@ public class OvernightFutureContractSpecTest {
   @Test
   public void test_of_lookup_null() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> OvernightFutureContractSpec.of((String) null));
+        .isThrownBy(() -> OvernightFutureContractSpec.of(null));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Adding 3 ibor contract specs : 

USD LIBOR  - CME “GLB” 1M  (exists already)
EUR EURIBOR - ICE  IFLL “I” 3M & EUREX “FEU3” 3M (ICE contract already exists)

Adding 7 overnight contract specs : 

CHF SARON - ICE IFLL “SA3” 3M & EUREX “FSR3” 3M
EUR ESTR - ICE IFLL “EON” 1M
GBP SONIA - ICE IFLL “SO3” 3M (exists already)
USD SOFR - CME ”SR1” 1M & CME ”SR3” 3M (3M exists already)
USD FED FUNDS - CME “ZQ” 1M (exists already)