### PR TITLE
Create OvernightOvernightSwapConventions

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightOvernightSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightOvernightSwapConvention.java
@@ -63,8 +63,7 @@ public final class ImmutableOvernightOvernightSwapConvention
   /**
    * The market convention of the floating leg that has the spread applied.
    * <p>
-   * The spread is the market price of the instrument.
-   * It is added to the observed interest rate.
+   * The spread is the market price of the instrument. It is added to the observed interest rate.
    */
   @PropertyDefinition(validate = "notNull", overrideGet = true)
   private final OvernightRateSwapLegConvention spreadLeg;
@@ -84,7 +83,7 @@ public final class ImmutableOvernightOvernightSwapConvention
 
   //-------------------------------------------------------------------------
   /**
-   * Obtains a convention based on the specified name and leg conventions.
+   * Obtains a convention based on the specified name, leg conventions and spot date offset.
    * <p>
    * The two leg conventions must be in the same currency.
    *
@@ -198,8 +197,7 @@ public final class ImmutableOvernightOvernightSwapConvention
   /**
    * Gets the market convention of the floating leg that has the spread applied.
    * <p>
-   * The spread is the market price of the instrument.
-   * It is added to the observed interest rate.
+   * The spread is the market price of the instrument. It is added to the observed interest rate.
    * @return the value of the property, not null
    */
   @Override
@@ -496,8 +494,7 @@ public final class ImmutableOvernightOvernightSwapConvention
     /**
      * Sets the market convention of the floating leg that has the spread applied.
      * <p>
-     * The spread is the market price of the instrument.
-     * It is added to the observed interest rate.
+     * The spread is the market price of the instrument. It is added to the observed interest rate.
      * @param spreadLeg  the new value, not null
      * @return this, for chaining, not null
      */

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightOvernightSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/ImmutableOvernightOvernightSwapConvention.java
@@ -1,0 +1,551 @@
+/*
+ * Copyright (C) 2024 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.joda.beans.Bean;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaBean;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.gen.BeanDefinition;
+import org.joda.beans.gen.ImmutableValidator;
+import org.joda.beans.gen.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.common.PayReceive;
+import com.opengamma.strata.product.swap.Swap;
+import com.opengamma.strata.product.swap.SwapLeg;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * A market convention for Overnight-Overnight swap trades.
+ * <p>
+ * This defines the market convention for a Overnight-Overnight single currency swap.
+ * The convention is formed by combining two swap leg conventions in the same currency.
+ * <p>
+ * The market price is for the difference (spread) between the values of the two legs.
+ * This convention has two legs, the "spread leg" and the "flat leg". The spread will be
+ * added to the "spread leg".
+ * <p>
+ * The convention is defined by four key dates.
+ * <ul>
+ * <li>Trade date, the date that the trade is agreed
+ * <li>Spot date, the base for date calculations, typically 2 business days after the trade date
+ * <li>Start date, the date on which the interest calculation starts, often the same as the spot date
+ * <li>End date, the date on which the interest calculation ends, typically a number of years after the start date
+ * </ul>
+ */
+@BeanDefinition
+public final class ImmutableOvernightOvernightSwapConvention
+    implements OvernightOvernightSwapConvention, ImmutableBean, Serializable {
+
+  /**
+   * The convention name, such as 'USD-SOFR-3M-FED-FUND-3M'.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final String name;
+  /**
+   * The market convention of the floating leg that has the spread applied.
+   * <p>
+   * The spread is the market price of the instrument.
+   * It is added to the observed interest rate.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final OvernightRateSwapLegConvention spreadLeg;
+  /**
+   * The market convention of the floating leg that does not have the spread applied.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final OvernightRateSwapLegConvention flatLeg;
+  /**
+   * The offset of the spot value date from the trade date.
+   * <p>
+   * The offset is applied to the trade date to find the start date.
+   * A typical value is "plus 2 business days".
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final DaysAdjustment spotDateOffset;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains a convention based on the specified name and leg conventions.
+   * <p>
+   * The two leg conventions must be in the same currency.
+   *
+   * @param name  the unique name of the convention
+   * @param spreadLeg  the market convention for the leg that the spread is added to
+   * @param flatLeg  the market convention for the other leg, known as the flat leg
+   * @param spotDateOffset  the offset of the spot value date from the trade date
+   * @return the convention
+   */
+  public static ImmutableOvernightOvernightSwapConvention of(
+      String name,
+      OvernightRateSwapLegConvention spreadLeg,
+      OvernightRateSwapLegConvention flatLeg,
+      DaysAdjustment spotDateOffset) {
+
+    return new ImmutableOvernightOvernightSwapConvention(name, spreadLeg, flatLeg, spotDateOffset);
+  }
+
+  //-------------------------------------------------------------------------
+  @ImmutableValidator
+  private void validate() {
+    ArgChecker.isTrue(spreadLeg.getCurrency().equals(flatLeg.getCurrency()), "Conventions must have same currency");
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public SwapTrade toTrade(
+      TradeInfo tradeInfo,
+      LocalDate startDate,
+      LocalDate endDate,
+      BuySell buySell,
+      double notional,
+      double spread) {
+
+    Optional<LocalDate> tradeDate = tradeInfo.getTradeDate();
+    if (tradeDate.isPresent()) {
+      ArgChecker.inOrderOrEqual(tradeDate.get(), startDate, "tradeDate", "startDate");
+    }
+    SwapLeg leg1 = spreadLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isBuy()), notional, spread);
+    SwapLeg leg2 = flatLeg.toLeg(startDate, endDate, PayReceive.ofPay(buySell.isSell()), notional);
+    return SwapTrade.builder()
+        .info(tradeInfo)
+        .product(Swap.of(leg1, leg2))
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  /**
+   * The meta-bean for {@code ImmutableOvernightOvernightSwapConvention}.
+   * @return the meta-bean, not null
+   */
+  public static ImmutableOvernightOvernightSwapConvention.Meta meta() {
+    return ImmutableOvernightOvernightSwapConvention.Meta.INSTANCE;
+  }
+
+  static {
+    MetaBean.register(ImmutableOvernightOvernightSwapConvention.Meta.INSTANCE);
+  }
+
+  /**
+   * The serialization version id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static ImmutableOvernightOvernightSwapConvention.Builder builder() {
+    return new ImmutableOvernightOvernightSwapConvention.Builder();
+  }
+
+  private ImmutableOvernightOvernightSwapConvention(
+      String name,
+      OvernightRateSwapLegConvention spreadLeg,
+      OvernightRateSwapLegConvention flatLeg,
+      DaysAdjustment spotDateOffset) {
+    JodaBeanUtils.notNull(name, "name");
+    JodaBeanUtils.notNull(spreadLeg, "spreadLeg");
+    JodaBeanUtils.notNull(flatLeg, "flatLeg");
+    JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
+    this.name = name;
+    this.spreadLeg = spreadLeg;
+    this.flatLeg = flatLeg;
+    this.spotDateOffset = spotDateOffset;
+    validate();
+  }
+
+  @Override
+  public ImmutableOvernightOvernightSwapConvention.Meta metaBean() {
+    return ImmutableOvernightOvernightSwapConvention.Meta.INSTANCE;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the convention name, such as 'USD-SOFR-3M-FED-FUND-3M'.
+   * @return the value of the property, not null
+   */
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the floating leg that has the spread applied.
+   * <p>
+   * The spread is the market price of the instrument.
+   * It is added to the observed interest rate.
+   * @return the value of the property, not null
+   */
+  @Override
+  public OvernightRateSwapLegConvention getSpreadLeg() {
+    return spreadLeg;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the floating leg that does not have the spread applied.
+   * @return the value of the property, not null
+   */
+  @Override
+  public OvernightRateSwapLegConvention getFlatLeg() {
+    return flatLeg;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the offset of the spot value date from the trade date.
+   * <p>
+   * The offset is applied to the trade date to find the start date.
+   * A typical value is "plus 2 business days".
+   * @return the value of the property, not null
+   */
+  @Override
+  public DaysAdjustment getSpotDateOffset() {
+    return spotDateOffset;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      ImmutableOvernightOvernightSwapConvention other = (ImmutableOvernightOvernightSwapConvention) obj;
+      return JodaBeanUtils.equal(name, other.name) &&
+          JodaBeanUtils.equal(spreadLeg, other.spreadLeg) &&
+          JodaBeanUtils.equal(flatLeg, other.flatLeg) &&
+          JodaBeanUtils.equal(spotDateOffset, other.spotDateOffset);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = getClass().hashCode();
+    hash = hash * 31 + JodaBeanUtils.hashCode(name);
+    hash = hash * 31 + JodaBeanUtils.hashCode(spreadLeg);
+    hash = hash * 31 + JodaBeanUtils.hashCode(flatLeg);
+    hash = hash * 31 + JodaBeanUtils.hashCode(spotDateOffset);
+    return hash;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code ImmutableOvernightOvernightSwapConvention}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code name} property.
+     */
+    private final MetaProperty<String> name = DirectMetaProperty.ofImmutable(
+        this, "name", ImmutableOvernightOvernightSwapConvention.class, String.class);
+    /**
+     * The meta-property for the {@code spreadLeg} property.
+     */
+    private final MetaProperty<OvernightRateSwapLegConvention> spreadLeg = DirectMetaProperty.ofImmutable(
+        this, "spreadLeg", ImmutableOvernightOvernightSwapConvention.class, OvernightRateSwapLegConvention.class);
+    /**
+     * The meta-property for the {@code flatLeg} property.
+     */
+    private final MetaProperty<OvernightRateSwapLegConvention> flatLeg = DirectMetaProperty.ofImmutable(
+        this, "flatLeg", ImmutableOvernightOvernightSwapConvention.class, OvernightRateSwapLegConvention.class);
+    /**
+     * The meta-property for the {@code spotDateOffset} property.
+     */
+    private final MetaProperty<DaysAdjustment> spotDateOffset = DirectMetaProperty.ofImmutable(
+        this, "spotDateOffset", ImmutableOvernightOvernightSwapConvention.class, DaysAdjustment.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "name",
+        "spreadLeg",
+        "flatLeg",
+        "spotDateOffset");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          return name;
+        case 1302781851:  // spreadLeg
+          return spreadLeg;
+        case -778843179:  // flatLeg
+          return flatLeg;
+        case 746995843:  // spotDateOffset
+          return spotDateOffset;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public ImmutableOvernightOvernightSwapConvention.Builder builder() {
+      return new ImmutableOvernightOvernightSwapConvention.Builder();
+    }
+
+    @Override
+    public Class<? extends ImmutableOvernightOvernightSwapConvention> beanType() {
+      return ImmutableOvernightOvernightSwapConvention.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code name} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<String> name() {
+      return name;
+    }
+
+    /**
+     * The meta-property for the {@code spreadLeg} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<OvernightRateSwapLegConvention> spreadLeg() {
+      return spreadLeg;
+    }
+
+    /**
+     * The meta-property for the {@code flatLeg} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<OvernightRateSwapLegConvention> flatLeg() {
+      return flatLeg;
+    }
+
+    /**
+     * The meta-property for the {@code spotDateOffset} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<DaysAdjustment> spotDateOffset() {
+      return spotDateOffset;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          return ((ImmutableOvernightOvernightSwapConvention) bean).getName();
+        case 1302781851:  // spreadLeg
+          return ((ImmutableOvernightOvernightSwapConvention) bean).getSpreadLeg();
+        case -778843179:  // flatLeg
+          return ((ImmutableOvernightOvernightSwapConvention) bean).getFlatLeg();
+        case 746995843:  // spotDateOffset
+          return ((ImmutableOvernightOvernightSwapConvention) bean).getSpotDateOffset();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code ImmutableOvernightOvernightSwapConvention}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<ImmutableOvernightOvernightSwapConvention> {
+
+    private String name;
+    private OvernightRateSwapLegConvention spreadLeg;
+    private OvernightRateSwapLegConvention flatLeg;
+    private DaysAdjustment spotDateOffset;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(ImmutableOvernightOvernightSwapConvention beanToCopy) {
+      this.name = beanToCopy.getName();
+      this.spreadLeg = beanToCopy.getSpreadLeg();
+      this.flatLeg = beanToCopy.getFlatLeg();
+      this.spotDateOffset = beanToCopy.getSpotDateOffset();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          return name;
+        case 1302781851:  // spreadLeg
+          return spreadLeg;
+        case -778843179:  // flatLeg
+          return flatLeg;
+        case 746995843:  // spotDateOffset
+          return spotDateOffset;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 3373707:  // name
+          this.name = (String) newValue;
+          break;
+        case 1302781851:  // spreadLeg
+          this.spreadLeg = (OvernightRateSwapLegConvention) newValue;
+          break;
+        case -778843179:  // flatLeg
+          this.flatLeg = (OvernightRateSwapLegConvention) newValue;
+          break;
+        case 746995843:  // spotDateOffset
+          this.spotDateOffset = (DaysAdjustment) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public ImmutableOvernightOvernightSwapConvention build() {
+      return new ImmutableOvernightOvernightSwapConvention(
+          name,
+          spreadLeg,
+          flatLeg,
+          spotDateOffset);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the convention name, such as 'USD-SOFR-3M-FED-FUND-3M'.
+     * @param name  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder name(String name) {
+      JodaBeanUtils.notNull(name, "name");
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the market convention of the floating leg that has the spread applied.
+     * <p>
+     * The spread is the market price of the instrument.
+     * It is added to the observed interest rate.
+     * @param spreadLeg  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder spreadLeg(OvernightRateSwapLegConvention spreadLeg) {
+      JodaBeanUtils.notNull(spreadLeg, "spreadLeg");
+      this.spreadLeg = spreadLeg;
+      return this;
+    }
+
+    /**
+     * Sets the market convention of the floating leg that does not have the spread applied.
+     * @param flatLeg  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder flatLeg(OvernightRateSwapLegConvention flatLeg) {
+      JodaBeanUtils.notNull(flatLeg, "flatLeg");
+      this.flatLeg = flatLeg;
+      return this;
+    }
+
+    /**
+     * Sets the offset of the spot value date from the trade date.
+     * <p>
+     * The offset is applied to the trade date to find the start date.
+     * A typical value is "plus 2 business days".
+     * @param spotDateOffset  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder spotDateOffset(DaysAdjustment spotDateOffset) {
+      JodaBeanUtils.notNull(spotDateOffset, "spotDateOffset");
+      this.spotDateOffset = spotDateOffset;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(160);
+      buf.append("ImmutableOvernightOvernightSwapConvention.Builder{");
+      buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
+      buf.append("spreadLeg").append('=').append(JodaBeanUtils.toString(spreadLeg)).append(',').append(' ');
+      buf.append("flatLeg").append('=').append(JodaBeanUtils.toString(flatLeg)).append(',').append(' ');
+      buf.append("spotDateOffset").append('=').append(JodaBeanUtils.toString(spotDateOffset));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConvention.java
@@ -24,7 +24,7 @@ import com.opengamma.strata.product.swap.SwapTrade;
 /**
  * A market convention for Overnight-Overnight swap trades.
  * <p>
- * This defines the market convention for a Overnight-Overnight single currency swap.
+ * This defines the market convention for an Overnight-Overnight single currency swap.
  * The convention is formed by combining two swap leg conventions in the same currency.
  * <p>
  * To manually create a convention, see {@link ImmutableOvernightOvernightSwapConvention}.
@@ -80,14 +80,14 @@ public interface OvernightOvernightSwapConvention extends SingleCurrencySwapConv
    * of 5 years creates a swap starting on the spot date and maturing 5 years later.
    * <p>
    * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
-   * 
+   * If buying the swap, the rate of the flat leg is received from the counterparty,
+   * with the rate of the spread leg being paid. If selling the swap, the opposite occurs.
+   *
    * @param tradeDate  the date of the trade
    * @param tenor  the tenor of the swap
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param spread  the spread, typically derived from the market
    * @param refData  the reference data, used to resolve the trade dates
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
@@ -113,15 +113,15 @@ public interface OvernightOvernightSwapConvention extends SingleCurrencySwapConv
    * and maturing 5 years later.
    * <p>
    * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
-   * 
+   * If buying the swap, the rate of the flat leg is received from the counterparty,
+   * with the rate of the spread leg being paid. If selling the swap, the opposite occurs.
+   *
    * @param tradeDate  the date of the trade
    * @param periodToStart  the period between the spot date and the start date
    * @param tenor  the tenor of the swap
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param spread  the spread, typically derived from the market
    * @param refData  the reference data, used to resolve the trade dates
    * @return the trade
    * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
@@ -146,15 +146,15 @@ public interface OvernightOvernightSwapConvention extends SingleCurrencySwapConv
    * This returns a trade based on the specified dates.
    * <p>
    * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
-   * 
+   * If buying the swap, the rate of the flat leg is received from the counterparty,
+   * with the rate of the spread leg being paid. If selling the swap, the opposite occurs.
+   *
    * @param tradeDate  the date of the trade
    * @param startDate  the start date
    * @param endDate  the end date
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param spread  the spread, typically derived from the market
    * @return the trade
    */
   @Override
@@ -176,15 +176,15 @@ public interface OvernightOvernightSwapConvention extends SingleCurrencySwapConv
    * This returns a trade based on the specified dates.
    * <p>
    * The notional is unsigned, with buy/sell determining the direction of the trade.
-   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
-   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
-   * 
+   * If buying the swap, the rate of the flat leg is received from the counterparty,
+   * with the rate of the spread leg being paid. If selling the swap, the opposite occurs.
+   *
    * @param tradeInfo  additional information about the trade
    * @param startDate  the start date
    * @param endDate  the end date
    * @param buySell  the buy/sell flag
    * @param notional  the notional amount
-   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param spread  the spread, typically derived from the market
    * @return the trade
    */
   @Override

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConvention.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConvention.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2024 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.ReferenceDataNotFoundException;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.collect.ArgChecker;
+import com.opengamma.strata.collect.named.ExtendedEnum;
+import com.opengamma.strata.collect.named.Named;
+import com.opengamma.strata.product.TradeInfo;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * A market convention for Overnight-Overnight swap trades.
+ * <p>
+ * This defines the market convention for a Overnight-Overnight single currency swap.
+ * The convention is formed by combining two swap leg conventions in the same currency.
+ * <p>
+ * To manually create a convention, see {@link ImmutableOvernightOvernightSwapConvention}.
+ * To register a specific convention, see {@code OvernightOvernightSwapConvention.ini}.
+ */
+public interface OvernightOvernightSwapConvention extends SingleCurrencySwapConvention, Named {
+
+  /**
+   * Obtains an instance from the specified unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the convention
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static OvernightOvernightSwapConvention of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return extendedEnum().lookup(uniqueName);
+  }
+
+  /**
+   * Gets the extended enum helper.
+   * <p>
+   * This helper allows instances of the convention to be looked up.
+   * It also provides the complete set of available instances.
+   * 
+   * @return the extended enum helper
+   */
+  public static ExtendedEnum<OvernightOvernightSwapConvention> extendedEnum() {
+    return OvernightOvernightSwapConventions.ENUM_LOOKUP;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the market convention of the spread leg.
+   * 
+   * @return the spread leg convention
+   */
+  public abstract OvernightRateSwapLegConvention getSpreadLeg();
+
+  /**
+   * Gets the market convention of the flat leg.
+   * 
+   * @return the flat leg convention
+   */
+  public abstract OvernightRateSwapLegConvention getFlatLeg();
+
+  //-------------------------------------------------------------------------
+  /**
+   * Creates a spot-starting trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified tenor. For example, a tenor
+   * of 5 years creates a swap starting on the spot date and maturing 5 years later.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param tenor  the tenor of the swap
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  @Override
+  public default SwapTrade createTrade(
+      LocalDate tradeDate,
+      Tenor tenor,
+      BuySell buySell,
+      double notional,
+      double spread,
+      ReferenceData refData) {
+
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, tenor, buySell, notional, spread, refData);
+  }
+
+  /**
+   * Creates a forward-starting trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified period and tenor. For example, a period of
+   * 3 months and a tenor of 5 years creates a swap starting three months after the spot date
+   * and maturing 5 years later.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param periodToStart  the period between the spot date and the start date
+   * @param tenor  the tenor of the swap
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @param refData  the reference data, used to resolve the trade dates
+   * @return the trade
+   * @throws ReferenceDataNotFoundException if an identifier cannot be resolved in the reference data
+   */
+  @Override
+  public default SwapTrade createTrade(
+      LocalDate tradeDate,
+      Period periodToStart,
+      Tenor tenor,
+      BuySell buySell,
+      double notional,
+      double spread,
+      ReferenceData refData) {
+
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.createTrade(tradeDate, periodToStart, tenor, buySell, notional, spread, refData);
+  }
+
+  /**
+   * Creates a trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified dates.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeDate  the date of the trade
+   * @param startDate  the start date
+   * @param endDate  the end date
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @return the trade
+   */
+  @Override
+  public default SwapTrade toTrade(
+      LocalDate tradeDate,
+      LocalDate startDate,
+      LocalDate endDate,
+      BuySell buySell,
+      double notional,
+      double spread) {
+
+    // override for Javadoc
+    return SingleCurrencySwapConvention.super.toTrade(tradeDate, startDate, endDate, buySell, notional, spread);
+  }
+
+  /**
+   * Creates a trade based on this convention.
+   * <p>
+   * This returns a trade based on the specified dates.
+   * <p>
+   * The notional is unsigned, with buy/sell determining the direction of the trade.
+   * If buying the swap, the Ibor rate is received from the counterparty, with the overnight and spread being paid.
+   * If selling the swap, the Ibor rate is paid to the counterparty, with the overnight and spread being received.
+   * 
+   * @param tradeInfo  additional information about the trade
+   * @param startDate  the start date
+   * @param endDate  the end date
+   * @param buySell  the buy/sell flag
+   * @param notional  the notional amount
+   * @param spread  the spread of added the overnight rates, typically derived from the market
+   * @return the trade
+   */
+  @Override
+  public abstract SwapTrade toTrade(
+      TradeInfo tradeInfo,
+      LocalDate startDate,
+      LocalDate endDate,
+      BuySell buySell,
+      double notional,
+      double spread);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this convention.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public abstract String getName();
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import com.opengamma.strata.collect.named.ExtendedEnum;
+
+/**
+ * Market standard Overnight-Overnight swap conventions.
+ */
+public final class OvernightOvernightSwapConventions {
+
+  /**
+   * The extended enum lookup from name to instance.
+   */
+  static final ExtendedEnum<OvernightOvernightSwapConvention> ENUM_LOOKUP =
+      ExtendedEnum.of(OvernightOvernightSwapConvention.class);
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 'USD-FED-FUND-AA-LIBOR-3M' swap convention.
+   * <p>
+   * USD Fed Fund Arithmetic Average 3M v Libor 3M swap.
+   * Both legs use day count 'Act/360'.
+   * The spot date offset is 2 days, the rate cut-off period is 2 days.
+   */
+  public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
+      OvernightOvernightSwapConvention.of(StandardOvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private OvernightOvernightSwapConventions() {
+  }
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
@@ -27,7 +27,7 @@ public final class OvernightOvernightSwapConventions {
    * The spot date offset is 2 days.
    */
   public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
-      OvernightOvernightSwapConvention.of(StandardOvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M.getName());
+      OvernightOvernightSwapConvention.of(StandardOvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M.getName());
 
   //-------------------------------------------------------------------------
   /**

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
@@ -26,7 +26,7 @@ public final class OvernightOvernightSwapConventions {
    * <p>
    * The spot date offset is 2 days.
    */
-  public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
+  public static final OvernightOvernightSwapConvention USD_SOFR_3M_FED_FUND_3M =
       OvernightOvernightSwapConvention.of(StandardOvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M.getName());
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventions.java
@@ -20,11 +20,11 @@ public final class OvernightOvernightSwapConventions {
 
   //-------------------------------------------------------------------------
   /**
-   * The 'USD-FED-FUND-AA-LIBOR-3M' swap convention.
+   * The 'USD-SOFR-3M-FED-FUND-3M' swap convention.
    * <p>
-   * USD Fed Fund Arithmetic Average 3M v Libor 3M swap.
-   * Both legs use day count 'Act/360'.
-   * The spot date offset is 2 days, the rate cut-off period is 2 days.
+   * USD SOFR v USD Fed Fund 3M swap.
+   * <p>
+   * The spot date offset is 2 days.
    */
   public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
       OvernightOvernightSwapConvention.of(StandardOvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M.getName());

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightIborSwapConventions.java
@@ -5,8 +5,6 @@
  */
 package com.opengamma.strata.product.swap.type;
 
-import static com.opengamma.strata.basics.date.DayCounts.ACT_360;
-import static com.opengamma.strata.basics.date.DayCounts.ACT_365F;
 import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
 import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
 import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
@@ -16,7 +14,6 @@ import static com.opengamma.strata.basics.schedule.Frequency.P3M;
 import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED;
 import static com.opengamma.strata.product.swap.OvernightAccrualMethod.COMPOUNDED;
 
-import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.HolidayCalendarId;
 import com.opengamma.strata.basics.index.IborIndex;
@@ -39,7 +36,7 @@ final class StandardOvernightIborSwapConventions {
    * The spot date offset is 2 days and the cut-off period is 2 days.
    */
   public static final OvernightIborSwapConvention USD_FED_FUND_AA_LIBOR_3M =
-      makeConvention("USD-FED-FUND-AA-LIBOR-3M", USD_FED_FUND, USD_LIBOR_3M, ACT_360, P3M, 0, 2, AVERAGED);
+      makeConvention("USD-FED-FUND-AA-LIBOR-3M", USD_FED_FUND, USD_LIBOR_3M, P3M, 0, 2, AVERAGED);
 
   /**
    * GBP Sonia compounded 1Y v LIBOR 3M .
@@ -48,7 +45,7 @@ final class StandardOvernightIborSwapConventions {
    * The spot date offset is 0 days and payment offset is 0 days.
    */
   public static final OvernightIborSwapConvention GBP_SONIA_OIS_1Y_LIBOR_3M =
-      makeConvention("GBP-SONIA-OIS-1Y-LIBOR-3M", GBP_SONIA, GBP_LIBOR_3M, ACT_365F, P12M, 0, 0, COMPOUNDED);
+      makeConvention("GBP-SONIA-OIS-1Y-LIBOR-3M", GBP_SONIA, GBP_LIBOR_3M, P12M, 0, 0, COMPOUNDED);
 
   //-------------------------------------------------------------------------
   // build conventions
@@ -56,7 +53,6 @@ final class StandardOvernightIborSwapConventions {
       String name,
       OvernightIndex onIndex,
       IborIndex iborIndex,
-      DayCount dayCount,
       Frequency frequency,
       int paymentLag,
       int cutOffDays,

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
@@ -24,7 +24,7 @@ final class StandardOvernightOvernightSwapConventions {
    * <p>
    * The spot date offset is 2 days.
    */
-  static final OvernightOvernightSwapConvention USD_SOFR_3M_FED_FUND_3M =
+  public static final OvernightOvernightSwapConvention USD_SOFR_3M_FED_FUND_3M =
       makeConvention("USD-SOFR-3M-FED-FUND-3M", USD_SOFR, USD_FED_FUND, P3M, 2, 2);
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
@@ -13,8 +13,6 @@ import com.opengamma.strata.basics.date.DaysAdjustment;
 import com.opengamma.strata.basics.date.HolidayCalendarId;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.schedule.Frequency;
-import com.opengamma.strata.basics.schedule.StubConvention;
-import com.opengamma.strata.product.swap.OvernightAccrualMethod;
 
 /**
  * Market standard Overnight-Overnight swap conventions.
@@ -22,13 +20,12 @@ import com.opengamma.strata.product.swap.OvernightAccrualMethod;
 final class StandardOvernightOvernightSwapConventions {
 
   /**
-   * USD SOFR vs USD Fed Fund 3M swap .
+   * USD SOFR vs USD Fed Fund 3M swap.
    * <p>
-   * The spot date offset is 2 days and the cut-off period is 2 days.
+   * The spot date offset is 2 days.
    */
   public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
       makeConvention("USD-SOFR-3M-FED-FUND-3M", USD_SOFR, USD_FED_FUND, P3M, 2, 2);
-
 
   //-------------------------------------------------------------------------
   // build conventions
@@ -41,28 +38,12 @@ final class StandardOvernightOvernightSwapConventions {
       int spotLag) {
 
     HolidayCalendarId calendar = spreadIndex.getFixingCalendar();
-    DaysAdjustment paymentDateOffset = DaysAdjustment.ofBusinessDays(paymentLag, calendar);
     DaysAdjustment spotDateOffset = DaysAdjustment.ofBusinessDays(spotLag, calendar);
     return ImmutableOvernightOvernightSwapConvention.of(
         name,
-        OvernightRateSwapLegConvention.builder()
-            .index(spreadIndex)
-            .accrualMethod(OvernightAccrualMethod.COMPOUNDED)
-            .accrualFrequency(frequency)
-            .paymentFrequency(frequency)
-            .paymentDateOffset(paymentDateOffset)
-            .stubConvention(StubConvention.SMART_INITIAL)
-            .build(),
-        OvernightRateSwapLegConvention.builder()
-            .index(flatIndex)
-            .accrualMethod(OvernightAccrualMethod.COMPOUNDED)
-            .accrualFrequency(frequency)
-            .paymentFrequency(frequency)
-            .paymentDateOffset(paymentDateOffset)
-            .stubConvention(StubConvention.SMART_INITIAL)
-            .build(),
-        spotDateOffset
-    );
+        OvernightRateSwapLegConvention.of(spreadIndex, frequency, paymentLag),
+        OvernightRateSwapLegConvention.of(flatIndex, frequency, paymentLag),
+        spotDateOffset);
   }
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
@@ -24,7 +24,7 @@ final class StandardOvernightOvernightSwapConventions {
    * <p>
    * The spot date offset is 2 days.
    */
-  public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
+  public static final OvernightOvernightSwapConvention USD_SOFR_3M_FED_FUND_3M =
       makeConvention("USD-SOFR-3M-FED-FUND-3M", USD_SOFR, USD_FED_FUND, P3M, 2, 2);
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_SOFR;
+import static com.opengamma.strata.basics.schedule.Frequency.P3M;
+
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.date.HolidayCalendarId;
+import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.product.swap.OvernightAccrualMethod;
+
+/**
+ * Market standard Overnight-Overnight swap conventions.
+ */
+final class StandardOvernightOvernightSwapConventions {
+
+  /**
+   * USD SOFR vs USD Fed Fund 3M swap .
+   * <p>
+   * The spot date offset is 2 days and the cut-off period is 2 days.
+   */
+  public static final OvernightOvernightSwapConvention USD_FED_FUND_SOFR_3M =
+      makeConvention("USD-SOFR-3M-FED-FUND-3M", USD_SOFR, USD_FED_FUND, P3M, 2, 2);
+
+
+  //-------------------------------------------------------------------------
+  // build conventions
+  private static OvernightOvernightSwapConvention makeConvention(
+      String name,
+      OvernightIndex spreadIndex,
+      OvernightIndex flatIndex,
+      Frequency frequency,
+      int paymentLag,
+      int spotLag) {
+
+    HolidayCalendarId calendar = spreadIndex.getFixingCalendar();
+    DaysAdjustment paymentDateOffset = DaysAdjustment.ofBusinessDays(paymentLag, calendar);
+    DaysAdjustment spotDateOffset = DaysAdjustment.ofBusinessDays(spotLag, calendar);
+    return ImmutableOvernightOvernightSwapConvention.of(
+        name,
+        OvernightRateSwapLegConvention.builder()
+            .index(spreadIndex)
+            .accrualMethod(OvernightAccrualMethod.COMPOUNDED)
+            .accrualFrequency(frequency)
+            .paymentFrequency(frequency)
+            .paymentDateOffset(paymentDateOffset)
+            .stubConvention(StubConvention.SMART_INITIAL)
+            .build(),
+        OvernightRateSwapLegConvention.builder()
+            .index(flatIndex)
+            .accrualMethod(OvernightAccrualMethod.COMPOUNDED)
+            .accrualFrequency(frequency)
+            .paymentFrequency(frequency)
+            .paymentDateOffset(paymentDateOffset)
+            .stubConvention(StubConvention.SMART_INITIAL)
+            .build(),
+        spotDateOffset
+    );
+  }
+
+  //-------------------------------------------------------------------------
+
+  /**
+   * Restricted constructor.
+   */
+  private StandardOvernightOvernightSwapConventions() {
+  }
+
+}

--- a/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/swap/type/StandardOvernightOvernightSwapConventions.java
@@ -24,7 +24,7 @@ final class StandardOvernightOvernightSwapConventions {
    * <p>
    * The spot date offset is 2 days.
    */
-  public static final OvernightOvernightSwapConvention USD_SOFR_3M_FED_FUND_3M =
+  static final OvernightOvernightSwapConvention USD_SOFR_3M_FED_FUND_3M =
       makeConvention("USD-SOFR-3M-FED-FUND-3M", USD_SOFR, USD_FED_FUND, P3M, 2, 2);
 
   //-------------------------------------------------------------------------

--- a/modules/product/src/main/resources/META-INF/com/opengamma/strata/config/base/OvernightOvernightSwapConvention.ini
+++ b/modules/product/src/main/resources/META-INF/com/opengamma/strata/config/base/OvernightOvernightSwapConvention.ini
@@ -1,0 +1,15 @@
+# OvernightOvernightSwapConvention configuration
+
+# The providers are the classes that define the enum
+# The key is of the form 'provider.full.class.name'
+# The value is either
+#  'constants', the public static final constants from the class
+#  'lookup', the class implements NamedLookup with a no-args constructor
+#  'instance', the class has a static field named INSTANCE that is of type NamedLookup
+[providers]
+com.opengamma.strata.product.swap.type.StandardOvernightOvernightSwapConventions = constants
+
+# The set of alternate names
+# The key is the alternate name
+# The value is the standard name (loaded by a provider)
+[alternates]

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionTest.java
@@ -142,7 +142,7 @@ public class OvernightOvernightSwapConventionTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_name() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, "USD-SOFR-3M-FED-FUND-3M"},
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, "USD-SOFR-3M-FED-FUND-3M"},
     };
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionTest.java
@@ -7,11 +7,9 @@ package com.opengamma.strata.product.swap.type;
 
 import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
 import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
-import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
-import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
-import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
 import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
-import static com.opengamma.strata.basics.schedule.Frequency.P12M;
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_SOFR;
+import static com.opengamma.strata.basics.schedule.Frequency.P3M;
 import static com.opengamma.strata.collect.TestHelper.assertSerialization;
 import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
 import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
@@ -19,7 +17,6 @@ import static com.opengamma.strata.collect.TestHelper.date;
 import static com.opengamma.strata.product.common.BuySell.BUY;
 import static com.opengamma.strata.product.common.PayReceive.PAY;
 import static com.opengamma.strata.product.common.PayReceive.RECEIVE;
-import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -34,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.google.common.collect.ImmutableMap;
 import com.opengamma.strata.basics.ReferenceData;
 import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.index.OvernightIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
 import com.opengamma.strata.basics.schedule.StubConvention;
 import com.opengamma.strata.product.common.BuySell;
@@ -41,7 +39,7 @@ import com.opengamma.strata.product.swap.Swap;
 import com.opengamma.strata.product.swap.SwapTrade;
 
 /**
- * Test {@link OvernightIborSwapConvention}.
+ * Test {@link OvernightOvernightSwapConvention}.
  */
 public class OvernightOvernightSwapConventionTest {
 
@@ -50,87 +48,93 @@ public class OvernightOvernightSwapConventionTest {
   private static final DaysAdjustment PLUS_ONE_DAY = DaysAdjustment.ofBusinessDays(1, GBLO);
   private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
 
-  private static final String NAME = "USD-FF";
-  private static final OvernightRateSwapLegConvention FFUND_LEG =
+  private static final String NAME = "USD-SOFR-FF";
+
+  private static final OvernightRateSwapLegConvention SOFR_LEG =
       OvernightRateSwapLegConvention.builder()
-          .index(USD_FED_FUND)
-          .accrualMethod(AVERAGED)
+          .index(USD_SOFR)
           .accrualFrequency(Frequency.P3M)
           .paymentFrequency(Frequency.P3M)
           .stubConvention(StubConvention.SMART_INITIAL)
           .rateCutOffDays(2)
           .build();
-  private static final OvernightRateSwapLegConvention FFUND_LEG2 =
-      OvernightRateSwapLegConvention.of(USD_FED_FUND, P12M, 3);
-  private static final OvernightRateSwapLegConvention FLOATING_LEG2 =
-      OvernightRateSwapLegConvention.of(GBP_SONIA, P12M, 0);
-  private static final IborRateSwapLegConvention USD_LIBOR_3M_LEG = IborRateSwapLegConvention.of(USD_LIBOR_3M);
-  private static final IborRateSwapLegConvention GBP_LIBOR_3M_LEG = IborRateSwapLegConvention.of(GBP_LIBOR_3M);
+
+  private static final OvernightRateSwapLegConvention FFUND_LEG =
+      OvernightRateSwapLegConvention.builder()
+          .index(USD_FED_FUND)
+          .accrualFrequency(Frequency.P3M)
+          .paymentFrequency(Frequency.P3M)
+          .stubConvention(StubConvention.SMART_INITIAL)
+          .rateCutOffDays(2)
+          .build();
 
   //-------------------------------------------------------------------------
   @Test
   public void test_of() {
-    ImmutableOvernightIborSwapConvention test =
-        ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    OvernightOvernightSwapConvention test =
+        ImmutableOvernightOvernightSwapConvention.of(NAME, SOFR_LEG, FFUND_LEG, PLUS_TWO_DAYS);
     assertThat(test.getName()).isEqualTo(NAME);
-    assertThat(test.getOvernightLeg()).isEqualTo(FFUND_LEG);
-    assertThat(test.getIborLeg()).isEqualTo(USD_LIBOR_3M_LEG);
+    assertThat(test.getSpreadLeg()).isEqualTo(SOFR_LEG);
+    assertThat(test.getFlatLeg()).isEqualTo(FFUND_LEG);
     assertThat(test.getSpotDateOffset()).isEqualTo(PLUS_TWO_DAYS);
   }
 
   @Test
   public void test_builder() {
-    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.builder()
+    ImmutableOvernightOvernightSwapConvention test = ImmutableOvernightOvernightSwapConvention.builder()
         .name(NAME)
-        .overnightLeg(FFUND_LEG)
-        .iborLeg(USD_LIBOR_3M_LEG)
+        .spreadLeg(SOFR_LEG)
+        .flatLeg(FFUND_LEG)
         .spotDateOffset(PLUS_ONE_DAY)
         .build();
     assertThat(test.getName()).isEqualTo(NAME);
-    assertThat(test.getOvernightLeg()).isEqualTo(FFUND_LEG);
-    assertThat(test.getIborLeg()).isEqualTo(USD_LIBOR_3M_LEG);
+    assertThat(test.getSpreadLeg()).isEqualTo(SOFR_LEG);
+    assertThat(test.getFlatLeg()).isEqualTo(FFUND_LEG);
     assertThat(test.getSpotDateOffset()).isEqualTo(PLUS_ONE_DAY);
   }
 
   //-------------------------------------------------------------------------
   @Test
   public void test_toTrade_tenor() {
-    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    OvernightOvernightSwapConvention base =
+        ImmutableOvernightOvernightSwapConvention.of(NAME, SOFR_LEG, FFUND_LEG, PLUS_TWO_DAYS);
     LocalDate tradeDate = LocalDate.of(2015, 5, 5);
     LocalDate startDate = date(2015, 5, 7);
     LocalDate endDate = date(2025, 5, 7);
     SwapTrade test = base.createTrade(tradeDate, TENOR_10Y, BUY, NOTIONAL_2M, 0.25d, REF_DATA);
     Swap expected = Swap.of(
-        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
-        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+        SOFR_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        FFUND_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
     assertThat(test.getInfo().getTradeDate()).isEqualTo(Optional.of(tradeDate));
     assertThat(test.getProduct()).isEqualTo(expected);
   }
 
   @Test
   public void test_toTrade_periodTenor() {
-    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    OvernightOvernightSwapConvention base =
+        ImmutableOvernightOvernightSwapConvention.of(NAME, SOFR_LEG, FFUND_LEG, PLUS_TWO_DAYS);
     LocalDate tradeDate = LocalDate.of(2015, 5, 5);
     LocalDate startDate = date(2015, 8, 7);
     LocalDate endDate = date(2025, 8, 7);
     SwapTrade test = base.createTrade(tradeDate, Period.ofMonths(3), TENOR_10Y, BuySell.SELL, NOTIONAL_2M, 0.25d, REF_DATA);
     Swap expected = Swap.of(
-        FFUND_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M, 0.25d),
-        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M));
+        SOFR_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M, 0.25d),
+        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M));
     assertThat(test.getInfo().getTradeDate()).isEqualTo(Optional.of(tradeDate));
     assertThat(test.getProduct()).isEqualTo(expected);
   }
 
   @Test
   public void test_toTrade_dates() {
-    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    OvernightOvernightSwapConvention base =
+        ImmutableOvernightOvernightSwapConvention.of(NAME, SOFR_LEG, FFUND_LEG, PLUS_TWO_DAYS);
     LocalDate tradeDate = LocalDate.of(2015, 5, 5);
     LocalDate startDate = date(2015, 8, 5);
     LocalDate endDate = date(2015, 11, 5);
     SwapTrade test = base.toTrade(tradeDate, startDate, endDate, BUY, NOTIONAL_2M, 0.25d);
     Swap expected = Swap.of(
-        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
-        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+        SOFR_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        FFUND_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
     assertThat(test.getInfo().getTradeDate()).isEqualTo(Optional.of(tradeDate));
     assertThat(test.getProduct()).isEqualTo(expected);
   }
@@ -138,66 +142,66 @@ public class OvernightOvernightSwapConventionTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_name() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, "USD-FED-FUND-AA-LIBOR-3M"},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, "USD-SOFR-3M-FED-FUND-3M"},
     };
   }
 
   @ParameterizedTest
   @MethodSource("data_name")
-  public void test_name(OvernightIborSwapConvention convention, String name) {
+  public void test_name(OvernightOvernightSwapConvention convention, String name) {
     assertThat(convention.getName()).isEqualTo(name);
   }
 
   @ParameterizedTest
   @MethodSource("data_name")
-  public void test_toString(OvernightIborSwapConvention convention, String name) {
+  public void test_toString(OvernightOvernightSwapConvention convention, String name) {
     assertThat(convention.toString()).isEqualTo(name);
   }
 
   @ParameterizedTest
   @MethodSource("data_name")
-  public void test_of_lookup(OvernightIborSwapConvention convention, String name) {
-    assertThat(OvernightIborSwapConvention.of(name)).isEqualTo(convention);
+  public void test_of_lookup(OvernightOvernightSwapConvention convention, String name) {
+    assertThat(OvernightOvernightSwapConvention.of(name)).isEqualTo(convention);
   }
 
   @ParameterizedTest
   @MethodSource("data_name")
-  public void test_extendedEnum(OvernightIborSwapConvention convention, String name) {
-    OvernightIborSwapConvention.of(name);  // ensures map is populated
-    ImmutableMap<String, OvernightIborSwapConvention> map = OvernightIborSwapConvention.extendedEnum().lookupAll();
+  public void test_extendedEnum(OvernightOvernightSwapConvention convention, String name) {
+    OvernightOvernightSwapConvention.of(name);  // ensures map is populated
+    ImmutableMap<String, OvernightOvernightSwapConvention> map = OvernightOvernightSwapConvention.extendedEnum().lookupAll();
     assertThat(map.get(name)).isEqualTo(convention);
   }
 
   @Test
   public void test_of_lookup_notFound() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> OvernightIborSwapConvention.of("Rubbish"));
+        .isThrownBy(() -> OvernightOvernightSwapConvention.of("Rubbish"));
   }
 
   @Test
   public void test_of_lookup_null() {
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> OvernightIborSwapConvention.of((String) null));
+        .isThrownBy(() -> OvernightOvernightSwapConvention.of(null));
   }
 
   //-------------------------------------------------------------------------
   @Test
   public void coverage() {
-    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.of(
-        NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    ImmutableOvernightOvernightSwapConvention test =
+        ImmutableOvernightOvernightSwapConvention.of(NAME, SOFR_LEG, FFUND_LEG, PLUS_TWO_DAYS);
     coverImmutableBean(test);
-    ImmutableOvernightIborSwapConvention test2 = ImmutableOvernightIborSwapConvention.of(
-        "GBP-Swap", FLOATING_LEG2, GBP_LIBOR_3M_LEG, PLUS_ONE_DAY);
+    ImmutableOvernightOvernightSwapConvention test2 = ImmutableOvernightOvernightSwapConvention.of(
+        "EUR-EONIA-ESTR",
+        OvernightRateSwapLegConvention.of(OvernightIndices.EUR_EONIA, P3M, 2),
+        OvernightRateSwapLegConvention.of(OvernightIndices.EUR_EONIA, P3M, 2),
+        PLUS_TWO_DAYS);
     coverBeanEquals(test, test2);
-    ImmutableOvernightIborSwapConvention test3 = ImmutableOvernightIborSwapConvention.of(
-        "USD-Swap2", FFUND_LEG2, USD_LIBOR_3M_LEG, PLUS_ONE_DAY);
-    coverBeanEquals(test, test3);
   }
 
   @Test
   public void test_serialization() {
-    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.of(
-        NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    OvernightOvernightSwapConvention test =
+        ImmutableOvernightOvernightSwapConvention.of(NAME, SOFR_LEG, FFUND_LEG, PLUS_TWO_DAYS);
     assertSerialization(test);
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2024 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.basics.date.HolidayCalendarIds.GBLO;
+import static com.opengamma.strata.basics.date.Tenor.TENOR_10Y;
+import static com.opengamma.strata.basics.index.IborIndices.GBP_LIBOR_3M;
+import static com.opengamma.strata.basics.index.IborIndices.USD_LIBOR_3M;
+import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
+import static com.opengamma.strata.basics.index.OvernightIndices.USD_FED_FUND;
+import static com.opengamma.strata.basics.schedule.Frequency.P12M;
+import static com.opengamma.strata.collect.TestHelper.assertSerialization;
+import static com.opengamma.strata.collect.TestHelper.coverBeanEquals;
+import static com.opengamma.strata.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.strata.collect.TestHelper.date;
+import static com.opengamma.strata.product.common.BuySell.BUY;
+import static com.opengamma.strata.product.common.PayReceive.PAY;
+import static com.opengamma.strata.product.common.PayReceive.RECEIVE;
+import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableMap;
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.date.DaysAdjustment;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.basics.schedule.StubConvention;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.swap.Swap;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * Test {@link OvernightIborSwapConvention}.
+ */
+public class OvernightOvernightSwapConventionTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final double NOTIONAL_2M = 2_000_000d;
+  private static final DaysAdjustment PLUS_ONE_DAY = DaysAdjustment.ofBusinessDays(1, GBLO);
+  private static final DaysAdjustment PLUS_TWO_DAYS = DaysAdjustment.ofBusinessDays(2, GBLO);
+
+  private static final String NAME = "USD-FF";
+  private static final OvernightRateSwapLegConvention FFUND_LEG =
+      OvernightRateSwapLegConvention.builder()
+          .index(USD_FED_FUND)
+          .accrualMethod(AVERAGED)
+          .accrualFrequency(Frequency.P3M)
+          .paymentFrequency(Frequency.P3M)
+          .stubConvention(StubConvention.SMART_INITIAL)
+          .rateCutOffDays(2)
+          .build();
+  private static final OvernightRateSwapLegConvention FFUND_LEG2 =
+      OvernightRateSwapLegConvention.of(USD_FED_FUND, P12M, 3);
+  private static final OvernightRateSwapLegConvention FLOATING_LEG2 =
+      OvernightRateSwapLegConvention.of(GBP_SONIA, P12M, 0);
+  private static final IborRateSwapLegConvention USD_LIBOR_3M_LEG = IborRateSwapLegConvention.of(USD_LIBOR_3M);
+  private static final IborRateSwapLegConvention GBP_LIBOR_3M_LEG = IborRateSwapLegConvention.of(GBP_LIBOR_3M);
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_of() {
+    ImmutableOvernightIborSwapConvention test =
+        ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    assertThat(test.getName()).isEqualTo(NAME);
+    assertThat(test.getOvernightLeg()).isEqualTo(FFUND_LEG);
+    assertThat(test.getIborLeg()).isEqualTo(USD_LIBOR_3M_LEG);
+    assertThat(test.getSpotDateOffset()).isEqualTo(PLUS_TWO_DAYS);
+  }
+
+  @Test
+  public void test_builder() {
+    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.builder()
+        .name(NAME)
+        .overnightLeg(FFUND_LEG)
+        .iborLeg(USD_LIBOR_3M_LEG)
+        .spotDateOffset(PLUS_ONE_DAY)
+        .build();
+    assertThat(test.getName()).isEqualTo(NAME);
+    assertThat(test.getOvernightLeg()).isEqualTo(FFUND_LEG);
+    assertThat(test.getIborLeg()).isEqualTo(USD_LIBOR_3M_LEG);
+    assertThat(test.getSpotDateOffset()).isEqualTo(PLUS_ONE_DAY);
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void test_toTrade_tenor() {
+    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 5, 7);
+    LocalDate endDate = date(2025, 5, 7);
+    SwapTrade test = base.createTrade(tradeDate, TENOR_10Y, BUY, NOTIONAL_2M, 0.25d, REF_DATA);
+    Swap expected = Swap.of(
+        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+    assertThat(test.getInfo().getTradeDate()).isEqualTo(Optional.of(tradeDate));
+    assertThat(test.getProduct()).isEqualTo(expected);
+  }
+
+  @Test
+  public void test_toTrade_periodTenor() {
+    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 8, 7);
+    LocalDate endDate = date(2025, 8, 7);
+    SwapTrade test = base.createTrade(tradeDate, Period.ofMonths(3), TENOR_10Y, BuySell.SELL, NOTIONAL_2M, 0.25d, REF_DATA);
+    Swap expected = Swap.of(
+        FFUND_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M, 0.25d),
+        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M));
+    assertThat(test.getInfo().getTradeDate()).isEqualTo(Optional.of(tradeDate));
+    assertThat(test.getProduct()).isEqualTo(expected);
+  }
+
+  @Test
+  public void test_toTrade_dates() {
+    OvernightIborSwapConvention base = ImmutableOvernightIborSwapConvention.of(NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    LocalDate tradeDate = LocalDate.of(2015, 5, 5);
+    LocalDate startDate = date(2015, 8, 5);
+    LocalDate endDate = date(2015, 11, 5);
+    SwapTrade test = base.toTrade(tradeDate, startDate, endDate, BUY, NOTIONAL_2M, 0.25d);
+    Swap expected = Swap.of(
+        FFUND_LEG.toLeg(startDate, endDate, PAY, NOTIONAL_2M, 0.25d),
+        USD_LIBOR_3M_LEG.toLeg(startDate, endDate, RECEIVE, NOTIONAL_2M));
+    assertThat(test.getInfo().getTradeDate()).isEqualTo(Optional.of(tradeDate));
+    assertThat(test.getProduct()).isEqualTo(expected);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_name() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, "USD-FED-FUND-AA-LIBOR-3M"},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_name(OvernightIborSwapConvention convention, String name) {
+    assertThat(convention.getName()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_toString(OvernightIborSwapConvention convention, String name) {
+    assertThat(convention.toString()).isEqualTo(name);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_of_lookup(OvernightIborSwapConvention convention, String name) {
+    assertThat(OvernightIborSwapConvention.of(name)).isEqualTo(convention);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_name")
+  public void test_extendedEnum(OvernightIborSwapConvention convention, String name) {
+    OvernightIborSwapConvention.of(name);  // ensures map is populated
+    ImmutableMap<String, OvernightIborSwapConvention> map = OvernightIborSwapConvention.extendedEnum().lookupAll();
+    assertThat(map.get(name)).isEqualTo(convention);
+  }
+
+  @Test
+  public void test_of_lookup_notFound() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> OvernightIborSwapConvention.of("Rubbish"));
+  }
+
+  @Test
+  public void test_of_lookup_null() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> OvernightIborSwapConvention.of((String) null));
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void coverage() {
+    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.of(
+        NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    coverImmutableBean(test);
+    ImmutableOvernightIborSwapConvention test2 = ImmutableOvernightIborSwapConvention.of(
+        "GBP-Swap", FLOATING_LEG2, GBP_LIBOR_3M_LEG, PLUS_ONE_DAY);
+    coverBeanEquals(test, test2);
+    ImmutableOvernightIborSwapConvention test3 = ImmutableOvernightIborSwapConvention.of(
+        "USD-Swap2", FFUND_LEG2, USD_LIBOR_3M_LEG, PLUS_ONE_DAY);
+    coverBeanEquals(test, test3);
+  }
+
+  @Test
+  public void test_serialization() {
+    ImmutableOvernightIborSwapConvention test = ImmutableOvernightIborSwapConvention.of(
+        NAME, FFUND_LEG, USD_LIBOR_3M_LEG, PLUS_TWO_DAYS);
+    assertSerialization(test);
+  }
+
+}

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2024 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.product.swap.type;
+
+import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.date.BusinessDayConvention;
+import com.opengamma.strata.basics.date.BusinessDayConventions;
+import com.opengamma.strata.basics.date.DayCount;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.Tenor;
+import com.opengamma.strata.basics.index.IborIndex;
+import com.opengamma.strata.basics.index.IborIndices;
+import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.basics.index.OvernightIndices;
+import com.opengamma.strata.basics.schedule.Frequency;
+import com.opengamma.strata.product.common.BuySell;
+import com.opengamma.strata.product.common.PayReceive;
+import com.opengamma.strata.product.swap.ResolvedSwap;
+import com.opengamma.strata.product.swap.SwapTrade;
+
+/**
+ * Test {@link OvernightIborSwapConventions}.
+ */
+public class OvernightOvernightSwapConventionsTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+
+  public static Object[][] data_spot_lag() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, 2},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, 0},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_spot_lag")
+  public void test_spot_lag(ImmutableOvernightIborSwapConvention convention, int lag) {
+    assertThat(convention.getSpotDateOffset().getDays()).isEqualTo(lag);
+    assertThat(convention.getSpotDateOffset()).isEqualTo(convention.getIborLeg().getIndex().getEffectiveDateOffset());
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_period_on() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P12M},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_period_on")
+  public void test_accrualPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertThat(convention.getOvernightLeg().getAccrualFrequency()).isEqualTo(frequency);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_period_on")
+  public void test_paymentPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertThat(convention.getOvernightLeg().getPaymentFrequency()).isEqualTo(frequency);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_period_ibor() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P3M},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_period_ibor")
+  public void test_accrualPeriod_ibor(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertThat(convention.getIborLeg().getAccrualFrequency()).isEqualTo(frequency);
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_period_ibor")
+  public void test_paymentPeriod_ibor(OvernightIborSwapConvention convention, Frequency frequency) {
+    assertThat(convention.getIborLeg().getPaymentFrequency()).isEqualTo(frequency);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_day_count() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, DayCounts.ACT_360},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, DayCounts.ACT_365F},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_day_count")
+  public void test_day_count(OvernightIborSwapConvention convention, DayCount dayCount) {
+    assertThat(convention.getOvernightLeg().getDayCount()).isEqualTo(dayCount);
+    assertThat(convention.getIborLeg().getDayCount()).isEqualTo(dayCount);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_float_leg() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, OvernightIndices.USD_FED_FUND},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, OvernightIndices.GBP_SONIA},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_float_leg")
+  public void test_float_leg(OvernightIborSwapConvention convention, OvernightIndex floatLeg) {
+    assertThat(convention.getOvernightLeg().getIndex()).isEqualTo(floatLeg);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_ibor_leg() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, IborIndices.USD_LIBOR_3M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, IborIndices.GBP_LIBOR_3M},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_ibor_leg")
+  public void test_ibor_leg(OvernightIborSwapConvention convention, IborIndex iborLeg) {
+    assertThat(convention.getIborLeg().getIndex()).isEqualTo(iborLeg);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_day_convention() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_day_convention")
+  public void test_day_convention(OvernightIborSwapConvention convention, BusinessDayConvention dayConvention) {
+    assertThat(convention.getOvernightLeg().getAccrualBusinessDayAdjustment().getConvention()).isEqualTo(dayConvention);
+  }
+
+  //-------------------------------------------------------------------------
+  public static Object[][] data_stub_on() {
+    return new Object[][] {
+        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
+        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Tenor.of(Period.ofMonths(13))},
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource("data_stub_on")
+  public void test_stub_overnight(OvernightIborSwapConvention convention, Tenor tenor) {
+    LocalDate tradeDate = LocalDate.of(2015, 10, 20);
+    SwapTrade swap = convention.createTrade(tradeDate, tenor, BuySell.BUY, 1, 0.01, REF_DATA);
+    ResolvedSwap swapResolved = swap.getProduct().resolve(REF_DATA);
+    LocalDate endDate = swapResolved.getLeg(PayReceive.PAY).get().getEndDate();
+    assertThat(endDate.isAfter(tradeDate.plus(tenor).minusDays(7))).isTrue();
+    assertThat(endDate.isBefore(tradeDate.plus(tenor).plusDays(7))).isTrue();
+  }
+
+  //-------------------------------------------------------------------------
+  @Test
+  public void coverage() {
+    coverPrivateConstructor(OvernightIborSwapConventions.class);
+    coverPrivateConstructor(StandardOvernightIborSwapConventions.class);
+  }
+
+}

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionsTest.java
@@ -37,7 +37,7 @@ public class OvernightOvernightSwapConventionsTest {
 
   public static Object[][] data_spot_lag() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, 2},
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, 2},
     };
   }
 
@@ -50,7 +50,7 @@ public class OvernightOvernightSwapConventionsTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_period() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, Frequency.P3M}
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, Frequency.P3M}
     };
   }
 
@@ -71,7 +71,7 @@ public class OvernightOvernightSwapConventionsTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_day_count() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, DayCounts.ACT_360},
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, DayCounts.ACT_360},
     };
   }
 
@@ -85,7 +85,7 @@ public class OvernightOvernightSwapConventionsTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_float_index() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, OvernightIndices.USD_SOFR, OvernightIndices.USD_FED_FUND},
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, OvernightIndices.USD_SOFR, OvernightIndices.USD_FED_FUND},
     };
   }
 
@@ -103,7 +103,7 @@ public class OvernightOvernightSwapConventionsTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_day_convention() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, BusinessDayConventions.MODIFIED_FOLLOWING}
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, BusinessDayConventions.MODIFIED_FOLLOWING}
     };
   }
 
@@ -117,7 +117,7 @@ public class OvernightOvernightSwapConventionsTest {
   //-------------------------------------------------------------------------
   public static Object[][] data_stub_on() {
     return new Object[][] {
-        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, Tenor.TENOR_4M}
+        {OvernightOvernightSwapConventions.USD_SOFR_3M_FED_FUND_3M, Tenor.TENOR_4M}
     };
   }
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionsTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/swap/type/OvernightOvernightSwapConventionsTest.java
@@ -9,7 +9,6 @@ import static com.opengamma.strata.collect.TestHelper.coverPrivateConstructor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,8 +20,6 @@ import com.opengamma.strata.basics.date.BusinessDayConventions;
 import com.opengamma.strata.basics.date.DayCount;
 import com.opengamma.strata.basics.date.DayCounts;
 import com.opengamma.strata.basics.date.Tenor;
-import com.opengamma.strata.basics.index.IborIndex;
-import com.opengamma.strata.basics.index.IborIndices;
 import com.opengamma.strata.basics.index.OvernightIndex;
 import com.opengamma.strata.basics.index.OvernightIndices;
 import com.opengamma.strata.basics.schedule.Frequency;
@@ -32,7 +29,7 @@ import com.opengamma.strata.product.swap.ResolvedSwap;
 import com.opengamma.strata.product.swap.SwapTrade;
 
 /**
- * Test {@link OvernightIborSwapConventions}.
+ * Test {@link OvernightOvernightSwapConventions}.
  */
 public class OvernightOvernightSwapConventionsTest {
 
@@ -40,126 +37,93 @@ public class OvernightOvernightSwapConventionsTest {
 
   public static Object[][] data_spot_lag() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, 2},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, 0},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, 2},
     };
   }
 
   @ParameterizedTest
   @MethodSource("data_spot_lag")
-  public void test_spot_lag(ImmutableOvernightIborSwapConvention convention, int lag) {
+  public void test_spot_lag(OvernightOvernightSwapConvention convention, int lag) {
     assertThat(convention.getSpotDateOffset().getDays()).isEqualTo(lag);
-    assertThat(convention.getSpotDateOffset()).isEqualTo(convention.getIborLeg().getIndex().getEffectiveDateOffset());
   }
 
   //-------------------------------------------------------------------------
-  public static Object[][] data_period_on() {
+  public static Object[][] data_period() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P12M},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, Frequency.P3M}
     };
   }
 
   @ParameterizedTest
-  @MethodSource("data_period_on")
-  public void test_accrualPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertThat(convention.getOvernightLeg().getAccrualFrequency()).isEqualTo(frequency);
+  @MethodSource("data_period")
+  public void test_accrualPeriod_on(OvernightOvernightSwapConvention convention, Frequency frequency) {
+    assertThat(convention.getSpreadLeg().getAccrualFrequency()).isEqualTo(frequency);
+    assertThat(convention.getFlatLeg().getAccrualFrequency()).isEqualTo(frequency);
   }
 
   @ParameterizedTest
-  @MethodSource("data_period_on")
-  public void test_paymentPeriod_on(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertThat(convention.getOvernightLeg().getPaymentFrequency()).isEqualTo(frequency);
-  }
-
-  //-------------------------------------------------------------------------
-  public static Object[][] data_period_ibor() {
-    return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Frequency.P3M},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Frequency.P3M},
-    };
-  }
-
-  @ParameterizedTest
-  @MethodSource("data_period_ibor")
-  public void test_accrualPeriod_ibor(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertThat(convention.getIborLeg().getAccrualFrequency()).isEqualTo(frequency);
-  }
-
-  @ParameterizedTest
-  @MethodSource("data_period_ibor")
-  public void test_paymentPeriod_ibor(OvernightIborSwapConvention convention, Frequency frequency) {
-    assertThat(convention.getIborLeg().getPaymentFrequency()).isEqualTo(frequency);
+  @MethodSource("data_period")
+  public void test_paymentPeriod_on(OvernightOvernightSwapConvention convention, Frequency frequency) {
+    assertThat(convention.getSpreadLeg().getPaymentFrequency()).isEqualTo(frequency);
+    assertThat(convention.getFlatLeg().getPaymentFrequency()).isEqualTo(frequency);
   }
 
   //-------------------------------------------------------------------------
   public static Object[][] data_day_count() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, DayCounts.ACT_360},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, DayCounts.ACT_365F},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, DayCounts.ACT_360},
     };
   }
 
   @ParameterizedTest
   @MethodSource("data_day_count")
-  public void test_day_count(OvernightIborSwapConvention convention, DayCount dayCount) {
-    assertThat(convention.getOvernightLeg().getDayCount()).isEqualTo(dayCount);
-    assertThat(convention.getIborLeg().getDayCount()).isEqualTo(dayCount);
+  public void test_day_count(OvernightOvernightSwapConvention convention, DayCount dayCount) {
+    assertThat(convention.getSpreadLeg().getDayCount()).isEqualTo(dayCount);
+    assertThat(convention.getFlatLeg().getDayCount()).isEqualTo(dayCount);
   }
 
   //-------------------------------------------------------------------------
-  public static Object[][] data_float_leg() {
+  public static Object[][] data_float_index() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, OvernightIndices.USD_FED_FUND},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, OvernightIndices.GBP_SONIA},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, OvernightIndices.USD_SOFR, OvernightIndices.USD_FED_FUND},
     };
   }
 
   @ParameterizedTest
-  @MethodSource("data_float_leg")
-  public void test_float_leg(OvernightIborSwapConvention convention, OvernightIndex floatLeg) {
-    assertThat(convention.getOvernightLeg().getIndex()).isEqualTo(floatLeg);
-  }
+  @MethodSource("data_float_index")
+  public void test_float_leg(
+      OvernightOvernightSwapConvention convention,
+      OvernightIndex spreadLegIndex,
+      OvernightIndex flatLegIndex) {
 
-  //-------------------------------------------------------------------------
-  public static Object[][] data_ibor_leg() {
-    return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, IborIndices.USD_LIBOR_3M},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, IborIndices.GBP_LIBOR_3M},
-    };
-  }
-
-  @ParameterizedTest
-  @MethodSource("data_ibor_leg")
-  public void test_ibor_leg(OvernightIborSwapConvention convention, IborIndex iborLeg) {
-    assertThat(convention.getIborLeg().getIndex()).isEqualTo(iborLeg);
+    assertThat(convention.getSpreadLeg().getIndex()).isEqualTo(spreadLegIndex);
+    assertThat(convention.getFlatLeg().getIndex()).isEqualTo(flatLegIndex);
   }
 
   //-------------------------------------------------------------------------
   public static Object[][] data_day_convention() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, BusinessDayConventions.MODIFIED_FOLLOWING},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, BusinessDayConventions.MODIFIED_FOLLOWING}
     };
   }
 
   @ParameterizedTest
   @MethodSource("data_day_convention")
-  public void test_day_convention(OvernightIborSwapConvention convention, BusinessDayConvention dayConvention) {
-    assertThat(convention.getOvernightLeg().getAccrualBusinessDayAdjustment().getConvention()).isEqualTo(dayConvention);
+  public void test_day_convention(OvernightOvernightSwapConvention convention, BusinessDayConvention dayConvention) {
+    assertThat(convention.getSpreadLeg().getAccrualBusinessDayAdjustment().getConvention()).isEqualTo(dayConvention);
+    assertThat(convention.getFlatLeg().getAccrualBusinessDayAdjustment().getConvention()).isEqualTo(dayConvention);
   }
 
   //-------------------------------------------------------------------------
   public static Object[][] data_stub_on() {
     return new Object[][] {
-        {OvernightIborSwapConventions.USD_FED_FUND_AA_LIBOR_3M, Tenor.TENOR_4M},
-        {OvernightIborSwapConventions.GBP_SONIA_OIS_1Y_LIBOR_3M, Tenor.of(Period.ofMonths(13))},
+        {OvernightOvernightSwapConventions.USD_FED_FUND_SOFR_3M, Tenor.TENOR_4M}
     };
   }
 
   @ParameterizedTest
   @MethodSource("data_stub_on")
-  public void test_stub_overnight(OvernightIborSwapConvention convention, Tenor tenor) {
+  public void test_stub_overnight(OvernightOvernightSwapConvention convention, Tenor tenor) {
     LocalDate tradeDate = LocalDate.of(2015, 10, 20);
     SwapTrade swap = convention.createTrade(tradeDate, tenor, BuySell.BUY, 1, 0.01, REF_DATA);
     ResolvedSwap swapResolved = swap.getProduct().resolve(REF_DATA);
@@ -171,8 +135,7 @@ public class OvernightOvernightSwapConventionsTest {
   //-------------------------------------------------------------------------
   @Test
   public void coverage() {
-    coverPrivateConstructor(OvernightIborSwapConventions.class);
-    coverPrivateConstructor(StandardOvernightIborSwapConventions.class);
+    coverPrivateConstructor(OvernightOvernightSwapConventions.class);
+    coverPrivateConstructor(StandardOvernightOvernightSwapConventions.class);
   }
-
 }


### PR DESCRIPTION
Initially only needed for trade creation; hence `CurveNode` and `TradeTemplate` implementations have not been created