### PR TITLE
Implied vol for intrinsic value close to 0.

### DIFF
--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepository.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepository.java
@@ -1137,7 +1137,7 @@ public final class BlackFormulaRepository {
       double timeToExpiry,
       boolean isCall) {
 
-    ArgChecker.isTrue(price >= 0d, "negative/NaN price; have {}", price);
+    ArgChecker.isTrue(price >= -NEAR_ZERO * forward, "negative/NaN price; have {}", price);
     ArgChecker.isTrue(forward > 0d, "negative/NaN forward; have {}", forward);
     ArgChecker.isTrue(strike >= 0d, "negative/NaN strike; have {}", strike);
     ArgChecker.isTrue(timeToExpiry >= 0d, "negative/NaN timeToExpiry; have {}", timeToExpiry);
@@ -1172,7 +1172,7 @@ public final class BlackFormulaRepository {
       double timeToExpiry,
       boolean isCall) {
 
-    ArgChecker.isTrue(price >= 0d, "negative/NaN price; have {}", price);
+    ArgChecker.isTrue(price >= -NEAR_ZERO * forward, "negative/NaN price; have {}", price);
     ArgChecker.isTrue(forward > 0d, "negative/NaN forward; have {}", forward);
     ArgChecker.isTrue(strike >= 0d, "negative/NaN strike; have {}", strike);
     ArgChecker.isTrue(timeToExpiry >= 0d, "negative/NaN timeToExpiry; have {}", timeToExpiry);
@@ -1211,7 +1211,7 @@ public final class BlackFormulaRepository {
       double timeToExpiry,
       double volGuess) {
 
-    ArgChecker.isTrue(otmPrice >= 0d, "negative/NaN otmPrice; have {}", otmPrice);
+    ArgChecker.isTrue(otmPrice >= -NEAR_ZERO * forward, "negative/NaN otmPrice; have {}", otmPrice);
     ArgChecker.isTrue(forward >= 0d, "negative/NaN forward; have {}", forward);
     ArgChecker.isTrue(strike >= 0d, "negative/NaN strike; have {}", strike);
     ArgChecker.isTrue(timeToExpiry >= 0d, "negative/NaN timeToExpiry; have {}", timeToExpiry);
@@ -1223,8 +1223,8 @@ public final class BlackFormulaRepository {
     ArgChecker.isFalse(Double.isInfinite(timeToExpiry), "timeToExpiry is Infinity");
     ArgChecker.isFalse(Double.isInfinite(volGuess), "volGuess is Infinity");
 
-    if (otmPrice == 0) {
-      return 0;
+    if (Math.abs(otmPrice) < NEAR_ZERO * forward) {
+      return 0.0d;
     }
     ArgChecker.isTrue(otmPrice < Math.min(forward, strike), "otmPrice of {} exceeded upper bound of {}", otmPrice,
         Math.min(forward, strike));
@@ -1274,6 +1274,9 @@ public final class BlackFormulaRepository {
       double timeToExpiry,
       double volGuess) {
 
+    if (Math.abs(otmPrice) < NEAR_ZERO * forward) {
+      return ValueDerivatives.of(0.0d, DoubleArray.of(0.0d));
+    }
     double impliedVolatility = impliedVolatility(otmPrice, forward, strike, timeToExpiry, volGuess);
     boolean isCall = strike >= forward;
     ValueDerivatives price = priceAdjoint(forward, strike, timeToExpiry, impliedVolatility, isCall);

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepositoryTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepositoryTest.java
@@ -8315,7 +8315,7 @@ public class BlackFormulaRepositoryTest {
 
   /* Implied vol computation with limit cases option price near intrinsic price */
   @Test
-  public void impliedVol_nearintrinsic() {
+  public void impliedVol_near_intrinsic() {
     double optionPrice = 19.98d;
     double forward = 79.98d;
     double strike = 60.00d;

--- a/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepositoryTest.java
+++ b/modules/pricer/src/test/java/com/opengamma/strata/pricer/impl/option/BlackFormulaRepositoryTest.java
@@ -8313,6 +8313,22 @@ public class BlackFormulaRepositoryTest {
     }
   }
 
+  /* Implied vol computation with limit cases option price near intrinsic price */
+  @Test
+  public void impliedVol_nearintrinsic() {
+    double optionPrice = 19.98d;
+    double forward = 79.98d;
+    double strike = 60.00d;
+    double timeToExpiry = 0.0d;
+    double iv = BlackFormulaRepository.impliedVolatility(optionPrice, forward, strike, timeToExpiry, true);
+    assertThat(iv).isCloseTo(0.0, offset(1e-12));
+    ValueDerivatives ivAdj = BlackFormulaRepository
+        .impliedVolatilityAdjoint(optionPrice, forward, strike, timeToExpiry, true);
+    assertThat(ivAdj.getValue()).isCloseTo(0.0, offset(1e-12));
+    assertThat(ivAdj.getDerivatives().size()).isEqualTo(1);
+    assertThat(ivAdj.getDerivative(0)).isCloseTo(0.0, offset(1e-12));
+  }
+
   @Test
   public void implied_volatility_adjoint() {
     double vol = 0.4342; // Deliberately picked an arbitrary vol


### PR DESCRIPTION
Due to Java handling of double, in some cases the calculated intrinsic price of options is negative even if they should be 0 in theory. 
Added some threshold such that when the price is below it, it is considered as 0. Used 1.0E-16 * forward. 