### PR TITLE
Update DerivedCalculationFunctionTest.java

### DIFF
--- a/modules/calc/src/test/java/com/opengamma/strata/calc/runner/DerivedCalculationFunctionTest.java
+++ b/modules/calc/src/test/java/com/opengamma/strata/calc/runner/DerivedCalculationFunctionTest.java
@@ -286,7 +286,6 @@ final class TestTarget implements CalculationTarget {  // CSIGNORE
     this.value = value;
   }
 
-  @Test
   public int getValue() {
     return value;
   }


### PR DESCRIPTION
#2507 
According to the issue, not best practice to return statement in @Test methods, so removed the annotation 