### PR TITLE
Make ProductType constructor public

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/ProductType.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/ProductType.java
@@ -194,7 +194,7 @@ public final class ProductType
    * @param description  the description
    * @return a type instance with the specified name
    */
-  private static ProductType of(String name, String description) {
+  public static ProductType of(String name, String description) {
     return new ProductType(name, description);
   }
 


### PR DESCRIPTION
 So ProductTypes can be defined in other packages, alongside new Trade and Position implementations