### PR TITLE
Fix overnight future contract spec

### DIFF
--- a/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
+++ b/modules/product/src/main/java/com/opengamma/strata/product/index/type/StandardOvernightFutureContractSpecs.java
@@ -22,6 +22,8 @@ import static com.opengamma.strata.basics.index.OvernightIndices.USD_SOFR;
 import static com.opengamma.strata.product.swap.OvernightAccrualMethod.AVERAGED_DAILY;
 import static com.opengamma.strata.product.swap.OvernightAccrualMethod.COMPOUNDED;
 
+import java.time.Period;
+
 import com.opengamma.strata.basics.date.BusinessDayAdjustment;
 import com.opengamma.strata.basics.date.DaysAdjustment;
 
@@ -183,8 +185,9 @@ final class StandardOvernightFutureContractSpecs {
       ImmutableOvernightFutureContractSpec.builder()
           .name("USD-SOFR-3M-IMM-CME")
           .index(USD_SOFR)
-          .dateSequence(QUARTERLY_IMM)
+          .dateSequence(QUARTERLY_IMM_6_SERIAL)
           .accrualMethod(COMPOUNDED)
+          .accrualPeriod(Period.ofMonths(3))
           .notional(1_000_000d)
           .build();
 

--- a/modules/product/src/test/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecTest.java
+++ b/modules/product/src/test/java/com/opengamma/strata/product/index/type/OvernightFutureContractSpecTest.java
@@ -330,6 +330,21 @@ public class OvernightFutureContractSpecTest {
     assertThat(trade.getProduct().getNotional()).isEqualTo(5_000_000d);
   }
 
+  @Test
+  public void test_createPosition_usdSofr3mCme() {
+    OvernightFutureContractSpec test = OvernightFutureContractSpecs.USD_SOFR_3M_IMM_CME;
+    OvernightFuturePosition trade = test.createPosition(SecurityId.of("OG", "1"), YearMonth.of(2025, 7), 20, REF_DATA);
+    assertThat(trade.getCurrency()).isEqualTo(Currency.USD);
+    assertThat(trade.getQuantity()).isEqualTo(20);
+    assertThat(trade.getProduct().getIndex()).isEqualTo(USD_SOFR);
+    assertThat(trade.getProduct().getAccrualMethod()).isEqualTo(COMPOUNDED);
+    assertThat(trade.getProduct().getAccrualFactor()).isEqualTo(3 / 12d);
+    assertThat(trade.getProduct().getStartDate()).isEqualTo(date(2025, 7, 16));
+    assertThat(trade.getProduct().getEndDate()).isEqualTo(date(2025, 10, 14));
+    assertThat(trade.getProduct().getLastTradeDate()).isEqualTo(date(2025, 10, 14));
+    assertThat(trade.getProduct().getNotional()).isEqualTo(1_000_000d);
+  }
+
   //-------------------------------------------------------------------------
   public static Object[][] data_name() {
     return new Object[][] {


### PR DESCRIPTION
We currently rely on the `DateSequence` to determine the end date for overnight futures. We assume that the next 'sequence date' after the start date is the correct end date.

This works fine in the case where we have futures with no overlapping observation periods. For example, the SOFR 1M future is issued every month and each contract has a month long accrual period. Therefore the start date of each SOFR 1M future is the day immediately after the end date of the previous future;  there is no overlap.

However for SOFR 3M we have a problem. Currently, we model this future using the `QUARTERLY` date sequence, which means that we only expect futures to be issued in Mar, Jun, Sep and Dec. This is incorrect; we can see [here](https://www.cmegroup.com/markets/interest-rates/stirs/three-month-sofr.calendar.html) that in addition to quarterly futures going out for ~10 years, there are also monthly contracts available for each of the next 6 months.

Therefore, to get the `DateSequence` correct we need to change the date sequence to `QUARTERLY_IMM_6_SERIAL`, as I've done in this PR.

This should create 'overlapping' periods, because the accrual period of the contract (3M) is not aligned with the frequency of the contract issuance (monthly for the first 6 months). For example
- May contract accrual period: May to Aug
- June contract accrual period: June to Sep
- July contract accrual period: July to Oct

This causes our logic for computing the end date to break, as we use the 'base sequence' (in this case Quarterly IMM) to compute the end date. Hence we always select an end date that is in one of the four IMM quarters; this behaviour is only correct when the contract month itself is also the IMM month.

In order to generate a correct end date we need two pieces of information
1. The length of the accrual period
   - This has been added to `OvernightFutureContractSpec`, as it's a property of the contract not the date sequence
   - This can then be added to the start date
2. The adjustment to be applied in order to ensure the date is valid  according to the rules for that specific future (e.g. a valid IMM date)
     - This is done using the `dateMatching` method of `DateSequence`
     - This is a bit of a hack as the end date calculation is not really a concern of the `DateSequence`; but currently the `DateSequence` is the class which knows the correct adjustment rule, and I don't really want to duplicate that adjustment rule onto the contract spec.

This change is implicitly changing the meaning/usage of the date sequence. Previously it was assumed to represent a 'non overlapping' sequence of dates which define the accrual periods for a chain of futures. Whereas now it is representing the start date of the accrual periods for the futures chain only, with the end dates being calculated based on additional logic