### PR TITLE
Fix Juneteenth observance for US calendars

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/date/GlobalHolidayCalendars.java
@@ -337,7 +337,7 @@ final class GlobalHolidayCalendars {
     }
     // juneteenth (seems like it wasn't widely applied in 2021)
     if (year >= 2022) {
-      holidays.add(bumpToFriOrMon(date(year, 6, 19)));
+      holidays.add(bumpBack ? bumpToFriOrMon(date(year, 6, 19)) : bumpSunToMon(date(year, 6, 19)));
     }
     // labor day
     holidays.add(date(year, 9, 1).with(firstInMonth(MONDAY)));

--- a/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
+++ b/modules/basics/src/test/java/com/opengamma/strata/basics/date/GlobalHolidayCalendarsTest.java
@@ -623,6 +623,15 @@ public class GlobalHolidayCalendarsTest {
     }
   }
 
+  @Test
+  public void test_usJuneteenthSaturdayObservance() {
+    LocalDate observedDate = LocalDate.of(2027, 6, 18);
+    assertThat(USGS.isHoliday(observedDate)).isTrue();
+    assertThat(NYSE.isHoliday(observedDate)).isTrue();
+    assertThat(USNY.isHoliday(observedDate)).isFalse();
+    assertThat(NYFD.isHoliday(observedDate)).isFalse();
+  }
+
   //-------------------------------------------------------------------------
   private static final HolidayCalendar JPTO = GlobalHolidayCalendars.generateTokyo();
 


### PR DESCRIPTION
Fixes #2726.

## Summary

Make Juneteenth use the existing `bumpBack` setting in the common US holiday-calendar generator, matching the handling already used for Independence Day and Christmas.

When Juneteenth falls on Saturday:

- USGS and NYSE continue to observe the holiday on Friday when `bumpBack` is enabled.
- USNY and NYFD keep Friday open when `bumpBack` is disabled.

The regression test covers all four calendars for Friday, June 18, 2027.

## Validation

- `mvn -pl modules/basics -am -Dtest=GlobalHolidayCalendarsTest -Dsurefire.failIfNoSpecifiedTests=false test` - 405 tests passed
- `mvn -pl modules/basics -am test` - 5,814 tests passed
- Maven Checkstyle
- `git diff --check`
