### PR TITLE
Make DiscreteQuantileMethod abstract methods protected

### DIFF
--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/DiscreteQuantileMethod.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/DiscreteQuantileMethod.java
@@ -62,29 +62,29 @@ public abstract class DiscreteQuantileMethod
   //-------------------------------------------------------------------------
 
   /**
-   * Internal method computing the index for a give quantile multiply by sample size.
+   * Computes the index for a given quantile multiplied by sample size.
    * <p>
    * The quantile size is given by quantile * sample size.
    *
    * @param quantileSize  the quantile size
    * @return the index in the sample
    */
-  abstract int index(double quantileSize);
+  protected abstract int index(double quantileSize);
 
   /**
-   * Internal method returning the sample size correction for the specific implementation.
+   * Returns the sample size correction for the specific implementation.
    *
    * @param sampleSize  the sample size
    * @return the correction
    */
-  abstract int sampleCorrection(int sampleSize);
+  protected abstract int sampleCorrection(int sampleSize);
 
   /**
    * Shift added to/subtracted from index during intermediate steps in the expected shortfall computation.
    *
    * @return the index shift
    */
-  abstract double indexShift();
+  protected abstract double indexShift();
 
   /**
    * Generate an index of doubles.

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/IndexAboveQuantileMethod.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/IndexAboveQuantileMethod.java
@@ -20,17 +20,17 @@ public final class IndexAboveQuantileMethod
   public static final IndexAboveQuantileMethod DEFAULT = new IndexAboveQuantileMethod();
 
   @Override
-  int index(double quantileSize) {
+  protected int index(double quantileSize) {
     return (int) Math.ceil(quantileSize);
   }
 
   @Override
-  int sampleCorrection(int sampleSize) {
+  protected int sampleCorrection(int sampleSize) {
     return sampleSize;
   }
 
   @Override
-  double indexShift() {
+  protected double indexShift() {
     return 0d;
   }
 }

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/NearestIndexQuantileMethod.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/NearestIndexQuantileMethod.java
@@ -21,12 +21,12 @@ public final class NearestIndexQuantileMethod
   public static final NearestIndexQuantileMethod DEFAULT = new NearestIndexQuantileMethod();
 
   @Override
-  int index(double quantileSize) {
+  protected int index(double quantileSize) {
     return (int) Math.round(quantileSize);
   }
 
   @Override
-  int sampleCorrection(int sampleSize) {
+  protected int sampleCorrection(int sampleSize) {
     return sampleSize;
   }
 

--- a/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/SamplePlusOneNearestIndexQuantileMethod.java
+++ b/modules/math/src/main/java/com/opengamma/strata/math/impl/statistics/descriptive/SamplePlusOneNearestIndexQuantileMethod.java
@@ -21,12 +21,12 @@ public final class SamplePlusOneNearestIndexQuantileMethod
   public static final SamplePlusOneNearestIndexQuantileMethod DEFAULT = new SamplePlusOneNearestIndexQuantileMethod();
 
   @Override
-  int index(double quantileSize) {
+  protected int index(double quantileSize) {
     return (int) Math.round(quantileSize);
   }
 
   @Override
-  int sampleCorrection(int sampleSize) {
+  protected int sampleCorrection(int sampleSize) {
     return sampleSize + 1;
   }
 


### PR DESCRIPTION
Exposes abstract methods in `DiscreteQuantileMethod` as protected to allow for implementations outside of `DiscreteQuantileMethod` package.