### PR TITLE
Fixing ValueStepSequence resolving with RollConvensions

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueStepSequence.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/value/ValueStepSequence.java
@@ -120,17 +120,18 @@ public final class ValueStepSequence
   List<ValueStep> resolve(List<ValueStep> existingSteps, RollConvention rollConv) {
     ImmutableList.Builder<ValueStep> steps = ImmutableList.builder();
     steps.addAll(existingSteps);
-    LocalDate prev = firstStepDate;
-    LocalDate date = firstStepDate;
-    while (!date.isAfter(lastStepDate)) {
+    LocalDate prev = rollConv.adjust(firstStepDate);
+    LocalDate date = rollConv.adjust(firstStepDate);
+    LocalDate adjustedLastStepDate = rollConv.adjust(lastStepDate);
+    while (!date.isAfter(adjustedLastStepDate)) {
       steps.add(ValueStep.of(date, adjustment));
       prev = date;
       date = rollConv.next(date, frequency);
     }
-    if (!prev.equals(lastStepDate)) {
+    if (!prev.equals(adjustedLastStepDate)) {
       throw new IllegalArgumentException(Messages.format(
           "ValueStepSequence lastStepDate did not match frequency '{}' using roll convention '{}', {} != {}",
-          frequency, rollConv, lastStepDate, prev));
+          frequency, rollConv, adjustedLastStepDate, prev));
     }
     return steps.build();
   }

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueStepSequenceTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/value/ValueStepSequenceTest.java
@@ -60,6 +60,18 @@ public class ValueStepSequenceTest {
   }
 
   @Test
+  public void test_resolve_with_roll_convention() {
+    ValueStepSequence test = ValueStepSequence.of(date(2022, 9, 21), date(2026, 9, 21), Frequency.P12M, ADJ);
+    List<ValueStep> steps = test.resolve(ImmutableList.of(), RollConventions.IMM);
+    assertThat(steps.size()).isEqualTo(5);
+    assertThat(steps.get(0)).isEqualTo(ValueStep.of(date(2022, 9, 21), ADJ));
+    assertThat(steps.get(1)).isEqualTo(ValueStep.of(date(2023, 9, 20), ADJ));
+    assertThat(steps.get(2)).isEqualTo(ValueStep.of(date(2024, 9, 18), ADJ));
+    assertThat(steps.get(3)).isEqualTo(ValueStep.of(date(2025, 9, 17), ADJ));
+    assertThat(steps.get(4)).isEqualTo(ValueStep.of(date(2026, 9, 16), ADJ));
+  }
+
+  @Test
   public void test_resolve_invalid() {
     ValueStepSequence test = ValueStepSequence.of(date(2016, 4, 20), date(2016, 10, 20), Frequency.P12M, ADJ);
     ValueStep baseStep = ValueStep.of(date(2016, 1, 20), ValueAdjustment.ofReplace(500d));


### PR DESCRIPTION
Fixes issue that caused date mismatched with the IMM roll conversion when resolving ValueStepSequences.

Adjusting the start and end dates before resolving the individual steps has fixed the issue.

Example error:

> ValueStepSequence lastStepDate did not match frequency 'P12M' using roll convention 'IMM', 2044-12-20 != 2043-12-16