### PR TITLE
Fx single validate checks

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/FxSingle.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/FxSingle.java
@@ -6,6 +6,8 @@
 package com.opengamma.strata.product.fx;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -291,6 +293,14 @@ public final class FxSingle
         Math.signum(baseCurrencyPayment.getAmount()) != -Math.signum(counterCurrencyPayment.getAmount())) {
       throw new IllegalArgumentException("Amounts must have different signs");
     }
+    // To be able to summarise the trade, the fx rate needs to a positive whole number
+    double fxRateUnscaled = counterCurrencyPayment.getAmount() / baseCurrencyPayment.getAmount();
+    BigDecimal fxRate = BigDecimal.valueOf(fxRateUnscaled)
+        .setScale(
+            baseCurrencyPayment.getCurrency().getMinorUnitDigits() + 2,
+            RoundingMode.HALF_UP)
+        .abs();
+    ArgChecker.notNegativeOrZero(fxRate.doubleValue(), "fxRate");
   }
 
   @ImmutablePreBuild

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/FxSingle.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/FxSingle.java
@@ -295,12 +295,13 @@ public final class FxSingle
     }
     // To be able to summarise the trade, the fx rate needs to a positive whole number
     double fxRateUnscaled = counterCurrencyPayment.getAmount() / baseCurrencyPayment.getAmount();
+    int baseCurrencyMinorDigits = baseCurrencyPayment.getCurrency().getMinorUnitDigits();
     BigDecimal fxRate = BigDecimal.valueOf(fxRateUnscaled)
-        .setScale(
-            baseCurrencyPayment.getCurrency().getMinorUnitDigits() + 2,
-            RoundingMode.HALF_UP)
+        .setScale(baseCurrencyMinorDigits + 2, RoundingMode.HALF_UP)
         .abs();
-    ArgChecker.notNegativeOrZero(fxRate.doubleValue(), "fxRate");
+    if (fxRate.doubleValue() <= 0) {
+      throw new IllegalArgumentException("Amounts must result in a positive exchange rate");
+    }
   }
 
   @ImmutablePreBuild

--- a/modules/product/src/main/java/com/opengamma/strata/product/fx/FxSingle.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/fx/FxSingle.java
@@ -289,18 +289,19 @@ public final class FxSingle
     if (baseCurrencyPayment.getCurrency().equals(counterCurrencyPayment.getCurrency())) {
       throw new IllegalArgumentException("Amounts must have different currencies");
     }
-    if ((baseCurrencyPayment.getAmount() != 0d || counterCurrencyPayment.getAmount() != 0d) &&
-        Math.signum(baseCurrencyPayment.getAmount()) != -Math.signum(counterCurrencyPayment.getAmount())) {
-      throw new IllegalArgumentException("Amounts must have different signs");
-    }
-    // To be able to summarise the trade, the fx rate needs to a positive whole number
-    double fxRateUnscaled = counterCurrencyPayment.getAmount() / baseCurrencyPayment.getAmount();
-    int baseCurrencyMinorDigits = baseCurrencyPayment.getCurrency().getMinorUnitDigits();
-    BigDecimal fxRate = BigDecimal.valueOf(fxRateUnscaled)
-        .setScale(baseCurrencyMinorDigits + 2, RoundingMode.HALF_UP)
-        .abs();
-    if (fxRate.doubleValue() <= 0) {
-      throw new IllegalArgumentException("Amounts must result in a positive exchange rate");
+    if ((baseCurrencyPayment.getAmount() != 0d || counterCurrencyPayment.getAmount() != 0d)) {
+      if (Math.signum(baseCurrencyPayment.getAmount()) != -Math.signum(counterCurrencyPayment.getAmount())) {
+        throw new IllegalArgumentException("Amounts must have different signs");
+      }
+
+      double fxRateUnscaled = counterCurrencyPayment.getAmount() / baseCurrencyPayment.getAmount();
+      int baseCurrencyMinorDigits = baseCurrencyPayment.getCurrency().getMinorUnitDigits();
+      BigDecimal fxRate = BigDecimal.valueOf(fxRateUnscaled)
+          .setScale(baseCurrencyMinorDigits + 2, RoundingMode.HALF_UP)
+          .abs();
+      if (fxRate.doubleValue() <= 0) {
+        throw new IllegalArgumentException("Amounts must result in a positive exchange rate");
+      }
     }
   }
 


### PR DESCRIPTION
Currently when trying to summarise FxSingle trades with impossible fx rates we get an exception. 

Idea is to catch this earlier when creating the trade instead, so if amounts don't make sense throw exception