### PR TITLE
Modifiers in inflation bond pricers

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondProductPricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondProductPricer.java
@@ -202,8 +202,19 @@ public class DiscountingCapitalIndexedBondProductPricer {
         bond, ratesProvider, discountingProvider, ratesProvider.getValuationDate());
   }
 
-  // calculate the present value sensitivity
-  PointSensitivityBuilder presentValueSensitivity(
+  /**
+   * Calculates the present value sensitivity of the bond product for the specified reference date.
+   * <p>
+   * The present value sensitivity of the product is the sensitivity of the present value to
+   * the underlying curves.
+   *
+   * @param bond  the product
+   * @param ratesProvider  the rates provider, used to determine price index values
+   * @param discountingProvider  the discount factors provider
+   * @param referenceDate  the reference date
+   * @return the present value curve sensitivity of the product
+   */
+  public PointSensitivityBuilder presentValueSensitivity(
       ResolvedCapitalIndexedBond bond,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider discountingProvider,
@@ -392,8 +403,20 @@ public class DiscountingCapitalIndexedBondProductPricer {
     return dirtyNominalPriceFromCurves(bond, ratesProvider, discountingProvider, settlementDate);
   }
 
-  // calculate the dirty price
-  double dirtyNominalPriceFromCurves(
+  /**
+   * Calculates the dirty price of the bond security for the specified settlement date.
+   * <p>
+   * The bond is represented as {@link Security} where standard ID of the bond is stored.
+   * <p>
+   * Strata uses <i>decimal prices</i> for bonds. For example, a price of 99.32% is represented in Strata by 0.9932.
+   *
+   * @param bond  the product
+   * @param ratesProvider  the rates provider, used to determine price index values
+   * @param discountingProvider  the discount factors provider
+   * @param settlementDate  the settlement date
+   * @return the dirty price of the bond security
+   */
+  public double dirtyNominalPriceFromCurves(
       ResolvedCapitalIndexedBond bond,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider discountingProvider,
@@ -480,8 +503,19 @@ public class DiscountingCapitalIndexedBondProductPricer {
     return dirtyNominalPriceSensitivity(bond, ratesProvider, discountingProvider, settlementDate);
   }
 
-  // calculate the dirty price sensitivity
-  PointSensitivityBuilder dirtyNominalPriceSensitivity(
+  /**
+   * Calculates the dirty price sensitivity of the bond security for the specified settlement date.
+   * <p>
+   * The dirty price sensitivity of the security is the sensitivity of the dirty price value to
+   * the underlying curves.
+   *
+   * @param bond  the product
+   * @param ratesProvider  the rates provider, used to determine price index values
+   * @param discountingProvider  the discount factors provider
+   * @param settlementDate  the settlement date
+   * @return the dirty price curve sensitivity of the security
+   */
+  public PointSensitivityBuilder dirtyNominalPriceSensitivity(
       ResolvedCapitalIndexedBond bond,
       RatesProvider ratesProvider,
       LegalEntityDiscountingProvider discountingProvider,

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricer.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricer.java
@@ -58,6 +58,16 @@ public class DiscountingCapitalIndexedBondTradePricer {
 
   //-------------------------------------------------------------------------
   /**
+   * Gets the capital indexed bond product pricer.
+   *
+   * @return the product pricer
+   */
+  public DiscountingCapitalIndexedBondProductPricer getProductPricer() {
+    return productPricer;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
    * Calculates the present value of the bond trade.
    * <p>
    * The present value of the trade is the value on the valuation date.
@@ -683,13 +693,23 @@ public class DiscountingCapitalIndexedBondTradePricer {
   }
 
   //-------------------------------------------------------------------------
-  // calculate the settlement date
-  private LocalDate settlementDate(ResolvedCapitalIndexedBondTrade trade, LocalDate valuationDate) {
+
+  /**
+   * Calculates the settlement date.
+   * <p>
+   * The valuation date is returned if the settlement details are not stored.
+   *
+   * @param trade  the trade
+   * @param valuationDate  the valuation date
+   * @return the settlement date
+   */
+  public LocalDate settlementDate(ResolvedCapitalIndexedBondTrade trade, LocalDate valuationDate) {
     return trade.getSettlement()
         .map(settle -> settle.getSettlementDate())
         .orElse(valuationDate);
   }
 
+  //-------------------------------------------------------------------------
   private void validate(RatesProvider ratesProvider, LegalEntityDiscountingProvider discountingProvider) {
     ArgChecker.isTrue(ratesProvider.getValuationDate().isEqual(discountingProvider.getValuationDate()),
         "the rates providers should be for the same date");

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricerTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/bond/DiscountingCapitalIndexedBondTradePricerTest.java
@@ -208,8 +208,7 @@ public class DiscountingCapitalIndexedBondTradePricerTest {
   private static final double TOL = 1.0e-12;
   private static final double EPS = 1.0e-6;
   private static final DiscountingCapitalIndexedBondTradePricer PRICER = DiscountingCapitalIndexedBondTradePricer.DEFAULT;
-  private static final DiscountingCapitalIndexedBondProductPricer PRODUCT_PRICER =
-      DiscountingCapitalIndexedBondProductPricer.DEFAULT;
+  private static final DiscountingCapitalIndexedBondProductPricer PRODUCT_PRICER = PRICER.getProductPricer();
   private static final DiscountingCapitalIndexedBondPaymentPeriodPricer PERIOD_PRICER =
       DiscountingCapitalIndexedBondPaymentPeriodPricer.DEFAULT;
   private static final DiscountingPaymentPricer PAYMENT_PRICER = DiscountingPaymentPricer.DEFAULT;


### PR DESCRIPTION
* Change modifiers in DiscountingCapitalIndexedBondTradePricer and DiscountingCapitalIndexedBondProductPricer so that they are used in the inflation curve calibration