### PR TITLE
Add Frequency to InterpolatedNodalCurveDefinition

### DIFF
--- a/modules/market/src/main/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinition.java
+++ b/modules/market/src/main/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinition.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.joda.beans.Bean;
 import org.joda.beans.ImmutableBean;
@@ -88,6 +89,14 @@ public final class InterpolatedNodalCurveDefinition
    */
   @PropertyDefinition(get = "optional")
   private final DayCount dayCount;
+  /**
+   * The frequency, optional.
+   * <p>
+   * The number of compounding periods per year of the zero-coupon rate.
+   * This is used for a zero rate periodically-compounded curve. 
+   */
+  @PropertyDefinition(get = "optional")
+  private final Integer frequency;
   /**
    * The nodes in the curve.
    * <p>
@@ -211,7 +220,7 @@ public final class InterpolatedNodalCurveDefinition
     // return the resolved definition
     List<CurveNode> filteredNodes = nodeDates.stream().map(p -> p.getSecond()).collect(toImmutableList());
     return new InterpolatedNodalCurveDefinition(
-        name, xValueType, yValueType, dayCount, filteredNodes, interpolator, extrapolatorLeft, extrapolatorRight);
+        name, xValueType, yValueType, dayCount, frequency, filteredNodes, interpolator, extrapolatorLeft, extrapolatorRight);
   }
 
   //-------------------------------------------------------------------------
@@ -220,13 +229,14 @@ public final class InterpolatedNodalCurveDefinition
     List<DatedParameterMetadata> nodeMetadata = nodes.stream()
         .map(node -> node.metadata(valuationDate, refData))
         .collect(toImmutableList());
-    return DefaultCurveMetadata.builder()
+    DefaultCurveMetadataBuilder curveMetadataBuilder = DefaultCurveMetadata.builder()
         .curveName(name)
         .xValueType(xValueType)
         .yValueType(yValueType)
         .dayCount(dayCount)
-        .parameterMetadata(nodeMetadata)
-        .build();
+        .parameterMetadata(nodeMetadata);
+    getFrequency().ifPresent(frequency -> curveMetadataBuilder.addInfo(CurveInfoType.COMPOUNDING_PER_YEAR, frequency));
+    return curveMetadataBuilder.build();
   }
 
   //-------------------------------------------------------------------------
@@ -296,6 +306,7 @@ public final class InterpolatedNodalCurveDefinition
       ValueType xValueType,
       ValueType yValueType,
       DayCount dayCount,
+      Integer frequency,
       List<? extends CurveNode> nodes,
       CurveInterpolator interpolator,
       CurveExtrapolator extrapolatorLeft,
@@ -311,6 +322,7 @@ public final class InterpolatedNodalCurveDefinition
     this.xValueType = xValueType;
     this.yValueType = yValueType;
     this.dayCount = dayCount;
+    this.frequency = frequency;
     this.nodes = ImmutableList.copyOf(nodes);
     this.interpolator = interpolator;
     this.extrapolatorLeft = extrapolatorLeft;
@@ -376,6 +388,18 @@ public final class InterpolatedNodalCurveDefinition
 
   //-----------------------------------------------------------------------
   /**
+   * Gets the frequency, optional.
+   * <p>
+   * The number of compounding periods per year of the zero-coupon rate.
+   * This is used for a zero rate periodically-compounded curve.
+   * @return the optional value of the property, not null
+   */
+  public OptionalInt getFrequency() {
+    return frequency != null ? OptionalInt.of(frequency) : OptionalInt.empty();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
    * Gets the nodes in the curve.
    * <p>
    * The nodes are used to find the par rates and calibrate the curve.
@@ -434,6 +458,7 @@ public final class InterpolatedNodalCurveDefinition
           JodaBeanUtils.equal(xValueType, other.xValueType) &&
           JodaBeanUtils.equal(yValueType, other.yValueType) &&
           JodaBeanUtils.equal(dayCount, other.dayCount) &&
+          JodaBeanUtils.equal(frequency, other.frequency) &&
           JodaBeanUtils.equal(nodes, other.nodes) &&
           JodaBeanUtils.equal(interpolator, other.interpolator) &&
           JodaBeanUtils.equal(extrapolatorLeft, other.extrapolatorLeft) &&
@@ -449,6 +474,7 @@ public final class InterpolatedNodalCurveDefinition
     hash = hash * 31 + JodaBeanUtils.hashCode(xValueType);
     hash = hash * 31 + JodaBeanUtils.hashCode(yValueType);
     hash = hash * 31 + JodaBeanUtils.hashCode(dayCount);
+    hash = hash * 31 + JodaBeanUtils.hashCode(frequency);
     hash = hash * 31 + JodaBeanUtils.hashCode(nodes);
     hash = hash * 31 + JodaBeanUtils.hashCode(interpolator);
     hash = hash * 31 + JodaBeanUtils.hashCode(extrapolatorLeft);
@@ -458,12 +484,13 @@ public final class InterpolatedNodalCurveDefinition
 
   @Override
   public String toString() {
-    StringBuilder buf = new StringBuilder(288);
+    StringBuilder buf = new StringBuilder(320);
     buf.append("InterpolatedNodalCurveDefinition{");
     buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
     buf.append("xValueType").append('=').append(JodaBeanUtils.toString(xValueType)).append(',').append(' ');
     buf.append("yValueType").append('=').append(JodaBeanUtils.toString(yValueType)).append(',').append(' ');
     buf.append("dayCount").append('=').append(JodaBeanUtils.toString(dayCount)).append(',').append(' ');
+    buf.append("frequency").append('=').append(JodaBeanUtils.toString(frequency)).append(',').append(' ');
     buf.append("nodes").append('=').append(JodaBeanUtils.toString(nodes)).append(',').append(' ');
     buf.append("interpolator").append('=').append(JodaBeanUtils.toString(interpolator)).append(',').append(' ');
     buf.append("extrapolatorLeft").append('=').append(JodaBeanUtils.toString(extrapolatorLeft)).append(',').append(' ');
@@ -503,6 +530,11 @@ public final class InterpolatedNodalCurveDefinition
     private final MetaProperty<DayCount> dayCount = DirectMetaProperty.ofImmutable(
         this, "dayCount", InterpolatedNodalCurveDefinition.class, DayCount.class);
     /**
+     * The meta-property for the {@code frequency} property.
+     */
+    private final MetaProperty<Integer> frequency = DirectMetaProperty.ofImmutable(
+        this, "frequency", InterpolatedNodalCurveDefinition.class, Integer.class);
+    /**
      * The meta-property for the {@code nodes} property.
      */
     @SuppressWarnings({"unchecked", "rawtypes" })
@@ -532,6 +564,7 @@ public final class InterpolatedNodalCurveDefinition
         "xValueType",
         "yValueType",
         "dayCount",
+        "frequency",
         "nodes",
         "interpolator",
         "extrapolatorLeft",
@@ -554,6 +587,8 @@ public final class InterpolatedNodalCurveDefinition
           return yValueType;
         case 1905311443:  // dayCount
           return dayCount;
+        case -70023844:  // frequency
+          return frequency;
         case 104993457:  // nodes
           return nodes;
         case 2096253127:  // interpolator
@@ -615,6 +650,14 @@ public final class InterpolatedNodalCurveDefinition
     }
 
     /**
+     * The meta-property for the {@code frequency} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Integer> frequency() {
+      return frequency;
+    }
+
+    /**
      * The meta-property for the {@code nodes} property.
      * @return the meta-property, not null
      */
@@ -658,6 +701,8 @@ public final class InterpolatedNodalCurveDefinition
           return ((InterpolatedNodalCurveDefinition) bean).getYValueType();
         case 1905311443:  // dayCount
           return ((InterpolatedNodalCurveDefinition) bean).dayCount;
+        case -70023844:  // frequency
+          return ((InterpolatedNodalCurveDefinition) bean).frequency;
         case 104993457:  // nodes
           return ((InterpolatedNodalCurveDefinition) bean).getNodes();
         case 2096253127:  // interpolator
@@ -691,6 +736,7 @@ public final class InterpolatedNodalCurveDefinition
     private ValueType xValueType;
     private ValueType yValueType;
     private DayCount dayCount;
+    private Integer frequency;
     private List<? extends CurveNode> nodes = ImmutableList.of();
     private CurveInterpolator interpolator;
     private CurveExtrapolator extrapolatorLeft;
@@ -712,6 +758,7 @@ public final class InterpolatedNodalCurveDefinition
       this.xValueType = beanToCopy.getXValueType();
       this.yValueType = beanToCopy.getYValueType();
       this.dayCount = beanToCopy.dayCount;
+      this.frequency = beanToCopy.frequency;
       this.nodes = beanToCopy.getNodes();
       this.interpolator = beanToCopy.getInterpolator();
       this.extrapolatorLeft = beanToCopy.getExtrapolatorLeft();
@@ -730,6 +777,8 @@ public final class InterpolatedNodalCurveDefinition
           return yValueType;
         case 1905311443:  // dayCount
           return dayCount;
+        case -70023844:  // frequency
+          return frequency;
         case 104993457:  // nodes
           return nodes;
         case 2096253127:  // interpolator
@@ -758,6 +807,9 @@ public final class InterpolatedNodalCurveDefinition
           break;
         case 1905311443:  // dayCount
           this.dayCount = (DayCount) newValue;
+          break;
+        case -70023844:  // frequency
+          this.frequency = (Integer) newValue;
           break;
         case 104993457:  // nodes
           this.nodes = (List<? extends CurveNode>) newValue;
@@ -790,6 +842,7 @@ public final class InterpolatedNodalCurveDefinition
           xValueType,
           yValueType,
           dayCount,
+          frequency,
           nodes,
           interpolator,
           extrapolatorLeft,
@@ -854,6 +907,19 @@ public final class InterpolatedNodalCurveDefinition
     }
 
     /**
+     * Sets the frequency, optional.
+     * <p>
+     * The number of compounding periods per year of the zero-coupon rate.
+     * This is used for a zero rate periodically-compounded curve.
+     * @param frequency  the new value
+     * @return this, for chaining, not null
+     */
+    public Builder frequency(Integer frequency) {
+      this.frequency = frequency;
+      return this;
+    }
+
+    /**
      * Sets the nodes in the curve.
      * <p>
      * The nodes are used to find the par rates and calibrate the curve.
@@ -913,12 +979,13 @@ public final class InterpolatedNodalCurveDefinition
     //-----------------------------------------------------------------------
     @Override
     public String toString() {
-      StringBuilder buf = new StringBuilder(288);
+      StringBuilder buf = new StringBuilder(320);
       buf.append("InterpolatedNodalCurveDefinition.Builder{");
       buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
       buf.append("xValueType").append('=').append(JodaBeanUtils.toString(xValueType)).append(',').append(' ');
       buf.append("yValueType").append('=').append(JodaBeanUtils.toString(yValueType)).append(',').append(' ');
       buf.append("dayCount").append('=').append(JodaBeanUtils.toString(dayCount)).append(',').append(' ');
+      buf.append("frequency").append('=').append(JodaBeanUtils.toString(frequency)).append(',').append(' ');
       buf.append("nodes").append('=').append(JodaBeanUtils.toString(nodes)).append(',').append(' ');
       buf.append("interpolator").append('=').append(JodaBeanUtils.toString(interpolator)).append(',').append(' ');
       buf.append("extrapolatorLeft").append('=').append(JodaBeanUtils.toString(extrapolatorLeft)).append(',').append(' ');

--- a/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinitionTest.java
+++ b/modules/market/src/test/java/com/opengamma/strata/market/curve/InterpolatedNodalCurveDefinitionTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.junit.jupiter.api.Test;
 
@@ -75,6 +76,32 @@ public class InterpolatedNodalCurveDefinitionTest {
     assertThat(test.getExtrapolatorLeft()).isEqualTo(CurveExtrapolators.FLAT);
     assertThat(test.getExtrapolatorRight()).isEqualTo(CurveExtrapolators.FLAT);
     assertThat(test.getParameterCount()).isEqualTo(2);
+    assertThat(test.getFrequency()).isEmpty();
+  }
+
+  @Test
+  public void test_builder_periodic() {
+    InterpolatedNodalCurveDefinition test = InterpolatedNodalCurveDefinition.builder()
+        .name(CURVE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.ZERO_RATE)
+        .dayCount(ACT_365F)
+        .nodes(NODES)
+        .interpolator(CurveInterpolators.LINEAR)
+        .extrapolatorLeft(CurveExtrapolators.FLAT)
+        .extrapolatorRight(CurveExtrapolators.FLAT)
+        .frequency(4)
+        .build();
+    assertThat(test.getName()).isEqualTo(CURVE_NAME);
+    assertThat(test.getXValueType()).isEqualTo(ValueType.YEAR_FRACTION);
+    assertThat(test.getYValueType()).isEqualTo(ValueType.ZERO_RATE);
+    assertThat(test.getDayCount()).isEqualTo(Optional.of(ACT_365F));
+    assertThat(test.getNodes()).isEqualTo(NODES);
+    assertThat(test.getInterpolator()).isEqualTo(CurveInterpolators.LINEAR);
+    assertThat(test.getExtrapolatorLeft()).isEqualTo(CurveExtrapolators.FLAT);
+    assertThat(test.getExtrapolatorRight()).isEqualTo(CurveExtrapolators.FLAT);
+    assertThat(test.getParameterCount()).isEqualTo(2);
+    assertThat(test.getFrequency()).isEqualTo(OptionalInt.of(4));
   }
 
   //-------------------------------------------------------------------------
@@ -291,6 +318,30 @@ public class InterpolatedNodalCurveDefinitionTest {
     assertThat(test.metadata(VAL_DATE, REF_DATA)).isEqualTo(expected);
   }
 
+  @Test
+  public void test_metadata_periodic() {
+    InterpolatedNodalCurveDefinition test = InterpolatedNodalCurveDefinition.builder()
+        .name(CURVE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.ZERO_RATE)
+        .dayCount(ACT_365F)
+        .nodes(NODES)
+        .interpolator(CurveInterpolators.LINEAR)
+        .extrapolatorLeft(CurveExtrapolators.FLAT)
+        .extrapolatorRight(CurveExtrapolators.FLAT)
+        .frequency(2)
+        .build();
+    DefaultCurveMetadata expected = DefaultCurveMetadata.builder()
+        .curveName(CURVE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.ZERO_RATE)
+        .dayCount(ACT_365F)
+        .addInfo(CurveInfoType.COMPOUNDING_PER_YEAR, 2)
+        .parameterMetadata(NODES.get(0).metadata(VAL_DATE, REF_DATA), NODES.get(1).metadata(VAL_DATE, REF_DATA))
+        .build();
+    assertThat(test.metadata(VAL_DATE, REF_DATA)).isEqualTo(expected);
+  }
+
   //-------------------------------------------------------------------------
   @Test
   public void test_curve() {
@@ -311,6 +362,31 @@ public class InterpolatedNodalCurveDefinitionTest {
         .dayCount(ACT_365F)
         .parameterMetadata(NODES.get(0).metadata(VAL_DATE, REF_DATA), NODES.get(1).metadata(VAL_DATE, REF_DATA))
         .build();
+    InterpolatedNodalCurve expected = InterpolatedNodalCurve.builder()
+        .metadata(metadata)
+        .xValues(DoubleArray.of(ACT_365F.yearFraction(VAL_DATE, DATE1), ACT_365F.yearFraction(VAL_DATE, DATE2)))
+        .yValues(DoubleArray.of(1d, 1.5d))
+        .interpolator(CurveInterpolators.LINEAR)
+        .extrapolatorLeft(CurveExtrapolators.FLAT)
+        .extrapolatorRight(CurveExtrapolators.FLAT)
+        .build();
+    assertThat(test.curve(VAL_DATE, metadata, DoubleArray.of(1d, 1.5d))).isEqualTo(expected);
+  }
+
+  @Test
+  public void test_curve_periodic() {
+    InterpolatedNodalCurveDefinition test = InterpolatedNodalCurveDefinition.builder()
+        .name(CURVE_NAME)
+        .xValueType(ValueType.YEAR_FRACTION)
+        .yValueType(ValueType.ZERO_RATE)
+        .dayCount(ACT_365F)
+        .nodes(NODES)
+        .interpolator(CurveInterpolators.LINEAR)
+        .extrapolatorLeft(CurveExtrapolators.FLAT)
+        .extrapolatorRight(CurveExtrapolators.FLAT)
+        .frequency(4)
+        .build();
+    CurveMetadata metadata = test.metadata(VAL_DATE, REF_DATA);
     InterpolatedNodalCurve expected = InterpolatedNodalCurve.builder()
         .metadata(metadata)
         .xValues(DoubleArray.of(ACT_365F.yearFraction(VAL_DATE, DATE1), ACT_365F.yearFraction(VAL_DATE, DATE2)))


### PR DESCRIPTION
Added Frequency to InterpolatedNodalCurveDefinition as an optional field so that the curve calibrator can handle periodically compouneded zero rate curves. 