### PR TITLE
Add Asian ETD option type

### DIFF
--- a/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvLoaderUtils.java
+++ b/modules/loader/src/main/java/com/opengamma/strata/loader/csv/CsvLoaderUtils.java
@@ -39,7 +39,6 @@ import com.opengamma.strata.basics.date.HolidayCalendarIds;
 import com.opengamma.strata.collect.ArgChecker;
 import com.opengamma.strata.collect.Decimal;
 import com.opengamma.strata.collect.io.CsvRow;
-import com.opengamma.strata.collect.result.FailureReason;
 import com.opengamma.strata.collect.result.ParseFailureException;
 import com.opengamma.strata.collect.tuple.DoublesPair;
 import com.opengamma.strata.collect.tuple.Pair;
@@ -292,9 +291,13 @@ public final class CsvLoaderUtils {
       case "EUROPEAN":
       case "E":
         return EtdOptionType.EUROPEAN;
+      case "ASIAN":
+      case "T":
+        return EtdOptionType.ASIAN;
       default:
         throw new ParseFailureException(
-            "Unable to parse ETD option type from '{value}', must be 'American', 'European', 'A' or 'E' (case insensitive)", str);
+            "Unable to parse ETD option type from '{value}', must be 'American', 'European', 'Asian', 'A', 'E' or " +
+                "'T' (case insensitive)", str);
     }
   }
 

--- a/modules/loader/src/test/java/com/opengamma/strata/loader/csv/CsvLoaderUtilsTest.java
+++ b/modules/loader/src/test/java/com/opengamma/strata/loader/csv/CsvLoaderUtilsTest.java
@@ -53,6 +53,9 @@ public class CsvLoaderUtilsTest {
     assertThat(CsvLoaderUtils.parseEtdOptionType("E")).isEqualTo(EtdOptionType.EUROPEAN);
     assertThat(CsvLoaderUtils.parseEtdOptionType("EUROPEAN")).isEqualTo(EtdOptionType.EUROPEAN);
     assertThat(CsvLoaderUtils.parseEtdOptionType("e")).isEqualTo(EtdOptionType.EUROPEAN);
+    assertThat(CsvLoaderUtils.parseEtdOptionType("T")).isEqualTo(EtdOptionType.ASIAN);
+    assertThat(CsvLoaderUtils.parseEtdOptionType("ASIAN")).isEqualTo(EtdOptionType.ASIAN);
+    assertThat(CsvLoaderUtils.parseEtdOptionType("t")).isEqualTo(EtdOptionType.ASIAN);
     assertThatExceptionOfType(ParseFailureException.class).isThrownBy(() -> CsvLoaderUtils.parseEtdOptionType(""));
   }
 

--- a/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdOptionType.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdOptionType.java
@@ -12,7 +12,7 @@ import com.opengamma.strata.collect.named.EnumNames;
 import com.opengamma.strata.collect.named.NamedEnum;
 
 /**
- * The option expiry type, 'American' or 'European'.
+ * The option expiry type, 'American', 'European' or 'Asian'.
  */
 public enum EtdOptionType implements NamedEnum {
 
@@ -25,7 +25,13 @@ public enum EtdOptionType implements NamedEnum {
    * European option.
    * Can be exercised only on a single date.
    */
-  EUROPEAN("E");
+  EUROPEAN("E"),
+  /**
+   * Asian option.
+   * Payoff depends on the average price over a certain period of time.
+   * Sometimes referred as a Traded Average Price Option (TAPO).
+   */
+  ASIAN("T");
 
   // helper for name conversions
   private static final EnumNames<EtdOptionType> NAMES = EnumNames.of(EtdOptionType.class);
@@ -68,6 +74,8 @@ public enum EtdOptionType implements NamedEnum {
         return AMERICAN;
       case "E":
         return EUROPEAN;
+      case "T":
+        return ASIAN;
       default:
         throw new IllegalArgumentException("Unknown EtdOptionType code: " + code);
     }

--- a/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdVariant.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdVariant.java
@@ -65,7 +65,7 @@ public final class EtdVariant
   @PropertyDefinition(get = "optional")
   private final EtdSettlementType settlementType;
   /**
-   * The optional option type, 'American' or 'European', populated for Flex Options.
+   * The optional option type, such as 'American' or 'European', populated for Flex Options.
    */
   @PropertyDefinition(get = "optional")
   private final EtdOptionType optionType;
@@ -288,7 +288,7 @@ public final class EtdVariant
 
   //-----------------------------------------------------------------------
   /**
-   * Gets the optional option type, 'American' or 'European', populated for Flex Options.
+   * Gets the optional option type, such as 'American' or 'European', populated for Flex Options.
    * @return the optional value of the property, not null
    */
   public Optional<EtdOptionType> getOptionType() {

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdOptionTypeTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdOptionTypeTest.java
@@ -25,6 +25,7 @@ public class EtdOptionTypeTest {
     return new Object[][] {
         {EtdOptionType.AMERICAN, "American", "A"},
         {EtdOptionType.EUROPEAN, "European", "E"},
+        {EtdOptionType.ASIAN, "Asian", "T"},
     };
   }
 


### PR DESCRIPTION
Adding Asian ETD option type and support for parsing. 

As `EtdOptionType.AMERICAN` already uses letter "A", have elected "T" which stands for TAPO, however Asian is probably a more common term for the option style.