### PR TITLE
Add support for splitting contract specs and security IDs with hyphen ("-") in the contract code

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/common/ExchangeIds.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/common/ExchangeIds.java
@@ -153,6 +153,9 @@ public final class ExchangeIds {
   /** OMIClear Exchange. */
   public static final ExchangeId OMIC = ExchangeId.of("OMIC");
 
+  /** National Stock Exchange Of India. */
+  public static final ExchangeId XNSE = ExchangeId.of("XNSE");
+
   //-------------------------------------------------------------------------
   /**
    * Restricted constructor.

--- a/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
@@ -14,10 +14,14 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Splitter;
+import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.basics.StandardSchemes;
 import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.Messages;
 import com.opengamma.strata.product.SecurityId;
 import com.opengamma.strata.product.common.ExchangeId;
 import com.opengamma.strata.product.common.PutCall;
@@ -31,6 +35,20 @@ import com.opengamma.strata.product.common.PutCall;
  * We do not recommend parsing the combined identifier to retrieve individual fields.
  */
 public final class EtdIdUtils {
+
+  /**
+   * Separator that is always present between the contract details and expiry + option details.
+   * <p>
+   * Example separator "-202304" in "F-IFEN-ABC-202304" or "O-IFEN-AB-CD-202304-PM12.34-U202309"
+   */
+  private static final String GROUPS_SEPARATOR = "-(?=\\d{6})";
+  private static final String CONTRACT_DETAILS_REGEX_GROUP_NAME = "contractDetails";
+  private static final String EXPIRY_AND_OPTION_DETAILS_GROUP_NAME = "expiryAndOptionDetails";
+  private static final Pattern SECURITY_ID_PATTERN = Pattern.compile(Messages.format(
+      "^(?<{}>.*){}(?<{}>.*)$",
+      CONTRACT_DETAILS_REGEX_GROUP_NAME,
+      GROUPS_SEPARATOR,
+      EXPIRY_AND_OPTION_DETAILS_GROUP_NAME));
 
   /**
    * Scheme used for ETDs.
@@ -243,7 +261,11 @@ public final class EtdIdUtils {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + specId);
     }
     String value = specId.getStandardId().getValue();
-    List<String> split = Splitter.on('-').limit(3).splitToList(value);
+    List<String> split = Splitter.on('-')
+        // sometimes a contract code can have "-" in the name, like F-IFEN-BAJAJ-AUTO, so we need
+        // limit the split to 3: type, exchangeId, and contract code
+        .limit(3)
+        .splitToList(value);
     if (split.size() < 3) {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + specId);
     }
@@ -275,17 +297,31 @@ public final class EtdIdUtils {
    */
   public static SplitEtdId splitId(SecurityId securityId) {
     ArgChecker.notNull(securityId, "securityId");
-    if (!securityId.getStandardId().getScheme().equals(ETD_SCHEME)) {
+    StandardId standardId = securityId.getStandardId();
+    if (!standardId.getScheme().equals(ETD_SCHEME)) {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + securityId);
     }
-    List<String> split = Splitter.on('-').splitToList(securityId.getStandardId().getValue());
-    if (split.size() < 4) {
+
+    Matcher matcher = SECURITY_ID_PATTERN.matcher(standardId.getValue());
+    if (!matcher.matches()) {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + securityId);
     }
+
+    // Example: F-IFEN-ABC or F-IFEN-ABC-XYZ
+    String contractDetailsSubstring = matcher.group(CONTRACT_DETAILS_REGEX_GROUP_NAME);
+    List<String> contractDetailsSplit = Splitter.on('-').limit(3).splitToList(contractDetailsSubstring);
+    if (contractDetailsSplit.size() != 3) {
+      throw new IllegalArgumentException("ETD ID cannot be parsed: " + securityId);
+    }
+
     // common fields
-    ExchangeId exchangeId = ExchangeId.of(split.get(1));
-    EtdContractCode contractCode = EtdContractCode.of(split.get(2));
-    String dateStr = split.get(3);
+    ExchangeId exchangeId = ExchangeId.of(contractDetailsSplit.get(1));
+    EtdContractCode contractCode = EtdContractCode.of(contractDetailsSplit.get(2));
+
+    // Example: 20230412 for futures or 202304-V3-PM12.43-U202304 for options
+    String expiryAndOptionDetailsSubstring = matcher.group(EXPIRY_AND_OPTION_DETAILS_GROUP_NAME);
+    List<String> expiryAndOptionDetailsSplit = Splitter.on("-").splitToList(expiryAndOptionDetailsSubstring);
+    String dateStr = expiryAndOptionDetailsSplit.get(0);
     if (dateStr.length() < 6) {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + securityId);
     }
@@ -297,11 +333,13 @@ public final class EtdIdUtils {
         .contractCode(contractCode)
         .expiry(month)
         .variant(variant);
+
     // future vs option
-    if (securityId.getStandardId().getValue().startsWith(FUT_PREFIX) && split.size() == 4) {
+    if (standardId.getValue().startsWith(FUT_PREFIX) && expiryAndOptionDetailsSplit.size() == 1) {
       return parsed.build();
-    } else if (securityId.getStandardId().getValue().startsWith(OPT_PREFIX) && split.size() > 4) {
-      SplitEtdOption parsedOption = parseEtdOptionId(split, securityId);
+    } else if (standardId.getValue().startsWith(OPT_PREFIX) && expiryAndOptionDetailsSplit.size() > 1) {
+      List<String> optionDetailsSplit = expiryAndOptionDetailsSplit.subList(1, expiryAndOptionDetailsSplit.size());
+      SplitEtdOption parsedOption = parseEtdOptionId(optionDetailsSplit, securityId);
       return parsed.option(parsedOption).build();
     } else {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + securityId);
@@ -309,10 +347,10 @@ public final class EtdIdUtils {
   }
 
   // parses an option
-  private static SplitEtdOption parseEtdOptionId(List<String> split, SecurityId securityId) {
-    String versionStr = split.get(4);
-    String putCallStrikeStr = split.size() > 5 ? split.get(5) : "";
-    String underlyingMonthStr = split.size() > 6 ? split.get(6) : "";
+  private static SplitEtdOption parseEtdOptionId(List<String> optionDetailsSplit, SecurityId securityId) {
+    String versionStr = optionDetailsSplit.get(0);
+    String putCallStrikeStr = optionDetailsSplit.size() > 1 ? optionDetailsSplit.get(1) : "";
+    String underlyingMonthStr = optionDetailsSplit.size() > 2 ? optionDetailsSplit.get(2) : "";
     int version = 0;
     if (versionStr.startsWith("V")) {
       version = Integer.parseInt(versionStr.substring(1));

--- a/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
@@ -242,8 +242,9 @@ public final class EtdIdUtils {
     if (!specId.getStandardId().getScheme().equals(ETD_SCHEME)) {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + specId);
     }
-    List<String> split = Splitter.on('-').splitToList(specId.getStandardId().getValue());
-    if (split.size() != 3) {
+    String value = specId.getStandardId().getValue();
+    List<String> split = Splitter.on('-').limit(3).splitToList(value);
+    if (split.size() < 3) {
       throw new IllegalArgumentException("ETD ID cannot be parsed: " + specId);
     }
     EtdType type = null;

--- a/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/etd/EtdIdUtils.java
@@ -38,8 +38,9 @@ public final class EtdIdUtils {
 
   /**
    * Separator that is always present between the contract details and expiry + option details.
+   * Only applies to identifiers with {@link StandardSchemes#OG_ETD_SCHEME}.
    * <p>
-   * Example separator "-202304" in "F-IFEN-ABC-202304" or "O-IFEN-AB-CD-202304-PM12.34-U202309"
+   * Example separator "-202304" in "F-IFEN-ABC-202304" or "O-IFEN-ABC-202304-PM12.34-U202309"
    */
   private static final String GROUPS_SEPARATOR = "-(?=\\d{6})";
   private static final String CONTRACT_DETAILS_REGEX_GROUP_NAME = "contractDetails";

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
@@ -46,7 +46,7 @@ public class EtdIdUtilsTest {
   }
 
   @Test
-  void test_contractSpecIdWithHyphen_future() {
+  void test_contractSpecIdWithExtraHyphen_future() {
     EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.FUTURE, ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"));
     assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-XNSE-BAJAJ-AUTO"));
     assertThat(EtdIdUtils.splitId(test))
@@ -72,7 +72,7 @@ public class EtdIdUtilsTest {
   }
 
   @Test
-  void test_contractSpecIdWithHyphen_option() {
+  void test_contractSpecIdWithExtraHyphen_option() {
     EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.OPTION, ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"));
     assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-XNSE-BAJAJ-AUTO"));
     assertThat(EtdIdUtils.splitId(test))
@@ -120,6 +120,20 @@ public class EtdIdUtilsTest {
             .securityId(test)
             .exchangeId(ExchangeIds.ECAG)
             .contractCode(FGBS)
+            .expiry(EXPIRY)
+            .variant(MONTHLY)
+            .build());
+  }
+
+  @Test
+  public void test_futureIdWithExtraHyphen_monthly() {
+    SecurityId test = EtdIdUtils.futureId(ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"), EXPIRY, MONTHLY);
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-XNSE-BAJAJ-AUTO-201706"));
+    assertThat(EtdIdUtils.splitId(test))
+        .isEqualTo(SplitEtdId.builder()
+            .securityId(test)
+            .exchangeId(ExchangeId.of("XNSE"))
+            .contractCode(EtdContractCode.of("BAJAJ-AUTO"))
             .expiry(EXPIRY)
             .variant(MONTHLY)
             .build());
@@ -340,7 +354,7 @@ public class EtdIdUtilsTest {
         .isThrownBy(() -> EtdIdUtils.splitId(SecurityId.of("A", "B")));
     assertThatIllegalArgumentException()
         .isThrownBy(() -> EtdIdUtils.splitId(SecurityId.of(OG_ETD_SCHEME, "B")));
-    assertThatExceptionOfType(DateTimeParseException.class)
+    assertThatIllegalArgumentException()
         .isThrownBy(() -> EtdIdUtils.splitId(SecurityId.of(OG_ETD_SCHEME, "F-ECAG-AB-ABCDEF")));
     assertThatIllegalArgumentException()
         .isThrownBy(() -> EtdIdUtils.splitId(SecurityId.of(OG_ETD_SCHEME, "F-ECAG-AB-20206")));

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
@@ -9,17 +9,14 @@ import static com.opengamma.strata.basics.StandardSchemes.OG_ETD_SCHEME;
 import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static com.opengamma.strata.product.etd.EtdVariant.MONTHLY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.time.YearMonth;
-import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.product.SecurityId;
-import com.opengamma.strata.product.common.ExchangeId;
 import com.opengamma.strata.product.common.ExchangeIds;
 import com.opengamma.strata.product.common.PutCall;
 
@@ -31,6 +28,7 @@ public class EtdIdUtilsTest {
   private static final YearMonth EXPIRY = YearMonth.of(2017, 6);
   private static final EtdContractCode OGBS = EtdContractCode.of("OGBS");
   private static final EtdContractCode FGBS = EtdContractCode.of("FGBS");
+  private static final EtdContractCode BAJAJ_AUTO = EtdContractCode.of("BAJAJ-AUTO");
 
   @Test
   public void test_contractSpecId_future() {
@@ -47,14 +45,14 @@ public class EtdIdUtilsTest {
 
   @Test
   void test_contractSpecIdWithExtraHyphen_future() {
-    EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.FUTURE, ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"));
+    EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.FUTURE, ExchangeIds.XNSE, BAJAJ_AUTO);
     assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-XNSE-BAJAJ-AUTO"));
     assertThat(EtdIdUtils.splitId(test))
         .isEqualTo(SplitEtdContractSpecId.builder()
             .specId(test)
             .type(EtdType.FUTURE)
-            .exchangeId(ExchangeId.of("XNSE"))
-            .contractCode(EtdContractCode.of("BAJAJ-AUTO"))
+            .exchangeId(ExchangeIds.XNSE)
+            .contractCode(BAJAJ_AUTO)
             .build());
   }
 
@@ -73,14 +71,14 @@ public class EtdIdUtilsTest {
 
   @Test
   void test_contractSpecIdWithExtraHyphen_option() {
-    EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.OPTION, ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"));
+    EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.OPTION, ExchangeIds.XNSE, BAJAJ_AUTO);
     assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-XNSE-BAJAJ-AUTO"));
     assertThat(EtdIdUtils.splitId(test))
         .isEqualTo(SplitEtdContractSpecId.builder()
             .specId(test)
             .type(EtdType.OPTION)
-            .exchangeId(ExchangeId.of("XNSE"))
-            .contractCode(EtdContractCode.of("BAJAJ-AUTO"))
+            .exchangeId(ExchangeIds.XNSE)
+            .contractCode(BAJAJ_AUTO)
             .build());
   }
 
@@ -127,13 +125,13 @@ public class EtdIdUtilsTest {
 
   @Test
   public void test_futureIdWithExtraHyphen_monthly() {
-    SecurityId test = EtdIdUtils.futureId(ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"), EXPIRY, MONTHLY);
+    SecurityId test = EtdIdUtils.futureId(ExchangeIds.XNSE, BAJAJ_AUTO, EXPIRY, MONTHLY);
     assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-XNSE-BAJAJ-AUTO-201706"));
     assertThat(EtdIdUtils.splitId(test))
         .isEqualTo(SplitEtdId.builder()
             .securityId(test)
-            .exchangeId(ExchangeId.of("XNSE"))
-            .contractCode(EtdContractCode.of("BAJAJ-AUTO"))
+            .exchangeId(ExchangeIds.XNSE)
+            .contractCode(BAJAJ_AUTO)
             .expiry(EXPIRY)
             .variant(MONTHLY)
             .build());
@@ -263,6 +261,23 @@ public class EtdIdUtilsTest {
             .securityId(test)
             .exchangeId(ExchangeIds.ECAG)
             .contractCode(FGBS)
+            .expiry(EXPIRY)
+            .variant(MONTHLY)
+            .option(SplitEtdOption.of(0, PutCall.PUT, 12.34, underlyingMonth))
+            .build());
+  }
+
+  @Test
+  public void test_optionIdUnderlyingWithHyphen_monthly() {
+    YearMonth underlyingMonth = YearMonth.of(2017, 9);
+    SecurityId test = EtdIdUtils.optionId(
+        ExchangeIds.XNSE, BAJAJ_AUTO, EXPIRY, MONTHLY, 0, PutCall.PUT, 12.34, underlyingMonth);
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-XNSE-BAJAJ-AUTO-201706-P12.34-U201709"));
+    assertThat(EtdIdUtils.splitId(test))
+        .isEqualTo(SplitEtdId.builder()
+            .securityId(test)
+            .exchangeId(ExchangeIds.XNSE)
+            .contractCode(BAJAJ_AUTO)
             .expiry(EXPIRY)
             .variant(MONTHLY)
             .option(SplitEtdOption.of(0, PutCall.PUT, 12.34, underlyingMonth))

--- a/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/etd/EtdIdUtilsTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import com.opengamma.strata.basics.StandardId;
 import com.opengamma.strata.product.SecurityId;
+import com.opengamma.strata.product.common.ExchangeId;
 import com.opengamma.strata.product.common.ExchangeIds;
 import com.opengamma.strata.product.common.PutCall;
 
@@ -45,6 +46,19 @@ public class EtdIdUtilsTest {
   }
 
   @Test
+  void test_contractSpecIdWithHyphen_future() {
+    EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.FUTURE, ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "F-XNSE-BAJAJ-AUTO"));
+    assertThat(EtdIdUtils.splitId(test))
+        .isEqualTo(SplitEtdContractSpecId.builder()
+            .specId(test)
+            .type(EtdType.FUTURE)
+            .exchangeId(ExchangeId.of("XNSE"))
+            .contractCode(EtdContractCode.of("BAJAJ-AUTO"))
+            .build());
+  }
+
+  @Test
   public void test_contractSpecId_option() {
     EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.OPTION, ExchangeIds.ECAG, OGBS);
     assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-ECAG-OGBS"));
@@ -54,6 +68,19 @@ public class EtdIdUtilsTest {
             .type(EtdType.OPTION)
             .exchangeId(ExchangeIds.ECAG)
             .contractCode(OGBS)
+            .build());
+  }
+
+  @Test
+  void test_contractSpecIdWithHyphen_option() {
+    EtdContractSpecId test = EtdIdUtils.contractSpecId(EtdType.OPTION, ExchangeId.of("XNSE"), EtdContractCode.of("BAJAJ-AUTO"));
+    assertThat(test.getStandardId()).isEqualTo(StandardId.of(OG_ETD_SCHEME, "O-XNSE-BAJAJ-AUTO"));
+    assertThat(EtdIdUtils.splitId(test))
+        .isEqualTo(SplitEtdContractSpecId.builder()
+            .specId(test)
+            .type(EtdType.OPTION)
+            .exchangeId(ExchangeId.of("XNSE"))
+            .contractCode(EtdContractCode.of("BAJAJ-AUTO"))
             .build());
   }
 
@@ -305,8 +332,6 @@ public class EtdIdUtilsTest {
         .isThrownBy(() -> EtdIdUtils.splitId(EtdContractSpecId.of("A", "B")));
     assertThatIllegalArgumentException()
         .isThrownBy(() -> EtdIdUtils.splitId(EtdContractSpecId.of(OG_ETD_SCHEME, "B")));
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> EtdIdUtils.splitId(EtdContractSpecId.of(OG_ETD_SCHEME, "F-ECAG-AB-ABCDEF")));
   }
 
   @Test


### PR DESCRIPTION
Example: `F-XNSE-BAJAJ-AUTO`