### PR TITLE
Enable Claude PR review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,14 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    uses: OpenGamma/og-github-actions/.github/workflows/claude-pr-review.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary
Add `.github/workflows/pr-review.yml` to enable the Claude PR review workflow, calling the shared reusable workflow `OpenGamma/og-github-actions/.github/workflows/claude-pr-review.yml@v1` with `secrets: inherit`.