### PR TITLE
Duplicate adjusted dates when combinePeriodsIfNecessary=true and Frequency 1D

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/schedule/PeriodicSchedule.java
@@ -453,10 +453,12 @@ public final class PeriodicSchedule implements ImmutableBean, Serializable {
       if (combinePeriodsIfNecessary) {
         adj = new ArrayList<>(adj);
         unadj = new ArrayList<>(unadj);
-        for (int i = 0; i < adj.size() - 1; i++) {
+        for (int i = 0; i < adj.size() - 1; ) {
           if (adj.get(i).equals(adj.get(i + 1))) {
             adj.remove(i);
             unadj.remove(i);
+          } else {
+            i++;
           }
         }
       }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -1328,6 +1328,23 @@ public class PeriodicScheduleTest {
         .withMessageMatching(".*duplicate unadjusted dates.*");
   }
 
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_of_schedule_with_combinePeriodsIfNecessary() {
+    LocalDate startDate = LocalDate.of(2022, 12, 1);
+    LocalDate endDate = LocalDate.of(2022, 12, 31);
+    BusinessDayAdjustment BDA = BusinessDayAdjustment.of(FOLLOWING, SAT_SUN);
+    PeriodicSchedule scheduleDefinition = PeriodicSchedule.builder()
+            .startDate(startDate)
+            .endDate(endDate)
+            .frequency(Frequency.P1D)
+            .businessDayAdjustment(BDA)
+            .build();
+    Schedule schedule = scheduleDefinition.createSchedule(REF_DATA, true);
+    assertThat(schedule.size()).isEqualTo(22);
+  }
+
   //-------------------------------------------------------------------------
   @ParameterizedTest
   @MethodSource("data_generation")

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/schedule/PeriodicScheduleTest.java
@@ -1328,18 +1328,16 @@ public class PeriodicScheduleTest {
         .withMessageMatching(".*duplicate unadjusted dates.*");
   }
 
-
   //-------------------------------------------------------------------------
   @Test
   public void test_of_schedule_with_combinePeriodsIfNecessary() {
     LocalDate startDate = LocalDate.of(2022, 12, 1);
     LocalDate endDate = LocalDate.of(2022, 12, 31);
-    BusinessDayAdjustment BDA = BusinessDayAdjustment.of(FOLLOWING, SAT_SUN);
     PeriodicSchedule scheduleDefinition = PeriodicSchedule.builder()
             .startDate(startDate)
             .endDate(endDate)
             .frequency(Frequency.P1D)
-            .businessDayAdjustment(BDA)
+            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, SAT_SUN))
             .build();
     Schedule schedule = scheduleDefinition.createSchedule(REF_DATA, true);
     assertThat(schedule.size()).isEqualTo(22);


### PR DESCRIPTION
Resolved an issue with the schedule calculation that caused the return
of duplicate adjusted dates when the 'combinePeriodsIfNecessary' flag
was set to 'true'. The current implementation is not handling correctly consecutive duplicate dates.

```
PeriodicSchedule.builder()
            .startDate(LocalDate.of(2022, 12, 1))
            .endDate(LocalDate.of(2022, 12, 31))
            .frequency(Frequency.P1D)
            .businessDayAdjustment(BusinessDayAdjustment.of(FOLLOWING, SAT_SUN))
            .build();

```
Returns:

```
com.opengamma.strata.basics.schedule.ScheduleException: Schedule
calculation resulted in duplicate adjusted dates [2022-12-01,
2022-12-02, 2022-12-05, 2022-12-05, 2022-12-05, 2022-12-06,
2022-12-07, 2022-12-08, 2022-12-09, 2022-12-12, 2022-12-12,
2022-12-12, 2022-12-13, 2022-12-14, 2022-12-15, 2022-12-16,
2022-12-19, 2022-12-19, 2022-12-19, 2022-12-20, 2022-12-21,
2022-12-22, 2022-12-23, 2022-12-26, 2022-12-26, 2022-12-26,
2022-12-27, 2022-12-28, 2022-12-29, 2022-12-30, 2023-01-02] from
unadjusted dates [2022-12-01, 2022-12-02, 2022-12-03, 2022-12-04,
2022-12-05, 2022-12-06, 2022-12-07, 2022-12-08, 2022-12-09,
2022-12-10, 2022-12-11, 2022-12-12, 2022-12-13, 2022-12-14,
2022-12-15, 2022-12-16, 2022-12-17, 2022-12-18, 2022-12-19,
2022-12-20, 2022-12-21, 2022-12-22, 2022-12-23, 2022-12-24,
2022-12-25, 2022-12-26, 2022-12-27, 2022-12-28, 2022-12-29,
2022-12-30, 2022-12-31] using adjustment 'Following using calendar
Sat/Sun'

```